### PR TITLE
fix(discovery): makes pong send only IP without hostname

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/discovery/PeerExplorer.java
+++ b/rskj-core/src/main/java/co/rsk/net/discovery/PeerExplorer.java
@@ -259,7 +259,7 @@ public class PeerExplorer {
             this.pendingPingRequests.remove(message.getMessageId());
             NodeChallenge challenge = this.challengeManager.removeChallenge(message.getMessageId());
             if (challenge == null) {
-                this.addConnection(message, request.getAddress().getHostString(), request.getAddress().getPort());
+                this.addConnection(message, request.getAddress().getAddress().getHostAddress(), request.getAddress().getPort());
             }
         } else {
             logger.debug("handlePong - Peer discovery request with id [{}] is either null or invalid", message.getMessageId());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
As RSK user I want IP addresses (instead of DNS names) to be sent to other peers in response to FIND_NODE peer discovery message

## Description
<!--- Describe your changes in detail -->
Instead of DNS hostnames a node always sends IP addresses in response to the FIND_NODE peer discovery message

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As of now, in the peer discovery protocol, when a peer asks for neighbours by sending FIND_NODE message in response it gets a sub list of other discovered peers in a network. Sometimes, instead of IP addresses of remote peers that list might include DNS names resolved via reverse DNS lookup in a context of the peer that returns that response. In some cases this might lead to issues when the reverse DNS resolution happens in different network contexts, for instance, when inside AWS VPC an IP can be resolved to ip-10-10-133-54.us-west-2.compute.internal, but outside that host name would make no sense.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test included.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
