### PR TITLE
Improve performance of mock getOriginAddress, getCallerAddress

### DIFF
--- a/rskj-core/src/test/java/org/ethereum/vm/program/invoke/ProgramInvokeMockImpl.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/program/invoke/ProgramInvokeMockImpl.java
@@ -111,21 +111,13 @@ public class ProgramInvokeMockImpl implements ProgramInvoke {
     /*           ORIGIN op         */
     @Override
     public DataWord getOriginAddress() {
-
-        byte[] cowPrivKey = HashUtil.keccak256("horse".getBytes(StandardCharsets.UTF_8));
-        byte[] addr = ECKey.fromPrivate(cowPrivKey).getAddress();
-
-        return DataWord.valueOf(addr);
+        return DataWord.valueFromHex("00000000000000000000000013978aee95f38490e9769c39b2773ed763d9cd5f");
     }
 
     /*           CALLER op         */
     @Override
     public DataWord getCallerAddress() {
-
-        byte[] cowPrivKey = HashUtil.keccak256("monkey".getBytes(StandardCharsets.UTF_8));
-        byte[] addr = ECKey.fromPrivate(cowPrivKey).getAddress();
-
-        return DataWord.valueOf(addr);
+        return DataWord.valueFromHex("000000000000000000000000885f93eed577f2fc341ebb9a5c9b2ce4465d96c4");
     }
 
     /*           GASPRICE op       */


### PR DESCRIPTION
## Description

## Motivation and Context

The overloaded methods `getOriginAddress` and `getCallerAddress` in `ProgramInvokeMockImpl` perform hashing and secp256k1 base point multiplication each time `ORIGIN` or `CALLER` are executed.

https://github.com/rsksmart/rskj/blob/12c9b322cfb968c1ed7adb93bad32e7ed14c62b6/rskj-core/src/test/java/org/ethereum/vm/program/invoke/ProgramInvokeMockImpl.java#L111-L129

This makes these opcodes unnecessary slow and it impedes my effort to detect genuine performance issues with the EVM itself.

## How Has This Been Tested?

With this test harness (rskj-core/src/test/java/co/rsk/vm/Poc.java):

```java
package co.rsk.vm;

import org.ethereum.config.blockchain.upgrades.ActivationConfig;
import co.rsk.config.TestSystemProperties;
import co.rsk.config.VmConfig;
import org.ethereum.vm.*;
import org.ethereum.core.BlockFactory;
import org.ethereum.core.BlockTxSignatureCache;
import org.ethereum.core.ReceivedTxSignatureCache;
import org.ethereum.vm.program.invoke.ProgramInvokeMockImpl;
import java.util.HashSet;
import org.ethereum.vm.program.Program;
import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
import javax.xml.bind.DatatypeConverter;
import org.junit.jupiter.api.Test;

public class Poc {
    @Test
    void testPoc() {
        TestSystemProperties config = new TestSystemProperties();
        PrecompiledContracts precompiledContracts = new PrecompiledContracts(config, null, new BlockTxSignatureCache(new ReceivedTxSignatureCache()));
        BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
        VmConfig vmConfig = config.getVmConfig();
        ProgramInvokeMockImpl invoke = new ProgramInvokeMockImpl();
        ActivationConfig.ForBlock activations = ActivationConfigsForTest.arrowhead600().forBlock(0);

        byte[] code = DatatypeConverter.parseHexBinary("5b3333331a1a56");

        invoke.setGas(6800000); /* block limit */
        VM vm = new VM(vmConfig, precompiledContracts);
        Program program = new Program(vmConfig, precompiledContracts, blockFactory, activations, code, invoke,null, new HashSet<>(), new BlockTxSignatureCache(new ReceivedTxSignatureCache()));

        try {
            while (!program.isStopped())
                vm.step(program);
        } catch (RuntimeException e) {
            program.setRuntimeFailure(e);
        }
    }
}
```

Runtime before this fix: 10 minutes, 17 seconds
Runtime after this fix: 6 seconds

Using:

```sh
time ./gradlew test  --tests co.rsk.vm.Poc.testPoc
```

On Linux x64, Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)