### PR TITLE
Changes RemascFederationProvider.getFederatorAddress logic and adds t…

### DIFF
--- a/rskj-core/src/main/java/co/rsk/remasc/RemascFederationProvider.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/RemascFederationProvider.java
@@ -45,10 +45,23 @@ public class RemascFederationProvider {
 
     public RskAddress getFederatorAddress(int n) {
         if(!activations.isActive(ConsensusRule.RSKIP415)) {
-            byte[] btcPublicKey = this.federationSupport.getFederatorBtcPublicKey(n);
-            return new RskAddress(ECKey.fromPublicOnly(btcPublicKey).getAddress());
+            return getRskAddressFromBtcKey(n);
         }
-        byte[] rskPublicKey = this.federationSupport.getFederatorPublicKeyOfType(n, FederationMember.KeyType.RSK);
-        return new RskAddress(ECKey.fromPublicOnly(rskPublicKey).getAddress());
+        return getRskAddressFromRskKey(n);
     }
+
+    private RskAddress getRskAddressFromBtcKey(int n) {
+        byte[] btcPublicKey = this.federationSupport.getFederatorBtcPublicKey(n);
+        return getRskAddressFromKey(btcPublicKey);
+    }
+
+    private RskAddress getRskAddressFromRskKey(int n) {
+        byte[] rskPublicKey = this.federationSupport.getFederatorPublicKeyOfType(n, FederationMember.KeyType.RSK);
+        return getRskAddressFromKey(rskPublicKey);
+    }
+
+    private RskAddress getRskAddressFromKey(byte[] publicKey) {
+        return new RskAddress(ECKey.fromPublicOnly(publicKey).getAddress());
+    }
+
 }

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascFederationProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascFederationProviderTest.java
@@ -2,17 +2,30 @@ package co.rsk.remasc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.config.BridgeRegTestConstants;
+import co.rsk.core.RskAddress;
+import co.rsk.peg.*;
 import co.rsk.test.builders.BlockChainBuilder;
+import co.rsk.util.HexUtils;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.Blockchain;
 import org.ethereum.core.Genesis;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.vm.PrecompiledContracts;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.*;
 
 /**
  * Created by ajlopez on 14/11/2017.
  */
 class RemascFederationProviderTest {
+
+    private static final String BTC_PUBLIC_KEY = "0x03a5e32151f974c35c5d08af36a8d6af0593248e8e4adca7ed0148192eb2f5d1bf";
+    private static final String RSK_PUBLIC_KEY = "0x02f3b5fb3121932db9450121b0a37f3f051dc8b3fd5f1ea5e7cf726947d8f69c28";
+
     @Test
     void getDefaultFederationSize() {
         RemascFederationProvider provider = getRemascFederationProvider();
@@ -20,25 +33,79 @@ class RemascFederationProviderTest {
     }
 
     @Test
-    void getFederatorAddress() {
-        RemascFederationProvider provider = getRemascFederationProvider();
+    void getFederatorAddress_preRSKIP415_returnsRskAddressDerivedFromBtcPublicKey() {
 
-        byte[] address = provider.getFederatorAddress(0).getBytes();
+        int federatorIndex = 0;
 
-        Assertions.assertNotNull(address);
-        Assertions.assertEquals(20, address.length);
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP415)).thenReturn(false);
+
+        FederationSupport federationSupport =  mock(FederationSupport.class);
+
+        byte[] btcPublicKey = HexUtils.strHexOrStrNumberToByteArray(BTC_PUBLIC_KEY);
+
+        when(federationSupport.getFederatorBtcPublicKey(federatorIndex))
+                .thenReturn(btcPublicKey);
+
+        RemascFederationProvider provider = new RemascFederationProvider(activations, federationSupport);
+
+        RskAddress actualRskAddress = provider.getFederatorAddress(federatorIndex);
+        RskAddress expectedRskAddress = new RskAddress(ECKey.fromPublicOnly(btcPublicKey).getAddress());
+
+        Assertions.assertEquals(expectedRskAddress, actualRskAddress);
+        verify(federationSupport, never()).getFederatorPublicKeyOfType(federatorIndex, FederationMember.KeyType.RSK);
+        verify(federationSupport, times(1)).getFederatorBtcPublicKey(federatorIndex);
+
+    }
+
+    @Test
+    void getFederatorAddress_postRSKIP415_returnsRskAddressDerivedFromRskPublicKey() {
+
+        int federatorIndex = 0;
+
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP415)).thenReturn(true);
+
+        FederationSupport federationSupport =  mock(FederationSupport.class);
+
+        byte[] rskPublicKey = HexUtils.strHexOrStrNumberToByteArray(RSK_PUBLIC_KEY);
+
+        when(federationSupport.getFederatorPublicKeyOfType(federatorIndex, FederationMember.KeyType.RSK))
+                .thenReturn(rskPublicKey);
+
+        RemascFederationProvider provider = new RemascFederationProvider(activations, federationSupport);
+
+        RskAddress actualRskAddress = provider.getFederatorAddress(federatorIndex);
+        RskAddress expectedRskAddress = new RskAddress(ECKey.fromPublicOnly(rskPublicKey).getAddress());
+
+        Assertions.assertEquals(expectedRskAddress, actualRskAddress);
+        verify(federationSupport, never()).getFederatorBtcPublicKey(federatorIndex);
+        verify(federationSupport, times(1)).getFederatorPublicKeyOfType(federatorIndex, FederationMember.KeyType.RSK);
+
     }
 
     private static RemascFederationProvider getRemascFederationProvider() {
+
         Genesis genesisBlock = new BlockGenerator().getGenesisBlock();
         BlockChainBuilder builder = new BlockChainBuilder().setTesting(true).setGenesis(genesisBlock);
         Blockchain blockchain = builder.build();
 
-        return new RemascFederationProvider(
-                ActivationConfigsForTest.all(),
-                BridgeRegTestConstants.getInstance(),
+        ActivationConfig.ForBlock activations = ActivationConfigsForTest.all().forBlock(blockchain.getBestBlock().getNumber());
+
+        BridgeRegTestConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
+
+        BridgeStorageProvider bridgeStorageProvider = new BridgeStorageProvider(
                 builder.getRepository(),
-                blockchain.getBestBlock()
+                PrecompiledContracts.BRIDGE_ADDR,
+                bridgeRegTestConstants,
+                activations
+        );
+
+        FederationSupport federationSupport = new FederationSupport(bridgeRegTestConstants, bridgeStorageProvider, blockchain.getBestBlock(), activations);
+
+        return new RemascFederationProvider(
+                activations,
+                federationSupport
         );
     }
 }

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascFederationProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascFederationProviderTest.java
@@ -1,7 +1,7 @@
 package co.rsk.remasc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.BridgeRegTestConstants;
+import co.rsk.config.BridgeMainNetConstants;
 import co.rsk.core.RskAddress;
 import co.rsk.peg.*;
 import co.rsk.test.builders.BlockChainBuilder;
@@ -11,7 +11,6 @@ import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.Blockchain;
 import org.ethereum.core.Genesis;
-import org.ethereum.crypto.ECKey;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -24,12 +23,14 @@ import static org.mockito.Mockito.*;
 class RemascFederationProviderTest {
 
     private static final String BTC_PUBLIC_KEY = "0x03a5e32151f974c35c5d08af36a8d6af0593248e8e4adca7ed0148192eb2f5d1bf";
+    private static final String RSK_ADDRESS_FROM_BTC_PUBLIC_KEY = "131c7c821b0e4a1ab570feed952d9304e03fddd1";
     private static final String RSK_PUBLIC_KEY = "0x02f3b5fb3121932db9450121b0a37f3f051dc8b3fd5f1ea5e7cf726947d8f69c28";
+    private static final String RSK_ADDRESS_FROM_RSK_PUBLIC_KEY = "54a948b3d76ce84e5c7b4b3cd01f2af1f18d41e0";
 
     @Test
     void getDefaultFederationSize() {
         RemascFederationProvider provider = getRemascFederationProvider();
-        Assertions.assertEquals(3, provider.getFederationSize());
+        Assertions.assertEquals(15, provider.getFederationSize());
     }
 
     @Test
@@ -50,9 +51,8 @@ class RemascFederationProviderTest {
         RemascFederationProvider provider = new RemascFederationProvider(activations, federationSupport);
 
         RskAddress actualRskAddress = provider.getFederatorAddress(federatorIndex);
-        RskAddress expectedRskAddress = new RskAddress(ECKey.fromPublicOnly(btcPublicKey).getAddress());
 
-        Assertions.assertEquals(expectedRskAddress, actualRskAddress);
+        Assertions.assertEquals(RSK_ADDRESS_FROM_BTC_PUBLIC_KEY, actualRskAddress.toHexString());
         verify(federationSupport, never()).getFederatorPublicKeyOfType(federatorIndex, FederationMember.KeyType.RSK);
         verify(federationSupport, times(1)).getFederatorBtcPublicKey(federatorIndex);
 
@@ -76,11 +76,10 @@ class RemascFederationProviderTest {
         RemascFederationProvider provider = new RemascFederationProvider(activations, federationSupport);
 
         RskAddress actualRskAddress = provider.getFederatorAddress(federatorIndex);
-        RskAddress expectedRskAddress = new RskAddress(ECKey.fromPublicOnly(rskPublicKey).getAddress());
 
-        Assertions.assertEquals(expectedRskAddress, actualRskAddress);
-        verify(federationSupport, never()).getFederatorBtcPublicKey(federatorIndex);
+        Assertions.assertEquals(RSK_ADDRESS_FROM_RSK_PUBLIC_KEY, actualRskAddress.toHexString());
         verify(federationSupport, times(1)).getFederatorPublicKeyOfType(federatorIndex, FederationMember.KeyType.RSK);
+        verify(federationSupport, never()).getFederatorBtcPublicKey(federatorIndex);
 
     }
 
@@ -92,16 +91,16 @@ class RemascFederationProviderTest {
 
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.all().forBlock(blockchain.getBestBlock().getNumber());
 
-        BridgeRegTestConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
+        BridgeMainNetConstants bridgeMainNetConstants = BridgeMainNetConstants.getInstance();
 
         BridgeStorageProvider bridgeStorageProvider = new BridgeStorageProvider(
                 builder.getRepository(),
                 PrecompiledContracts.BRIDGE_ADDR,
-                bridgeRegTestConstants,
+                bridgeMainNetConstants,
                 activations
         );
 
-        FederationSupport federationSupport = new FederationSupport(bridgeRegTestConstants, bridgeStorageProvider, blockchain.getBestBlock(), activations);
+        FederationSupport federationSupport = new FederationSupport(bridgeMainNetConstants, bridgeStorageProvider, blockchain.getBestBlock(), activations);
 
         return new RemascFederationProvider(
                 activations,

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascStorageProviderTest.java
@@ -29,13 +29,12 @@ import co.rsk.db.MutableTrieCache;
 import co.rsk.db.MutableTrieImpl;
 import co.rsk.db.RepositoryLocator;
 import co.rsk.db.RepositorySnapshot;
-import co.rsk.peg.BridgeSupportFactory;
-import co.rsk.peg.PegTestUtils;
-import co.rsk.peg.RepositoryBtcBlockStoreWithCache;
+import co.rsk.peg.*;
 import co.rsk.test.builders.BlockChainBuilder;
 import co.rsk.trie.Trie;
 import org.ethereum.TestUtils;
 import org.ethereum.config.Constants;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.*;
@@ -293,7 +292,20 @@ class RemascStorageProviderTest {
         Blockchain blockchain = testRunner.getBlockChain();
         RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
         RepositorySnapshot repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
-        RemascFederationProvider federationProvider = new RemascFederationProvider(config.getActivationConfig(), config.getNetworkConstants().getBridgeConstants(), repository.startTracking(), testRunner.getBlockChain().getBestBlock());
+        Block executionBlock = testRunner.getBlockChain().getBestBlock();
+
+        ActivationConfig.ForBlock activations = config.getActivationConfig().forBlock(executionBlock.getNumber());
+
+        BridgeStorageProvider bridgeStorageProvider = new BridgeStorageProvider(
+                repository.startTracking(),
+                PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(),
+                activations
+        );
+
+        FederationSupport federationSupport = new FederationSupport(config.getNetworkConstants().getBridgeConstants(), bridgeStorageProvider, executionBlock, activations);
+
+        RemascFederationProvider federationProvider = new RemascFederationProvider(config.getActivationConfig().forBlock(executionBlock.getNumber()), federationSupport);
         assertEquals(Coin.valueOf(0), this.getRemascStorageProvider(repository).getFederationBalance());
         long federatorBalance = (168 / federationProvider.getFederationSize()) * 2;
         assertEquals(Coin.valueOf(federatorBalance), RemascTestRunner.getAccountBalance(repository, federationProvider.getFederatorAddress(0)));
@@ -320,7 +332,20 @@ class RemascStorageProviderTest {
         Blockchain blockchain = testRunner.getBlockChain();
         RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
         RepositorySnapshot repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
-        RemascFederationProvider federationProvider = new RemascFederationProvider(config.getActivationConfig(), config.getNetworkConstants().getBridgeConstants(), repository.startTracking(), testRunner.getBlockChain().getBestBlock());
+        Block executionBlock = testRunner.getBlockChain().getBestBlock();
+
+        ActivationConfig.ForBlock activations = config.getActivationConfig().forBlock(executionBlock.getNumber());
+
+        BridgeStorageProvider bridgeStorageProvider = new BridgeStorageProvider(
+                repository.startTracking(),
+                PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(),
+                activations
+        );
+
+        FederationSupport federationSupport = new FederationSupport(config.getNetworkConstants().getBridgeConstants(), bridgeStorageProvider, executionBlock, activations);
+
+        RemascFederationProvider federationProvider = new RemascFederationProvider(config.getActivationConfig().forBlock(executionBlock.getNumber()), federationSupport);
         assertEquals(Coin.valueOf(336), this.getRemascStorageProvider(repository).getFederationBalance());
         assertEquals(null, RemascTestRunner.getAccountBalance(repository, federationProvider.getFederatorAddress(0)));
     }
@@ -370,7 +395,20 @@ class RemascStorageProviderTest {
         Blockchain blockchain = testRunner.getBlockChain();
         RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
         RepositorySnapshot repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
-        RemascFederationProvider federationProvider = new RemascFederationProvider(config.getActivationConfig(), config.getNetworkConstants().getBridgeConstants(), repository.startTracking(), testRunner.getBlockChain().getBestBlock());
+        Block executionBlock = testRunner.getBlockChain().getBestBlock();
+
+        ActivationConfig.ForBlock activations = config.getActivationConfig().forBlock(executionBlock.getNumber());
+
+        BridgeStorageProvider bridgeStorageProvider = new BridgeStorageProvider(
+                repository.startTracking(),
+                PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(),
+                activations
+        );
+
+        FederationSupport federationSupport = new FederationSupport(config.getNetworkConstants().getBridgeConstants(), bridgeStorageProvider, executionBlock, activations);
+
+        RemascFederationProvider federationProvider = new RemascFederationProvider(config.getActivationConfig().forBlock(executionBlock.getNumber()), federationSupport);
         long federatorBalance = (1680 / federationProvider.getFederationSize()) * 2;
         assertEquals(Coin.valueOf(0), this.getRemascStorageProvider(repository).getFederationBalance());
         assertEquals(Coin.valueOf(federatorBalance), RemascTestRunner.getAccountBalance(repository, federationProvider.getFederatorAddress(0)));


### PR DESCRIPTION
Changes:

* Refactored `RemascFederationProvider` constructor to receive only `ActivationConfig.ForBlock activations` and `FederationSupport federationSupport`, since this class only needs these 2 dependencies. It was receiving many other dependencies only to create the  `FederationSupport` instance. Hence, I decided to simplify it by only receiving 2 dependencies instead of 4.
* Included an activations check in `RemascFederationProvider:: getFederatorAddress`. If `RSKIP415` is active, then use the rsk federator public key to generate the rsk address. Otherwise, keep using the btc public key.
* Refactored the files using the `RemascFederationProvider` to pass the new paramemters to the constructor.
* Created 2 new tests for `RemascFederationProvider` in `RemascFederationProviderTest` file. The `RemascFederationProvider` class is very simply. It only uses a `FederationSupport` support instance and the activations. So, in reality what we need to check is that `federationSupport.getFederatorBtcPublicKey` is still called when `RSKIP415` is not active, and when `RSKIP415` is active, then the one to call is `federationSupport.getFederatorPublicKeyOfType(n, FederationMember.KeyType.RSK)`. Due to the simplicity of the requirements, I didn't include more tests.
