### PR TITLE
Set peg-out tx index bridge constants

### DIFF
--- a/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeMainNetConstants.java
@@ -151,7 +151,7 @@ public class BridgeMainNetConstants extends BridgeConstants {
 
         numberOfBlocksBetweenPegouts = 360; // 3 hours of RSK blocks (considering 1 block every 30 seconds)
 
-        btcHeightWhenPegoutTxIndexActivates = 100; // TODO: TBD and change current mock value. This is an estimation of the btc block number once RSKIP379 is activated.
+        btcHeightWhenPegoutTxIndexActivates = 837_589; // Estimated date Wed, 03 Apr 2024 15:00:00 GMT. 832,430 was the block number at time of calculation
         pegoutTxIndexGracePeriodInBtcBlocks = 4_320; // 30 days in BTC blocks (considering 1 block every 10 minutes)
     }
 

--- a/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/config/BridgeTestNetConstants.java
@@ -169,8 +169,8 @@ public class BridgeTestNetConstants extends BridgeConstants {
 
         numberOfBlocksBetweenPegouts = 360; // 3 hours of RSK blocks (considering 1 block every 30 seconds)
 
-        btcHeightWhenPegoutTxIndexActivates = 150; // TODO: TBD and change current mock value. This is an estimation of the btc block number once RSKIP379 is activated.
-        pegoutTxIndexGracePeriodInBtcBlocks = 4_320; // 30 days in BTC blocks (considering 1 block every 10 minutes)
+        btcHeightWhenPegoutTxIndexActivates = 2_589_553; // Estimated date Wed, 20 Mar 2024 15:00:00 GMT. 2,579,823 was the block number at time of calculation
+        pegoutTxIndexGracePeriodInBtcBlocks = 1_440; // 10 days in BTC blocks (considering 1 block every 10 minutes)
     }
 
     public static BridgeTestNetConstants getInstance() {

--- a/rskj-core/src/test/java/co/rsk/config/BridgeConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/config/BridgeConstantsTest.java
@@ -124,8 +124,8 @@ class BridgeConstantsTest {
 
     private static Stream<Arguments> getBtcHeightWhenPegoutTxIndexActivatesArgProvider() {
         return Stream.of(
-            Arguments.of(BridgeMainNetConstants.getInstance(), 100),
-            Arguments.of(BridgeTestNetConstants.getInstance(), 150),
+            Arguments.of(BridgeMainNetConstants.getInstance(), 837589),
+            Arguments.of(BridgeTestNetConstants.getInstance(), 2589553),
             Arguments.of(BridgeRegTestConstants.getInstance(), 250)
         );
     }
@@ -143,7 +143,7 @@ class BridgeConstantsTest {
     private static Stream<Arguments> getPegoutTxIndexGracePeriodInBtcBlocksArgProvider() {
         return Stream.of(
             Arguments.of(BridgeMainNetConstants.getInstance(), 4_320),
-            Arguments.of(BridgeTestNetConstants.getInstance(), 4_320),
+            Arguments.of(BridgeTestNetConstants.getInstance(), 1_440),
             Arguments.of(BridgeRegTestConstants.getInstance(), 100)
         );
     }


### PR DESCRIPTION
- Set estimatedPegoutTxIndexBtcActivationHeight final value.
- Set pegoutTxIndexGracePeriodInBtcBlocks final value.

*ci:rc600-modifier*
*fed:ARROWHEAD-6.0.0-rc*
*rit:ARROWHEAD-6.0.0-rc*