### PR TITLE
Cover cases with uneven division in getSublistGasLimit

### DIFF
--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockUtilsTest.java
@@ -186,12 +186,13 @@ class BlockUtilsTest {
     @Test
     void sublistGasLimit_ShouldDivideGasLimitEquallyAmongAllSets() {
         long minSequentialSetGasLimit = Constants.regtest().getMinSequentialSetGasLimit();
-        long mockedBlockGasLimit =  10_000_000L;
+        long mockedBlockGasLimit =  9_000_000L;
         Block block = mock(Block.class);
         when(block.getGasLimit()).thenReturn(BigInteger.valueOf(mockedBlockGasLimit).toByteArray());
 
         long expectedLimit = mockedBlockGasLimit / (Constants.getTransactionExecutionThreads() + 1);
         assertEquals(expectedLimit, BlockUtils.getSublistGasLimit(block, false, minSequentialSetGasLimit));
+        assertEquals(expectedLimit, BlockUtils.getSublistGasLimit(block, true, minSequentialSetGasLimit));
     }
 
     @Test
@@ -201,7 +202,23 @@ class BlockUtilsTest {
         Block block = mock(Block.class);
         when(block.getGasLimit()).thenReturn(BigInteger.valueOf(mockedBlockGasLimit).toByteArray());
 
-        long expectedLimit = (mockedBlockGasLimit - minSequentialSetGasLimit) / (Constants.getTransactionExecutionThreads());
-        assertEquals(expectedLimit, BlockUtils.getSublistGasLimit(block, false, minSequentialSetGasLimit));
+        assertEquals(minSequentialSetGasLimit, BlockUtils.getSublistGasLimit(block, true, minSequentialSetGasLimit));
+
+        long expectedParallelLimit = (mockedBlockGasLimit - minSequentialSetGasLimit) / (Constants.getTransactionExecutionThreads());
+        assertEquals(expectedParallelLimit, BlockUtils.getSublistGasLimit(block, false, minSequentialSetGasLimit));
+    }
+
+    @Test
+    void sublistGasLimit_ShouldAssignExtraGasLimitToSequentialSet() {
+        long minSequentialSetGasLimit = Constants.regtest().getMinSequentialSetGasLimit();
+        long mockedBlockGasLimit =  10_000_010L;
+        Block block = mock(Block.class);
+        when(block.getGasLimit()).thenReturn(BigInteger.valueOf(mockedBlockGasLimit).toByteArray());
+
+        long expectedSequentialLimit = 3_333_338L;
+        assertEquals(expectedSequentialLimit, BlockUtils.getSublistGasLimit(block, true, minSequentialSetGasLimit));
+
+        long expectedParallelLimit = 3_333_336L;
+        assertEquals(expectedParallelLimit, BlockUtils.getSublistGasLimit(block, false, minSequentialSetGasLimit));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Refactored `getSublistGasLimit` in `BlockUtils` to manage cases when the operands of the block gas limit division are not  evenly divisible.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current implementation does not cover the cases mentioned above, this could lead to the lost of some gas limit during the distribution.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
