### PR TITLE
RskAddress derives properly from rsk key

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -956,7 +956,7 @@ public class BridgeStorageProvider {
         pegoutTxSigHashes.add(sigHash);
     }
 
-    private void savePegoutTxSigHashes() {
+    protected void savePegoutTxSigHashes() {
         if (!activations.isActive(RSKIP379) || pegoutTxSigHashes == null) {
             return;
         }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1428,7 +1428,7 @@ public class BridgeSupport {
         Optional<Federation> optionalFederation = getFederationFromPublicKey(federatorPublicKey);
         if (!optionalFederation.isPresent()) {
             logger.warn(
-                "Supplied federator public key {} does not belong to any of the federators.",
+                "[addSignature] Supplied federator btc public key {} does not belong to any of the federators.",
                 federatorPublicKey
             );
             return;
@@ -1438,8 +1438,8 @@ public class BridgeSupport {
         Optional<FederationMember> federationMember = federation.getMemberByBtcPublicKey(federatorPublicKey);
         if (!federationMember.isPresent()){
             logger.warn(
-                "Supplied federator public key {} does not belong to any of the federators.",
-                federatorPublicKey
+                "[addSignature] Supplied federator btc public key {} doest not match any of the federator member btc public keys {}.",
+                federatorPublicKey, federation.getBtcPublicKeys()
             );
             return;
         }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1435,7 +1435,15 @@ public class BridgeSupport {
         }
 
         Federation federation = optionalFederation.get();
-        FederationMember signingFederationMember = federation.getMemberByBtcPublicKey(federatorPublicKey).get();
+        Optional<FederationMember> federationMember = federation.getMemberByBtcPublicKey(federatorPublicKey);
+        if (!federationMember.isPresent()){
+            logger.warn(
+                "Supplied federator public key {} does not belong to any of the federators.",
+                federatorPublicKey
+            );
+            return;
+        }
+        FederationMember signingFederationMember = federationMember.get();
 
         BtcTransaction btcTx = provider.getPegoutsWaitingForSignatures().get(new Keccak256(rskTxHash));
         if (btcTx == null) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1490,7 +1490,7 @@ public class BridgeSupport {
         BtcTransaction btcTx,
         Federation federation) throws IOException {
 
-        BtcECKey federatorPublicKey = federatorMember.getBtcPublicKey();
+        BtcECKey federatorBtcPublicKey = federatorMember.getBtcPublicKey();
         // Build input hashes for signatures
         int numInputs = btcTx.getInputs().size();
 
@@ -1522,13 +1522,13 @@ public class BridgeSupport {
 
             Sha256Hash sighash = sighashes.get(i);
 
-            if (!federatorPublicKey.verify(sighash, sig)) {
+            if (!federatorBtcPublicKey.verify(sighash, sig)) {
                 logger.warn(
                     "Signature {} {} is not valid for hash {} and public key {}",
                     i,
                     ByteUtil.toHexString(sig.encodeToDER()),
                     sighash,
-                    federatorPublicKey
+                    federatorBtcPublicKey
                 );
                 return;
             }
@@ -1550,24 +1550,24 @@ public class BridgeSupport {
             Script inputScript = input.getScriptSig();
 
             boolean alreadySignedByThisFederator = BridgeUtils.isInputSignedByThisFederator(
-                    federatorPublicKey,
+                    federatorBtcPublicKey,
                     sighash,
                     input);
 
             // Sign the input if it wasn't already
             if (!alreadySignedByThisFederator) {
                 try {
-                    int sigIndex = inputScript.getSigInsertionIndex(sighash, federatorPublicKey);
+                    int sigIndex = inputScript.getSigInsertionIndex(sighash, federatorBtcPublicKey);
                     inputScript = ScriptBuilder.updateScriptWithSignature(inputScript, txSigs.get(i).encodeToBitcoin(), sigIndex, 1, 1);
                     input.setScriptSig(inputScript);
                     logger.debug("Tx input {} for tx {} signed.", i, new Keccak256(rskTxHash));
                     signed = true;
                 } catch (IllegalStateException e) {
                     Federation retiringFederation = getRetiringFederation();
-                    if (getActiveFederation().hasBtcPublicKey(federatorPublicKey)) {
+                    if (getActiveFederation().hasBtcPublicKey(federatorBtcPublicKey)) {
                         logger.debug("A member of the active federation is trying to sign a tx of the retiring one");
                         return;
-                    } else if (retiringFederation != null && retiringFederation.hasBtcPublicKey(federatorPublicKey)) {
+                    } else if (retiringFederation != null && retiringFederation.hasBtcPublicKey(federatorBtcPublicKey)) {
                         logger.debug("A member of the retiring federation is trying to sign a tx of the active one");
                         return;
                     }

--- a/rskj-core/src/main/java/co/rsk/peg/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Federation.java
@@ -64,6 +64,10 @@ public abstract class Federation {
         return members;
     }
 
+    public Optional<FederationMember> getMemberByBtcPublicKey(BtcECKey btcPublicKey) {
+        return members.stream().filter(federationMember -> federationMember.getBtcPublicKey().equals(btcPublicKey)).findFirst();
+    }
+
     public List<BtcECKey> getBtcPublicKeys() {
         // Copy instances since we don't control
         // immutability of BtcECKey instances

--- a/rskj-core/src/main/java/co/rsk/peg/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Federation.java
@@ -68,7 +68,8 @@ public abstract class Federation {
         if (btcPublicKey == null){
             return Optional.empty();
         }
-        return members.stream().filter(federationMember -> Arrays.equals(federationMember.getBtcPublicKey().getPubKey(), btcPublicKey.getPubKey())).findAny();
+        final BtcECKey btcPublicKeyOnly = BtcECKey.fromPublicOnly(btcPublicKey.getPubKey());
+        return members.stream().filter(federationMember -> federationMember.getBtcPublicKey().equals(btcPublicKeyOnly)).findAny();
     }
 
     public List<BtcECKey> getBtcPublicKeys() {

--- a/rskj-core/src/main/java/co/rsk/peg/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Federation.java
@@ -65,7 +65,10 @@ public abstract class Federation {
     }
 
     public Optional<FederationMember> getMemberByBtcPublicKey(BtcECKey btcPublicKey) {
-        return members.stream().filter(federationMember -> federationMember.getBtcPublicKey().equals(btcPublicKey)).findAny();
+        if (btcPublicKey == null){
+            return Optional.empty();
+        }
+        return members.stream().filter(federationMember -> Arrays.equals(federationMember.getBtcPublicKey().getPubKey(), btcPublicKey.getPubKey())).findAny();
     }
 
     public List<BtcECKey> getBtcPublicKeys() {

--- a/rskj-core/src/main/java/co/rsk/peg/Federation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Federation.java
@@ -65,7 +65,7 @@ public abstract class Federation {
     }
 
     public Optional<FederationMember> getMemberByBtcPublicKey(BtcECKey btcPublicKey) {
-        return members.stream().filter(federationMember -> federationMember.getBtcPublicKey().equals(btcPublicKey)).findFirst();
+        return members.stream().filter(federationMember -> federationMember.getBtcPublicKey().equals(btcPublicKey)).findAny();
     }
 
     public List<BtcECKey> getBtcPublicKeys() {

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
@@ -22,6 +22,7 @@ import co.rsk.bitcoinj.core.*;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.peg.Federation;
+import co.rsk.peg.FederationMember;
 import co.rsk.peg.pegin.RejectedPeginReason;
 import org.ethereum.core.Block;
 import org.ethereum.core.Transaction;
@@ -36,7 +37,7 @@ public interface BridgeEventLogger {
 
     void logUpdateCollections(Transaction rskTx);
 
-    void logAddSignature(BtcECKey federatorPublicKey, BtcTransaction btcTx, byte[] rskTxHash);
+    void logAddSignature(FederationMember federationMember, BtcTransaction btcTx, byte[] rskTxHash);
 
     void logReleaseBtc(BtcTransaction btcTx, byte[] rskTxHash);
 

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -77,7 +77,7 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
 
     @Override
     public void logAddSignature(FederationMember federationMember, BtcTransaction btcTx, byte[] rskTxHash) {
-        String federatorRskAddress = ByteUtil.toHexString(getFederatorPublicKey(federationMember).getAddress());;
+        String federatorRskAddress = ByteUtil.toHexString(getFederatorPublicKey(federationMember).getAddress());
         logAddSignatureInSolidityFormat(rskTxHash, federatorRskAddress, federationMember.getBtcPublicKey());
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -23,6 +23,7 @@ import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.peg.BridgeEvents;
 import co.rsk.peg.Federation;
+import co.rsk.peg.FederationMember;
 import co.rsk.peg.pegin.RejectedPeginReason;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
@@ -75,10 +76,19 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
     }
 
     @Override
-    public void logAddSignature(BtcECKey federatorPublicKey, BtcTransaction btcTx, byte[] rskTxHash) {
-        ECKey key = ECKey.fromPublicOnly(federatorPublicKey.getPubKey());
-        String federatorRskAddress = ByteUtil.toHexString(key.getAddress());
-        logAddSignatureInSolidityFormat(rskTxHash, federatorRskAddress, federatorPublicKey);
+    public void logAddSignature(FederationMember federationMember, BtcTransaction btcTx, byte[] rskTxHash) {
+        if (shouldUseRskPublicKey()){
+            String federatorRskAddress = ByteUtil.toHexString(federationMember.getRskPublicKey().getAddress());
+            logAddSignatureInSolidityFormat(rskTxHash, federatorRskAddress, federationMember.getBtcPublicKey());
+        } else {
+            ECKey ecKeyFromBtcPublicKey = ECKey.fromPublicOnly(federationMember.getBtcPublicKey().getPubKey());
+            String federatorRskAddressFromBtcPublicKey = ByteUtil.toHexString(ecKeyFromBtcPublicKey.getAddress());
+            logAddSignatureInSolidityFormat(rskTxHash, federatorRskAddressFromBtcPublicKey, federationMember.getBtcPublicKey());
+        }
+    }
+
+    private boolean shouldUseRskPublicKey() {
+        return activations.isActive(ConsensusRule.RSKIP415);
     }
 
     private void logAddSignatureInSolidityFormat(byte[] rskTxHash, String federatorRskAddress, BtcECKey federatorPublicKey) {

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -77,17 +77,16 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
 
     @Override
     public void logAddSignature(FederationMember federationMember, BtcTransaction btcTx, byte[] rskTxHash) {
-        String federatorRskAddress = getFederatorRskAddress(federationMember);
+        String federatorRskAddress = ByteUtil.toHexString(getFederatorPublicKey(federationMember).getAddress());;
         logAddSignatureInSolidityFormat(rskTxHash, federatorRskAddress, federationMember.getBtcPublicKey());
     }
 
-    private String getFederatorRskAddress(FederationMember federationMember){
-        if (shouldUseRskPublicKey()){
-            return ByteUtil.toHexString(federationMember.getRskPublicKey().getAddress());
+    private ECKey getFederatorPublicKey(FederationMember federationMember) {
+        if (!shouldUseRskPublicKey()) {
+            return ECKey.fromPublicOnly(federationMember.getBtcPublicKey().getPubKey());
         }
 
-        ECKey ecKeyFromBtcPublicKey = ECKey.fromPublicOnly(federationMember.getBtcPublicKey().getPubKey());
-        return ByteUtil.toHexString(ecKeyFromBtcPublicKey.getAddress());
+        return federationMember.getRskPublicKey();
     }
 
     private boolean shouldUseRskPublicKey() {

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -77,7 +77,8 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
 
     @Override
     public void logAddSignature(FederationMember federationMember, BtcTransaction btcTx, byte[] rskTxHash) {
-        String federatorRskAddress = ByteUtil.toHexString(getFederatorPublicKey(federationMember).getAddress());
+        ECKey federatorPublicKey = getFederatorPublicKey(federationMember);
+        String federatorRskAddress = ByteUtil.toHexString(federatorPublicKey.getAddress());
         logAddSignatureInSolidityFormat(rskTxHash, federatorRskAddress, federationMember.getBtcPublicKey());
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -77,14 +77,17 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
 
     @Override
     public void logAddSignature(FederationMember federationMember, BtcTransaction btcTx, byte[] rskTxHash) {
+        String federatorRskAddress = getFederatorRskAddress(federationMember);
+        logAddSignatureInSolidityFormat(rskTxHash, federatorRskAddress, federationMember.getBtcPublicKey());
+    }
+
+    private String getFederatorRskAddress(FederationMember federationMember){
         if (shouldUseRskPublicKey()){
-            String federatorRskAddress = ByteUtil.toHexString(federationMember.getRskPublicKey().getAddress());
-            logAddSignatureInSolidityFormat(rskTxHash, federatorRskAddress, federationMember.getBtcPublicKey());
-        } else {
-            ECKey ecKeyFromBtcPublicKey = ECKey.fromPublicOnly(federationMember.getBtcPublicKey().getPubKey());
-            String federatorRskAddressFromBtcPublicKey = ByteUtil.toHexString(ecKeyFromBtcPublicKey.getAddress());
-            logAddSignatureInSolidityFormat(rskTxHash, federatorRskAddressFromBtcPublicKey, federationMember.getBtcPublicKey());
+            return ByteUtil.toHexString(federationMember.getRskPublicKey().getAddress());
         }
+
+        ECKey ecKeyFromBtcPublicKey = ECKey.fromPublicOnly(federationMember.getBtcPublicKey().getPubKey());
+        return ByteUtil.toHexString(ecKeyFromBtcPublicKey.getAddress());
     }
 
     private boolean shouldUseRskPublicKey() {

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BrigeEventLoggerLegacyImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BrigeEventLoggerLegacyImpl.java
@@ -23,6 +23,7 @@ import co.rsk.config.BridgeConstants;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.DeprecatedMethodCallException;
 import co.rsk.peg.Federation;
+import co.rsk.peg.FederationMember;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.Block;
@@ -77,7 +78,7 @@ public class BrigeEventLoggerLegacyImpl implements BridgeEventLogger {
     }
 
     @Override
-    public void logAddSignature(BtcECKey federatorPublicKey, BtcTransaction btcTx, byte[] rskTxHash) {
+    public void logAddSignature(FederationMember federationMember, BtcTransaction btcTx, byte[] rskTxHash) {
         if (activations.isActive(ConsensusRule.RSKIP146)) {
             throw new DeprecatedMethodCallException(
                 "Calling BrigeEventLoggerLegacyImpl.logAddSignature method after RSKIP146 activation"
@@ -85,7 +86,7 @@ public class BrigeEventLoggerLegacyImpl implements BridgeEventLogger {
         }
         List<DataWord> topics = Collections.singletonList(Bridge.ADD_SIGNATURE_TOPIC);
         byte[] data = RLP.encodeList(RLP.encodeString(btcTx.getHashAsString()),
-            RLP.encodeElement(federatorPublicKey.getPubKeyHash()),
+            RLP.encodeElement(federationMember.getBtcPublicKey().getPubKeyHash()),
             RLP.encodeElement(rskTxHash));
 
         this.logs.add(new LogInfo(BRIDGE_CONTRACT_ADDRESS, topics, data));

--- a/rskj-core/src/main/java/co/rsk/remasc/Remasc.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/Remasc.java
@@ -180,7 +180,7 @@ public class Remasc {
         Coin payToRskLabs = syntheticReward.divide(BigInteger.valueOf(remascConstants.getRskLabsDivisor()));
         feesPayer.payMiningFees(processingBlockHeader.getHash().getBytes(), payToRskLabs, rskLabsAddress, logs);
         syntheticReward = syntheticReward.subtract(payToRskLabs);
-        Coin payToFederation = payToFederation(constants, processingBlock, processingBlockHeader, syntheticReward);
+        Coin payToFederation = payToFederation(constants, processingBlock, syntheticReward);
         syntheticReward = syntheticReward.subtract(payToFederation);
 
         if (!siblings.isEmpty()) {
@@ -206,7 +206,7 @@ public class Remasc {
         return isRskip218Enabled ? remascConstants.getRskLabsAddressRskip218() : remascConstants.getRskLabsAddress();
     }
 
-    private Coin payToFederation(Constants constants, Block processingBlock, BlockHeader processingBlockHeader, Coin syntheticReward) {
+    private Coin payToFederation(Constants constants, Block processingBlock, Coin syntheticReward) {
         BridgeConstants bridgeConstants = constants.getBridgeConstants();
 
         BridgeStorageProvider bridgeStorageProvider = new BridgeStorageProvider(
@@ -222,7 +222,7 @@ public class Remasc {
         Coin federationReward = syntheticReward.divide(BigInteger.valueOf(remascConstants.getFederationDivisor()));
 
         Coin payToFederation = provider.getFederationBalance().add(federationReward);
-        byte[] processingBlockHash = processingBlockHeader.getHash().getBytes();
+        byte[] processingBlockHash = processingBlock.getHeader().getHash().getBytes();
         int nfederators = federationProvider.getFederationSize();
         Coin[] payAndRemainderToFederator = payToFederation.divideAndRemainder(BigInteger.valueOf(nfederators));
         Coin payToFederator = payAndRemainderToFederator[0];

--- a/rskj-core/src/main/java/co/rsk/remasc/RemascFederationProvider.java
+++ b/rskj-core/src/main/java/co/rsk/remasc/RemascFederationProvider.java
@@ -45,10 +45,23 @@ public class RemascFederationProvider {
 
     public RskAddress getFederatorAddress(int n) {
         if(!activations.isActive(ConsensusRule.RSKIP415)) {
-            byte[] btcPublicKey = this.federationSupport.getFederatorBtcPublicKey(n);
-            return new RskAddress(ECKey.fromPublicOnly(btcPublicKey).getAddress());
+            return getRskAddressFromBtcKey(n);
         }
-        byte[] rskPublicKey = this.federationSupport.getFederatorPublicKeyOfType(n, FederationMember.KeyType.RSK);
-        return new RskAddress(ECKey.fromPublicOnly(rskPublicKey).getAddress());
+        return getRskAddressFromRskKey(n);
     }
+
+    private RskAddress getRskAddressFromBtcKey(int n) {
+        byte[] btcPublicKey = this.federationSupport.getFederatorBtcPublicKey(n);
+        return getRskAddressFromKey(btcPublicKey);
+    }
+
+    private RskAddress getRskAddressFromRskKey(int n) {
+        byte[] rskPublicKey = this.federationSupport.getFederatorPublicKeyOfType(n, FederationMember.KeyType.RSK);
+        return getRskAddressFromKey(rskPublicKey);
+    }
+
+    private RskAddress getRskAddressFromKey(byte[] publicKey) {
+        return new RskAddress(ECKey.fromPublicOnly(publicKey).getAddress());
+    }
+
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -91,6 +91,7 @@ public enum ConsensusRule {
     RSKIP398("rskip398"),
     RSKIP400("rskip400"), // From EIP-2028 calldata gas cost reduction
     RSKIP412("rskip412"), // From EIP-3198 BASEFEE opcode
+    RSKIP415("rskip415"),
     ;
 
     private String configKey;

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -90,6 +90,7 @@ blockchain = {
              rskip398 = <hardforkName>
              rskip400 = <hardforkName>
              rskip412 = <hardforkName>
+             rskip415 = <hardforkName>
          }
     }
     gc = {

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -77,6 +77,7 @@ blockchain = {
             rskip398 = arrowhead600
             rskip400 = arrowhead600
             rskip412 = arrowhead600
+            rskip415 = arrowhead600
         }
     }
     gc = {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderPegoutTxIndexTests.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderPegoutTxIndexTests.java
@@ -18,9 +18,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.stream.Stream;
 
 import static co.rsk.peg.BridgeStorageIndexKey.PEGOUT_TX_SIG_HASH;
+import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP134;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -285,8 +287,8 @@ class BridgeStorageProviderPegoutTxIndexTests {
     void setPegoutTxSigHash_null(boolean isRskip379HardForkActive) throws IOException {
         // Arrange
         ActivationConfig.ForBlock activations = isRskip379HardForkActive ?
-                                                    ActivationConfigsForTest.arrowhead600().forBlock(0) :
-                                                    ActivationConfigsForTest.fingerroot500().forBlock(0);
+                                                    getArrowHeadActivationExceptLockingCap() :
+                                                    getFingerrootActivationsExceptLockingCap();
 
         Repository repository = mock(Repository.class);
 
@@ -319,8 +321,8 @@ class BridgeStorageProviderPegoutTxIndexTests {
     void setPegoutTxSigHash_non_null(boolean isRskip379HardForkActive, Sha256Hash sigHash) throws IOException {
         // Arrange
         ActivationConfig.ForBlock activations = isRskip379HardForkActive ?
-                                                    ActivationConfigsForTest.arrowhead600().forBlock(0) :
-                                                    ActivationConfigsForTest.fingerroot500().forBlock(0);
+                                                    getArrowHeadActivationExceptLockingCap() :
+                                                    getFingerrootActivationsExceptLockingCap();
 
         Repository repository = mock(Repository.class);
         BridgeStorageProvider provider = new BridgeStorageProvider(
@@ -358,6 +360,14 @@ class BridgeStorageProviderPegoutTxIndexTests {
                 any()
             );
         }
+    }
+
+    private ActivationConfig.ForBlock getFingerrootActivationsExceptLockingCap() {
+        return ActivationConfigsForTest.fingerroot500(Collections.singletonList(RSKIP134)).forBlock(0);
+    }
+
+    private ActivationConfig.ForBlock getArrowHeadActivationExceptLockingCap() {
+        return ActivationConfigsForTest.arrowhead600(Collections.singletonList(RSKIP134)).forBlock(0);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderPegoutTxIndexTests.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderPegoutTxIndexTests.java
@@ -287,8 +287,8 @@ class BridgeStorageProviderPegoutTxIndexTests {
     void setPegoutTxSigHash_null(boolean isRskip379HardForkActive) throws IOException {
         // Arrange
         ActivationConfig.ForBlock activations = isRskip379HardForkActive ?
-                                                    getArrowHeadActivationExceptLockingCap() :
-                                                    getFingerrootActivationsExceptLockingCap();
+                                                    ActivationConfigsForTest.arrowhead600().forBlock(0) :
+                                                    ActivationConfigsForTest.fingerroot500().forBlock(0);
 
         Repository repository = mock(Repository.class);
 
@@ -301,7 +301,7 @@ class BridgeStorageProviderPegoutTxIndexTests {
 
         // Act
         provider.setPegoutTxSigHash(null);
-        provider.save();
+        provider.savePegoutTxSigHashes();
 
         // Assert
         verify(repository, never()).getStorageBytes(
@@ -321,8 +321,8 @@ class BridgeStorageProviderPegoutTxIndexTests {
     void setPegoutTxSigHash_non_null(boolean isRskip379HardForkActive, Sha256Hash sigHash) throws IOException {
         // Arrange
         ActivationConfig.ForBlock activations = isRskip379HardForkActive ?
-                                                    getArrowHeadActivationExceptLockingCap() :
-                                                    getFingerrootActivationsExceptLockingCap();
+                                                    ActivationConfigsForTest.arrowhead600().forBlock(0) :
+                                                    ActivationConfigsForTest.fingerroot500().forBlock(0);
 
         Repository repository = mock(Repository.class);
         BridgeStorageProvider provider = new BridgeStorageProvider(
@@ -334,7 +334,7 @@ class BridgeStorageProviderPegoutTxIndexTests {
 
         // Act
         provider.setPegoutTxSigHash(sigHash);
-        provider.save();
+        provider.savePegoutTxSigHashes();
 
         // Assert
         if (isRskip379HardForkActive) {
@@ -360,14 +360,6 @@ class BridgeStorageProviderPegoutTxIndexTests {
                 any()
             );
         }
-    }
-
-    private ActivationConfig.ForBlock getFingerrootActivationsExceptLockingCap() {
-        return ActivationConfigsForTest.fingerroot500(Collections.singletonList(RSKIP134)).forBlock(0);
-    }
-
-    private ActivationConfig.ForBlock getArrowHeadActivationExceptLockingCap() {
-        return ActivationConfigsForTest.arrowhead600(Collections.singletonList(RSKIP134)).forBlock(0);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
@@ -377,12 +377,13 @@ class BridgeSupportAddSignatureTest {
         }
 
         BtcECKey federatorPubKey = BridgeRegTestConstants.REGTEST_FEDERATION_PUBLIC_KEYS.get(indexOfKeyToSignWith);
+        FederationMember federationMember = FederationTestUtils.getFederationMemberWithKey(federatorPubKey);
         bridgeSupport.addSignature(federatorPubKey, derEncodedSigs, rskTxHash.getBytes());
         if(shouldSignTwice) {
             bridgeSupport.addSignature(federatorPubKey, derEncodedSigs, rskTxHash.getBytes());
         }
 
-        verify(eventLogger, times(wantedNumberOfInvocations)).logAddSignature(federatorPubKey, btcTx, rskTxHash.getBytes());
+        verify(eventLogger, times(wantedNumberOfInvocations)).logAddSignature(federationMember, btcTx, rskTxHash.getBytes());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportRegisterBtcTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportRegisterBtcTransactionTest.java
@@ -35,6 +35,7 @@ import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockTxSignatureCache;
 import org.ethereum.core.ReceivedTxSignatureCache;
+import org.ethereum.core.Repository;
 import org.ethereum.core.SignatureCache;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
@@ -503,9 +504,14 @@ class BridgeSupportRegisterBtcTransactionTest {
     }
 
     private BridgeSupport buildBridgeSupport(ActivationConfig.ForBlock activations) {
+        Repository repository = mock(Repository.class);
+        when(repository.getBalance(PrecompiledContracts.BRIDGE_ADDR)).thenReturn(co.rsk.core.Coin.fromBitcoin(bridgeMainnetConstants.getMaxRbtc()));
+        when(provider.getLockingCap()).thenReturn(bridgeMainnetConstants.getMaxRbtc());
+
         return new BridgeSupportBuilder()
             .withBtcBlockStoreFactory(mockFactory)
             .withBridgeConstants(bridgeMainnetConstants)
+            .withRepository(repository)
             .withProvider(provider)
             .withActivations(activations)
             .withSignatureCache(signatureCache)
@@ -534,8 +540,6 @@ class BridgeSupportRegisterBtcTransactionTest {
         RskAddress rskAddress = new RskAddress(senderRskKey.getAddress());
 
         btcTransaction.addInput(BitcoinTestUtils.createHash(1), FIRST_OUTPUT_INDEX, ScriptBuilder.createInputScript(null, senderBtcKey));
-
-
 
         Coin amountToSend = shouldSendAmountBelowMinimum ? belowMinimumPeginTxValue : minimumPeginTxValue;
         btcTransaction.addOutput(amountToSend, userAddress);

--- a/rskj-core/src/test/java/co/rsk/peg/LegacyErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/LegacyErpFederationTest.java
@@ -698,7 +698,7 @@ class LegacyErpFederationTest {
     }
 
     @Test
-    void test_getMemberByBtcPublicKey_passing_existing_btcPublicKey(){
+    void getMemberByBtcPublicKey_passing_existing_btcPublicKey_should_return_found_member(){
         BtcECKey existingMemberBtcPublicKey = standardKeys.get(0);
         Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(existingMemberBtcPublicKey);
         Assertions.assertTrue(foundMember.isPresent());
@@ -706,14 +706,14 @@ class LegacyErpFederationTest {
     }
 
     @Test
-    void test_getMemberByBtcPublicKey_passing_non_existing_btcPublicKey(){
+    void getMemberByBtcPublicKey_passing_non_existing_btcPublicKey_should_return_empty(){
         BtcECKey noExistingBtcPublicKey = new BtcECKey();
         Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(noExistingBtcPublicKey);
         Assertions.assertFalse(foundMember.isPresent());
     }
 
     @Test
-    void test_getMemberByBtcPublicKey_passing_null_btcPublicKey(){
+    void getMemberByBtcPublicKey_passing_null_btcPublicKey_should_return_empty(){
         Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(null);
         Assertions.assertFalse(foundMember.isPresent());
     }

--- a/rskj-core/src/test/java/co/rsk/peg/LegacyErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/LegacyErpFederationTest.java
@@ -14,7 +14,6 @@ import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.core.ScriptException;
 import co.rsk.bitcoinj.core.Utils;
-import co.rsk.bitcoinj.script.ErpFederationRedeemScriptParser;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptOpCodes;
 import co.rsk.config.BridgeConstants;
@@ -36,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
@@ -695,6 +695,27 @@ class LegacyErpFederationTest {
             true,
             false
         ));
+    }
+
+    @Test
+    void test_getMemberByBtcPublicKey_passing_existing_btcPublicKey(){
+        BtcECKey existingMemberBtcPublicKey = standardKeys.get(0);
+        Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(existingMemberBtcPublicKey);
+        Assertions.assertTrue(foundMember.isPresent());
+        Assertions.assertEquals(existingMemberBtcPublicKey, foundMember.get().getBtcPublicKey());
+    }
+
+    @Test
+    void test_getMemberByBtcPublicKey_passing_non_existing_btcPublicKey(){
+        BtcECKey noExistingBtcPublicKey = new BtcECKey();
+        Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(noExistingBtcPublicKey);
+        Assertions.assertFalse(foundMember.isPresent());
+    }
+
+    @Test
+    void test_getMemberByBtcPublicKey_passing_null_btcPublicKey(){
+        Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(null);
+        Assertions.assertFalse(foundMember.isPresent());
     }
 
     private void createErpFederation(BridgeConstants constants, boolean isRskip293Active) {

--- a/rskj-core/src/test/java/co/rsk/peg/P2shErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/P2shErpFederationTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -452,6 +453,27 @@ class P2shErpFederationTest {
             value.minus(fee),
             signWithEmergencyMultisig
         ));
+    }
+
+    @Test
+    void test_getMemberByBtcPublicKey_passing_existing_btcPublicKey(){
+        BtcECKey existingMemberBtcPublicKey = standardKeys.get(0);
+        Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(existingMemberBtcPublicKey);
+        Assertions.assertTrue(foundMember.isPresent());
+        Assertions.assertEquals(existingMemberBtcPublicKey, foundMember.get().getBtcPublicKey());
+    }
+
+    @Test
+    void test_getMemberByBtcPublicKey_passing_non_existing_btcPublicKey(){
+        BtcECKey noExistingBtcPublicKey = new BtcECKey();
+        Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(noExistingBtcPublicKey);
+        Assertions.assertFalse(foundMember.isPresent());
+    }
+
+    @Test
+    void test_getMemberByBtcPublicKey_passing_null_btcPublicKey(){
+        Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(null);
+        Assertions.assertFalse(foundMember.isPresent());
     }
 
     private void validateP2shErpRedeemScript(

--- a/rskj-core/src/test/java/co/rsk/peg/P2shErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/P2shErpFederationTest.java
@@ -456,7 +456,7 @@ class P2shErpFederationTest {
     }
 
     @Test
-    void test_getMemberByBtcPublicKey_passing_existing_btcPublicKey(){
+    void getMemberByBtcPublicKey_passing_existing_btcPublicKey_should_return_found_member(){
         BtcECKey existingMemberBtcPublicKey = standardKeys.get(0);
         Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(existingMemberBtcPublicKey);
         Assertions.assertTrue(foundMember.isPresent());
@@ -464,14 +464,14 @@ class P2shErpFederationTest {
     }
 
     @Test
-    void test_getMemberByBtcPublicKey_passing_non_existing_btcPublicKey(){
+    void getMemberByBtcPublicKey_passing_non_existing_btcPublicKey_should_return_empty(){
         BtcECKey noExistingBtcPublicKey = new BtcECKey();
         Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(noExistingBtcPublicKey);
         Assertions.assertFalse(foundMember.isPresent());
     }
 
     @Test
-    void test_getMemberByBtcPublicKey_passing_null_btcPublicKey(){
+    void getMemberByBtcPublicKey_passing_null_btcPublicKey_should_return_empty(){
         Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(null);
         Assertions.assertFalse(foundMember.isPresent());
     }

--- a/rskj-core/src/test/java/co/rsk/peg/PowpegMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PowpegMigrationTest.java
@@ -88,6 +88,9 @@ class PowpegMigrationTest {
             activations
         );
 
+        repository.addBalance(PrecompiledContracts.BRIDGE_ADDR, co.rsk.core.Coin.fromBitcoin(bridgeConstants.getMaxRbtc()));
+        bridgeStorageProvider.setLockingCap(bridgeConstants.getMaxRbtc());
+
         BtcBlockStoreWithCache.Factory btcBlockStoreFactory = new RepositoryBtcBlockStoreWithCache.Factory(
             bridgeConstants.getBtcParams(),
             100,

--- a/rskj-core/src/test/java/co/rsk/peg/StandardMultisigFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/StandardMultisigFederationTest.java
@@ -320,4 +320,25 @@ class StandardMultisigFederationTest {
         FederationMember invalidPubKeys = new FederationMember(invalidBtcKey, invalidRskKey, invalidRskKey);
         assertFalse(federation.isMember(invalidPubKeys));
     }
+
+    @Test
+    void test_getMemberByBtcPublicKey_passing_existing_btcPublicKey(){
+        BtcECKey existingMemberBtcPublicKey = sortedPublicKeys.get(0);
+        Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(existingMemberBtcPublicKey);
+        Assertions.assertTrue(foundMember.isPresent());
+        Assertions.assertEquals(existingMemberBtcPublicKey, foundMember.get().getBtcPublicKey());
+    }
+
+    @Test
+    void test_getMemberByBtcPublicKey_passing_non_existing_btcPublicKey(){
+        BtcECKey noExistingBtcPublicKey = new BtcECKey();
+        Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(noExistingBtcPublicKey);
+        Assertions.assertFalse(foundMember.isPresent());
+    }
+
+    @Test
+    void test_getMemberByBtcPublicKey_passing_null_btcPublicKey(){
+        Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(null);
+        Assertions.assertFalse(foundMember.isPresent());
+    }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/StandardMultisigFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/StandardMultisigFederationTest.java
@@ -322,7 +322,7 @@ class StandardMultisigFederationTest {
     }
 
     @Test
-    void test_getMemberByBtcPublicKey_passing_existing_btcPublicKey(){
+    void getMemberByBtcPublicKey_passing_existing_btcPublicKey_should_return_found_member(){
         BtcECKey existingMemberBtcPublicKey = sortedPublicKeys.get(0);
         Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(existingMemberBtcPublicKey);
         Assertions.assertTrue(foundMember.isPresent());
@@ -330,14 +330,14 @@ class StandardMultisigFederationTest {
     }
 
     @Test
-    void test_getMemberByBtcPublicKey_passing_non_existing_btcPublicKey(){
+    void getMemberByBtcPublicKey_passing_non_existing_btcPublicKey_should_return_empty(){
         BtcECKey noExistingBtcPublicKey = new BtcECKey();
         Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(noExistingBtcPublicKey);
         Assertions.assertFalse(foundMember.isPresent());
     }
 
     @Test
-    void test_getMemberByBtcPublicKey_passing_null_btcPublicKey(){
+    void getMemberByBtcPublicKey_passing_null_btcPublicKey_should_return_empty(){
         Optional<FederationMember> foundMember = federation.getMemberByBtcPublicKey(null);
         Assertions.assertFalse(foundMember.isPresent());
     }

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
@@ -193,7 +193,8 @@ class BridgeEventLoggerImplTest {
         );
 
         return Stream.of(
-            Arguments.of(singleKeyFedMember, multiKeyFedMember)
+            Arguments.of(singleKeyFedMember),
+            Arguments.of(multiKeyFedMember)
         );
     }
 
@@ -224,8 +225,13 @@ class BridgeEventLoggerImplTest {
         assertTopics(3, eventLogs);
 
         ECKey federatorECKeyFromBtcPubKey = ECKey.fromPublicOnly(federationMember.getBtcPublicKey().getPubKey());
-        String derivedRskAddress = ByteUtil.toHexString(federatorECKeyFromBtcPubKey.getAddress());
-        assertEvent(eventLogs, 0, BridgeEvents.ADD_SIGNATURE.getEvent(), new Object[]{rskTxHash.getBytes(), derivedRskAddress}, new Object[]{federatorBtcPubKey.getPubKey()});
+        String expectedRskAddress = ByteUtil.toHexString(federatorECKeyFromBtcPubKey.getAddress());
+
+        CallTransaction.Function bridgeEvent = BridgeEvents.ADD_SIGNATURE.getEvent();
+        Object[] eventTopics = new Object[]{rskTxHash.getBytes(), expectedRskAddress};
+        Object[] eventParams = new Object[]{federatorBtcPubKey.getPubKey()};
+
+        assertEvent(eventLogs, 0, bridgeEvent, eventTopics, eventParams);
     }
 
     @ParameterizedTest()
@@ -253,8 +259,13 @@ class BridgeEventLoggerImplTest {
         commonAssertLogs(eventLogs);
         assertTopics(3, eventLogs);
 
-        String derivedRskAddress = ByteUtil.toHexString(federationMember.getRskPublicKey().getAddress());
-        assertEvent(eventLogs, 0, BridgeEvents.ADD_SIGNATURE.getEvent(), new Object[]{rskTxHash.getBytes(), derivedRskAddress}, new Object[]{federatorBtcPubKey.getPubKey()});
+        String expectedRskAddress = ByteUtil.toHexString(federationMember.getRskPublicKey().getAddress());
+
+        CallTransaction.Function bridgeEvent = BridgeEvents.ADD_SIGNATURE.getEvent();
+        Object[] eventTopics = new Object[]{rskTxHash.getBytes(), expectedRskAddress};
+        Object[] eventParams = new Object[]{federatorBtcPubKey.getPubKey()};
+
+        assertEvent(eventLogs, 0, bridgeEvent, eventTopics, eventParams);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerLegacyImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerLegacyImplTest.java
@@ -115,10 +115,11 @@ class BridgeEventLoggerLegacyImplTest {
 
         // Setup logAddSignature params
         BtcECKey federatorPubKey = BtcECKey.fromPrivate(BigInteger.valueOf(2L));
+        FederationMember federationMember = FederationTestUtils.getFederationMemberWithKey(federatorPubKey);
         when(btcTxMock.getHashAsString()).thenReturn("3e72fdbae7bbd103f08e876c765e3d5ba35db30ea46cb45ab52803f987ead9fb");
 
         // Act
-        eventLogger.logAddSignature(federatorPubKey, btcTxMock, rskTxHash.getBytes());
+        eventLogger.logAddSignature(federationMember, btcTxMock, rskTxHash.getBytes());
 
         // Assert log size
         Assertions.assertEquals(1, eventLogs.size());
@@ -147,8 +148,9 @@ class BridgeEventLoggerLegacyImplTest {
     void testLogAddSignatureAfterRskip146() {
         when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
         BtcECKey federatorPublicKey = new BtcECKey();
+        FederationMember federationMember = FederationTestUtils.getFederationMemberWithKey(federatorPublicKey);
         byte[] bytes = rskTxHash.getBytes();
-        assertThrows(DeprecatedMethodCallException.class, () -> eventLogger.logAddSignature(federatorPublicKey, btcTxMock, bytes));
+        assertThrows(DeprecatedMethodCallException.class, () -> eventLogger.logAddSignature(federationMember, btcTxMock, bytes));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascFederationProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascFederationProviderTest.java
@@ -2,17 +2,30 @@ package co.rsk.remasc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.config.BridgeRegTestConstants;
+import co.rsk.core.RskAddress;
+import co.rsk.peg.*;
 import co.rsk.test.builders.BlockChainBuilder;
+import co.rsk.util.HexUtils;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.Blockchain;
 import org.ethereum.core.Genesis;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.vm.PrecompiledContracts;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.*;
 
 /**
  * Created by ajlopez on 14/11/2017.
  */
 class RemascFederationProviderTest {
+
+    private static final String BTC_PUBLIC_KEY = "0x03a5e32151f974c35c5d08af36a8d6af0593248e8e4adca7ed0148192eb2f5d1bf";
+    private static final String RSK_PUBLIC_KEY = "0x02f3b5fb3121932db9450121b0a37f3f051dc8b3fd5f1ea5e7cf726947d8f69c28";
+
     @Test
     void getDefaultFederationSize() {
         RemascFederationProvider provider = getRemascFederationProvider();
@@ -20,25 +33,79 @@ class RemascFederationProviderTest {
     }
 
     @Test
-    void getFederatorAddress() {
-        RemascFederationProvider provider = getRemascFederationProvider();
+    void getFederatorAddress_preRSKIP415_returnsRskAddressDerivedFromBtcPublicKey() {
 
-        byte[] address = provider.getFederatorAddress(0).getBytes();
+        int federatorIndex = 0;
 
-        Assertions.assertNotNull(address);
-        Assertions.assertEquals(20, address.length);
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP415)).thenReturn(false);
+
+        FederationSupport federationSupport =  mock(FederationSupport.class);
+
+        byte[] btcPublicKey = HexUtils.strHexOrStrNumberToByteArray(BTC_PUBLIC_KEY);
+
+        when(federationSupport.getFederatorBtcPublicKey(federatorIndex))
+                .thenReturn(btcPublicKey);
+
+        RemascFederationProvider provider = new RemascFederationProvider(activations, federationSupport);
+
+        RskAddress actualRskAddress = provider.getFederatorAddress(federatorIndex);
+        RskAddress expectedRskAddress = new RskAddress(ECKey.fromPublicOnly(btcPublicKey).getAddress());
+
+        Assertions.assertEquals(expectedRskAddress, actualRskAddress);
+        verify(federationSupport, never()).getFederatorPublicKeyOfType(federatorIndex, FederationMember.KeyType.RSK);
+        verify(federationSupport, times(1)).getFederatorBtcPublicKey(federatorIndex);
+
+    }
+
+    @Test
+    void getFederatorAddress_postRSKIP415_returnsRskAddressDerivedFromRskPublicKey() {
+
+        int federatorIndex = 0;
+
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP415)).thenReturn(true);
+
+        FederationSupport federationSupport =  mock(FederationSupport.class);
+
+        byte[] rskPublicKey = HexUtils.strHexOrStrNumberToByteArray(RSK_PUBLIC_KEY);
+
+        when(federationSupport.getFederatorPublicKeyOfType(federatorIndex, FederationMember.KeyType.RSK))
+                .thenReturn(rskPublicKey);
+
+        RemascFederationProvider provider = new RemascFederationProvider(activations, federationSupport);
+
+        RskAddress actualRskAddress = provider.getFederatorAddress(federatorIndex);
+        RskAddress expectedRskAddress = new RskAddress(ECKey.fromPublicOnly(rskPublicKey).getAddress());
+
+        Assertions.assertEquals(expectedRskAddress, actualRskAddress);
+        verify(federationSupport, never()).getFederatorBtcPublicKey(federatorIndex);
+        verify(federationSupport, times(1)).getFederatorPublicKeyOfType(federatorIndex, FederationMember.KeyType.RSK);
+
     }
 
     private static RemascFederationProvider getRemascFederationProvider() {
+
         Genesis genesisBlock = new BlockGenerator().getGenesisBlock();
         BlockChainBuilder builder = new BlockChainBuilder().setTesting(true).setGenesis(genesisBlock);
         Blockchain blockchain = builder.build();
 
-        return new RemascFederationProvider(
-                ActivationConfigsForTest.all(),
-                BridgeRegTestConstants.getInstance(),
+        ActivationConfig.ForBlock activations = ActivationConfigsForTest.all().forBlock(blockchain.getBestBlock().getNumber());
+
+        BridgeRegTestConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
+
+        BridgeStorageProvider bridgeStorageProvider = new BridgeStorageProvider(
                 builder.getRepository(),
-                blockchain.getBestBlock()
+                PrecompiledContracts.BRIDGE_ADDR,
+                bridgeRegTestConstants,
+                activations
+        );
+
+        FederationSupport federationSupport = new FederationSupport(bridgeRegTestConstants, bridgeStorageProvider, blockchain.getBestBlock(), activations);
+
+        return new RemascFederationProvider(
+                activations,
+                federationSupport
         );
     }
 }

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascFederationProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascFederationProviderTest.java
@@ -1,7 +1,7 @@
 package co.rsk.remasc;
 
 import co.rsk.blockchain.utils.BlockGenerator;
-import co.rsk.config.BridgeRegTestConstants;
+import co.rsk.config.BridgeMainNetConstants;
 import co.rsk.core.RskAddress;
 import co.rsk.peg.*;
 import co.rsk.test.builders.BlockChainBuilder;
@@ -11,7 +11,6 @@ import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.Blockchain;
 import org.ethereum.core.Genesis;
-import org.ethereum.crypto.ECKey;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -24,12 +23,14 @@ import static org.mockito.Mockito.*;
 class RemascFederationProviderTest {
 
     private static final String BTC_PUBLIC_KEY = "0x03a5e32151f974c35c5d08af36a8d6af0593248e8e4adca7ed0148192eb2f5d1bf";
+    private static final String RSK_ADDRESS_FROM_BTC_PUBLIC_KEY = "131c7c821b0e4a1ab570feed952d9304e03fddd1";
     private static final String RSK_PUBLIC_KEY = "0x02f3b5fb3121932db9450121b0a37f3f051dc8b3fd5f1ea5e7cf726947d8f69c28";
+    private static final String RSK_ADDRESS_FROM_RSK_PUBLIC_KEY = "54a948b3d76ce84e5c7b4b3cd01f2af1f18d41e0";
 
     @Test
     void getDefaultFederationSize() {
         RemascFederationProvider provider = getRemascFederationProvider();
-        Assertions.assertEquals(3, provider.getFederationSize());
+        Assertions.assertEquals(15, provider.getFederationSize());
     }
 
     @Test
@@ -50,9 +51,8 @@ class RemascFederationProviderTest {
         RemascFederationProvider provider = new RemascFederationProvider(activations, federationSupport);
 
         RskAddress actualRskAddress = provider.getFederatorAddress(federatorIndex);
-        RskAddress expectedRskAddress = new RskAddress(ECKey.fromPublicOnly(btcPublicKey).getAddress());
 
-        Assertions.assertEquals(expectedRskAddress, actualRskAddress);
+        Assertions.assertEquals(RSK_ADDRESS_FROM_BTC_PUBLIC_KEY, actualRskAddress.toHexString());
         verify(federationSupport, never()).getFederatorPublicKeyOfType(federatorIndex, FederationMember.KeyType.RSK);
         verify(federationSupport, times(1)).getFederatorBtcPublicKey(federatorIndex);
 
@@ -76,11 +76,10 @@ class RemascFederationProviderTest {
         RemascFederationProvider provider = new RemascFederationProvider(activations, federationSupport);
 
         RskAddress actualRskAddress = provider.getFederatorAddress(federatorIndex);
-        RskAddress expectedRskAddress = new RskAddress(ECKey.fromPublicOnly(rskPublicKey).getAddress());
 
-        Assertions.assertEquals(expectedRskAddress, actualRskAddress);
-        verify(federationSupport, never()).getFederatorBtcPublicKey(federatorIndex);
+        Assertions.assertEquals(RSK_ADDRESS_FROM_RSK_PUBLIC_KEY, actualRskAddress.toHexString());
         verify(federationSupport, times(1)).getFederatorPublicKeyOfType(federatorIndex, FederationMember.KeyType.RSK);
+        verify(federationSupport, never()).getFederatorBtcPublicKey(federatorIndex);
 
     }
 
@@ -92,16 +91,16 @@ class RemascFederationProviderTest {
 
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.all().forBlock(blockchain.getBestBlock().getNumber());
 
-        BridgeRegTestConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
+        BridgeMainNetConstants bridgeMainNetConstants = BridgeMainNetConstants.getInstance();
 
         BridgeStorageProvider bridgeStorageProvider = new BridgeStorageProvider(
                 builder.getRepository(),
                 PrecompiledContracts.BRIDGE_ADDR,
-                bridgeRegTestConstants,
+                bridgeMainNetConstants,
                 activations
         );
 
-        FederationSupport federationSupport = new FederationSupport(bridgeRegTestConstants, bridgeStorageProvider, blockchain.getBestBlock(), activations);
+        FederationSupport federationSupport = new FederationSupport(bridgeMainNetConstants, bridgeStorageProvider, blockchain.getBestBlock(), activations);
 
         return new RemascFederationProvider(
                 activations,

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascRskAddressActivationTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascRskAddressActivationTest.java
@@ -53,31 +53,40 @@ class RemascRskAddressActivationTest {
         final RemascConfig remascConfig = spy(new RemascConfigFactory(RemascContract.REMASC_CONFIG)
                 .createRemascConfig("regtest"));
 
-        final Remasc remasc = new Remasc(Constants.regtest(), activationConfig, repositoryMock,
-                blockStoreMock, remascConfig, txMock, PrecompiledContracts.REMASC_ADDR, blockMock, logs);
-
         when(remascConfig.getRskLabsAddress()).thenReturn(rskLabsAddress);
         when(remascConfig.getRskLabsAddressRskip218()).thenReturn(rskLabsAddressRskip218);
 
-        when(activationConfig.isActive(ConsensusRule.RSKIP218, 1)).thenReturn(false);
-        when(activationConfig.isActive(ConsensusRule.RSKIP218, 2)).thenReturn(true);
+        ActivationConfig.ForBlock activationsBeforeRSKIP218 = mock(ActivationConfig.ForBlock.class);
+        when(activationsBeforeRSKIP218.isActive(ConsensusRule.RSKIP218)).thenReturn(false);
+
+        ActivationConfig.ForBlock activationsAfterRSKIP218 = mock(ActivationConfig.ForBlock.class);
+        when(activationsAfterRSKIP218.isActive(ConsensusRule.RSKIP218)).thenReturn(true);
+
+        when(activationConfig.forBlock(1)).thenReturn(activationsBeforeRSKIP218);
+        when(activationConfig.forBlock(2)).thenReturn(activationsAfterRSKIP218);
 
         when(blockMock.getNumber()).thenReturn(1L);
 
+        Remasc remasc = new Remasc(Constants.regtest(), activationConfig, repositoryMock,
+            blockStoreMock, remascConfig, txMock, PrecompiledContracts.REMASC_ADDR, blockMock, logs);
+
         RskAddress actualAddress = remasc.getRskLabsAddress();
 
-        Assertions.assertEquals(rskLabsAddress, actualAddress);
         Assertions.assertEquals(1L, blockMock.getNumber());
+        Assertions.assertEquals(rskLabsAddress, actualAddress);
+
         Assertions.assertFalse(activationConfig.isActive(ConsensusRule.RSKIP218, blockMock.getNumber()));
         verify(remascConfig).getRskLabsAddress();
 
         when(blockMock.getNumber()).thenReturn(2L);
 
+        remasc = new Remasc(Constants.regtest(), activationConfig, repositoryMock,
+            blockStoreMock, remascConfig, txMock, PrecompiledContracts.REMASC_ADDR, blockMock, logs);
+
         actualAddress = remasc.getRskLabsAddress();
 
         Assertions.assertEquals(rskLabsAddressRskip218, actualAddress);
         Assertions.assertEquals(2L, blockMock.getNumber());
-        Assertions.assertTrue(activationConfig.isActive(ConsensusRule.RSKIP218, blockMock.getNumber()));
         verify(remascConfig).getRskLabsAddressRskip218();
     }
 }

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascStorageProviderTest.java
@@ -29,13 +29,12 @@ import co.rsk.db.MutableTrieCache;
 import co.rsk.db.MutableTrieImpl;
 import co.rsk.db.RepositoryLocator;
 import co.rsk.db.RepositorySnapshot;
-import co.rsk.peg.BridgeSupportFactory;
-import co.rsk.peg.PegTestUtils;
-import co.rsk.peg.RepositoryBtcBlockStoreWithCache;
+import co.rsk.peg.*;
 import co.rsk.test.builders.BlockChainBuilder;
 import co.rsk.trie.Trie;
 import org.ethereum.TestUtils;
 import org.ethereum.config.Constants;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.*;
@@ -293,7 +292,20 @@ class RemascStorageProviderTest {
         Blockchain blockchain = testRunner.getBlockChain();
         RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
         RepositorySnapshot repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
-        RemascFederationProvider federationProvider = new RemascFederationProvider(config.getActivationConfig(), config.getNetworkConstants().getBridgeConstants(), repository.startTracking(), testRunner.getBlockChain().getBestBlock());
+        Block executionBlock = testRunner.getBlockChain().getBestBlock();
+
+        ActivationConfig.ForBlock activations = config.getActivationConfig().forBlock(executionBlock.getNumber());
+
+        BridgeStorageProvider bridgeStorageProvider = new BridgeStorageProvider(
+                repository.startTracking(),
+                PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(),
+                activations
+        );
+
+        FederationSupport federationSupport = new FederationSupport(config.getNetworkConstants().getBridgeConstants(), bridgeStorageProvider, executionBlock, activations);
+
+        RemascFederationProvider federationProvider = new RemascFederationProvider(config.getActivationConfig().forBlock(executionBlock.getNumber()), federationSupport);
         assertEquals(Coin.valueOf(0), this.getRemascStorageProvider(repository).getFederationBalance());
         long federatorBalance = (168 / federationProvider.getFederationSize()) * 2;
         assertEquals(Coin.valueOf(federatorBalance), RemascTestRunner.getAccountBalance(repository, federationProvider.getFederatorAddress(0)));
@@ -320,7 +332,20 @@ class RemascStorageProviderTest {
         Blockchain blockchain = testRunner.getBlockChain();
         RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
         RepositorySnapshot repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
-        RemascFederationProvider federationProvider = new RemascFederationProvider(config.getActivationConfig(), config.getNetworkConstants().getBridgeConstants(), repository.startTracking(), testRunner.getBlockChain().getBestBlock());
+        Block executionBlock = testRunner.getBlockChain().getBestBlock();
+
+        ActivationConfig.ForBlock activations = config.getActivationConfig().forBlock(executionBlock.getNumber());
+
+        BridgeStorageProvider bridgeStorageProvider = new BridgeStorageProvider(
+                repository.startTracking(),
+                PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(),
+                activations
+        );
+
+        FederationSupport federationSupport = new FederationSupport(config.getNetworkConstants().getBridgeConstants(), bridgeStorageProvider, executionBlock, activations);
+
+        RemascFederationProvider federationProvider = new RemascFederationProvider(config.getActivationConfig().forBlock(executionBlock.getNumber()), federationSupport);
         assertEquals(Coin.valueOf(336), this.getRemascStorageProvider(repository).getFederationBalance());
         assertEquals(null, RemascTestRunner.getAccountBalance(repository, federationProvider.getFederatorAddress(0)));
     }
@@ -370,7 +395,20 @@ class RemascStorageProviderTest {
         Blockchain blockchain = testRunner.getBlockChain();
         RepositoryLocator repositoryLocator = builder.getRepositoryLocator();
         RepositorySnapshot repository = repositoryLocator.snapshotAt(blockchain.getBestBlock().getHeader());
-        RemascFederationProvider federationProvider = new RemascFederationProvider(config.getActivationConfig(), config.getNetworkConstants().getBridgeConstants(), repository.startTracking(), testRunner.getBlockChain().getBestBlock());
+        Block executionBlock = testRunner.getBlockChain().getBestBlock();
+
+        ActivationConfig.ForBlock activations = config.getActivationConfig().forBlock(executionBlock.getNumber());
+
+        BridgeStorageProvider bridgeStorageProvider = new BridgeStorageProvider(
+                repository.startTracking(),
+                PrecompiledContracts.BRIDGE_ADDR,
+                config.getNetworkConstants().getBridgeConstants(),
+                activations
+        );
+
+        FederationSupport federationSupport = new FederationSupport(config.getNetworkConstants().getBridgeConstants(), bridgeStorageProvider, executionBlock, activations);
+
+        RemascFederationProvider federationProvider = new RemascFederationProvider(config.getActivationConfig().forBlock(executionBlock.getNumber()), federationSupport);
         long federatorBalance = (1680 / federationProvider.getFederationSize()) * 2;
         assertEquals(Coin.valueOf(0), this.getRemascStorageProvider(repository).getFederationBalance());
         assertEquals(Coin.valueOf(federatorBalance), RemascTestRunner.getAccountBalance(repository, federationProvider.getFederatorAddress(0)));

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascTest.java
@@ -1,0 +1,164 @@
+package co.rsk.remasc;
+
+import co.rsk.config.RemascConfig;
+import co.rsk.config.RemascConfigFactory;
+import co.rsk.core.Coin;
+import co.rsk.core.RskAddress;
+import co.rsk.peg.PegTestUtils;
+import org.ethereum.config.Constants;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockHeader;
+import org.ethereum.core.Repository;
+import org.ethereum.db.BlockStore;
+import org.ethereum.vm.DataWord;
+import org.ethereum.vm.LogInfo;
+import org.ethereum.vm.PrecompiledContracts;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+
+class RemascTest {
+
+    private final static ActivationConfig genesisActivations = ActivationConfigsForTest.genesis();
+    private final static ActivationConfig orchidActivations = ActivationConfigsForTest.orchid();
+    private final static Constants mainnet = Constants.mainnet();
+    private final static Coin minimumGasPrice = Coin.valueOf(100L);
+
+    Repository repository;
+    BlockStore blockStore;
+    Block nextBlockToReward;
+
+    private final static RemascConfig remascConfig = new RemascConfigFactory(RemascContract.REMASC_CONFIG).createRemascConfig("main");
+
+    RemascTransaction executionTx;
+
+    RskAddress remascAddr;
+
+    Block executionBlock;
+
+    BlockHeader blockHeader;
+
+    List<LogInfo> logs;
+
+    List<Block> blocks;
+
+    DataWord rewardBalanceKey = DataWord.fromString("rewardBalance");
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(Repository.class);
+        blockStore = mock(BlockStore.class);
+        nextBlockToReward = mock(Block.class);
+        long blockNumber = 3992L;
+        when(nextBlockToReward.getParentHash()).thenReturn(PegTestUtils.createHash3((int) (blockNumber-1)));
+        when(nextBlockToReward.getHash()).thenReturn(PegTestUtils.createHash3((int) blockNumber));
+        when(nextBlockToReward.getNumber()).thenReturn(blockNumber);
+        when(blockStore.getBlockByHash(nextBlockToReward.getParentHash().getBytes())).thenReturn(nextBlockToReward);
+
+        when(blockStore.getBlockAtDepthStartingAt(anyLong(), any(byte[].class))).thenReturn(nextBlockToReward);
+
+        executionTx = mock(RemascTransaction.class);
+
+        remascAddr = PrecompiledContracts.REMASC_ADDR;
+
+        executionBlock = mock(Block.class);
+        when(executionBlock.getMinimumGasPrice()).thenReturn(minimumGasPrice);
+        when(executionBlock.getNumber()).thenReturn(4100L);
+        when(executionBlock.getHash()).thenReturn(PegTestUtils.createHash3(4100));
+
+        blockHeader = mock(BlockHeader.class);
+        when(executionBlock.getHeader()).thenReturn(blockHeader);
+        when(executionBlock.getParentHash()).thenReturn(PegTestUtils.createHash3(1));
+
+        logs = new ArrayList<>();
+    }
+
+    private void mockBlockStore(Coin feesPerBlock) {
+        blocks = new ArrayList<>();
+        int uncleGenerationLimit = mainnet.getUncleGenerationLimit();
+
+        for (int i = 0; i < uncleGenerationLimit + 1; i++) {
+            Block currentBlock = mock(Block.class);
+            int currentBlockNumber = (int) (nextBlockToReward.getNumber() - i);
+            when(currentBlock.getParentHash()).thenReturn(PegTestUtils.createHash3(currentBlockNumber - 1));
+            when(currentBlock.getHash()).thenReturn(PegTestUtils.createHash3(currentBlockNumber));
+            when(currentBlock.getNumber()).thenReturn((long) currentBlockNumber);
+
+            BlockHeader blockHeader = mock(BlockHeader.class);
+
+            when(blockHeader.getPaidFees()).thenReturn(feesPerBlock);
+            when(blockHeader.getHash()).thenReturn(PegTestUtils.createHash3(currentBlockNumber));
+            when(blockHeader.getCoinbase()).thenReturn(PegTestUtils.createRandomRskAddress());
+
+            when(currentBlock.getHeader()).thenReturn(blockHeader);
+
+            when(blockStore.getBlockByHash(currentBlock.getHash().getBytes())).thenReturn(currentBlock);
+            blocks.add(currentBlock);
+        }
+    }
+
+    private static Stream<Arguments> processMinersFeesArgProvider() {
+        Coin minimumPayableGas = Coin.valueOf(mainnet.getMinimumPayableGas().longValue());
+        Coin minPayableFees = minimumGasPrice.multiply(minimumPayableGas.asBigInteger());
+
+        Coin equalToMinPayableFees = minPayableFees.multiply(BigInteger.valueOf(remascConfig.getSyntheticSpan()));
+        Coin belowMinPayableFees = equalToMinPayableFees.subtract(Coin.valueOf(1L));
+
+        return Stream.of(
+            Arguments.of(genesisActivations, belowMinPayableFees, true),
+            Arguments.of(orchidActivations, belowMinPayableFees, false),
+            Arguments.of(orchidActivations, equalToMinPayableFees, true)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("processMinersFeesArgProvider")
+    void test_processMinersFees(ActivationConfig activationConfig, Coin feesPerBlock, boolean success) {
+        mockBlockStore(feesPerBlock);
+
+        // Arrange
+        Remasc remasc = new Remasc(
+            mainnet,
+            activationConfig,
+            repository,
+            blockStore,
+            remascConfig,
+            executionTx,
+            remascAddr,
+            executionBlock,
+            logs
+        );
+
+        // Act
+        remasc.processMinersFees();
+        remasc.save();
+
+        // Assert
+        Coin syntheticReward = feesPerBlock.divide(BigInteger.valueOf(remascConfig.getSyntheticSpan()));
+        Coin expectedRemascPayment = feesPerBlock.subtract(syntheticReward);
+        Coin expectedRskLabPayment = syntheticReward.divide(BigInteger.valueOf(remascConfig.getRskLabsDivisor()));
+        RskAddress iovLabsAddress = remasc.getRskLabsAddress();
+
+        if (success) {
+            verify(this.repository, times(1)).addStorageRow(remascAddr, rewardBalanceKey, DataWord.valueOf(expectedRemascPayment.getBytes()));
+            verify(this.repository, times(1)).addBalance(remascAddr, expectedRskLabPayment.negate());
+            verify(this.repository, times(1)).addBalance(iovLabsAddress, expectedRskLabPayment);
+        } else {
+            verify(this.repository, times(1)).addStorageRow(remascAddr, rewardBalanceKey, DataWord.valueOf(feesPerBlock.getBytes()));
+            verify(this.repository, never()).addBalance(any(), any());
+            verify(this.repository, never()).addBalance(any(),any());
+        }
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/remasc/RemascTest.java
+++ b/rskj-core/src/test/java/co/rsk/remasc/RemascTest.java
@@ -16,7 +16,6 @@ import org.ethereum.vm.DataWord;
 import org.ethereum.vm.LogInfo;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -117,6 +117,7 @@ class ActivationConfigTest {
             "    rskip398: arrowhead600",
             "    rskip400: arrowhead600",
             "    rskip412: arrowhead600",
+            "    rskip415: arrowhead600",
             "}"
     ));
 

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
@@ -182,7 +182,8 @@ public class ActivationConfigsForTest {
             ConsensusRule.RSKIP379,
             ConsensusRule.RSKIP398,
             ConsensusRule.RSKIP400,
-            ConsensusRule.RSKIP203
+            ConsensusRule.RSKIP203,
+            ConsensusRule.RSKIP415
         ));
 
         return rskips;

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
@@ -178,11 +178,11 @@ public class ActivationConfigsForTest {
     private static List<ConsensusRule> getArrowhead600Rskips() {
         List<ConsensusRule> rskips = new ArrayList<>();
         rskips.addAll(Arrays.asList(
+            ConsensusRule.RSKIP203,
             ConsensusRule.RSKIP376,
             ConsensusRule.RSKIP379,
             ConsensusRule.RSKIP398,
             ConsensusRule.RSKIP400,
-            ConsensusRule.RSKIP203,
             ConsensusRule.RSKIP415
         ));
 

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
@@ -95,6 +95,7 @@ public class ActivationConfigsForTest {
     private static List<ConsensusRule> getPapyrus200Rskips() {
         List<ConsensusRule> rskips = new ArrayList<>();
         rskips.addAll(Arrays.asList(
+            ConsensusRule.RSKIP134,
             ConsensusRule.RSKIP137,
             ConsensusRule.RSKIP140,
             ConsensusRule.RSKIP143,


### PR DESCRIPTION
Summary of changes

- Create a new method to get federation member by btc public key and added tests for it.
- logAddSignature method was refactored to receive a federation member instead of a btcPublicKey. Regarding, getting rid of btcTx, it was not removed because legacy implementation of BridgeEventLogger is using that parameter and logging it.
- New tests were added, and existing tests were updated to call the method using the new signature.
- Refactored RemascFederationProvider constructor to receive only ActivationConfig.ForBlock activations and FederationSupport federationSupport, since this class only needs these 2 dependencies. It was receiving many other dependencies only to create the FederationSupport instance. Hence, I decided to simplify it by only receiving 2 dependencies instead of 4.
- Included an activations check in RemascFederationProvider:: getFederatorAddress. If RSKIP415 is active, then use the rsk federator public key to generate the rsk address. Otherwise, keep using the btc public key.
- Refactored the files using the RemascFederationProvider to pass the new paramemters to the constructor.
- Created 2 new tests for RemascFederationProvider in RemascFederationProviderTest file. The RemascFederationProvider class is very simply. It only uses a FederationSupport support instance and the activations. So, in reality what we need to check is that federationSupport.getFederatorBtcPublicKey is still called when RSKIP415 is not active, and when RSKIP415 is active, then the one to call is federationSupport.getFederatorPublicKeyOfType(n, FederationMember.KeyType.RSK). Due to the simplicity of the requirements, I didn't include more tests.

*ci:rc600-modifier*
*fed:ARROWHEAD-6.0.0-rc*
*rit:ARROWHEAD-6.0.0-rc*