### PR TITLE
Remove dependency between BridgeConstants and Federation classes

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -60,11 +60,9 @@ import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP293;
  */
 public class BridgeUtils {
 
-    private static BridgeConstants bridgeConstants;
     private static final Logger logger = LoggerFactory.getLogger(BridgeUtils.class);
 
-    private BridgeUtils(BridgeConstants bridgeConstants) {
-        BridgeUtils.bridgeConstants = bridgeConstants;
+    private BridgeUtils() {
     }
 
     public static Wallet getFederationNoSpendWallet(
@@ -406,7 +404,7 @@ public class BridgeUtils {
                !activations.isActive(ConsensusRule.ARE_BRIDGE_TXS_PAID) &&
                rskTx.acceptTransactionSignature(constants.getChainId()) &&
                (
-                       isFromGenesisFederation(senderAddress) ||
+                       isFromGenesisFederation(senderAddress, bridgeConstants.getGenesisFederationPublicKeys()) ||
                        isFromFederationChangeAuthorizedSender(rskTx, bridgeConstants, signatureCache) ||
                        isFromLockWhitelistChangeAuthorizedSender(rskTx, bridgeConstants, signatureCache) ||
                        isFromFeePerKbChangeAuthorizedSender(rskTx, bridgeConstants, signatureCache)
@@ -430,14 +428,16 @@ public class BridgeUtils {
     /**
      * Method that verify if an RskAddress is part of the Genesis Federation
      *
-     * @param rskAddress
+     * @param rskAddress                  RskAddress to find in Genesis Federation
+     * @param genesisFederationPublicKeys List of BtcECKey part of Genesis Federation
      * @return boolean
      */
-    private static boolean isFromGenesisFederation(RskAddress rskAddress) {
-        final List<BtcECKey> genesisFederationPublicKeys = bridgeConstants.getGenesisFederationPublicKeys();
-        return genesisFederationPublicKeys.stream().anyMatch(genesisBtcPublicKey ->
-                Arrays.equals((ECKey.fromPublicOnly(genesisBtcPublicKey.getPubKey())).getAddress()
-                        , rskAddress.getBytes()));
+    private static boolean isFromGenesisFederation(RskAddress rskAddress, List<BtcECKey> genesisFederationPublicKeys) {
+        return genesisFederationPublicKeys.stream().
+                anyMatch(genesisBtcPublicKey ->
+                        Arrays.equals(
+                                (ECKey.fromPublicOnly(genesisBtcPublicKey.getPubKey())).getAddress()
+                                , rskAddress.getBytes()));
     }
 
     public static Coin getCoinFromBigInteger(BigInteger value) throws BridgeIllegalArgumentException {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -58,7 +58,7 @@ import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP293;
 /**
  * @author Oscar Guindzberg
  */
-public class BridgeUtils {
+public final class BridgeUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(BridgeUtils.class);
 
@@ -433,11 +433,11 @@ public class BridgeUtils {
      * @return boolean
      */
     private static boolean isFromGenesisFederation(RskAddress rskAddress, List<BtcECKey> genesisFederationPublicKeys) {
-        return genesisFederationPublicKeys.stream().
-                anyMatch(genesisBtcPublicKey ->
-                        Arrays.equals(
-                                (ECKey.fromPublicOnly(genesisBtcPublicKey.getPubKey())).getAddress()
-                                , rskAddress.getBytes()));
+        return genesisFederationPublicKeys.stream().anyMatch(genesisBtcPublicKey -> {
+                    ECKey genesisEcKey = ECKey.fromPublicOnly(genesisBtcPublicKey.getPubKey());
+                    return Arrays.equals(genesisEcKey.getAddress(), rskAddress.getBytes());
+                }
+        );
     }
 
     public static Coin getCoinFromBigInteger(BigInteger value) throws BridgeIllegalArgumentException {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -397,7 +397,7 @@ public class BridgeUtils {
         }
 
         BridgeConstants bridgeConstants = constants.getBridgeConstants();
-        RskAddress rskAddress = rskTx.getSender(signatureCache);
+        RskAddress senderAddress = rskTx.getSender(signatureCache);
 
         // Temporary assumption: if areBridgeTxsFree() is true then the current federation
         // must be the genesis federation.
@@ -406,7 +406,7 @@ public class BridgeUtils {
                !activations.isActive(ConsensusRule.ARE_BRIDGE_TXS_PAID) &&
                rskTx.acceptTransactionSignature(constants.getChainId()) &&
                (
-                       isFromGenesisFederation(rskAddress) ||
+                       isFromGenesisFederation(senderAddress) ||
                        isFromFederationChangeAuthorizedSender(rskTx, bridgeConstants, signatureCache) ||
                        isFromLockWhitelistChangeAuthorizedSender(rskTx, bridgeConstants, signatureCache) ||
                        isFromFeePerKbChangeAuthorizedSender(rskTx, bridgeConstants, signatureCache)
@@ -435,8 +435,9 @@ public class BridgeUtils {
      */
     private static boolean isFromGenesisFederation(RskAddress rskAddress) {
         final List<BtcECKey> genesisFederationPublicKeys = bridgeConstants.getGenesisFederationPublicKeys();
-        final List<ECKey> genesisFederationECKeys = genesisFederationPublicKeys.stream().map(k -> ECKey.fromPublicOnly(k.getPubKey())).collect(Collectors.toList());
-        return genesisFederationECKeys.stream().anyMatch(m -> Arrays.equals(m.getAddress(), rskAddress.getBytes()));
+        return genesisFederationPublicKeys.stream().anyMatch(genesisBtcPublicKey ->
+                Arrays.equals((ECKey.fromPublicOnly(genesisBtcPublicKey.getPubKey())).getAddress()
+                        , rskAddress.getBytes()));
     }
 
     public static Coin getCoinFromBigInteger(BigInteger value) throws BridgeIllegalArgumentException {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -37,14 +37,17 @@ import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.SignatureCache;
 import org.ethereum.core.Transaction;
+import org.ethereum.crypto.ECKey;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.PrecompiledContracts;
+import org.ethereum.vm.program.InternalTransaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -57,9 +60,12 @@ import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP293;
  */
 public class BridgeUtils {
 
+    private static BridgeConstants bridgeConstants;
     private static final Logger logger = LoggerFactory.getLogger(BridgeUtils.class);
 
-    private BridgeUtils() {}
+    private BridgeUtils(BridgeConstants bridgeConstants) {
+        BridgeUtils.bridgeConstants = bridgeConstants;
+    }
 
     public static Wallet getFederationNoSpendWallet(
         Context btcContext,
@@ -152,7 +158,7 @@ public class BridgeUtils {
         if (addresses == null || addresses.isEmpty()){
             return Coin.ZERO;
         }
-        if (activations.isActive(ConsensusRule.RSKIP293)){
+        if (activations.isActive(RSKIP293)){
             return getAmountSentToAddresses(
                 context,
                 btcTx,
@@ -251,7 +257,7 @@ public class BridgeUtils {
         List<Address> addresses
 
     ) {
-        if (activations.isActive(ConsensusRule.RSKIP293)){
+        if (activations.isActive(RSKIP293)){
             return getUTXOsSentToAddresses(context, btcTx, addresses);
         } else {
             return BridgeUtilsLegacy.getUTXOsSentToAddress(
@@ -378,8 +384,8 @@ public class BridgeUtils {
         return true;
     }
 
-    public static Address recoverBtcAddressFromEthTransaction(org.ethereum.core.Transaction tx, NetworkParameters networkParameters) {
-        org.ethereum.crypto.ECKey key = tx.getKey();
+    public static Address recoverBtcAddressFromEthTransaction(Transaction tx, NetworkParameters networkParameters) {
+        ECKey key = tx.getKey();
         byte[] pubKey = key.getPubKey(true);
         return BtcECKey.fromPublicOnly(pubKey).toAddress(networkParameters);
     }
@@ -391,6 +397,7 @@ public class BridgeUtils {
         }
 
         BridgeConstants bridgeConstants = constants.getBridgeConstants();
+        RskAddress rskAddress = rskTx.getSender(signatureCache);
 
         // Temporary assumption: if areBridgeTxsFree() is true then the current federation
         // must be the genesis federation.
@@ -399,7 +406,7 @@ public class BridgeUtils {
                !activations.isActive(ConsensusRule.ARE_BRIDGE_TXS_PAID) &&
                rskTx.acceptTransactionSignature(constants.getChainId()) &&
                (
-                       isFromFederateMember(rskTx, bridgeConstants.getGenesisFederation(), signatureCache) ||
+                       isFromGenesisFederation(rskAddress) ||
                        isFromFederationChangeAuthorizedSender(rskTx, bridgeConstants, signatureCache) ||
                        isFromLockWhitelistChangeAuthorizedSender(rskTx, bridgeConstants, signatureCache) ||
                        isFromFeePerKbChangeAuthorizedSender(rskTx, bridgeConstants, signatureCache)
@@ -413,11 +420,23 @@ public class BridgeUtils {
      */
     public static boolean isContractTx(Transaction rskTx) {
         // Calls between contracts are done through internal transactions
-        return rskTx.getClass() == org.ethereum.vm.program.InternalTransaction.class;
+        return rskTx.getClass() == InternalTransaction.class;
     }
 
-    public static boolean isFromFederateMember(org.ethereum.core.Transaction rskTx, Federation federation, SignatureCache signatureCache) {
+    public static boolean isFromFederateMember(Transaction rskTx, Federation federation, SignatureCache signatureCache) {
         return federation.hasMemberWithRskAddress(rskTx.getSender(signatureCache).getBytes());
+    }
+
+    /**
+     * Method that verify if an RskAddress is part of the Genesis Federation
+     *
+     * @param rskAddress
+     * @return boolean
+     */
+    private static boolean isFromGenesisFederation(RskAddress rskAddress) {
+        final List<BtcECKey> genesisFederationPublicKeys = bridgeConstants.getGenesisFederationPublicKeys();
+        final List<ECKey> genesisFederationECKeys = genesisFederationPublicKeys.stream().map(k -> ECKey.fromPublicOnly(k.getPubKey())).collect(Collectors.toList());
+        return genesisFederationECKeys.stream().anyMatch(m -> Arrays.equals(m.getAddress(), rskAddress.getBytes()));
     }
 
     public static Coin getCoinFromBigInteger(BigInteger value) throws BridgeIllegalArgumentException {
@@ -431,17 +450,17 @@ public class BridgeUtils {
         }
     }
 
-    private static boolean isFromFederationChangeAuthorizedSender(org.ethereum.core.Transaction rskTx, BridgeConstants bridgeConfiguration, SignatureCache signatureCache) {
+    private static boolean isFromFederationChangeAuthorizedSender(Transaction rskTx, BridgeConstants bridgeConfiguration, SignatureCache signatureCache) {
         AddressBasedAuthorizer authorizer = bridgeConfiguration.getFederationChangeAuthorizer();
         return authorizer.isAuthorized(rskTx, signatureCache);
     }
 
-    private static boolean isFromLockWhitelistChangeAuthorizedSender(org.ethereum.core.Transaction rskTx, BridgeConstants bridgeConfiguration, SignatureCache signatureCache) {
+    private static boolean isFromLockWhitelistChangeAuthorizedSender(Transaction rskTx, BridgeConstants bridgeConfiguration, SignatureCache signatureCache) {
         AddressBasedAuthorizer authorizer = bridgeConfiguration.getLockWhitelistChangeAuthorizer();
         return authorizer.isAuthorized(rskTx, signatureCache);
     }
 
-    private static boolean isFromFeePerKbChangeAuthorizedSender(org.ethereum.core.Transaction rskTx, BridgeConstants bridgeConfiguration, SignatureCache signatureCache) {
+    private static boolean isFromFeePerKbChangeAuthorizedSender(Transaction rskTx, BridgeConstants bridgeConfiguration, SignatureCache signatureCache) {
         AddressBasedAuthorizer authorizer = bridgeConfiguration.getFeePerKbChangeAuthorizer();
         return authorizer.isAuthorized(rskTx, signatureCache);
     }
@@ -540,7 +559,7 @@ public class BridgeUtils {
         ActivationConfig.ForBlock activations,
         byte[] addressBytes) throws BridgeIllegalArgumentException {
 
-        if (!activations.isActive(ConsensusRule.RSKIP284)) {
+        if (!activations.isActive(RSKIP284)) {
             return BridgeUtilsLegacy.deserializeBtcAddressWithVersionLegacy(networkParameters, activations, addressBytes);
         }
 

--- a/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
@@ -41,6 +41,7 @@ public class FederationSupport {
     private final BridgeConstants bridgeConstants;
     private final Block executionBlock;
     private final ActivationConfig.ForBlock activations;
+    private static final long CREATION_BLOCK_NUMBER = 1L;
 
     public FederationSupport(BridgeConstants bridgeConstants, BridgeStorageProvider provider, Block executionBlock, ActivationConfig.ForBlock activations) {
         this.provider = provider;
@@ -244,11 +245,9 @@ public class FederationSupport {
      */
     private Federation getGenesisFederation() {
         final List<BtcECKey> genesisFederationPublicKeys = bridgeConstants.getGenesisFederationPublicKeys();
-        // IMPORTANT: BTC, RSK and MST keys are the same.
-        // Change upon implementation of the <INSERT FORK NAME HERE> fork.
         final List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(genesisFederationPublicKeys);
-        final Instant genesisFederationAddressCreatedAt = bridgeConstants.getGenesisFederationAddressCreatedAt();
-        final FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L, bridgeConstants.getBtcParams());
+        final Instant genesisFederationCreationTime = bridgeConstants.getGenesisFederationCreationTime();
+        final FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationCreationTime, CREATION_BLOCK_NUMBER, bridgeConstants.getBtcParams());
         return FederationFactory.buildStandardMultiSigFederation(federationArgs);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
@@ -21,12 +21,15 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.UTXO;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationArgs;
+import co.rsk.peg.federation.FederationFactory;
 import co.rsk.peg.federation.FederationMember;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.Block;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 
@@ -110,7 +113,7 @@ public class FederationSupport {
                 return provider.getOldFederation();
             case GENESIS:
             default:
-                return bridgeConstants.getGenesisFederation();
+                return this.getGenesisFederation();
         }
     }
 
@@ -232,5 +235,20 @@ public class FederationSupport {
     private boolean shouldFederationBeActive(Federation federation) {
         long federationAge = executionBlock.getNumber() - federation.getCreationBlockNumber();
         return federationAge >= bridgeConstants.getFederationActivationAge(activations);
+    }
+
+    /**
+     * Get the Genesis Federation from a List of Genesis Federation Public Keys
+     *
+     * @return Federation
+     */
+    private Federation getGenesisFederation() {
+        final List<BtcECKey> genesisFederationPublicKeys = bridgeConstants.getGenesisFederationPublicKeys();
+        // IMPORTANT: BTC, RSK and MST keys are the same.
+        // Change upon implementation of the <INSERT FORK NAME HERE> fork.
+        final List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(genesisFederationPublicKeys);
+        final Instant genesisFederationAddressCreatedAt = bridgeConstants.getGenesisFederationAddressCreatedAt();
+        final FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L, bridgeConstants.getBtcParams());
+        return FederationFactory.buildStandardMultiSigFederation(federationArgs);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
@@ -41,7 +41,6 @@ public class FederationSupport {
     private final BridgeConstants bridgeConstants;
     private final Block executionBlock;
     private final ActivationConfig.ForBlock activations;
-    private static final long CREATION_BLOCK_NUMBER = 1L;
 
     public FederationSupport(BridgeConstants bridgeConstants, BridgeStorageProvider provider, Block executionBlock, ActivationConfig.ForBlock activations) {
         this.provider = provider;
@@ -244,10 +243,11 @@ public class FederationSupport {
      * @return Federation
      */
     private Federation getGenesisFederation() {
+        final long GENESIS_FEDERATION_CREATION_BLOCK_NUMBER = 1L;
         final List<BtcECKey> genesisFederationPublicKeys = bridgeConstants.getGenesisFederationPublicKeys();
         final List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(genesisFederationPublicKeys);
         final Instant genesisFederationCreationTime = bridgeConstants.getGenesisFederationCreationTime();
-        final FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationCreationTime, CREATION_BLOCK_NUMBER, bridgeConstants.getBtcParams());
+        final FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationCreationTime, GENESIS_FEDERATION_CREATION_BLOCK_NUMBER, bridgeConstants.getBtcParams());
         return FederationFactory.buildStandardMultiSigFederation(federationArgs);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeConstants.java
@@ -22,17 +22,16 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.AddressBasedAuthorizer;
-import co.rsk.peg.federation.Federation;
-import java.util.List;
-
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 
+import java.time.Instant;
+import java.util.List;
+
 public abstract class BridgeConstants {
     protected String btcParamsString;
-
-    protected Federation genesisFederation;
-
+    protected List<BtcECKey> genesisFederationPublicKeys;
+    protected Instant genesisFederationAddressCreatedAt;
     protected int btc2RskMinimumAcceptableConfirmations;
     protected int btc2RskMinimumAcceptableConfirmationsOnRsk;
     protected int rsk2BtcMinimumAcceptableConfirmations;
@@ -98,7 +97,13 @@ public abstract class BridgeConstants {
         return btcParamsString;
     }
 
-    public Federation getGenesisFederation() { return genesisFederation; }
+    public List<BtcECKey> getGenesisFederationPublicKeys() {
+        return genesisFederationPublicKeys;
+    }
+
+    public Instant getGenesisFederationAddressCreatedAt() {
+        return genesisFederationAddressCreatedAt;
+    }
 
     public int getBtc2RskMinimumAcceptableConfirmations() {
         return btc2RskMinimumAcceptableConfirmations;

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeConstants.java
@@ -31,7 +31,7 @@ import java.util.List;
 public abstract class BridgeConstants {
     protected String btcParamsString;
     protected List<BtcECKey> genesisFederationPublicKeys;
-    protected Instant genesisFederationAddressCreatedAt;
+    protected Instant genesisFederationCreationTime;
     protected int btc2RskMinimumAcceptableConfirmations;
     protected int btc2RskMinimumAcceptableConfirmationsOnRsk;
     protected int rsk2BtcMinimumAcceptableConfirmations;
@@ -101,8 +101,8 @@ public abstract class BridgeConstants {
         return genesisFederationPublicKeys;
     }
 
-    public Instant getGenesisFederationAddressCreatedAt() {
-        return genesisFederationAddressCreatedAt;
+    public Instant getGenesisFederationCreationTime() {
+        return genesisFederationCreationTime;
     }
 
     public int getBtc2RskMinimumAcceptableConfirmations() {

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeDevNetConstants.java
@@ -22,16 +22,14 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.AddressBasedAuthorizer;
-import co.rsk.peg.federation.FederationArgs;
-import co.rsk.peg.federation.FederationMember;
-import co.rsk.peg.federation.FederationFactory;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.ECKey;
+
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.bouncycastle.util.encoders.Hex;
-import org.ethereum.crypto.ECKey;
 
 public class BridgeDevNetConstants extends BridgeConstants {
     // IMPORTANT: BTC, RSK and MST keys are the same.
@@ -51,16 +49,11 @@ public class BridgeDevNetConstants extends BridgeConstants {
     public BridgeDevNetConstants(List<BtcECKey> federationPublicKeys) {
         btcParamsString = NetworkParameters.ID_TESTNET;
 
-        List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(federationPublicKeys);
+        this.genesisFederationPublicKeys = federationPublicKeys;
 
         // Currently set to:
         // Monday, November 13, 2017 9:00:00 PM GMT-03:00
-        Instant genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1510617600l);
-
-        // Expected federation address is:
-        // 2NCEo1RdmGDj6MqiipD6DUSerSxKv79FNWX
-        FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L, getBtcParams());
-        genesisFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
+        genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1510617600l);
 
         btc2RskMinimumAcceptableConfirmations = 1;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 10;

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeDevNetConstants.java
@@ -45,6 +45,7 @@ public class BridgeDevNetConstants extends BridgeConstants {
                     Hex.decode("0309d9df35855aa45235a04e30d228889eb03e462874588e631359d5f9cdea6519")
             )
     ));
+    private static final BridgeDevNetConstants instance = new BridgeDevNetConstants(DEVNET_FEDERATION_PUBLIC_KEYS);
 
     public BridgeDevNetConstants(List<BtcECKey> federationPublicKeys) {
         btcParamsString = NetworkParameters.ID_TESTNET;
@@ -159,5 +160,8 @@ public class BridgeDevNetConstants extends BridgeConstants {
 
         btcHeightWhenPegoutTxIndexActivates = 1_000_000;
         pegoutTxIndexGracePeriodInBtcBlocks = 4_320; // 30 days in BTC blocks (considering 1 block every 10 minutes)
+    }
+    public static BridgeDevNetConstants getInstance() {
+        return instance;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeDevNetConstants.java
@@ -25,7 +25,7 @@ import co.rsk.peg.AddressBasedAuthorizer;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.ECKey;
 
-import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -51,9 +51,7 @@ public class BridgeDevNetConstants extends BridgeConstants {
 
         this.genesisFederationPublicKeys = federationPublicKeys;
 
-        // Currently set to:
-        // Monday, November 13, 2017 9:00:00 PM GMT-03:00
-        genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1510617600l);
+        genesisFederationCreationTime = ZonedDateTime.parse("2017-11-14T00:00:00Z").toInstant();
 
         btc2RskMinimumAcceptableConfirmations = 1;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 10;

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeMainNetConstants.java
@@ -8,7 +8,7 @@ import com.google.common.collect.Lists;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.ECKey;
 
-import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -43,9 +43,7 @@ public class BridgeMainNetConstants extends BridgeConstants {
             federator12PublicKey, federator13PublicKey, federator14PublicKey
         );
 
-        // Currently set to:
-        // Wednesday, January 3, 2018 12:00:00 AM GMT-03:00
-        genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1514948400L);
+        genesisFederationCreationTime = ZonedDateTime.parse("2018-01-03T03:00:00Z").toInstant();
 
         btc2RskMinimumAcceptableConfirmations = 100;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 1000;

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeMainNetConstants.java
@@ -4,16 +4,14 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.AddressBasedAuthorizer;
-import co.rsk.peg.federation.FederationArgs;
-import co.rsk.peg.federation.FederationMember;
-import co.rsk.peg.federation.FederationFactory;
 import com.google.common.collect.Lists;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.ECKey;
+
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.bouncycastle.util.encoders.Hex;
-import org.ethereum.crypto.ECKey;
 
 public class BridgeMainNetConstants extends BridgeConstants {
     private static final BridgeMainNetConstants instance = new BridgeMainNetConstants();
@@ -37,7 +35,7 @@ public class BridgeMainNetConstants extends BridgeConstants {
         BtcECKey federator13PublicKey = BtcECKey.fromPublicOnly(Hex.decode("02c6018fcbd3e89f3cf9c7f48b3232ea3638eb8bf217e59ee290f5f0cfb2fb9259"));
         BtcECKey federator14PublicKey = BtcECKey.fromPublicOnly(Hex.decode("03b65694ccccda83cbb1e56b31308acd08e993114c33f66a456b627c2c1c68bed6"));
 
-        List<BtcECKey> genesisFederationPublicKeys = Lists.newArrayList(
+        genesisFederationPublicKeys = Lists.newArrayList(
             federator0PublicKey, federator1PublicKey, federator2PublicKey,
             federator3PublicKey, federator4PublicKey, federator5PublicKey,
             federator6PublicKey, federator7PublicKey, federator8PublicKey,
@@ -45,16 +43,9 @@ public class BridgeMainNetConstants extends BridgeConstants {
             federator12PublicKey, federator13PublicKey, federator14PublicKey
         );
 
-        // IMPORTANT: BTC, RSK and MST keys are the same.
-        // Change upon implementation of the <INSERT FORK NAME HERE> fork.
-        List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(genesisFederationPublicKeys);
-
         // Currently set to:
         // Wednesday, January 3, 2018 12:00:00 AM GMT-03:00
-        Instant genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1514948400L);
-
-        FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L, getBtcParams());
-        genesisFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
+        genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1514948400L);
 
         btc2RskMinimumAcceptableConfirmations = 100;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 1000;

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
@@ -52,7 +52,7 @@ public class BridgeRegTestConstants extends BridgeConstants {
 
         this.genesisFederationPublicKeys = federationPublicKeys;
 
-        genesisFederationAddressCreatedAt = ZonedDateTime.parse("2016-01-01T00:00:00Z").toInstant();
+        genesisFederationCreationTime = ZonedDateTime.parse("2016-01-01T00:00:00Z").toInstant();
 
         btc2RskMinimumAcceptableConfirmations = 3;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 5;

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
@@ -22,19 +22,16 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.AddressBasedAuthorizer;
-import co.rsk.peg.federation.FederationArgs;
-import co.rsk.peg.federation.FederationMember;
-import co.rsk.peg.federation.FederationFactory;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.crypto.HashUtil;
+
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.bouncycastle.util.encoders.Hex;
-import org.ethereum.crypto.ECKey;
-import org.ethereum.crypto.HashUtil;
 
 public class BridgeRegTestConstants extends BridgeConstants {
     // IMPORTANT: BTC, RSK and MST keys are the same.
@@ -53,12 +50,9 @@ public class BridgeRegTestConstants extends BridgeConstants {
     public BridgeRegTestConstants(List<BtcECKey> federationPublicKeys) {
         btcParamsString = NetworkParameters.ID_REGTEST;
 
-        List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(federationPublicKeys);
+        this.genesisFederationPublicKeys = federationPublicKeys;
 
-        Instant genesisFederationCreatedAt = ZonedDateTime.parse("2016-01-01T00:00:00Z").toInstant();
-
-        FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationCreatedAt, 1L, getBtcParams());
-        genesisFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
+        genesisFederationAddressCreatedAt = ZonedDateTime.parse("2016-01-01T00:00:00Z").toInstant();
 
         btc2RskMinimumAcceptableConfirmations = 3;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 5;

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeTestNetConstants.java
@@ -25,7 +25,7 @@ import co.rsk.peg.AddressBasedAuthorizer;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.ECKey;
 
-import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -56,8 +56,7 @@ public class BridgeTestNetConstants extends BridgeConstants {
             federator3PublicKey
         );
 
-        // Currently set to: Monday, October 8, 2018 12:00:00 AM GMT-03:00
-        genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1538967600l);
+        genesisFederationCreationTime = ZonedDateTime.parse("2018-10-08T03:00:00Z").toInstant();
 
         btc2RskMinimumAcceptableConfirmations = 10;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 10;

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeTestNetConstants.java
@@ -22,15 +22,13 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.AddressBasedAuthorizer;
-import co.rsk.peg.federation.FederationArgs;
-import co.rsk.peg.federation.FederationMember;
-import co.rsk.peg.federation.FederationFactory;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.ECKey;
+
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.bouncycastle.util.encoders.Hex;
-import org.ethereum.crypto.ECKey;
 
 public class BridgeTestNetConstants extends BridgeConstants {
     private static final BridgeTestNetConstants instance = new BridgeTestNetConstants();
@@ -51,23 +49,15 @@ public class BridgeTestNetConstants extends BridgeConstants {
             Hex.decode("034844a99cd7028aa319476674cc381df006628be71bc5593b8b5fdb32bb42ef85")
         );
 
-        List<BtcECKey> genesisFederationPublicKeys = Arrays.asList(
+        genesisFederationPublicKeys = Arrays.asList(
             federator0PublicKey,
             federator1PublicKey,
             federator2PublicKey,
             federator3PublicKey
         );
 
-        // IMPORTANT: BTC, RSK and MST keys are the same.
-        // Change upon implementation of the <INSERT FORK NAME HERE> fork.
-        List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(genesisFederationPublicKeys);
-
-        // Currently set to:
         // Currently set to: Monday, October 8, 2018 12:00:00 AM GMT-03:00
-        Instant genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1538967600l);
-
-        FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationAddressCreatedAt, 1L, getBtcParams());
-        genesisFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
+        genesisFederationAddressCreatedAt = Instant.ofEpochMilli(1538967600l);
 
         btc2RskMinimumAcceptableConfirmations = 10;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 10;

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -280,7 +280,7 @@ class BridgeStorageProviderTest {
         Repository track = repository.startTracking();
 
         // Federation is the genesis federation ATM
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeMainNetConstants);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeMainNetConstants);
 
         BridgeStorageProvider provider0 = new BridgeStorageProvider(
             track,
@@ -288,8 +288,8 @@ class BridgeStorageProviderTest {
             bridgeTestnetInstance,
             activationsBeforeFork
         );
-        provider0.getNewFederationBtcUTXOs().add(new UTXO(hash1, 1, Coin.COIN, 0, false, ScriptBuilder.createOutputScript(federation.getAddress())));
-        provider0.getNewFederationBtcUTXOs().add(new UTXO(hash2, 2, Coin.FIFTY_COINS, 0, false, ScriptBuilder.createOutputScript(federation.getAddress())));
+        provider0.getNewFederationBtcUTXOs().add(new UTXO(hash1, 1, Coin.COIN, 0, false, ScriptBuilder.createOutputScript(genesisFederation.getAddress())));
+        provider0.getNewFederationBtcUTXOs().add(new UTXO(hash2, 2, Coin.FIFTY_COINS, 0, false, ScriptBuilder.createOutputScript(genesisFederation.getAddress())));
         provider0.save();
         track.commit();
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -93,6 +93,7 @@ class BridgeStorageProviderTest {
     private final ActivationConfig.ForBlock activationsBeforeFork = ActivationConfigsForTest.genesis().forBlock(0L);
     private final ActivationConfig.ForBlock activationsAllForks = ActivationConfigsForTest.all().forBlock(0);
     private final BridgeTestNetConstants bridgeTestnetInstance = BridgeTestNetConstants.getInstance();
+    private final BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
     private final NetworkParameters networkParameters = bridgeTestnetInstance.getBtcParams();
 
     private int transactionOffset;
@@ -278,9 +279,8 @@ class BridgeStorageProviderTest {
         Repository repository = createRepository();
         Repository track = repository.startTracking();
 
-        BridgeConstants bridgeConstants = bridgeTestnetInstance;
         // Federation is the genesis federation ATM
-        Federation federation = bridgeConstants.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
 
         BridgeStorageProvider provider0 = new BridgeStorageProvider(
             track,

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -93,7 +93,7 @@ class BridgeStorageProviderTest {
     private final ActivationConfig.ForBlock activationsBeforeFork = ActivationConfigsForTest.genesis().forBlock(0L);
     private final ActivationConfig.ForBlock activationsAllForks = ActivationConfigsForTest.all().forBlock(0);
     private final BridgeTestNetConstants bridgeTestnetInstance = BridgeTestNetConstants.getInstance();
-    private final BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
+    private final BridgeConstants bridgeMainNetConstants = BridgeMainNetConstants.getInstance();
     private final NetworkParameters networkParameters = bridgeTestnetInstance.getBtcParams();
 
     private int transactionOffset;
@@ -280,7 +280,7 @@ class BridgeStorageProviderTest {
         Repository track = repository.startTracking();
 
         // Federation is the genesis federation ATM
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeMainNetConstants);
 
         BridgeStorageProvider provider0 = new BridgeStorageProvider(
             track,

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
@@ -58,8 +58,8 @@ class BridgeSupportAddSignatureTest {
 
     private static final RskAddress contractAddress = PrecompiledContracts.BRIDGE_ADDR;
 
-    private final BridgeConstants bridgeConstantsRegtest = BridgeRegTestConstants.getInstance();
-    private final NetworkParameters btcRegTestParams = bridgeConstantsRegtest.getBtcParams();
+    private final BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
+    private final NetworkParameters btcRegTestParams = bridgeRegTestConstants.getBtcParams();
     private final Instant creationTime = Instant.ofEpochMilli(1000L);
     private final long creationBlockNumber = 0L;
 
@@ -97,14 +97,14 @@ class BridgeSupportAddSignatureTest {
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         BridgeSupport bridgeSupport = new BridgeSupport(
-            bridgeConstantsRegtest,
+                bridgeRegTestConstants,
             provider,
             mock(BridgeEventLogger.class),
             new BtcLockSenderProvider(),
             new PeginInstructionsProvider(),
             mock(Repository.class),
             mock(Block.class),
-            new Context(bridgeConstantsRegtest.getBtcParams()),
+            new Context(bridgeRegTestConstants.getBtcParams()),
             mockFederationSupport,
             null,
             null,
@@ -129,14 +129,14 @@ class BridgeSupportAddSignatureTest {
         FederationSupport mockFederationSupport = mock(FederationSupport.class);
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         BridgeSupport bridgeSupport = new BridgeSupport(
-            bridgeConstantsRegtest,
+                bridgeRegTestConstants,
             provider,
             mock(BridgeEventLogger.class),
             new BtcLockSenderProvider(),
             new PeginInstructionsProvider(),
             mock(Repository.class),
             mock(Block.class),
-            new Context(bridgeConstantsRegtest.getBtcParams()),
+            new Context(bridgeRegTestConstants.getBtcParams()),
             mockFederationSupport,
             null,
             null,
@@ -192,14 +192,14 @@ class BridgeSupportAddSignatureTest {
         FederationSupport mockFederationSupport = mock(FederationSupport.class);
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         BridgeSupport bridgeSupport = new BridgeSupport(
-            bridgeConstantsRegtest,
+                bridgeRegTestConstants,
             provider,
             mock(BridgeEventLogger.class),
             new BtcLockSenderProvider(),
             new PeginInstructionsProvider(),
             mock(Repository.class),
             mock(Block.class),
-            new Context(bridgeConstantsRegtest.getBtcParams()),
+            new Context(bridgeRegTestConstants.getBtcParams()),
             mockFederationSupport,
             null,
             null,
@@ -254,7 +254,7 @@ class BridgeSupportAddSignatureTest {
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
 
         BridgeSupport bridgeSupport = bridgeSupportBuilder
-            .withBridgeConstants(bridgeConstantsRegtest)
+            .withBridgeConstants(bridgeRegTestConstants)
             .withProvider(provider)
             .withEventLogger(mock(BridgeEventLogger.class))
             .build();
@@ -271,18 +271,18 @@ class BridgeSupportAddSignatureTest {
     @Test
     void addSignatureToMissingTransaction() throws Exception {
         // Federation is the genesis federation ATM
-        Federation federation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
         Repository repository = createRepository();
 
         BridgeStorageProvider providerForSupport = new BridgeStorageProvider(
             repository,
             PrecompiledContracts.BRIDGE_ADDR,
-            bridgeConstantsRegtest,
+                bridgeRegTestConstants,
             activationsBeforeForks
         );
 
         BridgeSupport bridgeSupport = bridgeSupportBuilder
-            .withBridgeConstants(bridgeConstantsRegtest)
+            .withBridgeConstants(bridgeRegTestConstants)
             .withProvider(providerForSupport)
             .withRepository(repository)
             .build();
@@ -297,7 +297,7 @@ class BridgeSupportAddSignatureTest {
         BridgeStorageProvider provider = new BridgeStorageProvider(
             repository,
             PrecompiledContracts.BRIDGE_ADDR,
-            bridgeConstantsRegtest,
+                bridgeRegTestConstants,
             activationsBeforeForks
         );
 
@@ -310,11 +310,11 @@ class BridgeSupportAddSignatureTest {
         Repository repository = createRepository();
 
         BridgeSupport bridgeSupport = bridgeSupportBuilder
-                .withBridgeConstants(bridgeConstantsRegtest)
+                .withBridgeConstants(bridgeRegTestConstants)
                 .withProvider(new BridgeStorageProvider(
                         repository,
                         PrecompiledContracts.BRIDGE_ADDR,
-                        bridgeConstantsRegtest,
+                        bridgeRegTestConstants,
                         activationsBeforeForks))
                 .withRepository(repository)
                 .build();
@@ -323,7 +323,7 @@ class BridgeSupportAddSignatureTest {
         bridgeSupport.save();
 
         BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR,
-                bridgeConstantsRegtest, activationsBeforeForks);
+                bridgeRegTestConstants, activationsBeforeForks);
 
         assertTrue(provider.getPegoutsWaitingForSignatures().isEmpty());
     }
@@ -355,9 +355,9 @@ class BridgeSupportAddSignatureTest {
 
     private void test_addSignature_EventEmitted(boolean rskip326Active, boolean useValidSignature, int wantedNumberOfInvocations, boolean shouldSignTwice) throws Exception {
         // Setup
-        Federation federation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
         Repository track = createRepository().startTracking();
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, bridgeConstantsRegtest, activationsBeforeForks);
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, bridgeRegTestConstants, activationsBeforeForks);
 
         // Build prev btc tx
         BtcTransaction prevTx = new BtcTransaction(btcRegTestParams);
@@ -385,7 +385,7 @@ class BridgeSupportAddSignatureTest {
         when(activations.isActive(ConsensusRule.RSKIP326)).thenReturn(rskip326Active);
 
         BridgeSupport bridgeSupport = bridgeSupportBuilder
-                .withBridgeConstants(bridgeConstantsRegtest)
+                .withBridgeConstants(bridgeRegTestConstants)
                 .withProvider(provider)
                 .withRepository(track)
                 .withEventLogger(eventLogger)
@@ -478,13 +478,13 @@ class BridgeSupportAddSignatureTest {
     @Test
     void addSignatureMultipleInputsPartiallyValid() throws Exception {
         // Federation is the genesis federation ATM
-        Federation federation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
         Repository repository = createRepository();
 
         final Keccak256 keccak256 = createHash3(1);
 
         BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR,
-                bridgeConstantsRegtest, activationsBeforeForks);
+                bridgeRegTestConstants, activationsBeforeForks);
 
         BtcTransaction prevTx1 = new BtcTransaction(btcRegTestParams);
         TransactionOutput prevOut1 = new TransactionOutput(btcRegTestParams, prevTx1, Coin.FIFTY_COINS, federation.getAddress());
@@ -509,10 +509,10 @@ class BridgeSupportAddSignatureTest {
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         List<LogInfo> logs = new ArrayList<>();
-        BridgeEventLogger eventLogger = new BrigeEventLoggerLegacyImpl(bridgeConstantsRegtest, activations, logs, signatureCache);
+        BridgeEventLogger eventLogger = new BrigeEventLoggerLegacyImpl(bridgeRegTestConstants, activations, logs, signatureCache);
 
         BridgeSupport bridgeSupport = bridgeSupportBuilder
-                .withBridgeConstants(bridgeConstantsRegtest)
+                .withBridgeConstants(bridgeRegTestConstants)
                 .withProvider(provider)
                 .withRepository(repository)
                 .withEventLogger(eventLogger)
@@ -565,7 +565,7 @@ class BridgeSupportAddSignatureTest {
         bridgeSupport.addSignature(findPublicKeySignedBy(federation.getBtcPublicKeys(), privateKeyOfSecondFed), derEncodedSigsSecondFed, keccak256.getBytes());
         bridgeSupport.save();
 
-        provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, bridgeConstantsRegtest, activationsBeforeForks);
+        provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, bridgeRegTestConstants, activationsBeforeForks);
 
         assertTrue(provider.getPegoutsWaitingForSignatures().isEmpty());
         assertThat(logs, is(not(empty())));
@@ -716,13 +716,13 @@ class BridgeSupportAddSignatureTest {
      */
     private void addSignatureFromValidFederator(List<BtcECKey> privateKeysToSignWith, int numberOfInputsToSign, boolean signatureCanonical, boolean signTwice, String expectedResult) throws Exception {
         // Federation is the genesis federation ATM
-        Federation federation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
         Repository repository = createRepository();
 
         final Keccak256 keccak256 = PegTestUtils.createHash3();
 
         Repository track = repository.startTracking();
-        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, bridgeConstantsRegtest, activationsBeforeForks);
+        BridgeStorageProvider provider = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, bridgeRegTestConstants, activationsBeforeForks);
 
         BtcTransaction prevTx = new BtcTransaction(btcRegTestParams);
         TransactionOutput prevOut = new TransactionOutput(btcRegTestParams, prevTx, Coin.FIFTY_COINS, federation.getAddress());
@@ -741,14 +741,14 @@ class BridgeSupportAddSignatureTest {
         track = repository.startTracking();
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         List<LogInfo> logs = new ArrayList<>();
-        BridgeEventLogger eventLogger = new BrigeEventLoggerLegacyImpl(bridgeConstantsRegtest, activations, logs, signatureCache);
+        BridgeEventLogger eventLogger = new BrigeEventLoggerLegacyImpl(bridgeRegTestConstants, activations, logs, signatureCache);
 
         BridgeSupport bridgeSupport = bridgeSupportBuilder
-                .withBridgeConstants(bridgeConstantsRegtest)
+                .withBridgeConstants(bridgeRegTestConstants)
                 .withProvider(new BridgeStorageProvider(
                         track,
                         contractAddress,
-                        bridgeConstantsRegtest,
+                        bridgeRegTestConstants,
                         activationsAfterForks
                 ))
                 .withRepository(track)
@@ -797,7 +797,7 @@ class BridgeSupportAddSignatureTest {
         bridgeSupport.save();
         track.commit();
 
-        provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, bridgeConstantsRegtest, activationsBeforeForks);
+        provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, bridgeRegTestConstants, activationsBeforeForks);
 
         if ("FullySigned".equals(expectedResult)) {
             assertTrue(provider.getPegoutsWaitingForSignatures().isEmpty());

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
@@ -98,17 +98,17 @@ class BridgeSupportAddSignatureTest {
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         BridgeSupport bridgeSupport = new BridgeSupport(
                 bridgeRegTestConstants,
-            provider,
-            mock(BridgeEventLogger.class),
-            new BtcLockSenderProvider(),
-            new PeginInstructionsProvider(),
-            mock(Repository.class),
-            mock(Block.class),
-            new Context(bridgeRegTestConstants.getBtcParams()),
-            mockFederationSupport,
-            null,
-            null,
-            null
+                provider,
+                mock(BridgeEventLogger.class),
+                new BtcLockSenderProvider(),
+                new PeginInstructionsProvider(),
+                mock(Repository.class),
+                mock(Block.class),
+                new Context(bridgeRegTestConstants.getBtcParams()),
+                mockFederationSupport,
+                null,
+                null,
+                null
         );
 
         when(mockFederationSupport.getActiveFederation()).thenReturn(activeFederation);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
@@ -97,18 +97,18 @@ class BridgeSupportAddSignatureTest {
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         BridgeSupport bridgeSupport = new BridgeSupport(
-                bridgeRegTestConstants,
-                provider,
-                mock(BridgeEventLogger.class),
-                new BtcLockSenderProvider(),
-                new PeginInstructionsProvider(),
-                mock(Repository.class),
-                mock(Block.class),
-                new Context(bridgeRegTestConstants.getBtcParams()),
-                mockFederationSupport,
-                null,
-                null,
-                null
+            bridgeRegTestConstants,
+            provider,
+            mock(BridgeEventLogger.class),
+            new BtcLockSenderProvider(),
+            new PeginInstructionsProvider(),
+            mock(Repository.class),
+            mock(Block.class),
+            new Context(bridgeRegTestConstants.getBtcParams()),
+            mockFederationSupport,
+            null,
+            null,
+            null
         );
 
         when(mockFederationSupport.getActiveFederation()).thenReturn(activeFederation);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportFlyoverTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportFlyoverTest.java
@@ -2823,9 +2823,9 @@ class BridgeSupportFlyoverTest {
             signatureCache
         ));
 
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
-        doReturn(federation).when(bridgeSupport).getActiveFederation();
+        doReturn(genesisFederation).when(bridgeSupport).getActiveFederation();
         doReturn(true).when(bridgeSupport).validationsForRegisterBtcTransaction(any(), anyInt(), any(), any());
         doReturn(PegTestUtils.createHash3(1)).when(bridgeSupport).getFlyoverDerivationHash(
             any(Keccak256.class),
@@ -2900,9 +2900,9 @@ class BridgeSupportFlyoverTest {
             activations,
             signatureCache
         ));
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
-        doReturn(federation).when(bridgeSupport).getActiveFederation();
+        doReturn(genesisFederation).when(bridgeSupport).getActiveFederation();
         doReturn(true).when(bridgeSupport).validationsForRegisterBtcTransaction(any(), anyInt(), any(), any());
         doReturn(Coin.COIN).when(bridgeSupport).getLockingCap();
         doReturn(PegTestUtils.createHash3(1)).when(bridgeSupport).getFlyoverDerivationHash(
@@ -2989,9 +2989,9 @@ class BridgeSupportFlyoverTest {
             signatureCache
         ));
 
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
-        doReturn(federation).when(bridgeSupport).getActiveFederation();
+        doReturn(genesisFederation).when(bridgeSupport).getActiveFederation();
         doReturn(true).when(bridgeSupport).validationsForRegisterBtcTransaction(any(), anyInt(), any(), any());
         doReturn(Coin.COIN).when(bridgeSupport).getLockingCap();
         doReturn(PegTestUtils.createHash3(1)).when(bridgeSupport).getFlyoverDerivationHash(
@@ -3078,9 +3078,9 @@ class BridgeSupportFlyoverTest {
             activations,
             signatureCache
         ));
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
-        doReturn(federation).when(bridgeSupport).getActiveFederation();
+        doReturn(genesisFederation).when(bridgeSupport).getActiveFederation();
         doReturn(true).when(bridgeSupport).validationsForRegisterBtcTransaction(any(), anyInt(), any(), any());
         doReturn(
             Coin.COIN, // The first time we simulate a lower locking cap than the value to register, to force the reimburse
@@ -3186,9 +3186,9 @@ class BridgeSupportFlyoverTest {
             signatureCache
         ));
 
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
-        doReturn(federation).when(bridgeSupport).getActiveFederation();
+        doReturn(genesisFederation).when(bridgeSupport).getActiveFederation();
         doReturn(true).when(bridgeSupport).validationsForRegisterBtcTransaction(any(), anyInt(), any(), any());
         doReturn(PegTestUtils.createHash3(1)).when(bridgeSupport).getFlyoverDerivationHash(
             any(Keccak256.class),
@@ -3275,9 +3275,9 @@ class BridgeSupportFlyoverTest {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP176)).thenReturn(true);
 
-        Federation fed = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         FederationSupport federationSupport = mock(FederationSupport.class);
-        when(federationSupport.getActiveFederation()).thenReturn(fed);
+        when(federationSupport.getActiveFederation()).thenReturn(genesisFederation);
 
         BridgeSupport bridgeSupport = new BridgeSupport(
             bridgeConstantsRegtest,
@@ -3294,8 +3294,8 @@ class BridgeSupportFlyoverTest {
             signatureCache
         );
 
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
-        Script federationRedeemScript = federation.getRedeemScript();
+        Federation genesisFederation2 = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Script federationRedeemScript = genesisFederation2.getRedeemScript();
 
         Script flyoverRedeemScript = FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
             federationRedeemScript,
@@ -3307,7 +3307,7 @@ class BridgeSupportFlyoverTest {
 
         FlyoverFederationInformation expectedFlyoverFederationInformation =
             new FlyoverFederationInformation(derivationHash,
-                fed.getP2SHScript().getPubKeyHash(),
+                genesisFederation.getP2SHScript().getPubKeyHash(),
                 flyoverP2SH.getPubKeyHash()
             );
 
@@ -3343,11 +3343,11 @@ class BridgeSupportFlyoverTest {
             signatureCache
         );
 
-        Federation fed = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         Keccak256 derivationHash = PegTestUtils.createHash3(1);
 
         Script flyoverRedeemScript = FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
-            fed.getRedeemScript(),
+            genesisFederation.getRedeemScript(),
             Sha256Hash.wrap(derivationHash.getBytes())
         );
 
@@ -3356,7 +3356,7 @@ class BridgeSupportFlyoverTest {
         FlyoverFederationInformation flyoverFederationInformation =
             new FlyoverFederationInformation(
                 derivationHash,
-                fed.getP2SHScript().getPubKeyHash(),
+                genesisFederation.getP2SHScript().getPubKeyHash(),
                 flyoverP2SH.getPubKeyHash()
             );
 
@@ -3459,8 +3459,8 @@ class BridgeSupportFlyoverTest {
     }
 
     private Address getFlyoverFederationAddress() {
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
-        Script federationRedeemScript = federation.getRedeemScript();
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Script federationRedeemScript = genesisFederation.getRedeemScript();
 
         Script flyoverRedeemScript = FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
             federationRedeemScript,

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportFlyoverTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportFlyoverTest.java
@@ -42,6 +42,7 @@ import co.rsk.peg.bitcoin.CoinbaseInformation;
 import co.rsk.peg.btcLockSender.BtcLockSender;
 import co.rsk.peg.btcLockSender.BtcLockSenderProvider;
 import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationTestUtils;
 import co.rsk.peg.flyover.FlyoverFederationInformation;
 import co.rsk.peg.flyover.FlyoverTxResponseCodes;
 import co.rsk.peg.pegininstructions.PeginInstructionsProvider;
@@ -2822,7 +2823,9 @@ class BridgeSupportFlyoverTest {
             signatureCache
         ));
 
-        doReturn(bridgeConstantsRegtest.getGenesisFederation()).when(bridgeSupport).getActiveFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+
+        doReturn(federation).when(bridgeSupport).getActiveFederation();
         doReturn(true).when(bridgeSupport).validationsForRegisterBtcTransaction(any(), anyInt(), any(), any());
         doReturn(PegTestUtils.createHash3(1)).when(bridgeSupport).getFlyoverDerivationHash(
             any(Keccak256.class),
@@ -2897,8 +2900,9 @@ class BridgeSupportFlyoverTest {
             activations,
             signatureCache
         ));
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
-        doReturn(bridgeConstantsRegtest.getGenesisFederation()).when(bridgeSupport).getActiveFederation();
+        doReturn(federation).when(bridgeSupport).getActiveFederation();
         doReturn(true).when(bridgeSupport).validationsForRegisterBtcTransaction(any(), anyInt(), any(), any());
         doReturn(Coin.COIN).when(bridgeSupport).getLockingCap();
         doReturn(PegTestUtils.createHash3(1)).when(bridgeSupport).getFlyoverDerivationHash(
@@ -2985,7 +2989,9 @@ class BridgeSupportFlyoverTest {
             signatureCache
         ));
 
-        doReturn(bridgeConstantsRegtest.getGenesisFederation()).when(bridgeSupport).getActiveFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+
+        doReturn(federation).when(bridgeSupport).getActiveFederation();
         doReturn(true).when(bridgeSupport).validationsForRegisterBtcTransaction(any(), anyInt(), any(), any());
         doReturn(Coin.COIN).when(bridgeSupport).getLockingCap();
         doReturn(PegTestUtils.createHash3(1)).when(bridgeSupport).getFlyoverDerivationHash(
@@ -3072,8 +3078,9 @@ class BridgeSupportFlyoverTest {
             activations,
             signatureCache
         ));
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
-        doReturn(bridgeConstantsRegtest.getGenesisFederation()).when(bridgeSupport).getActiveFederation();
+        doReturn(federation).when(bridgeSupport).getActiveFederation();
         doReturn(true).when(bridgeSupport).validationsForRegisterBtcTransaction(any(), anyInt(), any(), any());
         doReturn(
             Coin.COIN, // The first time we simulate a lower locking cap than the value to register, to force the reimburse
@@ -3179,7 +3186,9 @@ class BridgeSupportFlyoverTest {
             signatureCache
         ));
 
-        doReturn(bridgeConstantsRegtest.getGenesisFederation()).when(bridgeSupport).getActiveFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+
+        doReturn(federation).when(bridgeSupport).getActiveFederation();
         doReturn(true).when(bridgeSupport).validationsForRegisterBtcTransaction(any(), anyInt(), any(), any());
         doReturn(PegTestUtils.createHash3(1)).when(bridgeSupport).getFlyoverDerivationHash(
             any(Keccak256.class),
@@ -3266,7 +3275,7 @@ class BridgeSupportFlyoverTest {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP176)).thenReturn(true);
 
-        Federation fed = bridgeConstantsRegtest.getGenesisFederation();
+        Federation fed = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         FederationSupport federationSupport = mock(FederationSupport.class);
         when(federationSupport.getActiveFederation()).thenReturn(fed);
 
@@ -3285,8 +3294,11 @@ class BridgeSupportFlyoverTest {
             signatureCache
         );
 
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Script federationRedeemScript = federation.getRedeemScript();
+
         Script flyoverRedeemScript = FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
-            bridgeConstantsRegtest.getGenesisFederation().getRedeemScript(),
+            federationRedeemScript,
             PegTestUtils.createHash(1)
         );
 
@@ -3331,7 +3343,7 @@ class BridgeSupportFlyoverTest {
             signatureCache
         );
 
-        Federation fed = bridgeConstantsRegtest.getGenesisFederation();
+        Federation fed = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         Keccak256 derivationHash = PegTestUtils.createHash3(1);
 
         Script flyoverRedeemScript = FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
@@ -3447,8 +3459,11 @@ class BridgeSupportFlyoverTest {
     }
 
     private Address getFlyoverFederationAddress() {
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Script federationRedeemScript = federation.getRedeemScript();
+
         Script flyoverRedeemScript = FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
-            bridgeConstantsRegtest.getGenesisFederation().getRedeemScript(),
+            federationRedeemScript,
             PegTestUtils.createHash(1)
         );
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportFlyoverTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportFlyoverTest.java
@@ -3275,9 +3275,9 @@ class BridgeSupportFlyoverTest {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP176)).thenReturn(true);
 
-        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         FederationSupport federationSupport = mock(FederationSupport.class);
-        when(federationSupport.getActiveFederation()).thenReturn(genesisFederation);
+        when(federationSupport.getActiveFederation()).thenReturn(activeFederation);
 
         BridgeSupport bridgeSupport = new BridgeSupport(
             bridgeConstantsRegtest,
@@ -3294,8 +3294,8 @@ class BridgeSupportFlyoverTest {
             signatureCache
         );
 
-        Federation genesisFederation2 = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
-        Script federationRedeemScript = genesisFederation2.getRedeemScript();
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Script federationRedeemScript = genesisFederation.getRedeemScript();
 
         Script flyoverRedeemScript = FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
             federationRedeemScript,
@@ -3307,7 +3307,7 @@ class BridgeSupportFlyoverTest {
 
         FlyoverFederationInformation expectedFlyoverFederationInformation =
             new FlyoverFederationInformation(derivationHash,
-                genesisFederation.getP2SHScript().getPubKeyHash(),
+                activeFederation.getP2SHScript().getPubKeyHash(),
                 flyoverP2SH.getPubKeyHash()
             );
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportFlyoverTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportFlyoverTest.java
@@ -92,6 +92,7 @@ class BridgeSupportFlyoverTest {
     private final BridgeConstants bridgeConstantsRegtest = BridgeRegTestConstants.getInstance();
     private final BridgeConstants bridgeConstantsMainnet = BridgeMainNetConstants.getInstance();
     protected final NetworkParameters btcRegTestParams = bridgeConstantsRegtest.getBtcParams();
+    protected final NetworkParameters btcMainnetParams = bridgeConstantsMainnet.getBtcParams();
     private BridgeSupportBuilder bridgeSupportBuilder;
     private ActivationConfig.ForBlock activations;
     private SignatureCache signatureCache;
@@ -2804,12 +2805,12 @@ class BridgeSupportFlyoverTest {
         when(activations.isActive(ConsensusRule.RSKIP176)).thenReturn(true);
 
         Context btcContext = mock(Context.class);
-        when(btcContext.getParams()).thenReturn(bridgeConstantsRegtest.getBtcParams());
+        when(btcContext.getParams()).thenReturn(bridgeConstantsMainnet.getBtcParams());
 
         RskAddress lbcAddress = PegTestUtils.createRandomRskAddress();
 
         BridgeSupport bridgeSupport = spy(new BridgeSupport(
-            bridgeConstantsRegtest,
+            bridgeConstantsMainnet,
             mock(BridgeStorageProvider.class),
             mock(BridgeEventLogger.class),
             new BtcLockSenderProvider(),
@@ -2823,7 +2824,7 @@ class BridgeSupportFlyoverTest {
             signatureCache
         ));
 
-        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsMainnet);
 
         doReturn(genesisFederation).when(bridgeSupport).getActiveFederation();
         doReturn(true).when(bridgeSupport).validationsForRegisterBtcTransaction(any(), anyInt(), any(), any());
@@ -2834,7 +2835,7 @@ class BridgeSupportFlyoverTest {
             any(RskAddress.class)
         );
 
-        BtcTransaction tx = createBtcTransactionWithOutputToAddress(Coin.COIN, new BtcECKey().toAddress(btcRegTestParams));
+        BtcTransaction tx = createBtcTransactionWithOutputToAddress(Coin.COIN, new BtcECKey().toAddress(btcMainnetParams));
         InternalTransaction rskTx = new InternalTransaction(
             Keccak256.ZERO_HASH.getBytes(),
             0,

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportProcessFundsMigrationTest.java
@@ -119,9 +119,9 @@ class BridgeSupportProcessFundsMigrationTest {
         ActivationConfig.ForBlock activations,
         boolean inMigrationAge
     ) throws IOException {
-        BridgeEventLogger bridgeEventLogger = mock(BridgeEventLogger.class);
 
-        Federation oldFederation = bridgeConstants.getGenesisFederation();
+        BridgeEventLogger bridgeEventLogger = mock(BridgeEventLogger.class);
+        Federation oldFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         long federationActivationAge = bridgeConstants.getFederationActivationAge(activations);
 
         long federationCreationBlockNumber = 5L;

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportRegisterBtcTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportRegisterBtcTransactionTest.java
@@ -1,29 +1,76 @@
 package co.rsk.peg;
 
-import co.rsk.bitcoinj.core.*;
+import static co.rsk.peg.BridgeSupportTestUtil.mockChainOfStoredBlocks;
+import static co.rsk.peg.PegTestUtils.createBaseInputScriptThatSpendsFromTheFederation;
+import static co.rsk.peg.PegTestUtils.createBech32Output;
+import static co.rsk.peg.PegTestUtils.createFederation;
+import static co.rsk.peg.pegin.RejectedPeginReason.INVALID_AMOUNT;
+import static co.rsk.peg.pegin.RejectedPeginReason.LEGACY_PEGIN_MULTISIG_SENDER;
+import static co.rsk.peg.pegin.RejectedPeginReason.PEGIN_V1_INVALID_PAYLOAD;
+import static co.rsk.peg.utils.UnrefundablePeginReason.LEGACY_PEGIN_UNDETERMINED_SENDER;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import co.rsk.bitcoinj.core.Address;
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.bitcoinj.core.Context;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.core.PartialMerkleTree;
+import co.rsk.bitcoinj.core.Sha256Hash;
+import co.rsk.bitcoinj.core.StoredBlock;
+import co.rsk.bitcoinj.core.TransactionWitness;
+import co.rsk.bitcoinj.core.UTXO;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.store.BlockStoreException;
-import co.rsk.peg.constants.BridgeConstants;
-import co.rsk.peg.constants.BridgeMainNetConstants;
-import co.rsk.peg.constants.BridgeRegTestConstants;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.peg.bitcoin.BitcoinTestUtils;
 import co.rsk.peg.bitcoin.CoinbaseInformation;
 import co.rsk.peg.btcLockSender.BtcLockSenderProvider;
-import co.rsk.peg.federation.*;
+import co.rsk.peg.constants.BridgeConstants;
+import co.rsk.peg.constants.BridgeMainNetConstants;
+import co.rsk.peg.constants.BridgeRegTestConstants;
+import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationArgs;
+import co.rsk.peg.federation.FederationFactory;
+import co.rsk.peg.federation.FederationMember;
+import co.rsk.peg.federation.FederationTestUtils;
 import co.rsk.peg.pegin.RejectedPeginReason;
 import co.rsk.peg.pegininstructions.PeginInstructionsProvider;
 import co.rsk.peg.utils.BridgeEventLogger;
 import co.rsk.peg.utils.UnrefundablePeginReason;
 import co.rsk.peg.whitelist.LockWhitelist;
 import co.rsk.test.builders.BridgeSupportBuilder;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
-import org.ethereum.core.*;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockTxSignatureCache;
+import org.ethereum.core.ReceivedTxSignatureCache;
+import org.ethereum.core.Repository;
+import org.ethereum.core.SignatureCache;
+import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.jupiter.api.Assertions;
@@ -33,25 +80,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.io.IOException;
-import java.math.BigInteger;
-import java.time.Instant;
-import java.util.*;
-import java.util.stream.Stream;
-
-import static co.rsk.peg.BridgeSupportTestUtil.mockChainOfStoredBlocks;
-import static co.rsk.peg.PegTestUtils.*;
-import static co.rsk.peg.pegin.RejectedPeginReason.*;
-import static co.rsk.peg.utils.UnrefundablePeginReason.LEGACY_PEGIN_UNDETERMINED_SENDER;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-
 class BridgeSupportRegisterBtcTransactionTest {
 
     private static final BridgeConstants bridgeMainnetConstants = BridgeMainNetConstants.getInstance();
     private static final NetworkParameters btcMainnetParams = bridgeMainnetConstants.getBtcParams();
-    private final BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
-
     private static final ActivationConfig.ForBlock fingerrootActivations = ActivationConfigsForTest.fingerroot500().forBlock(0);
     private static final ActivationConfig.ForBlock arrowhead600Activations = ActivationConfigsForTest.arrowhead600().forBlock(0);
 
@@ -2400,6 +2432,7 @@ class BridgeSupportRegisterBtcTransactionTest {
         // arrange
         int height = shouldUsePegoutTxIndex ? heightAtWhichToStartUsingPegoutIndex : 1;
 
+        BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
         NetworkParameters btcRegTestsParams = bridgeRegTestConstants.getBtcParams();
         Context.propagate(new Context(btcRegTestsParams));
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportRegisterBtcTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportRegisterBtcTransactionTest.java
@@ -50,6 +50,7 @@ class BridgeSupportRegisterBtcTransactionTest {
 
     private static final BridgeConstants bridgeMainnetConstants = BridgeMainNetConstants.getInstance();
     private static final NetworkParameters btcMainnetParams = bridgeMainnetConstants.getBtcParams();
+    private final BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
 
     private static final ActivationConfig.ForBlock fingerrootActivations = ActivationConfigsForTest.fingerroot500().forBlock(0);
     private static final ActivationConfig.ForBlock arrowhead600Activations = ActivationConfigsForTest.arrowhead600().forBlock(0);
@@ -2399,7 +2400,6 @@ class BridgeSupportRegisterBtcTransactionTest {
         // arrange
         int height = shouldUsePegoutTxIndex ? heightAtWhichToStartUsingPegoutIndex : 1;
 
-        BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
         NetworkParameters btcRegTestsParams = bridgeRegTestConstants.getBtcParams();
         Context.propagate(new Context(btcRegTestsParams));
 
@@ -2422,7 +2422,7 @@ class BridgeSupportRegisterBtcTransactionTest {
         when(provider.getPegoutsWaitingForConfirmations()).thenReturn(pegoutsWaitingForConfirmations);
 
         Federation oldFederation = createFederation(bridgeRegTestConstants, REGTEST_OLD_FEDERATION_PRIVATE_KEYS);
-        Federation activeFederation = bridgeRegTestConstants.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
 
         BtcTransaction migrationTx = new BtcTransaction(btcRegTestsParams);
         migrationTx.addInput(

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -647,7 +647,7 @@ class BridgeSupportReleaseBtcTest {
     void test_processPegoutsIndividually_before_RSKIP271_activation() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(false);
 
-        Federation federation = bridgeConstants.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         List<UTXO> utxos = new ArrayList<>();
         utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN.multiply(3), federation.getAddress()));
 
@@ -681,7 +681,7 @@ class BridgeSupportReleaseBtcTest {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
         when(activationMock.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
 
-        Federation federation = bridgeConstants.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         List<UTXO> utxos = new ArrayList<>();
         utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN.multiply(4), federation.getAddress()));
 
@@ -797,7 +797,7 @@ class BridgeSupportReleaseBtcTest {
     void test_processPegoutsInBatch_after_rskip_271_Insufficient_Money() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
-        Federation federation = bridgeConstants.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         List<UTXO> utxos = new ArrayList<>();
         utxos.add(PegTestUtils.createUTXO(2, 0, Coin.COIN.multiply(4), federation.getAddress()));
 
@@ -833,7 +833,7 @@ class BridgeSupportReleaseBtcTest {
     void test_processPegoutsInBatch_after_rskip_271_divide_transaction_when_max_size_exceeded() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
-        Federation federation = bridgeConstants.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         List<UTXO> utxos = PegTestUtils.createUTXOs(610, federation.getAddress());
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -867,7 +867,7 @@ class BridgeSupportReleaseBtcTest {
     void test_processPegoutsInBatch_after_rskip_271_when_max_size_exceeded_for_one_pegout() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
-        Federation federation = bridgeConstants.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         List<UTXO> utxos = PegTestUtils.createUTXOs(700, federation.getAddress());
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -895,7 +895,7 @@ class BridgeSupportReleaseBtcTest {
     void test_processPegoutsInBatch_after_rskip_271_when_max_size_exceeded_for_two_pegout() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
-        Federation federation = bridgeConstants.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         List<UTXO> utxos = PegTestUtils.createUTXOs(1400, federation.getAddress());
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -923,7 +923,7 @@ class BridgeSupportReleaseBtcTest {
     void test_processPegoutsIndividually_before_rskip_271_no_funds_to_process_any_requests() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(false);
 
-        Federation federation = bridgeConstants.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         List<UTXO> utxos = new ArrayList<>();
         utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN, federation.getAddress()));
         utxos.add(PegTestUtils.createUTXO(2, 1, Coin.COIN, federation.getAddress()));
@@ -960,7 +960,7 @@ class BridgeSupportReleaseBtcTest {
     void test_processPegoutsIndividually_before_rskip_271_no_funds_to_process_any_requests_order_changes_in_queue() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(false);
 
-        Federation federation = bridgeConstants.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         List<UTXO> utxos = new ArrayList<>();
         utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN, federation.getAddress()));
         utxos.add(PegTestUtils.createUTXO(2, 1, Coin.COIN, federation.getAddress()));
@@ -1010,7 +1010,7 @@ class BridgeSupportReleaseBtcTest {
     void test_check_wallet_balance_before_rskip_271_process_at_least_one_request() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(false);
 
-        Federation federation = bridgeConstants.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         List<UTXO> utxos = new ArrayList<>();
         utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN.multiply(2), federation.getAddress()));
 
@@ -1041,7 +1041,7 @@ class BridgeSupportReleaseBtcTest {
     void test_check_wallet_balance_after_rskip_271_process_no_requests() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
-        Federation federation = bridgeConstants.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         List<UTXO> utxos = new ArrayList<>();
         utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN.multiply(4), federation.getAddress()));
         utxos.add(PegTestUtils.createUTXO(2, 1, Coin.COIN.multiply(4), federation.getAddress()));
@@ -1077,7 +1077,7 @@ class BridgeSupportReleaseBtcTest {
     void test_check_wallet_balance_after_rskip_271_process_all_requests_when_utxos_available() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
-        Federation federation = bridgeConstants.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         List<UTXO> utxos = new ArrayList<>();
         utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN.multiply(4), federation.getAddress()));
         utxos.add(PegTestUtils.createUTXO(2, 1, Coin.COIN.multiply(4), federation.getAddress()));

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -647,9 +647,9 @@ class BridgeSupportReleaseBtcTest {
     void test_processPegoutsIndividually_before_RSKIP271_activation() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(false);
 
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         List<UTXO> utxos = new ArrayList<>();
-        utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN.multiply(3), federation.getAddress()));
+        utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN.multiply(3), genesisFederation.getAddress()));
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         when(provider.getNewFederationBtcUTXOs()).thenReturn(utxos);
@@ -681,9 +681,9 @@ class BridgeSupportReleaseBtcTest {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
         when(activationMock.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
 
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         List<UTXO> utxos = new ArrayList<>();
-        utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN.multiply(4), federation.getAddress()));
+        utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN.multiply(4), genesisFederation.getAddress()));
 
         ReleaseRequestQueue pegoutRequests = new ReleaseRequestQueue(
             Arrays.asList(
@@ -797,9 +797,9 @@ class BridgeSupportReleaseBtcTest {
     void test_processPegoutsInBatch_after_rskip_271_Insufficient_Money() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         List<UTXO> utxos = new ArrayList<>();
-        utxos.add(PegTestUtils.createUTXO(2, 0, Coin.COIN.multiply(4), federation.getAddress()));
+        utxos.add(PegTestUtils.createUTXO(2, 0, Coin.COIN.multiply(4), genesisFederation.getAddress()));
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
 
@@ -833,8 +833,8 @@ class BridgeSupportReleaseBtcTest {
     void test_processPegoutsInBatch_after_rskip_271_divide_transaction_when_max_size_exceeded() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
-        List<UTXO> utxos = PegTestUtils.createUTXOs(610, federation.getAddress());
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        List<UTXO> utxos = PegTestUtils.createUTXOs(610, genesisFederation.getAddress());
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
 
@@ -867,8 +867,8 @@ class BridgeSupportReleaseBtcTest {
     void test_processPegoutsInBatch_after_rskip_271_when_max_size_exceeded_for_one_pegout() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
-        List<UTXO> utxos = PegTestUtils.createUTXOs(700, federation.getAddress());
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        List<UTXO> utxos = PegTestUtils.createUTXOs(700, genesisFederation.getAddress());
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
 
@@ -895,8 +895,8 @@ class BridgeSupportReleaseBtcTest {
     void test_processPegoutsInBatch_after_rskip_271_when_max_size_exceeded_for_two_pegout() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
-        List<UTXO> utxos = PegTestUtils.createUTXOs(1400, federation.getAddress());
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        List<UTXO> utxos = PegTestUtils.createUTXOs(1400, genesisFederation.getAddress());
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
 
@@ -923,10 +923,10 @@ class BridgeSupportReleaseBtcTest {
     void test_processPegoutsIndividually_before_rskip_271_no_funds_to_process_any_requests() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(false);
 
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         List<UTXO> utxos = new ArrayList<>();
-        utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN, federation.getAddress()));
-        utxos.add(PegTestUtils.createUTXO(2, 1, Coin.COIN, federation.getAddress()));
+        utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN, genesisFederation.getAddress()));
+        utxos.add(PegTestUtils.createUTXO(2, 1, Coin.COIN, genesisFederation.getAddress()));
 
         List<ReleaseRequestQueue.Entry> entries = Arrays.asList(
             new ReleaseRequestQueue.Entry(PegTestUtils.createRandomP2PKHBtcAddress(bridgeConstants.getBtcParams()), Coin.COIN.multiply(5)),
@@ -960,10 +960,10 @@ class BridgeSupportReleaseBtcTest {
     void test_processPegoutsIndividually_before_rskip_271_no_funds_to_process_any_requests_order_changes_in_queue() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(false);
 
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         List<UTXO> utxos = new ArrayList<>();
-        utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN, federation.getAddress()));
-        utxos.add(PegTestUtils.createUTXO(2, 1, Coin.COIN, federation.getAddress()));
+        utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN, genesisFederation.getAddress()));
+        utxos.add(PegTestUtils.createUTXO(2, 1, Coin.COIN, genesisFederation.getAddress()));
 
         List<ReleaseRequestQueue.Entry> entries = new ArrayList<>();
         int entriesSizeAboveMaxIterations = BridgeSupport.MAX_RELEASE_ITERATIONS + 10;
@@ -1010,9 +1010,9 @@ class BridgeSupportReleaseBtcTest {
     void test_check_wallet_balance_before_rskip_271_process_at_least_one_request() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(false);
 
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         List<UTXO> utxos = new ArrayList<>();
-        utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN.multiply(2), federation.getAddress()));
+        utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN.multiply(2), genesisFederation.getAddress()));
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         when(provider.getNewFederationBtcUTXOs()).thenReturn(utxos);
@@ -1041,11 +1041,11 @@ class BridgeSupportReleaseBtcTest {
     void test_check_wallet_balance_after_rskip_271_process_no_requests() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         List<UTXO> utxos = new ArrayList<>();
-        utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN.multiply(4), federation.getAddress()));
-        utxos.add(PegTestUtils.createUTXO(2, 1, Coin.COIN.multiply(4), federation.getAddress()));
-        utxos.add(PegTestUtils.createUTXO(3, 2, Coin.COIN.multiply(3), federation.getAddress()));
+        utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN.multiply(4), genesisFederation.getAddress()));
+        utxos.add(PegTestUtils.createUTXO(2, 1, Coin.COIN.multiply(4), genesisFederation.getAddress()));
+        utxos.add(PegTestUtils.createUTXO(3, 2, Coin.COIN.multiply(3), genesisFederation.getAddress()));
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         when(provider.getNewFederationBtcUTXOs()).thenReturn(utxos);
@@ -1077,11 +1077,11 @@ class BridgeSupportReleaseBtcTest {
     void test_check_wallet_balance_after_rskip_271_process_all_requests_when_utxos_available() throws IOException {
         when(activationMock.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
 
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         List<UTXO> utxos = new ArrayList<>();
-        utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN.multiply(4), federation.getAddress()));
-        utxos.add(PegTestUtils.createUTXO(2, 1, Coin.COIN.multiply(4), federation.getAddress()));
-        utxos.add(PegTestUtils.createUTXO(3, 2, Coin.COIN.multiply(3), federation.getAddress()));
+        utxos.add(PegTestUtils.createUTXO(1, 0, Coin.COIN.multiply(4), genesisFederation.getAddress()));
+        utxos.add(PegTestUtils.createUTXO(2, 1, Coin.COIN.multiply(4), genesisFederation.getAddress()));
+        utxos.add(PegTestUtils.createUTXO(3, 2, Coin.COIN.multiply(3), genesisFederation.getAddress()));
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         when(provider.getNewFederationBtcUTXOs()).thenReturn(utxos);
@@ -1109,7 +1109,7 @@ class BridgeSupportReleaseBtcTest {
         verify(eventLogger, never()).logBatchPegoutCreated(any(), any());
         verify(provider, never()).setNextPegoutHeight(any(Long.class));
 
-        utxos.add(PegTestUtils.createUTXO(4, 3, Coin.COIN.multiply(1), federation.getAddress()));
+        utxos.add(PegTestUtils.createUTXO(4, 3, Coin.COIN.multiply(1), genesisFederation.getAddress()));
         when(provider.getNewFederationBtcUTXOs()).thenReturn(utxos);
         bridgeSupport = bridgeSupportBuilder
             .withBridgeConstants(bridgeConstants)

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSigHashTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSigHashTest.java
@@ -6,7 +6,6 @@ import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.peg.bitcoin.BitcoinUtils;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.constants.BridgeMainNetConstants;
-import co.rsk.peg.constants.BridgeRegTestConstants;
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.FederationArgs;
 import co.rsk.peg.federation.FederationFactory;
@@ -34,7 +33,6 @@ import static org.mockito.Mockito.*;
 class BridgeSupportSigHashTest {
 
     private static final BridgeConstants bridgeMainnetConstants = BridgeMainNetConstants.getInstance();
-    private final BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
     private static final NetworkParameters btcMainnetParams = bridgeMainnetConstants.getBtcParams();
 
     private BridgeStorageProvider provider;
@@ -112,7 +110,7 @@ class BridgeSupportSigHashTest {
 
         PegoutsWaitingForConfirmations pegoutsWaitingForConfirmations = provider.getPegoutsWaitingForConfirmations();
 
-        Federation oldFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation oldFederation = FederationTestUtils.getGenesisFederation(bridgeMainnetConstants);
         long newFedCreationBlockNumber = 5L;
 
         FederationArgs newFederationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
@@ -178,7 +176,7 @@ class BridgeSupportSigHashTest {
         when(provider.getReleaseRequestQueue())
             .thenReturn(new ReleaseRequestQueue(PegTestUtils.createReleaseRequestQueueEntries(3)));
 
-        Federation oldFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation oldFederation = FederationTestUtils.getGenesisFederation(bridgeMainnetConstants);
 
         long newFedCreationBlockNumber = 5L;
         FederationArgs newFederationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSigHashTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSigHashTest.java
@@ -60,8 +60,8 @@ class BridgeSupportSigHashTest {
     @ParameterizedTest
     @MethodSource("pegoutTxIndexArgsProvider")
     void test_pegoutTxIndex_when_pegout_batch_is_created(ActivationConfig.ForBlock activations) throws IOException {
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeMainnetConstants);
-        Address federationAddress = federation.getAddress();
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeMainnetConstants);
+        Address federationAddress = genesisFederation.getAddress();
         // Arrange
         List<UTXO> fedUTXOs = PegTestUtils.createUTXOs(
             10,

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSigHashTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSigHashTest.java
@@ -1,16 +1,12 @@
 package co.rsk.peg;
 
-import co.rsk.bitcoinj.core.Coin;
-import co.rsk.bitcoinj.core.Context;
-import co.rsk.bitcoinj.core.NetworkParameters;
-import co.rsk.bitcoinj.core.Sha256Hash;
-import co.rsk.bitcoinj.core.TransactionOutput;
-import co.rsk.bitcoinj.core.UTXO;
+import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.wallet.Wallet;
 import co.rsk.blockchain.utils.BlockGenerator;
+import co.rsk.peg.bitcoin.BitcoinUtils;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.constants.BridgeMainNetConstants;
-import co.rsk.peg.bitcoin.BitcoinUtils;
+import co.rsk.peg.constants.BridgeRegTestConstants;
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.FederationArgs;
 import co.rsk.peg.federation.FederationFactory;
@@ -27,27 +23,18 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class BridgeSupportSigHashTest {
 
     private static final BridgeConstants bridgeMainnetConstants = BridgeMainNetConstants.getInstance();
+    private final BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
     private static final NetworkParameters btcMainnetParams = bridgeMainnetConstants.getBtcParams();
 
     private BridgeStorageProvider provider;
@@ -75,10 +62,12 @@ class BridgeSupportSigHashTest {
     @ParameterizedTest
     @MethodSource("pegoutTxIndexArgsProvider")
     void test_pegoutTxIndex_when_pegout_batch_is_created(ActivationConfig.ForBlock activations) throws IOException {
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeMainnetConstants);
+        Address federationAddress = federation.getAddress();
         // Arrange
         List<UTXO> fedUTXOs = PegTestUtils.createUTXOs(
             10,
-            bridgeMainnetConstants.getGenesisFederation().getAddress()
+            federationAddress
         );
         when(provider.getNewFederationBtcUTXOs())
             .thenReturn(fedUTXOs);
@@ -123,7 +112,7 @@ class BridgeSupportSigHashTest {
 
         PegoutsWaitingForConfirmations pegoutsWaitingForConfirmations = provider.getPegoutsWaitingForConfirmations();
 
-        Federation oldFederation = bridgeMainnetConstants.getGenesisFederation();
+        Federation oldFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
         long newFedCreationBlockNumber = 5L;
 
         FederationArgs newFederationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
@@ -189,7 +178,7 @@ class BridgeSupportSigHashTest {
         when(provider.getReleaseRequestQueue())
             .thenReturn(new ReleaseRequestQueue(PegTestUtils.createReleaseRequestQueueEntries(3)));
 
-        Federation oldFederation = bridgeMainnetConstants.getGenesisFederation();
+        Federation oldFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
 
         long newFedCreationBlockNumber = 5L;
         FederationArgs newFederationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -347,7 +347,7 @@ class BridgeSupportTest {
     @Test
     void getActivePowpegRedeemScript_after_RSKIP293_activation() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
         BridgeSupport bridgeSupport = bridgeSupportBuilder
@@ -355,7 +355,7 @@ class BridgeSupportTest {
             .withActivations(activations)
             .build();
 
-        Script federationRedeemScript = federation.getRedeemScript();
+        Script federationRedeemScript = genesisFederation.getRedeemScript();
 
         assertTrue(bridgeSupport.getActivePowpegRedeemScript().isPresent());
         assertEquals(
@@ -578,7 +578,7 @@ class BridgeSupportTest {
         when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(false);
         BridgeEventLogger mockedEventLogger = mock(BridgeEventLogger.class);
 
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         BridgeStorageProvider mockBridgeStorageProvider = mock(BridgeStorageProvider.class);
         when(mockBridgeStorageProvider.getHeightIfBtcTxhashIsAlreadyProcessed(any(Sha256Hash.class))).thenReturn(Optional.empty());
@@ -586,7 +586,7 @@ class BridgeSupportTest {
         LockWhitelist lockWhitelist = mock(LockWhitelist.class);
         when(lockWhitelist.isWhitelistedFor(any(Address.class), any(Coin.class), any(int.class))).thenReturn(true);
         when(mockBridgeStorageProvider.getLockWhitelist()).thenReturn(lockWhitelist);
-        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(federation);
+        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(genesisFederation);
 
         Block executionBlock = mock(Block.class);
         BtcBlockStoreWithCache.Factory btcBlockStoreFactory = mock(BtcBlockStoreWithCache.Factory.class);
@@ -637,7 +637,7 @@ class BridgeSupportTest {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
 
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         BridgeEventLogger mockedEventLogger = mock(BridgeEventLogger.class);
 
@@ -647,7 +647,7 @@ class BridgeSupportTest {
         LockWhitelist lockWhitelist = mock(LockWhitelist.class);
         when(lockWhitelist.isWhitelistedFor(any(Address.class), any(Coin.class), any(int.class))).thenReturn(true);
         when(mockBridgeStorageProvider.getLockWhitelist()).thenReturn(lockWhitelist);
-        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(federation);
+        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(genesisFederation);
 
         Block executionBlock = mock(Block.class);
         BtcBlockStoreWithCache.Factory btcBlockStoreFactory = mock(BtcBlockStoreWithCache.Factory.class);
@@ -710,7 +710,7 @@ class BridgeSupportTest {
         when(activations.isActive(ConsensusRule.RSKIP181)).thenReturn(false);
 
         BridgeEventLogger mockedEventLogger = mock(BridgeEventLogger.class);
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         BridgeStorageProvider mockBridgeStorageProvider = mock(BridgeStorageProvider.class);
         when(mockBridgeStorageProvider.getHeightIfBtcTxhashIsAlreadyProcessed(any(Sha256Hash.class))).thenReturn(Optional.empty());
@@ -718,7 +718,7 @@ class BridgeSupportTest {
         LockWhitelist lockWhitelist = mock(LockWhitelist.class);
         when(lockWhitelist.isWhitelistedFor(any(Address.class), any(Coin.class), any(int.class))).thenReturn(true);
         when(mockBridgeStorageProvider.getLockWhitelist()).thenReturn(lockWhitelist);
-        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(federation);
+        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(genesisFederation);
 
         Block executionBlock = mock(Block.class);
         BtcBlockStoreWithCache.Factory btcBlockStoreFactory = mock(BtcBlockStoreWithCache.Factory.class);
@@ -778,7 +778,7 @@ class BridgeSupportTest {
         when(activations.isActive(ConsensusRule.RSKIP181)).thenReturn(true);
 
         BridgeEventLogger mockedEventLogger = mock(BridgeEventLogger.class);
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         BridgeStorageProvider mockBridgeStorageProvider = mock(BridgeStorageProvider.class);
         when(mockBridgeStorageProvider.getHeightIfBtcTxhashIsAlreadyProcessed(any(Sha256Hash.class))).thenReturn(Optional.empty());
@@ -786,7 +786,7 @@ class BridgeSupportTest {
         LockWhitelist lockWhitelist = mock(LockWhitelist.class);
         when(lockWhitelist.isWhitelistedFor(any(Address.class), any(Coin.class), any(int.class))).thenReturn(true);
         when(mockBridgeStorageProvider.getLockWhitelist()).thenReturn(lockWhitelist);
-        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(federation);
+        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(genesisFederation);
 
         Block executionBlock = mock(Block.class);
         BtcBlockStoreWithCache.Factory btcBlockStoreFactory = mock(BtcBlockStoreWithCache.Factory.class);
@@ -846,7 +846,7 @@ class BridgeSupportTest {
         when(activations.isActive(ConsensusRule.RSKIP170)).thenReturn(false);
 
         BridgeEventLogger mockedEventLogger = mock(BridgeEventLogger.class);
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         BridgeStorageProvider mockBridgeStorageProvider = mock(BridgeStorageProvider.class);
         when(mockBridgeStorageProvider.getHeightIfBtcTxhashIsAlreadyProcessed(any(Sha256Hash.class))).thenReturn(Optional.empty());
@@ -854,7 +854,7 @@ class BridgeSupportTest {
         LockWhitelist lockWhitelist = mock(LockWhitelist.class);
         when(lockWhitelist.isWhitelistedFor(any(Address.class), any(Coin.class), any(int.class))).thenReturn(true);
         when(mockBridgeStorageProvider.getLockWhitelist()).thenReturn(lockWhitelist);
-        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(federation);
+        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(genesisFederation);
 
         Block executionBlock = mock(Block.class);
         BtcBlockStoreWithCache.Factory btcBlockStoreFactory = mock(BtcBlockStoreWithCache.Factory.class);
@@ -908,7 +908,7 @@ class BridgeSupportTest {
         when(activations.isActive(ConsensusRule.RSKIP170)).thenReturn(true);
 
         BridgeEventLogger mockedEventLogger = mock(BridgeEventLogger.class);
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         BridgeStorageProvider mockBridgeStorageProvider = mock(BridgeStorageProvider.class);
         when(mockBridgeStorageProvider.getHeightIfBtcTxhashIsAlreadyProcessed(any(Sha256Hash.class))).thenReturn(Optional.empty());
@@ -916,7 +916,7 @@ class BridgeSupportTest {
         LockWhitelist lockWhitelist = mock(LockWhitelist.class);
         when(lockWhitelist.isWhitelistedFor(any(Address.class), any(Coin.class), any(int.class))).thenReturn(true);
         when(mockBridgeStorageProvider.getLockWhitelist()).thenReturn(lockWhitelist);
-        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(federation);
+        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(genesisFederation);
 
         Block executionBlock = mock(Block.class);
         BtcBlockStoreWithCache.Factory btcBlockStoreFactory = mock(BtcBlockStoreWithCache.Factory.class);
@@ -5829,11 +5829,11 @@ class BridgeSupportTest {
     @Test
     void validationsForRegisterBtcTransaction_successful() throws IOException, BlockStoreException, BridgeIllegalArgumentException {
         BridgeStorageProvider mockBridgeStorageProvider = mock(BridgeStorageProvider.class);
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         when(mockBridgeStorageProvider.getHeightIfBtcTxhashIsAlreadyProcessed(any(Sha256Hash.class))).thenReturn(Optional.empty());
 
-        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(federation);
+        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(genesisFederation);
 
         BtcBlockStoreWithCache.Factory btcBlockStoreFactory = mock(BtcBlockStoreWithCache.Factory.class);
 
@@ -5974,8 +5974,8 @@ class BridgeSupportTest {
         when(activations.isActive(ConsensusRule.RSKIP170)).thenReturn(false);
 
         Repository repository = createRepository();
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
-        Address federationAddress = federation.getAddress();
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Address federationAddress = genesisFederation.getAddress();
 
         BtcTransaction btcTx = new BtcTransaction(btcRegTestParams);
         btcTx.addOutput(Coin.COIN.multiply(10), federationAddress);
@@ -6026,8 +6026,8 @@ class BridgeSupportTest {
         ECKey key = ECKey.fromPublicOnly(srcKey1.getPubKey());
         RskAddress rskAddress = new RskAddress(key.getAddress());
         Address btcSenderAddress = srcKey1.toAddress(btcRegTestParams);
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
-        Address federationAddress = federation.getAddress();
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Address federationAddress = genesisFederation.getAddress();
 
         BtcTransaction btcTx = new BtcTransaction(btcRegTestParams);
         btcTx.addOutput(Coin.COIN.multiply(10), federationAddress);
@@ -6362,8 +6362,8 @@ class BridgeSupportTest {
         ECKey key = ECKey.fromPublicOnly(srcKey1.getPubKey());
         Address btcAddress = srcKey1.toAddress(btcRegTestParams);
         RskAddress rskAddress = new RskAddress(key.getAddress());
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
-        Address federationAddress = federation.getAddress();
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Address federationAddress = genesisFederation.getAddress();
 
         BtcTransaction btcTx = new BtcTransaction(btcRegTestParams);
         btcTx.addOutput(Coin.COIN.multiply(10), federationAddress);
@@ -6605,7 +6605,7 @@ class BridgeSupportTest {
             PegTestUtils.createRandomBtcECKeys(7)
         );
 
-        Federation standardFed = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        Federation standardFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
 
         ActivationConfig.ForBlock preRSKIP271_activations = mock(ActivationConfig.ForBlock.class);
         when(preRSKIP271_activations.isActive(ConsensusRule.RSKIP271)).thenReturn(false);
@@ -6619,21 +6619,21 @@ class BridgeSupportTest {
             // active fed is standard and pegoutRequestsCount is equal to zero
             Arguments.of(
                 preRSKIP271_activations,
-                standardFed,
+                standardFederation,
                 0,
                 Coin.valueOf(0L)
             ),
             // active fed is standard and pegoutRequestsCount is equal to one
             Arguments.of(
                 preRSKIP271_activations,
-                standardFed,
+                standardFederation,
                 1,
                 Coin.valueOf(0L)
             ),
             // active fed is standard and there are many pegout requests
             Arguments.of(
                 preRSKIP271_activations,
-                standardFed,
+                standardFederation,
                 150,
                 Coin.valueOf(0L)
             ),
@@ -6667,7 +6667,7 @@ class BridgeSupportTest {
             PegTestUtils.createRandomBtcECKeys(7)
         );
 
-        Federation standardFed = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        Federation standardFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
 
         ActivationConfig.ForBlock preRSKIP385_activations = mock(ActivationConfig.ForBlock.class);
         when(preRSKIP385_activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
@@ -6685,21 +6685,21 @@ class BridgeSupportTest {
             // active fed is standard and pegoutRequestsCount is equal to zero
             Arguments.of(
                 preRSKIP385_activations,
-                standardFed,
+                standardFederation,
                 0,
                 Coin.valueOf(0L)
             ),
             // active fed is standard and pegoutRequestsCount is equal to one
             Arguments.of(
                 preRSKIP385_activations,
-                standardFed,
+                standardFederation,
                 1,
                 Coin.valueOf(bridgeConstants instanceof BridgeMainNetConstants? 237000L: 68600L)
             ),
             // active fed is standard and there are many pegout requests
             Arguments.of(
                 preRSKIP385_activations,
-                standardFed,
+                standardFederation,
                 150,
                 Coin.valueOf(bridgeConstants instanceof BridgeMainNetConstants? 713800L: 545400L)
             ),
@@ -6733,7 +6733,7 @@ class BridgeSupportTest {
         when(postRSKIP385_activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
         when(postRSKIP385_activations.isActive(ConsensusRule.RSKIP385)).thenReturn(true);
 
-        Federation standardFed = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        Federation standardFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         List<FederationMember> members = FederationMember.getFederationMembersFromKeys(
             PegTestUtils.createRandomBtcECKeys(7)
         );
@@ -6750,21 +6750,21 @@ class BridgeSupportTest {
             // active fed is standard and pegoutRequestsCount is equal to zero
             Arguments.of(
                 postRSKIP385_activations,
-                standardFed,
+                standardFederation,
                 0,
                 Coin.valueOf(bridgeConstants instanceof BridgeMainNetConstants? 233800L: 65400L)
             ),
             // active fed is standard and pegoutRequestsCount is equal to one
             Arguments.of(
                 postRSKIP385_activations,
-                standardFed,
+                standardFederation,
                 1,
                 Coin.valueOf(bridgeConstants instanceof BridgeMainNetConstants? 237000L: 68600L)
             ),
             // active fed is standard and there are many pegout requests
             Arguments.of(
                 postRSKIP385_activations,
-                standardFed,
+                standardFederation,
                 150,
                 Coin.valueOf(bridgeConstants instanceof BridgeMainNetConstants? 713800L: 545400L)
             ),
@@ -6850,8 +6850,8 @@ class BridgeSupportTest {
         List<ConsensusRule> consensusRules)
         throws IOException, RegisterBtcTransactionException, PeginInstructionsException {
 
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
-        Address federationAddress = federation.getAddress();
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Address federationAddress = genesisFederation.getAddress();
 
         // Arrange
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -347,6 +347,7 @@ class BridgeSupportTest {
     @Test
     void getActivePowpegRedeemScript_after_RSKIP293_activation() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
         BridgeSupport bridgeSupport = bridgeSupportBuilder
@@ -354,9 +355,11 @@ class BridgeSupportTest {
             .withActivations(activations)
             .build();
 
+        Script federationRedeemScript = federation.getRedeemScript();
+
         assertTrue(bridgeSupport.getActivePowpegRedeemScript().isPresent());
         assertEquals(
-            bridgeConstantsRegtest.getGenesisFederation().getRedeemScript(),
+            federationRedeemScript,
             bridgeSupport.getActivePowpegRedeemScript().get()
         );
     }
@@ -573,8 +576,9 @@ class BridgeSupportTest {
     void eventLoggerLogLockBtc_before_rskip_146_activation() throws Exception {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(false);
-
         BridgeEventLogger mockedEventLogger = mock(BridgeEventLogger.class);
+
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         BridgeStorageProvider mockBridgeStorageProvider = mock(BridgeStorageProvider.class);
         when(mockBridgeStorageProvider.getHeightIfBtcTxhashIsAlreadyProcessed(any(Sha256Hash.class))).thenReturn(Optional.empty());
@@ -582,7 +586,7 @@ class BridgeSupportTest {
         LockWhitelist lockWhitelist = mock(LockWhitelist.class);
         when(lockWhitelist.isWhitelistedFor(any(Address.class), any(Coin.class), any(int.class))).thenReturn(true);
         when(mockBridgeStorageProvider.getLockWhitelist()).thenReturn(lockWhitelist);
-        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(bridgeConstantsRegtest.getGenesisFederation());
+        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(federation);
 
         Block executionBlock = mock(Block.class);
         BtcBlockStoreWithCache.Factory btcBlockStoreFactory = mock(BtcBlockStoreWithCache.Factory.class);
@@ -633,6 +637,8 @@ class BridgeSupportTest {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP146)).thenReturn(true);
 
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+
         BridgeEventLogger mockedEventLogger = mock(BridgeEventLogger.class);
 
         BridgeStorageProvider mockBridgeStorageProvider = mock(BridgeStorageProvider.class);
@@ -641,7 +647,7 @@ class BridgeSupportTest {
         LockWhitelist lockWhitelist = mock(LockWhitelist.class);
         when(lockWhitelist.isWhitelistedFor(any(Address.class), any(Coin.class), any(int.class))).thenReturn(true);
         when(mockBridgeStorageProvider.getLockWhitelist()).thenReturn(lockWhitelist);
-        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(bridgeConstantsRegtest.getGenesisFederation());
+        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(federation);
 
         Block executionBlock = mock(Block.class);
         BtcBlockStoreWithCache.Factory btcBlockStoreFactory = mock(BtcBlockStoreWithCache.Factory.class);
@@ -704,6 +710,7 @@ class BridgeSupportTest {
         when(activations.isActive(ConsensusRule.RSKIP181)).thenReturn(false);
 
         BridgeEventLogger mockedEventLogger = mock(BridgeEventLogger.class);
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         BridgeStorageProvider mockBridgeStorageProvider = mock(BridgeStorageProvider.class);
         when(mockBridgeStorageProvider.getHeightIfBtcTxhashIsAlreadyProcessed(any(Sha256Hash.class))).thenReturn(Optional.empty());
@@ -711,7 +718,7 @@ class BridgeSupportTest {
         LockWhitelist lockWhitelist = mock(LockWhitelist.class);
         when(lockWhitelist.isWhitelistedFor(any(Address.class), any(Coin.class), any(int.class))).thenReturn(true);
         when(mockBridgeStorageProvider.getLockWhitelist()).thenReturn(lockWhitelist);
-        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(bridgeConstantsRegtest.getGenesisFederation());
+        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(federation);
 
         Block executionBlock = mock(Block.class);
         BtcBlockStoreWithCache.Factory btcBlockStoreFactory = mock(BtcBlockStoreWithCache.Factory.class);
@@ -771,6 +778,7 @@ class BridgeSupportTest {
         when(activations.isActive(ConsensusRule.RSKIP181)).thenReturn(true);
 
         BridgeEventLogger mockedEventLogger = mock(BridgeEventLogger.class);
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         BridgeStorageProvider mockBridgeStorageProvider = mock(BridgeStorageProvider.class);
         when(mockBridgeStorageProvider.getHeightIfBtcTxhashIsAlreadyProcessed(any(Sha256Hash.class))).thenReturn(Optional.empty());
@@ -778,7 +786,7 @@ class BridgeSupportTest {
         LockWhitelist lockWhitelist = mock(LockWhitelist.class);
         when(lockWhitelist.isWhitelistedFor(any(Address.class), any(Coin.class), any(int.class))).thenReturn(true);
         when(mockBridgeStorageProvider.getLockWhitelist()).thenReturn(lockWhitelist);
-        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(bridgeConstantsRegtest.getGenesisFederation());
+        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(federation);
 
         Block executionBlock = mock(Block.class);
         BtcBlockStoreWithCache.Factory btcBlockStoreFactory = mock(BtcBlockStoreWithCache.Factory.class);
@@ -838,6 +846,7 @@ class BridgeSupportTest {
         when(activations.isActive(ConsensusRule.RSKIP170)).thenReturn(false);
 
         BridgeEventLogger mockedEventLogger = mock(BridgeEventLogger.class);
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         BridgeStorageProvider mockBridgeStorageProvider = mock(BridgeStorageProvider.class);
         when(mockBridgeStorageProvider.getHeightIfBtcTxhashIsAlreadyProcessed(any(Sha256Hash.class))).thenReturn(Optional.empty());
@@ -845,7 +854,7 @@ class BridgeSupportTest {
         LockWhitelist lockWhitelist = mock(LockWhitelist.class);
         when(lockWhitelist.isWhitelistedFor(any(Address.class), any(Coin.class), any(int.class))).thenReturn(true);
         when(mockBridgeStorageProvider.getLockWhitelist()).thenReturn(lockWhitelist);
-        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(bridgeConstantsRegtest.getGenesisFederation());
+        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(federation);
 
         Block executionBlock = mock(Block.class);
         BtcBlockStoreWithCache.Factory btcBlockStoreFactory = mock(BtcBlockStoreWithCache.Factory.class);
@@ -899,6 +908,7 @@ class BridgeSupportTest {
         when(activations.isActive(ConsensusRule.RSKIP170)).thenReturn(true);
 
         BridgeEventLogger mockedEventLogger = mock(BridgeEventLogger.class);
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         BridgeStorageProvider mockBridgeStorageProvider = mock(BridgeStorageProvider.class);
         when(mockBridgeStorageProvider.getHeightIfBtcTxhashIsAlreadyProcessed(any(Sha256Hash.class))).thenReturn(Optional.empty());
@@ -906,7 +916,7 @@ class BridgeSupportTest {
         LockWhitelist lockWhitelist = mock(LockWhitelist.class);
         when(lockWhitelist.isWhitelistedFor(any(Address.class), any(Coin.class), any(int.class))).thenReturn(true);
         when(mockBridgeStorageProvider.getLockWhitelist()).thenReturn(lockWhitelist);
-        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(bridgeConstantsRegtest.getGenesisFederation());
+        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(federation);
 
         Block executionBlock = mock(Block.class);
         BtcBlockStoreWithCache.Factory btcBlockStoreFactory = mock(BtcBlockStoreWithCache.Factory.class);
@@ -1426,7 +1436,7 @@ class BridgeSupportTest {
 
         BridgeEventLogger bridgeEventLogger = mock(BridgeEventLogger.class);
 
-        Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation oldFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         FederationArgs newFederationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
@@ -1491,7 +1501,7 @@ class BridgeSupportTest {
 
         BridgeEventLogger bridgeEventLogger = mock(BridgeEventLogger.class);
 
-        Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation oldFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         FederationArgs newFederationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
@@ -1558,7 +1568,7 @@ class BridgeSupportTest {
 
         BridgeEventLogger bridgeEventLogger = mock(BridgeEventLogger.class);
 
-        Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation oldFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         FederationArgs newFederationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
@@ -1623,7 +1633,7 @@ class BridgeSupportTest {
 
         BridgeEventLogger bridgeEventLogger = mock(BridgeEventLogger.class);
 
-        Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation oldFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         FederationArgs newFederationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
@@ -1689,7 +1699,7 @@ class BridgeSupportTest {
 
         BridgeEventLogger bridgeEventLogger = mock(BridgeEventLogger.class);
 
-        Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation oldFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         FederationArgs newFederationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
@@ -1754,7 +1764,7 @@ class BridgeSupportTest {
 
         BridgeEventLogger bridgeEventLogger = mock(BridgeEventLogger.class);
 
-        Federation oldFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation oldFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         FederationArgs newFederationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
@@ -2138,7 +2148,7 @@ class BridgeSupportTest {
         ActivationConfig.ForBlock fingerrootActivations = ActivationConfigsForTest.fingerroot500().forBlock(0);
 
         // Set state to make concur a pegout migration tx and pegout batch creation on the same updateCollection
-        Federation oldFederation = bridgeConstants.getGenesisFederation();
+        Federation oldFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         FederationArgs newFederationArgs = new FederationArgs(FederationTestUtils.getFederationMembers(1),
             Instant.EPOCH,
             5L,
@@ -5819,9 +5829,11 @@ class BridgeSupportTest {
     @Test
     void validationsForRegisterBtcTransaction_successful() throws IOException, BlockStoreException, BridgeIllegalArgumentException {
         BridgeStorageProvider mockBridgeStorageProvider = mock(BridgeStorageProvider.class);
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+
         when(mockBridgeStorageProvider.getHeightIfBtcTxhashIsAlreadyProcessed(any(Sha256Hash.class))).thenReturn(Optional.empty());
 
-        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(bridgeConstantsRegtest.getGenesisFederation());
+        when(mockBridgeStorageProvider.getNewFederation()).thenReturn(federation);
 
         BtcBlockStoreWithCache.Factory btcBlockStoreFactory = mock(BtcBlockStoreWithCache.Factory.class);
 
@@ -5962,9 +5974,11 @@ class BridgeSupportTest {
         when(activations.isActive(ConsensusRule.RSKIP170)).thenReturn(false);
 
         Repository repository = createRepository();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Address federationAddress = federation.getAddress();
 
         BtcTransaction btcTx = new BtcTransaction(btcRegTestParams);
-        btcTx.addOutput(Coin.COIN.multiply(10), bridgeConstantsRegtest.getGenesisFederation().getAddress());
+        btcTx.addOutput(Coin.COIN.multiply(10), federationAddress);
         btcTx.addInput(PegTestUtils.createHash(1), 0, new Script(new byte[]{}));
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -6012,9 +6026,11 @@ class BridgeSupportTest {
         ECKey key = ECKey.fromPublicOnly(srcKey1.getPubKey());
         RskAddress rskAddress = new RskAddress(key.getAddress());
         Address btcSenderAddress = srcKey1.toAddress(btcRegTestParams);
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Address federationAddress = federation.getAddress();
 
         BtcTransaction btcTx = new BtcTransaction(btcRegTestParams);
-        btcTx.addOutput(Coin.COIN.multiply(10), bridgeConstantsRegtest.getGenesisFederation().getAddress());
+        btcTx.addOutput(Coin.COIN.multiply(10), federationAddress);
         btcTx.addInput(PegTestUtils.createHash(1), 0, new Script(new byte[]{}));
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -6346,9 +6362,11 @@ class BridgeSupportTest {
         ECKey key = ECKey.fromPublicOnly(srcKey1.getPubKey());
         Address btcAddress = srcKey1.toAddress(btcRegTestParams);
         RskAddress rskAddress = new RskAddress(key.getAddress());
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Address federationAddress = federation.getAddress();
 
         BtcTransaction btcTx = new BtcTransaction(btcRegTestParams);
-        btcTx.addOutput(Coin.COIN.multiply(10), bridgeConstantsRegtest.getGenesisFederation().getAddress());
+        btcTx.addOutput(Coin.COIN.multiply(10), federationAddress);
         btcTx.addInput(PegTestUtils.createHash(1), 0, new Script(new byte[]{}));
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
@@ -6587,7 +6605,7 @@ class BridgeSupportTest {
             PegTestUtils.createRandomBtcECKeys(7)
         );
 
-        Federation standardFed = bridgeConstants.getGenesisFederation();
+        Federation standardFed = FederationTestUtils.getGenesisFederation(bridgeConstants);
 
         ActivationConfig.ForBlock preRSKIP271_activations = mock(ActivationConfig.ForBlock.class);
         when(preRSKIP271_activations.isActive(ConsensusRule.RSKIP271)).thenReturn(false);
@@ -6649,7 +6667,7 @@ class BridgeSupportTest {
             PegTestUtils.createRandomBtcECKeys(7)
         );
 
-        Federation standardFed = bridgeConstants.getGenesisFederation();
+        Federation standardFed = FederationTestUtils.getGenesisFederation(bridgeConstants);
 
         ActivationConfig.ForBlock preRSKIP385_activations = mock(ActivationConfig.ForBlock.class);
         when(preRSKIP385_activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
@@ -6715,7 +6733,7 @@ class BridgeSupportTest {
         when(postRSKIP385_activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
         when(postRSKIP385_activations.isActive(ConsensusRule.RSKIP385)).thenReturn(true);
 
-        Federation standardFed = bridgeConstants.getGenesisFederation();
+        Federation standardFed = FederationTestUtils.getGenesisFederation(bridgeConstants);
         List<FederationMember> members = FederationMember.getFederationMembersFromKeys(
             PegTestUtils.createRandomBtcECKeys(7)
         );
@@ -6832,6 +6850,9 @@ class BridgeSupportTest {
         List<ConsensusRule> consensusRules)
         throws IOException, RegisterBtcTransactionException, PeginInstructionsException {
 
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Address federationAddress = federation.getAddress();
+
         // Arrange
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         for (ConsensusRule consensusRule : consensusRules) {
@@ -6849,7 +6870,7 @@ class BridgeSupportTest {
         }
 
         BtcTransaction btcTx = new BtcTransaction(btcRegTestParams);
-        btcTx.addOutput(Coin.COIN.multiply(10), bridgeConstantsRegtest.getGenesisFederation().getAddress());
+        btcTx.addOutput(Coin.COIN.multiply(10), federationAddress);
         btcTx.addInput(PegTestUtils.createHash(1), 0, new Script(new byte[]{}));
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
@@ -1799,7 +1799,9 @@ public class BridgeSupportTestIntegration {
             0L,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
-
+        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
+                activeFedArgs
+        );
         FederationArgs genesisFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithKeys(
             Stream.iterate(1, i -> i + 1)
                 .limit(6)
@@ -1812,7 +1814,7 @@ public class BridgeSupportTestIntegration {
         Federation genesisFederation = FederationFactory.buildStandardMultiSigFederation(
             genesisFedArgs
         );
-        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(true, null, genesisFederation, null, null, null, null);
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(true, activeFederation, genesisFederation, null, null, null, null);
 
         Assertions.assertEquals(6, bridgeSupport.getFederationSize().intValue());
         Assertions.assertEquals(4, bridgeSupport.getFederationThreshold().intValue());
@@ -1820,7 +1822,6 @@ public class BridgeSupportTestIntegration {
 
         List<FederationMember> members = genesisFederation.getMembers();
         for (int i = 0; i < 6; i++) {
-            //BtcECKey{pub HEX=02cfd70505faacd3caf4419000bf4b6ab9e7dc2e4bcf43bbcaa550839cf4713b42, isPubKeyOnly=true}
             Assertions.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getFederatorPublicKey(i)));
             Assertions.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
             Assertions.assertTrue(Arrays.equals(members.get(i).getRskPublicKey().getPubKey(true), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
@@ -1799,11 +1799,12 @@ public class BridgeSupportTestIntegration {
             0L,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
         );
-        Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
-            activeFedArgs
-        );
 
-        FederationArgs genesisFedArgs = new FederationArgs(FederationTestUtils.getFederationMembers(6),
+        FederationArgs genesisFedArgs = new FederationArgs(FederationTestUtils.getFederationMembersWithKeys(
+            Stream.iterate(1, i -> i + 1)
+                .limit(6)
+                .map(i -> BtcECKey.fromPrivate(BigInteger.valueOf((i) * 100)))
+                .collect(Collectors.toList())),
             Instant.ofEpochMilli(1000),
             0L,
             NetworkParameters.fromID(NetworkParameters.ID_REGTEST)
@@ -1811,13 +1812,15 @@ public class BridgeSupportTestIntegration {
         Federation genesisFederation = FederationFactory.buildStandardMultiSigFederation(
             genesisFedArgs
         );
-        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(true, activeFederation, genesisFederation, null, null, null, null);
+        BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(true, null, genesisFederation, null, null, null, null);
 
         Assertions.assertEquals(6, bridgeSupport.getFederationSize().intValue());
         Assertions.assertEquals(4, bridgeSupport.getFederationThreshold().intValue());
         Assertions.assertEquals(genesisFederation.getAddress().toString(), bridgeSupport.getFederationAddress().toString());
-        List<FederationMember> members = FederationTestUtils.getFederationMembers(6);
+
+        List<FederationMember> members = genesisFederation.getMembers();
         for (int i = 0; i < 6; i++) {
+            //BtcECKey{pub HEX=02cfd70505faacd3caf4419000bf4b6ab9e7dc2e4bcf43bbcaa550839cf4713b42, isPubKeyOnly=true}
             Assertions.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getFederatorPublicKey(i)));
             Assertions.assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
             Assertions.assertTrue(Arrays.equals(members.get(i).getRskPublicKey().getPubKey(true), bridgeSupport.getFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
@@ -119,7 +119,6 @@ import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.InternalTransaction;
 import org.ethereum.vm.program.Program;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -3912,9 +3911,9 @@ public class BridgeSupportTestIntegration {
         BridgeEventLogger eventLogger) throws IOException {
 
         BridgeConstants constantsMock = mock(BridgeConstants.class);
-        try(MockedStatic<FederationTestUtils> federationTestUtils = Mockito.mockStatic(FederationTestUtils.class)){
-            federationTestUtils.when(() -> FederationTestUtils.getGenesisFederation(constantsMock))
-                    .thenReturn(mockedGenesisFederation);
+        if (mockedGenesisFederation != null) {
+            when(constantsMock.getGenesisFederationCreationTime()).thenReturn(mockedGenesisFederation.getCreationTime());
+            when(constantsMock.getGenesisFederationPublicKeys()).thenReturn(mockedGenesisFederation.getBtcPublicKeys());
         }
 
         when(constantsMock.getBtcParams()).thenReturn(NetworkParameters.fromID(NetworkParameters.ID_REGTEST));

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
@@ -392,7 +392,7 @@ public class BridgeSupportTestIntegration {
     @Test
     void callUpdateCollectionsFundsEnoughForJustTheSmallerTx() throws IOException {
         // Federation is the genesis federation ATM
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
 
         Repository repository = createRepository();
         Repository track = repository.startTracking();
@@ -410,7 +410,7 @@ public class BridgeSupportTestIntegration {
                 Coin.valueOf(12, 0),
                 0,
                 false,
-                ScriptBuilder.createOutputScript(federation.getAddress())
+                ScriptBuilder.createOutputScript(genesisFederation.getAddress())
         ));
 
         provider0.save();
@@ -464,7 +464,7 @@ public class BridgeSupportTestIntegration {
     @Test
     void callUpdateCollectionsThrowsCouldNotAdjustDownwards() throws IOException {
         // Federation is the genesis federation ATM
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
 
         Repository repository = createRepository();
         Repository track = repository.startTracking();
@@ -479,7 +479,7 @@ public class BridgeSupportTestIntegration {
                 Coin.valueOf(1000000),
                 0,
                 false,
-                ScriptBuilder.createOutputScript(federation.getAddress())
+                ScriptBuilder.createOutputScript(genesisFederation.getAddress())
         ));
 
         provider0.save();
@@ -544,7 +544,7 @@ public class BridgeSupportTestIntegration {
     @Test
     void callUpdateCollectionsThrowsExceededMaxTransactionSize() throws IOException {
         // Federation is the genesis federation ATM
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
 
         Repository repository = createRepository();
         Repository track = repository.startTracking();
@@ -559,7 +559,7 @@ public class BridgeSupportTestIntegration {
                     Coin.CENT,
                     0,
                     false,
-                    ScriptBuilder.createOutputScript(federation.getAddress())
+                    ScriptBuilder.createOutputScript(genesisFederation.getAddress())
             ));
         }
 
@@ -718,7 +718,7 @@ public class BridgeSupportTestIntegration {
     @Test
     void callUpdateCollectionsChangeGetsOutOfDust() throws IOException {
         // Federation is the genesis federation ATM
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
 
         Map<byte[], BigInteger> preMineMap = new HashMap<>();
         preMineMap.put(PrecompiledContracts.BRIDGE_ADDR.getBytes(), LIMIT_MONETARY_BASE.asBigInteger());
@@ -743,7 +743,7 @@ public class BridgeSupportTestIntegration {
         BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, bridgeConstants, activationsBeforeForks);
 
         provider0.getReleaseRequestQueue().add(new BtcECKey().toAddress(btcParams), Coin.COIN);
-        provider0.getNewFederationBtcUTXOs().add(new UTXO(PegTestUtils.createHash(), 1, Coin.COIN.add(Coin.valueOf(100)), 0, false, ScriptBuilder.createOutputScript(federation.getAddress())));
+        provider0.getNewFederationBtcUTXOs().add(new UTXO(PegTestUtils.createHash(), 1, Coin.COIN.add(Coin.valueOf(100)), 0, false, ScriptBuilder.createOutputScript(genesisFederation.getAddress())));
 
         provider0.save();
 
@@ -1282,7 +1282,7 @@ public class BridgeSupportTestIntegration {
     @Test
     void registerBtcTransactionReleaseTx() throws BlockStoreException, AddressFormatException, IOException, BridgeIllegalArgumentException {
         // Federation is the genesis federation ATM
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         Repository repository = createRepository();
         repository.addBalance(PrecompiledContracts.BRIDGE_ADDR, LIMIT_MONETARY_BASE);
         Repository track = repository.startTracking();
@@ -1293,29 +1293,29 @@ public class BridgeSupportTestIntegration {
         BtcTransaction tx = new BtcTransaction(this.btcParams);
         Address address = ScriptBuilder.createP2SHOutputScript(2, Lists.newArrayList(new BtcECKey(), new BtcECKey(), new BtcECKey())).getToAddress(btcParams);
         tx.addOutput(Coin.COIN, address);
-        Address address2 = federation.getAddress();
+        Address address2 = genesisFederation.getAddress();
         tx.addOutput(Coin.COIN, address2);
 
         // Create previous tx
         BtcTransaction prevTx = new BtcTransaction(btcParams);
-        TransactionOutput prevOut = new TransactionOutput(btcParams, prevTx, Coin.FIFTY_COINS, federation.getAddress());
+        TransactionOutput prevOut = new TransactionOutput(btcParams, prevTx, Coin.FIFTY_COINS, genesisFederation.getAddress());
         prevTx.addOutput(prevOut);
         // Create tx input
         tx.addInput(prevOut);
         // Create tx input base script sig
-        Script scriptSig = PegTestUtils.createBaseInputScriptThatSpendsFromTheFederation(federation);
+        Script scriptSig = PegTestUtils.createBaseInputScriptThatSpendsFromTheFederation(genesisFederation);
         // Create sighash
-        Script redeemScript = ScriptBuilder.createRedeemScript(federation.getNumberOfSignaturesRequired(), federation.getBtcPublicKeys());
+        Script redeemScript = ScriptBuilder.createRedeemScript(genesisFederation.getNumberOfSignaturesRequired(), genesisFederation.getBtcPublicKeys());
         Sha256Hash sighash = tx.hashForSignature(0, redeemScript, BtcTransaction.SigHash.ALL, false);
         // Sign by federator 0
         BtcECKey.ECDSASignature sig0 = BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS.get(0).sign(sighash);
         TransactionSignature txSig0 = new TransactionSignature(sig0, BtcTransaction.SigHash.ALL, false);
-        int sigIndex0 = scriptSig.getSigInsertionIndex(sighash, federation.getBtcPublicKeys().get(0));
+        int sigIndex0 = scriptSig.getSigInsertionIndex(sighash, genesisFederation.getBtcPublicKeys().get(0));
         scriptSig = ScriptBuilder.updateScriptWithSignature(scriptSig, txSig0.encodeToBitcoin(), sigIndex0, 1, 1);
         // Sign by federator 1
         BtcECKey.ECDSASignature sig1 = BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS.get(1).sign(sighash);
         TransactionSignature txSig1 = new TransactionSignature(sig1, BtcTransaction.SigHash.ALL, false);
-        int sigIndex1 = scriptSig.getSigInsertionIndex(sighash, federation.getBtcPublicKeys().get(1));
+        int sigIndex1 = scriptSig.getSigInsertionIndex(sighash, genesisFederation.getBtcPublicKeys().get(1));
         scriptSig = ScriptBuilder.updateScriptWithSignature(scriptSig, txSig1.encodeToBitcoin(), sigIndex1, 1, 1);
         // Set scipt sign to tx input
         tx.getInput(0).setScriptSig(scriptSig);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
@@ -119,6 +119,7 @@ import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.InternalTransaction;
 import org.ethereum.vm.program.Program;
+import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -392,7 +393,7 @@ public class BridgeSupportTestIntegration {
     @Test
     void callUpdateCollectionsFundsEnoughForJustTheSmallerTx() throws IOException {
         // Federation is the genesis federation ATM
-        Federation federation = bridgeConstants.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
 
         Repository repository = createRepository();
         Repository track = repository.startTracking();
@@ -464,7 +465,7 @@ public class BridgeSupportTestIntegration {
     @Test
     void callUpdateCollectionsThrowsCouldNotAdjustDownwards() throws IOException {
         // Federation is the genesis federation ATM
-        Federation federation = bridgeConstants.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
 
         Repository repository = createRepository();
         Repository track = repository.startTracking();
@@ -544,7 +545,7 @@ public class BridgeSupportTestIntegration {
     @Test
     void callUpdateCollectionsThrowsExceededMaxTransactionSize() throws IOException {
         // Federation is the genesis federation ATM
-        Federation federation = bridgeConstants.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
 
         Repository repository = createRepository();
         Repository track = repository.startTracking();
@@ -624,7 +625,7 @@ public class BridgeSupportTestIntegration {
 
     @Test
     void minimumProcessFundsMigrationValue() throws IOException {
-        Federation oldFederation = bridgeConstants.getGenesisFederation();
+        Federation oldFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         BtcECKey key = new BtcECKey(new SecureRandom());
         FederationMember member = new FederationMember(key, new ECKey(), new ECKey());
         FederationArgs newFederationArgs = new FederationArgs(
@@ -718,7 +719,7 @@ public class BridgeSupportTestIntegration {
     @Test
     void callUpdateCollectionsChangeGetsOutOfDust() throws IOException {
         // Federation is the genesis federation ATM
-        Federation federation = bridgeConstants.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
 
         Map<byte[], BigInteger> preMineMap = new HashMap<>();
         preMineMap.put(PrecompiledContracts.BRIDGE_ADDR.getBytes(), LIMIT_MONETARY_BASE.asBigInteger());
@@ -1282,7 +1283,7 @@ public class BridgeSupportTestIntegration {
     @Test
     void registerBtcTransactionReleaseTx() throws BlockStoreException, AddressFormatException, IOException, BridgeIllegalArgumentException {
         // Federation is the genesis federation ATM
-        Federation federation = bridgeConstants.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         Repository repository = createRepository();
         repository.addBalance(PrecompiledContracts.BRIDGE_ADDR, LIMIT_MONETARY_BASE);
         Repository track = repository.startTracking();
@@ -3911,7 +3912,10 @@ public class BridgeSupportTestIntegration {
         BridgeEventLogger eventLogger) throws IOException {
 
         BridgeConstants constantsMock = mock(BridgeConstants.class);
-        when(constantsMock.getGenesisFederation()).thenReturn((StandardMultisigFederation) mockedGenesisFederation);
+        try(MockedStatic<FederationTestUtils> federationTestUtils = Mockito.mockStatic(FederationTestUtils.class)){
+            federationTestUtils.when(() -> FederationTestUtils.getGenesisFederation(constantsMock))
+                    .thenReturn(mockedGenesisFederation);
+        }
 
         when(constantsMock.getBtcParams()).thenReturn(NetworkParameters.fromID(NetworkParameters.ID_REGTEST));
         when(constantsMock.getFederationChangeAuthorizer()).thenReturn(bridgeConstants.getFederationChangeAuthorizer());

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -764,10 +764,10 @@ class BridgeTest {
     void receiveHeaders_after_RSKIP200_notFederation() {
         ActivationConfig activationConfig = ActivationConfigsForTest.iris300();
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
 
         when(bridgeSupportMock.getRetiringFederation()).thenReturn(null);
-        when(bridgeSupportMock.getActiveFederation()).thenReturn(federation);
+        when(bridgeSupportMock.getActiveFederation()).thenReturn(genesisFederation);
 
         Transaction txMock = mock(Transaction.class);
         RskAddress txSender = new RskAddress(new ECKey().getAddress());

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -11,7 +11,6 @@ import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.constants.BridgeMainNetConstants;
-import co.rsk.peg.constants.BridgeRegTestConstants;
 import co.rsk.peg.constants.BridgeTestNetConstants;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
@@ -50,7 +49,7 @@ class BridgeTest {
 
     private NetworkParameters networkParameters;
     private BridgeBuilder bridgeBuilder;
-    private final BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
+    private final BridgeConstants bridgeMainNetConstants = BridgeMainNetConstants.getInstance();
 
     @BeforeEach
     void resetConfigToMainnet() {
@@ -77,7 +76,8 @@ class BridgeTest {
         CallTransaction.Function getActivePowpegRedeemScriptFunction = BridgeMethods.GET_ACTIVE_POWPEG_REDEEM_SCRIPT.getFunction();
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
-        Script activePowpegRedeemScript = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants).getRedeemScript();
+        Script activePowpegRedeemScript = FederationTestUtils.getGenesisFederation(
+            bridgeMainNetConstants).getRedeemScript();
         when(bridgeSupportMock.getActivePowpegRedeemScript()).thenReturn(
             Optional.of(activePowpegRedeemScript)
         );
@@ -764,7 +764,8 @@ class BridgeTest {
     void receiveHeaders_after_RSKIP200_notFederation() {
         ActivationConfig activationConfig = ActivationConfigsForTest.iris300();
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
-        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(
+            bridgeMainNetConstants);
 
         when(bridgeSupportMock.getRetiringFederation()).thenReturn(null);
         when(bridgeSupportMock.getActiveFederation()).thenReturn(genesisFederation);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -50,6 +50,7 @@ class BridgeTest {
 
     private NetworkParameters networkParameters;
     private BridgeBuilder bridgeBuilder;
+    private final BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
 
     @BeforeEach
     void resetConfigToMainnet() {
@@ -76,7 +77,7 @@ class BridgeTest {
         CallTransaction.Function getActivePowpegRedeemScriptFunction = BridgeMethods.GET_ACTIVE_POWPEG_REDEEM_SCRIPT.getFunction();
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
-        Script activePowpegRedeemScript = BridgeRegTestConstants.getInstance().getGenesisFederation().getRedeemScript();
+        Script activePowpegRedeemScript = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants).getRedeemScript();
         when(bridgeSupportMock.getActivePowpegRedeemScript()).thenReturn(
             Optional.of(activePowpegRedeemScript)
         );
@@ -762,10 +763,11 @@ class BridgeTest {
     @Test
     void receiveHeaders_after_RSKIP200_notFederation() {
         ActivationConfig activationConfig = ActivationConfigsForTest.iris300();
-
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+
         when(bridgeSupportMock.getRetiringFederation()).thenReturn(null);
-        when(bridgeSupportMock.getActiveFederation()).thenReturn(BridgeRegTestConstants.getInstance().getGenesisFederation());
+        when(bridgeSupportMock.getActiveFederation()).thenReturn(federation);
 
         Transaction txMock = mock(Transaction.class);
         RskAddress txSender = new RskAddress(new ECKey().getAddress());

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTestIntegration.java
@@ -1016,7 +1016,7 @@ public class BridgeTestIntegration {
     @Test
     void getFederationAddress() throws Exception {
         // Case with genesis federation
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
         Repository repository = createRepository();
         Repository track = repository.startTracking();
 
@@ -1032,7 +1032,7 @@ public class BridgeTestIntegration {
 
         byte[] data = Bridge.GET_FEDERATION_ADDRESS.encode();
 
-        Assertions.assertArrayEquals(Bridge.GET_FEDERATION_ADDRESS.encodeOutputs(federation.getAddress().toString()), bridge.execute(data));
+        Assertions.assertArrayEquals(Bridge.GET_FEDERATION_ADDRESS.encodeOutputs(genesisFederation.getAddress().toString()), bridge.execute(data));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTestIntegration.java
@@ -52,6 +52,7 @@ import java.util.function.BiFunction;
 
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.FederationMember;
+import co.rsk.peg.federation.FederationTestUtils;
 import co.rsk.test.builders.BlockChainBuilder;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.TestUtils;
@@ -132,7 +133,7 @@ import co.rsk.util.HexUtils;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class BridgeTestIntegration {
     private static NetworkParameters networkParameters;
-    private static BridgeRegTestConstants bridgeConstants;
+    private static BridgeConstants bridgeRegTestConstants;
 
     private static final BigInteger AMOUNT = new BigInteger("1000000000000000000");
     private static final BigInteger NONCE = new BigInteger("0");
@@ -151,8 +152,8 @@ public class BridgeTestIntegration {
 
     @BeforeAll
      static void setUpBeforeClass() {
-        bridgeConstants = BridgeRegTestConstants.getInstance();
-        networkParameters = bridgeConstants.getBtcParams();
+        bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
+        networkParameters = bridgeRegTestConstants.getBtcParams();
         BtcECKey fedBTCPrivateKey = BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS.get(0);
         fedECPrivateKey = ECKey.fromPrivate(fedBTCPrivateKey.getPrivKey());
     }
@@ -176,7 +177,7 @@ public class BridgeTestIntegration {
         Repository repository = createRepository();
         Repository track = repository.startTracking();
 
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, bridgeConstants, activationConfigAll);
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, bridgeRegTestConstants, activationConfigAll);
 
         provider0.getPegoutsWaitingForConfirmations().add(tx1, 1L, PegTestUtils.createHash3(0));
         provider0.save();
@@ -198,8 +199,8 @@ public class BridgeTestIntegration {
         rskTx.sign(new ECKey().getPrivKeyBytes());
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -217,14 +218,14 @@ public class BridgeTestIntegration {
 
     @Test
     void callUpdateCollectionsWithTransactionsWaitingForConfirmation() throws IOException, VMException {
-        BtcTransaction tx1 = createTransaction(2, bridgeConstants.getMinimumPegoutTxValueInSatoshis());
-        BtcTransaction tx2 = createTransaction(3, bridgeConstants.getMinimumPegoutTxValueInSatoshis().add(Coin.MILLICOIN));
-        BtcTransaction tx3 = createTransaction(4, bridgeConstants.getMinimumPegoutTxValueInSatoshis().add(Coin.MILLICOIN).add(Coin.MILLICOIN));
+        BtcTransaction tx1 = createTransaction(2, bridgeRegTestConstants.getMinimumPegoutTxValueInSatoshis());
+        BtcTransaction tx2 = createTransaction(3, bridgeRegTestConstants.getMinimumPegoutTxValueInSatoshis().add(Coin.MILLICOIN));
+        BtcTransaction tx3 = createTransaction(4, bridgeRegTestConstants.getMinimumPegoutTxValueInSatoshis().add(Coin.MILLICOIN).add(Coin.MILLICOIN));
 
         Repository repository = createRepository();
         Repository track = repository.startTracking();
 
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, bridgeConstants, activationConfig.forBlock(0));
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, bridgeRegTestConstants, activationConfig.forBlock(0));
 
         provider0.getPegoutsWaitingForConfirmations().add(tx1, 1L);
         provider0.getPegoutsWaitingForConfirmations().add(tx2, 2L);
@@ -248,8 +249,8 @@ public class BridgeTestIntegration {
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
 
@@ -265,7 +266,7 @@ public class BridgeTestIntegration {
         track.commit();
 
         //Reusing same storage configuration as the height doesn't affect storage configurations for releases.
-        BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, bridgeConstants, activationConfigAll);
+        BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, bridgeRegTestConstants, activationConfigAll);
 
         Assertions.assertEquals(3, provider.getPegoutsWaitingForConfirmations().getEntries().size());
         Assertions.assertEquals(0, provider.getPegoutsWaitingForSignatures().size());
@@ -273,14 +274,14 @@ public class BridgeTestIntegration {
 
     @Test
     void callUpdateCollectionsWithTransactionsWaitingForConfirmationWithEnoughConfirmations() throws IOException, VMException {
-        BtcTransaction tx1 = createTransaction(2, bridgeConstants.getMinimumPegoutTxValueInSatoshis());
-        BtcTransaction tx2 = createTransaction(3, bridgeConstants.getMinimumPegoutTxValueInSatoshis().add(Coin.MILLICOIN));
-        BtcTransaction tx3 = createTransaction(4, bridgeConstants.getMinimumPegoutTxValueInSatoshis().add(Coin.MILLICOIN).add(Coin.MILLICOIN));
+        BtcTransaction tx1 = createTransaction(2, bridgeRegTestConstants.getMinimumPegoutTxValueInSatoshis());
+        BtcTransaction tx2 = createTransaction(3, bridgeRegTestConstants.getMinimumPegoutTxValueInSatoshis().add(Coin.MILLICOIN));
+        BtcTransaction tx3 = createTransaction(4, bridgeRegTestConstants.getMinimumPegoutTxValueInSatoshis().add(Coin.MILLICOIN).add(Coin.MILLICOIN));
 
         Repository repository = createRepository();
         Repository track = repository.startTracking();
 
-        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, bridgeConstants, activationConfig.forBlock(0));
+        BridgeStorageProvider provider0 = new BridgeStorageProvider(track, PrecompiledContracts.BRIDGE_ADDR, bridgeRegTestConstants, activationConfig.forBlock(0));
 
         provider0.getPegoutsWaitingForConfirmations().add(tx1, 1L);
         provider0.getPegoutsWaitingForConfirmations().add(tx2, 2L);
@@ -311,8 +312,8 @@ public class BridgeTestIntegration {
         world.getBlockStore().saveBlock(blocks.get(1), new BlockDifficulty(BigInteger.ONE), true);
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -324,7 +325,7 @@ public class BridgeTestIntegration {
         track.commit();
 
         // reusing same storage configuration as the height doesn't affect storage configurations for releases.
-        BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, bridgeConstants, activationConfigAll);
+        BridgeStorageProvider provider = new BridgeStorageProvider(repository, PrecompiledContracts.BRIDGE_ADDR, bridgeRegTestConstants, activationConfigAll);
 
         Assertions.assertEquals(2, provider.getPegoutsWaitingForConfirmations().getEntries().size());
         Assertions.assertEquals(1, provider.getPegoutsWaitingForSignatures().size());
@@ -336,8 +337,8 @@ public class BridgeTestIntegration {
         Repository track = repository.startTracking();
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -373,7 +374,7 @@ public class BridgeTestIntegration {
         BridgeSupportFactory bridgeSupportFactory = mock(BridgeSupportFactory.class);
         BridgeSupport bridgeSupport = mock(BridgeSupport.class);
         when(bridgeSupportFactory.newInstance(any(), any(), any(), any())).thenReturn(bridgeSupport);
-        when(bridgeSupport.getActiveFederation()).thenReturn(bridgeConstants.getGenesisFederation());
+        when(bridgeSupport.getActiveFederation()).thenReturn(FederationTestUtils.getGenesisFederation(bridgeRegTestConstants));
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
                 bridgeSupportFactory, signatureCache);
         bridge.init(rskTx, getGenesisBlock(), track, null, null, null);
@@ -405,8 +406,8 @@ public class BridgeTestIntegration {
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig, signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
                 bridgeSupportFactory, signatureCache);
@@ -436,8 +437,8 @@ public class BridgeTestIntegration {
     @Test
     void executeWithFunctionSignatureLengthTooShortBeforeRskip88() throws VMException {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig, signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
                 bridgeSupportFactory, signatureCache);
@@ -451,8 +452,8 @@ public class BridgeTestIntegration {
         doReturn(true).when(activationConfig).isActive(eq(RSKIP88), anyLong());
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache
         );
@@ -477,8 +478,8 @@ public class BridgeTestIntegration {
     @Test
     void executeWithInexistentFunctionBeforeRskip88() throws VMException {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -493,8 +494,8 @@ public class BridgeTestIntegration {
         doReturn(true).when(activationConfig).isActive(eq(RSKIP88), anyLong());
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -525,8 +526,8 @@ public class BridgeTestIntegration {
         rskTx.sign(new ECKey().getPrivKeyBytes());
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -560,8 +561,8 @@ public class BridgeTestIntegration {
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -620,7 +621,7 @@ public class BridgeTestIntegration {
         try (MockedStatic<BridgeUtils> bridgeUtilsMocked = mockStatic(BridgeUtils.class)) {
             bridgeUtilsMocked.when(() -> BridgeUtils.isFromFederateMember(any(), any(), any())).thenReturn(true);
 
-            MessageSerializer serializer = bridgeConstants.getBtcParams().getDefaultSerializer();
+            MessageSerializer serializer = bridgeRegTestConstants.getBtcParams().getDefaultSerializer();
             MessageSerializer spySerializer = Mockito.spy(serializer);
 
             NetworkParameters btcParamsMock = mock(NetworkParameters.class);
@@ -782,8 +783,8 @@ public class BridgeTestIntegration {
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig, signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
                 bridgeSupportFactory, signatureCache);
@@ -841,8 +842,8 @@ public class BridgeTestIntegration {
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig, signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
                 bridgeSupportFactory, signatureCache);
@@ -900,8 +901,8 @@ public class BridgeTestIntegration {
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -936,8 +937,8 @@ public class BridgeTestIntegration {
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -972,8 +973,8 @@ public class BridgeTestIntegration {
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -1015,13 +1016,13 @@ public class BridgeTestIntegration {
     @Test
     void getFederationAddress() throws Exception {
         // Case with genesis federation
-        Federation federation = bridgeConstants.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
         Repository repository = createRepository();
         Repository track = repository.startTracking();
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -1040,8 +1041,8 @@ public class BridgeTestIntegration {
         Repository track = repository.startTracking();
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -1051,7 +1052,7 @@ public class BridgeTestIntegration {
 
         byte[] data = Bridge.GET_MINIMUM_LOCK_TX_VALUE.encode();
 
-        Assertions.assertArrayEquals(Bridge.GET_MINIMUM_LOCK_TX_VALUE.encodeOutputs(bridgeConstants.getMinimumPeginTxValue(activationConfig.forBlock(0)).value), bridge.execute(data));
+        Assertions.assertArrayEquals(Bridge.GET_MINIMUM_LOCK_TX_VALUE.encodeOutputs(bridgeRegTestConstants.getMinimumPeginTxValue(activationConfig.forBlock(0)).value), bridge.execute(data));
     }
 
     @Test
@@ -1072,8 +1073,8 @@ public class BridgeTestIntegration {
         rskTx.sign(new ECKey().getPrivKeyBytes());
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -1111,8 +1112,8 @@ public class BridgeTestIntegration {
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -1145,8 +1146,8 @@ public class BridgeTestIntegration {
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -1179,8 +1180,8 @@ public class BridgeTestIntegration {
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -1213,8 +1214,8 @@ public class BridgeTestIntegration {
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -1337,8 +1338,8 @@ public class BridgeTestIntegration {
         Repository track = repository.startTracking();
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -1360,8 +1361,8 @@ public class BridgeTestIntegration {
         activationConfig = ActivationConfigsForTest.bridgeUnitTest();
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -1448,8 +1449,8 @@ public class BridgeTestIntegration {
     @Test
     void isBtcTxHashAlreadyProcessed_normalFlow() throws IOException, VMException {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -1476,8 +1477,8 @@ public class BridgeTestIntegration {
     @Test
     void isBtcTxHashAlreadyProcessed_exception() throws IOException {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -1497,8 +1498,8 @@ public class BridgeTestIntegration {
     @Test
     void getBtcTxHashProcessedHeight_normalFlow() throws IOException, VMException {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -1524,8 +1525,8 @@ public class BridgeTestIntegration {
     @Test
     void getBtcTxHashProcessedHeight_exception() throws IOException {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -1545,8 +1546,8 @@ public class BridgeTestIntegration {
     @Test
     void getFederationSize() {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -1580,8 +1581,8 @@ public class BridgeTestIntegration {
     @Test
     void getFederationCreationTime() {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -1707,8 +1708,8 @@ public class BridgeTestIntegration {
     @Test
     void getRetiringFederationSize() {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -1742,8 +1743,8 @@ public class BridgeTestIntegration {
     @Test
     void getRetiringFederationCreationTime() {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -2110,8 +2111,8 @@ public class BridgeTestIntegration {
     void commitFederation_ok() throws BridgeIllegalArgumentException {
         Transaction txMock = mock(Transaction.class);
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -2128,8 +2129,8 @@ public class BridgeTestIntegration {
     @Test
     void commitFederation_wrongParameterType() throws BridgeIllegalArgumentException {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -2164,8 +2165,8 @@ public class BridgeTestIntegration {
     @Test
     void getLockWhitelistSize() {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -2285,8 +2286,8 @@ public class BridgeTestIntegration {
         when(mockedTransaction.getSender(any(SignatureCache.class))).thenReturn(sender);
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -2313,8 +2314,8 @@ public class BridgeTestIntegration {
 
         Transaction mockedTransaction = mock(Transaction.class);
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -2367,8 +2368,8 @@ public class BridgeTestIntegration {
         when(mockedTransaction.getSender(any(SignatureCache.class))).thenReturn(sender);
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -2395,8 +2396,8 @@ public class BridgeTestIntegration {
 
         Transaction mockedTransaction = mock(Transaction.class);
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -2420,8 +2421,8 @@ public class BridgeTestIntegration {
         when(mockedTransaction.getSender(any(SignatureCache.class))).thenReturn(sender);
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -2444,8 +2445,8 @@ public class BridgeTestIntegration {
     void removeLockWhitelistAddress() {
         Transaction mockedTransaction = mock(Transaction.class);
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -2540,8 +2541,8 @@ public class BridgeTestIntegration {
 
         // Setup bridge
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -2725,8 +2726,8 @@ public class BridgeTestIntegration {
     void getBtcTransactionConfirmationsAfterWasabi_errorInBridgeSupport() throws Exception {
         Transaction txMock = mock(Transaction.class);
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
 
@@ -2794,8 +2795,8 @@ public class BridgeTestIntegration {
     void getBtcTransactionConfirmationsAfterWasabi_merkleBranchConstructionError() throws Exception {
         Transaction txMock = mock(Transaction.class);
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
 
@@ -2891,8 +2892,8 @@ public class BridgeTestIntegration {
     @Test
     void getBtcBlockchainBlockHashAtDepth() throws BlockStoreException, IOException, VMException {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -2939,12 +2940,11 @@ public class BridgeTestIntegration {
 
         // Run the program on the VM
         Program program = new Program(config.getVmConfig(), precompiledContracts, blockFactory, mock(ActivationConfig.ForBlock.class), code, invoke, tx, new HashSet<>(), new BlockTxSignatureCache(new ReceivedTxSignatureCache()));
-        Exception ex = Assertions.assertThrows(NullPointerException.class, () -> {
+        Assertions.assertThrows(NullPointerException.class, () -> {
             for (int i = 0; i < numOps; i++) {
                 vm.step(program);
             }
         });
-        Assertions.assertNull(ex.getMessage());
     }
 
     @Test
@@ -3141,7 +3141,7 @@ public class BridgeTestIntegration {
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         when(bridgeSupportMock.getRetiringFederation()).thenReturn(null);
-        when(bridgeSupportMock.getActiveFederation()).thenReturn(BridgeRegTestConstants.getInstance().getGenesisFederation());
+        when(bridgeSupportMock.getActiveFederation()).thenReturn(FederationTestUtils.getGenesisFederation(bridgeRegTestConstants));
 
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
@@ -3176,7 +3176,7 @@ public class BridgeTestIntegration {
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         when(bridgeSupportMock.getRetiringFederation()).thenReturn(null);
-        when(bridgeSupportMock.getActiveFederation()).thenReturn(BridgeRegTestConstants.getInstance().getGenesisFederation());
+        when(bridgeSupportMock.getActiveFederation()).thenReturn(FederationTestUtils.getGenesisFederation(bridgeRegTestConstants));
 
         BridgeSupportFactory bridgeSupportFactoryMock = mock(BridgeSupportFactory.class);
 
@@ -3272,8 +3272,8 @@ public class BridgeTestIntegration {
     @Test
     void getBtcBlockchainInitialBlockHeight() throws IOException, VMException {
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -3321,8 +3321,8 @@ public class BridgeTestIntegration {
         activationConfig = ActivationConfigsForTest.bridgeUnitTest();
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,
@@ -3382,8 +3382,8 @@ public class BridgeTestIntegration {
         rskTx.sign(fedECPrivateKey.getPrivKeyBytes());
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
-                new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams()),
-                bridgeConstants,
+                new RepositoryBtcBlockStoreWithCache.Factory(bridgeRegTestConstants.getBtcParams()),
+                bridgeRegTestConstants,
                 activationConfig,
                 signatureCache);
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig,

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -1476,15 +1476,15 @@ class BridgeUtilsTest {
     private BtcTransaction createPegOutTx(
         List<byte[]> signatures,
         int inputsToAdd,
-        Federation genesisFederation,
+        Federation federation,
         boolean isFlyover
     ) {
         // Setup
         Address address;
         byte[] program;
 
-        if (genesisFederation == null) {
-            genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        if (federation == null) {
+            federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         }
 
         if (isFlyover) {
@@ -1492,16 +1492,16 @@ class BridgeUtilsTest {
             Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
             Script flyoverRedeemScript;
 
-            if (genesisFederation instanceof ErpFederation) {
+            if (federation instanceof ErpFederation) {
                 flyoverRedeemScript =
                     FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-                        genesisFederation.getRedeemScript(),
+                        federation.getRedeemScript(),
                         derivationArgumentsHash
                     );
             } else {
                 flyoverRedeemScript =
                     FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
-                        genesisFederation.getRedeemScript(),
+                        federation.getRedeemScript(),
                         derivationArgumentsHash
                     );
             }
@@ -1512,8 +1512,8 @@ class BridgeUtilsTest {
             program = flyoverRedeemScript.getProgram();
 
         } else {
-            address = genesisFederation.getAddress();
-            program = genesisFederation.getRedeemScript().getProgram();
+            address = federation.getAddress();
+            program = federation.getRedeemScript().getProgram();
         }
 
         // Build prev btc tx
@@ -1532,7 +1532,7 @@ class BridgeUtilsTest {
         Script scriptSig;
 
         if (signatures.isEmpty()) {
-            scriptSig = PegTestUtils.createBaseInputScriptThatSpendsFromTheFederation(genesisFederation);
+            scriptSig = PegTestUtils.createBaseInputScriptThatSpendsFromTheFederation(federation);
         } else {
             scriptSig = ScriptBuilder.createMultiSigInputScriptBytes(signatures, program);
         }
@@ -1554,7 +1554,7 @@ class BridgeUtilsTest {
             networkParameters,
             btcTx,
             Coin.COIN,
-            genesisFederation.getAddress()
+            federation.getAddress()
         );
         btcTx.addOutput(changeOutput);
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -1476,15 +1476,15 @@ class BridgeUtilsTest {
     private BtcTransaction createPegOutTx(
         List<byte[]> signatures,
         int inputsToAdd,
-        Federation federation,
+        Federation genesisFederation,
         boolean isFlyover
     ) {
         // Setup
         Address address;
         byte[] program;
 
-        if (federation == null) {
-            federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        if (genesisFederation == null) {
+            genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         }
 
         if (isFlyover) {
@@ -1492,16 +1492,16 @@ class BridgeUtilsTest {
             Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
             Script flyoverRedeemScript;
 
-            if (federation instanceof ErpFederation) {
+            if (genesisFederation instanceof ErpFederation) {
                 flyoverRedeemScript =
                     FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-                        federation.getRedeemScript(),
+                        genesisFederation.getRedeemScript(),
                         derivationArgumentsHash
                     );
             } else {
                 flyoverRedeemScript =
                     FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
-                        federation.getRedeemScript(),
+                        genesisFederation.getRedeemScript(),
                         derivationArgumentsHash
                     );
             }
@@ -1512,8 +1512,8 @@ class BridgeUtilsTest {
             program = flyoverRedeemScript.getProgram();
 
         } else {
-            address = federation.getAddress();
-            program = federation.getRedeemScript().getProgram();
+            address = genesisFederation.getAddress();
+            program = genesisFederation.getRedeemScript().getProgram();
         }
 
         // Build prev btc tx
@@ -1532,7 +1532,7 @@ class BridgeUtilsTest {
         Script scriptSig;
 
         if (signatures.isEmpty()) {
-            scriptSig = PegTestUtils.createBaseInputScriptThatSpendsFromTheFederation(federation);
+            scriptSig = PegTestUtils.createBaseInputScriptThatSpendsFromTheFederation(genesisFederation);
         } else {
             scriptSig = ScriptBuilder.createMultiSigInputScriptBytes(signatures, program);
         }
@@ -1554,7 +1554,7 @@ class BridgeUtilsTest {
             networkParameters,
             btcTx,
             Coin.COIN,
-            federation.getAddress()
+            genesisFederation.getAddress()
         );
         btcTx.addOutput(changeOutput);
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -1339,7 +1339,7 @@ class BridgeUtilsTest {
     }
 
     private void getAmountSentToAddresses_no_output_for_address_by_network(BridgeConstants bridgeConstants) {
-        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsMainnet);
         Address receiver = genesisFederation.getAddress();
         BtcTransaction btcTx = new BtcTransaction(bridgeConstants.getBtcParams());
 
@@ -1363,7 +1363,7 @@ class BridgeUtilsTest {
     }
 
     private void getAmountSentToAddresses_output_value_is_0_by_network(BridgeConstants bridgeConstants) {
-        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsMainnet);
         Address receiver = genesisFederation.getAddress();
 
         Coin valueToTransfer = Coin.ZERO;

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -1339,7 +1339,7 @@ class BridgeUtilsTest {
     }
 
     private void getAmountSentToAddresses_no_output_for_address_by_network(BridgeConstants bridgeConstants) {
-        Federation genesisFederation = bridgeConstants.getGenesisFederation();
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         Address receiver = genesisFederation.getAddress();
         BtcTransaction btcTx = new BtcTransaction(bridgeConstants.getBtcParams());
 
@@ -1363,7 +1363,7 @@ class BridgeUtilsTest {
     }
 
     private void getAmountSentToAddresses_output_value_is_0_by_network(BridgeConstants bridgeConstants) {
-        Federation genesisFederation = bridgeConstants.getGenesisFederation();
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         Address receiver = genesisFederation.getAddress();
 
         Coin valueToTransfer = Coin.ZERO;
@@ -1465,7 +1465,7 @@ class BridgeUtilsTest {
     }
 
     private ErpFederation createNonStandardErpFederation() {
-        Federation genesisFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         FederationArgs genesisFederationArgs = genesisFederation.getArgs();
         List<BtcECKey> erpPubKeys = bridgeConstantsRegtest.getErpFedPubKeysList();
         long activationDelay = bridgeConstantsRegtest.getErpFedActivationDelay();
@@ -1484,7 +1484,7 @@ class BridgeUtilsTest {
         byte[] program;
 
         if (federation == null) {
-            federation = BridgeRegTestConstants.getInstance().getGenesisFederation();
+            federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         }
 
         if (isFlyover) {
@@ -1679,15 +1679,6 @@ class BridgeUtilsTest {
         inputScript = ScriptBuilder.updateScriptWithSignature(inputScript, txSig.encodeToBitcoin(), sigIndex, 1, 1);
 
         return inputScript;
-    }
-
-    private Federation getGenesisFederationForTest(BridgeConstants bridgeConstants, Context btcContext){
-        Federation federation = bridgeConstants.getGenesisFederation();
-        Wallet wallet = new BridgeBtcWallet(btcContext, Collections.singletonList(federation));
-        Address federationAddress = federation.getAddress();
-        wallet.addWatchedAddress(federationAddress, federation.getCreationTime().toEpochMilli());
-
-        return federation;
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/FederationSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationSupportTest.java
@@ -17,13 +17,26 @@
  */
 package co.rsk.peg;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.bitcoin.BitcoinTestUtils;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.constants.BridgeMainNetConstants;
 import co.rsk.peg.constants.BridgeTestNetConstants;
-import co.rsk.peg.federation.*;
+import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationArgs;
+import co.rsk.peg.federation.FederationFactory;
+import co.rsk.peg.federation.FederationMember;
+import co.rsk.peg.federation.FederationTestUtils;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
@@ -35,17 +48,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import java.time.Instant;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Stream;
-
-import static co.rsk.peg.federation.FederationTestUtils.GENESIS_FEDERATION_CREATION_BLOCK_NUMBER;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class FederationSupportTest {
 
@@ -74,18 +76,13 @@ class FederationSupportTest {
     void whenNewFederationIsNullThenActiveFederationIsGenesisFederation() {
         final BridgeConstants bridgeMainNetConstants = BridgeMainNetConstants.getInstance();
         final Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeMainNetConstants);
-        when(provider.getNewFederation())
-                .thenReturn(null);
+
+        when(provider.getNewFederation()).thenReturn(null);
         when(bridgeConstants.getGenesisFederationCreationTime()).thenReturn(genesisFederation.getCreationTime());
         when(bridgeConstants.getGenesisFederationPublicKeys()).thenReturn(genesisFederation.getBtcPublicKeys());
+        when(bridgeConstants.getBtcParams()).thenReturn(genesisFederation.getBtcParams());
 
-        final List<BtcECKey> genesisFederationPublicKeys = bridgeMainNetConstants.getGenesisFederationPublicKeys();
-        final List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(genesisFederationPublicKeys);
-        final Instant genesisFederationCreationTime = bridgeMainNetConstants.getGenesisFederationCreationTime();
-        final FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationCreationTime, GENESIS_FEDERATION_CREATION_BLOCK_NUMBER, bridgeMainNetConstants.getBtcParams());
-        final Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
-
-        assertThat(activeFederation, is(genesisFederation));
+        assertThat(federationSupport.getActiveFederation(), is(genesisFederation));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/FederationSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FederationSupportTest.java
@@ -22,7 +22,6 @@ import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.bitcoin.BitcoinTestUtils;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.constants.BridgeMainNetConstants;
-import co.rsk.peg.constants.BridgeRegTestConstants;
 import co.rsk.peg.constants.BridgeTestNetConstants;
 import co.rsk.peg.federation.*;
 import org.bouncycastle.util.encoders.Hex;
@@ -36,8 +35,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -54,7 +51,6 @@ class FederationSupportTest {
 
     private FederationSupport federationSupport;
     private BridgeConstants bridgeConstants;
-    private final BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
     private BridgeStorageProvider provider;
     private Block executionBlock;
     private ActivationConfig.ForBlock activations;
@@ -76,21 +72,20 @@ class FederationSupportTest {
 
     @Test
     void whenNewFederationIsNullThenActiveFederationIsGenesisFederation() {
-        final Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        final BridgeConstants bridgeMainNetConstants = BridgeMainNetConstants.getInstance();
+        final Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeMainNetConstants);
         when(provider.getNewFederation())
                 .thenReturn(null);
-        try (MockedStatic<FederationTestUtils> federationTestUtils = Mockito.mockStatic(FederationTestUtils.class)) {
-            federationTestUtils.when(() -> FederationTestUtils.getGenesisFederation(bridgeConstants))
-                    .thenReturn(genesisFederation);
+        when(bridgeConstants.getGenesisFederationCreationTime()).thenReturn(genesisFederation.getCreationTime());
+        when(bridgeConstants.getGenesisFederationPublicKeys()).thenReturn(genesisFederation.getBtcPublicKeys());
 
-            final List<BtcECKey> genesisFederationPublicKeys = bridgeRegTestConstants.getGenesisFederationPublicKeys();
-            final List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(genesisFederationPublicKeys);
-            final Instant genesisFederationCreationTime = bridgeRegTestConstants.getGenesisFederationCreationTime();
-            final FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationCreationTime, GENESIS_FEDERATION_CREATION_BLOCK_NUMBER, bridgeRegTestConstants.getBtcParams());
-            final Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
+        final List<BtcECKey> genesisFederationPublicKeys = bridgeMainNetConstants.getGenesisFederationPublicKeys();
+        final List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(genesisFederationPublicKeys);
+        final Instant genesisFederationCreationTime = bridgeMainNetConstants.getGenesisFederationCreationTime();
+        final FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationCreationTime, GENESIS_FEDERATION_CREATION_BLOCK_NUMBER, bridgeMainNetConstants.getBtcParams());
+        final Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
-            assertThat(activeFederation, is(genesisFederation));
-        }
+        assertThat(activeFederation, is(genesisFederation));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsGetTransactionTypeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsGetTransactionTypeTest.java
@@ -49,7 +49,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class PegUtilsGetTransactionTypeTest {
     private static final BridgeConstants bridgeMainnetConstants = BridgeMainNetConstants.getInstance();
-    private final BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
     private static final NetworkParameters btcMainnetParams = bridgeMainnetConstants.getBtcParams();
     private static final ActivationConfig.ForBlock activations = ActivationConfigsForTest.arrowhead600().forBlock(0);
 
@@ -726,7 +725,7 @@ class PegUtilsGetTransactionTypeTest {
         anyToAnyTx.addInput(BitcoinTestUtils.createHash(1), 0, new Script(new byte[]{}));
         anyToAnyTx.addOutput(minimumPeginTxValue, new Script(new byte[]{}) );
 
-        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeMainnetConstants);
 
         // Act
         PegTxType transactionType = PegUtils.getTransactionType(
@@ -754,7 +753,7 @@ class PegUtilsGetTransactionTypeTest {
         anyToAnyTx.addInput(BitcoinTestUtils.createHash(1), 0, new Script(new byte[]{}));
         anyToAnyTx.addOutput(belowMinimum, new Script(new byte[]{}));
 
-        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeMainnetConstants);
 
         // Act
         PegTxType transactionType = PegUtils.getTransactionType(
@@ -782,7 +781,7 @@ class PegUtilsGetTransactionTypeTest {
         anyToAnyTx.addInput(BitcoinTestUtils.createHash(1), 0, new Script(new byte[]{}));
         anyToAnyTx.addOutput(minimumPeginTxValue, new Script(new byte[]{}) );
 
-        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeMainnetConstants);
 
         // Act
         PegTxType transactionType = PegUtils.getTransactionType(
@@ -810,7 +809,7 @@ class PegUtilsGetTransactionTypeTest {
         anyToAnyTx.addInput(BitcoinTestUtils.createHash(1), 0, new Script(new byte[]{}));
         anyToAnyTx.addOutput(belowMinimum, new Script(new byte[]{}));
 
-        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeMainnetConstants);
 
         // Act
         PegTxType transactionType = PegUtils.getTransactionType(
@@ -861,7 +860,7 @@ class PegUtilsGetTransactionTypeTest {
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         Coin belowMinimumPeginTxValue = bridgeMainnetConstants.getMinimumPeginTxValue(activations).div(10);
 
-        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeMainnetConstants);
 
         BtcTransaction peginTx = new BtcTransaction(btcMainnetParams);
         peginTx.addInput(BitcoinTestUtils.createHash(1), 0, new Script(new byte[]{}));
@@ -896,7 +895,7 @@ class PegUtilsGetTransactionTypeTest {
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         Coin belowMinimumPeginTxValue = bridgeMainnetConstants.getMinimumPeginTxValue(activations).div(10);
 
-        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeMainnetConstants);
 
         BtcTransaction peginTx = new BtcTransaction(btcMainnetParams);
         peginTx.addInput(BitcoinTestUtils.createHash(1), 0, new Script(new byte[]{}));
@@ -952,7 +951,7 @@ class PegUtilsGetTransactionTypeTest {
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         Coin minimumPeginTxValue = bridgeMainnetConstants.getMinimumPeginTxValue(activations);
 
-        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeMainnetConstants);
 
         BtcTransaction peginTx = new BtcTransaction(btcMainnetParams);
         peginTx.addInput(BitcoinTestUtils.createHash(1), 0, new Script(new byte[]{}));
@@ -983,7 +982,7 @@ class PegUtilsGetTransactionTypeTest {
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         Coin minimumPeginTxValue = bridgeMainnetConstants.getMinimumPeginTxValue(activations).add(Coin.CENT);
 
-        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeMainnetConstants);
 
         BtcTransaction peginTx = new BtcTransaction(btcMainnetParams);
         peginTx.addInput(BitcoinTestUtils.createHash(1), 0, new Script(new byte[]{}));

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsGetTransactionTypeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsGetTransactionTypeTest.java
@@ -2245,21 +2245,19 @@ class PegUtilsGetTransactionTypeTest {
         PegTxType expectedType
     ) {
         // Arrange
-        BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
-        NetworkParameters btcRegTestsParams = bridgeRegTestConstants.getBtcParams();
-        Context.propagate(new Context(btcRegTestsParams));
+        Context.propagate(new Context(btcMainnetParams));
 
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
 
         List<BtcECKey> fedKeys = BitcoinTestUtils.getBtcEcKeysFromSeeds(
             new String[]{"fa01", "fa02", "fa03"}, true
         );
-        Federation retiredFederation = createFederation(bridgeRegTestConstants, fedKeys);
-        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation retiredFederation = createFederation(bridgeMainnetConstants, fedKeys);
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeMainnetConstants);
 
         when(provider.getLastRetiredFederationP2SHScript()).thenReturn(Optional.empty());
 
-        BtcTransaction migrationTx = new BtcTransaction(btcRegTestsParams);
+        BtcTransaction migrationTx = new BtcTransaction(btcMainnetParams);
 
         migrationTx.addInput(
             BitcoinTestUtils.createHash(1),
@@ -2279,7 +2277,7 @@ class PegUtilsGetTransactionTypeTest {
         PegTxType transactionType = PegUtils.getTransactionType(
             activations,
             provider,
-            bridgeRegTestConstants,
+            bridgeMainnetConstants,
             activeFederation,
             null,
             migrationTx,

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsGetTransactionTypeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsGetTransactionTypeTest.java
@@ -49,6 +49,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class PegUtilsGetTransactionTypeTest {
     private static final BridgeConstants bridgeMainnetConstants = BridgeMainNetConstants.getInstance();
+    private final BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
     private static final NetworkParameters btcMainnetParams = bridgeMainnetConstants.getBtcParams();
     private static final ActivationConfig.ForBlock activations = ActivationConfigsForTest.arrowhead600().forBlock(0);
 
@@ -725,7 +726,7 @@ class PegUtilsGetTransactionTypeTest {
         anyToAnyTx.addInput(BitcoinTestUtils.createHash(1), 0, new Script(new byte[]{}));
         anyToAnyTx.addOutput(minimumPeginTxValue, new Script(new byte[]{}) );
 
-        Federation activeFederation = bridgeMainnetConstants.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
 
         // Act
         PegTxType transactionType = PegUtils.getTransactionType(
@@ -753,7 +754,7 @@ class PegUtilsGetTransactionTypeTest {
         anyToAnyTx.addInput(BitcoinTestUtils.createHash(1), 0, new Script(new byte[]{}));
         anyToAnyTx.addOutput(belowMinimum, new Script(new byte[]{}));
 
-        Federation activeFederation = bridgeMainnetConstants.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
 
         // Act
         PegTxType transactionType = PegUtils.getTransactionType(
@@ -781,7 +782,7 @@ class PegUtilsGetTransactionTypeTest {
         anyToAnyTx.addInput(BitcoinTestUtils.createHash(1), 0, new Script(new byte[]{}));
         anyToAnyTx.addOutput(minimumPeginTxValue, new Script(new byte[]{}) );
 
-        Federation activeFederation = bridgeMainnetConstants.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
 
         // Act
         PegTxType transactionType = PegUtils.getTransactionType(
@@ -809,7 +810,7 @@ class PegUtilsGetTransactionTypeTest {
         anyToAnyTx.addInput(BitcoinTestUtils.createHash(1), 0, new Script(new byte[]{}));
         anyToAnyTx.addOutput(belowMinimum, new Script(new byte[]{}));
 
-        Federation activeFederation = bridgeMainnetConstants.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
 
         // Act
         PegTxType transactionType = PegUtils.getTransactionType(
@@ -860,7 +861,7 @@ class PegUtilsGetTransactionTypeTest {
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         Coin belowMinimumPeginTxValue = bridgeMainnetConstants.getMinimumPeginTxValue(activations).div(10);
 
-        Federation activeFederation = bridgeMainnetConstants.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
 
         BtcTransaction peginTx = new BtcTransaction(btcMainnetParams);
         peginTx.addInput(BitcoinTestUtils.createHash(1), 0, new Script(new byte[]{}));
@@ -895,7 +896,7 @@ class PegUtilsGetTransactionTypeTest {
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         Coin belowMinimumPeginTxValue = bridgeMainnetConstants.getMinimumPeginTxValue(activations).div(10);
 
-        Federation activeFederation = bridgeMainnetConstants.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
 
         BtcTransaction peginTx = new BtcTransaction(btcMainnetParams);
         peginTx.addInput(BitcoinTestUtils.createHash(1), 0, new Script(new byte[]{}));
@@ -951,7 +952,7 @@ class PegUtilsGetTransactionTypeTest {
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         Coin minimumPeginTxValue = bridgeMainnetConstants.getMinimumPeginTxValue(activations);
 
-        Federation activeFederation = bridgeMainnetConstants.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
 
         BtcTransaction peginTx = new BtcTransaction(btcMainnetParams);
         peginTx.addInput(BitcoinTestUtils.createHash(1), 0, new Script(new byte[]{}));
@@ -982,7 +983,7 @@ class PegUtilsGetTransactionTypeTest {
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         Coin minimumPeginTxValue = bridgeMainnetConstants.getMinimumPeginTxValue(activations).add(Coin.CENT);
 
-        Federation activeFederation = bridgeMainnetConstants.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
 
         BtcTransaction peginTx = new BtcTransaction(btcMainnetParams);
         peginTx.addInput(BitcoinTestUtils.createHash(1), 0, new Script(new byte[]{}));
@@ -2104,7 +2105,7 @@ class PegUtilsGetTransactionTypeTest {
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
 
         Federation oldFederation = createFederation(bridgeRegTestConstants, REGTEST_OLD_FEDERATION_PRIVATE_KEYS);
-        Federation activeFederation = bridgeRegTestConstants.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
 
         Assertions.assertEquals(oldFederation.getAddress().toString(), bridgeRegTestConstants.getOldFederationAddress());
 
@@ -2255,7 +2256,7 @@ class PegUtilsGetTransactionTypeTest {
             new String[]{"fa01", "fa02", "fa03"}, true
         );
         Federation retiredFederation = createFederation(bridgeRegTestConstants, fedKeys);
-        Federation activeFederation = bridgeRegTestConstants.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
 
         when(provider.getLastRetiredFederationP2SHScript()).thenReturn(Optional.empty());
 

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyGetTransactionTypeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyGetTransactionTypeTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.mock;
 
 class PegUtilsLegacyGetTransactionTypeTest {
     private static final BridgeConstants bridgeMainnetConstants = BridgeMainNetConstants.getInstance();
+    private final BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
     private static final NetworkParameters btcMainnetParams = bridgeMainnetConstants.getBtcParams();
 
     private static final Address oldFederationAddress = Address.fromBase58(
@@ -65,7 +66,7 @@ class PegUtilsLegacyGetTransactionTypeTest {
         );
 
         List<FederationMember> federationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(standardKeys);
-        Federation genesisFederation = bridgeMainnetConstants.getGenesisFederation();
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
         List<BtcECKey> erpPubKeys = bridgeMainnetConstants.getErpFedPubKeysList();
         long activationDelay = bridgeMainnetConstants.getErpFedActivationDelay();
         FederationArgs activeFedArgs =
@@ -121,7 +122,6 @@ class PegUtilsLegacyGetTransactionTypeTest {
     @ParameterizedTest
     @MethodSource("test_sentFromOldFed_Args")
     void test_sentFromOldFed(ActivationConfig.ForBlock activations, PegTxType expectedTxType) {
-        BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
         NetworkParameters btcRegTestsParams = bridgeRegTestConstants.getBtcParams();
         Context.propagate(new Context(btcRegTestsParams));
 
@@ -131,12 +131,17 @@ class PegUtilsLegacyGetTransactionTypeTest {
             BtcECKey.fromPrivate(Hex.decode("e1b17fcd0ef1942465eee61b20561b16750191143d365e71de08b33dd84a9788"))
         );
 
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        List<FederationMember> federationMembers = federation.getMembers();
+        Instant federationCreationTime = federation.getCreationTime();
+        NetworkParameters networkParameters = federation.getBtcParams();
+
         // Arrange
         FederationArgs federationArgs = new FederationArgs(
-            bridgeRegTestConstants.getGenesisFederation().getMembers(),
-            bridgeRegTestConstants.getGenesisFederation().getCreationTime(),
+            federationMembers,
+            federationCreationTime,
             5L,
-            bridgeRegTestConstants.getGenesisFederation().getBtcParams()
+            networkParameters
         );
         Federation activeFederation = FederationFactory.buildStandardMultiSigFederation(
             federationArgs
@@ -173,7 +178,7 @@ class PegUtilsLegacyGetTransactionTypeTest {
         // Arrange
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.hop400().forBlock(0);
 
-        Federation activeFederation = bridgeMainnetConstants.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
 
         List<BtcECKey> unknownFedSigners = BitcoinTestUtils.getBtcEcKeysFromSeeds(
             new String[]{"key1", "key2", "key3"}, true
@@ -539,7 +544,7 @@ class PegUtilsLegacyGetTransactionTypeTest {
     @Test
     void test_unknown_tx() {
         // Arrange
-        Federation activeFederation = bridgeMainnetConstants.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
 

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyGetTransactionTypeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyGetTransactionTypeTest.java
@@ -131,10 +131,10 @@ class PegUtilsLegacyGetTransactionTypeTest {
             BtcECKey.fromPrivate(Hex.decode("e1b17fcd0ef1942465eee61b20561b16750191143d365e71de08b33dd84a9788"))
         );
 
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
-        List<FederationMember> federationMembers = federation.getMembers();
-        Instant federationCreationTime = federation.getCreationTime();
-        NetworkParameters networkParameters = federation.getBtcParams();
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        List<FederationMember> federationMembers = genesisFederation.getMembers();
+        Instant federationCreationTime = genesisFederation.getCreationTime();
+        NetworkParameters networkParameters = genesisFederation.getBtcParams();
 
         // Arrange
         FederationArgs federationArgs = new FederationArgs(

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyGetTransactionTypeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyGetTransactionTypeTest.java
@@ -3,10 +3,10 @@ package co.rsk.peg;
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
+import co.rsk.peg.bitcoin.BitcoinTestUtils;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.constants.BridgeMainNetConstants;
 import co.rsk.peg.constants.BridgeRegTestConstants;
-import co.rsk.peg.bitcoin.BitcoinTestUtils;
 import co.rsk.peg.federation.*;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.mock;
 
 class PegUtilsLegacyGetTransactionTypeTest {
     private static final BridgeConstants bridgeMainnetConstants = BridgeMainNetConstants.getInstance();
-    private final BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
     private static final NetworkParameters btcMainnetParams = bridgeMainnetConstants.getBtcParams();
 
     private static final Address oldFederationAddress = Address.fromBase58(
@@ -66,7 +65,7 @@ class PegUtilsLegacyGetTransactionTypeTest {
         );
 
         List<FederationMember> federationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(standardKeys);
-        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeMainnetConstants);
         List<BtcECKey> erpPubKeys = bridgeMainnetConstants.getErpFedPubKeysList();
         long activationDelay = bridgeMainnetConstants.getErpFedActivationDelay();
         FederationArgs activeFedArgs =
@@ -122,6 +121,7 @@ class PegUtilsLegacyGetTransactionTypeTest {
     @ParameterizedTest
     @MethodSource("test_sentFromOldFed_Args")
     void test_sentFromOldFed(ActivationConfig.ForBlock activations, PegTxType expectedTxType) {
+        BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
         NetworkParameters btcRegTestsParams = bridgeRegTestConstants.getBtcParams();
         Context.propagate(new Context(btcRegTestsParams));
 
@@ -158,14 +158,14 @@ class PegUtilsLegacyGetTransactionTypeTest {
 
         // Act
         PegTxType transactionType = PegUtilsLegacy.getTransactionType(
-            migrationTx,
-            activeFederation,
-            null,
-            activations.isActive(RSKIP186)? retiredFederation.getP2SHScript(): null,
-            oldFederationAddress,
-            activations,
-            bridgeRegTestConstants.getMinimumPeginTxValue(activations),
-            new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation))
+                migrationTx,
+                activeFederation,
+                null,
+                activations.isActive(RSKIP186) ? retiredFederation.getP2SHScript() : null,
+                oldFederationAddress,
+                activations,
+                bridgeRegTestConstants.getMinimumPeginTxValue(activations),
+                new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation))
         );
 
         // Assert
@@ -178,7 +178,7 @@ class PegUtilsLegacyGetTransactionTypeTest {
         // Arrange
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.hop400().forBlock(0);
 
-        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeMainnetConstants);
 
         List<BtcECKey> unknownFedSigners = BitcoinTestUtils.getBtcEcKeysFromSeeds(
             new String[]{"key1", "key2", "key3"}, true
@@ -544,7 +544,7 @@ class PegUtilsLegacyGetTransactionTypeTest {
     @Test
     void test_unknown_tx() {
         // Arrange
-        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeMainnetConstants);
 
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
 

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
@@ -51,8 +51,7 @@ class PegUtilsLegacyTest {
     void testIsValidPegInTx() {
         // Peg-in is for the genesis federation ATM
         Context btcContext = new Context(networkParameters);
-
-        Federation federation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         Wallet wallet = new BridgeBtcWallet(btcContext, Collections.singletonList(federation));
         Address federationAddress = federation.getAddress();
         wallet.addWatchedAddress(federationAddress, federation.getCreationTime().toEpochMilli());
@@ -76,7 +75,7 @@ class PegUtilsLegacyTest {
             new TransactionOutPoint(networkParameters, 0, Sha256Hash.ZERO_HASH)
         );
         tx2.addInput(txIn);
-        signWithNecessaryKeys(bridgeConstantsRegtest.getGenesisFederation(), BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS, txIn, tx2);
+        signWithNecessaryKeys(federation, BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS, txIn, tx2);
         assertFalse(isValidPegInTx(tx2, federation, wallet, bridgeConstantsRegtest, activations));
 
         // Tx sending 1 btc to the federation, is a peg-in tx
@@ -96,7 +95,7 @@ class PegUtilsLegacyTest {
     void testIsValidPegInTx_less_than_minimum_not_pegin_after_iris() {
         // Tx sending less than the minimum allowed, not a peg-in tx
         Context btcContext = new Context(networkParameters);
-        Federation federation = this.getGenesisFederationForTest(bridgeConstantsRegtest, btcContext);
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         when(activations.isActive(ConsensusRule.RSKIP219)).thenReturn(true);
         Coin minimumPegInValueAfterIris = bridgeConstantsRegtest.getMinimumPeginTxValue(activations);
@@ -115,7 +114,7 @@ class PegUtilsLegacyTest {
         // Tx sending 1 btc to the federation, but also spending from the federation address,
         // the typical peg-out tx, not a peg-in tx.
         Context btcContext = new Context(networkParameters);
-        Federation federation = this.getGenesisFederationForTest(bridgeConstantsRegtest, btcContext);
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         when(activations.isActive(ConsensusRule.RSKIP219)).thenReturn(true);
 
@@ -128,7 +127,7 @@ class PegUtilsLegacyTest {
             new TransactionOutPoint(networkParameters, 0, Sha256Hash.ZERO_HASH)
         );
         tx.addInput(txIn);
-        signWithNecessaryKeys(bridgeConstantsRegtest.getGenesisFederation(), BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS, txIn, tx);
+        signWithNecessaryKeys(federation, BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS, txIn, tx);
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(federation));
         assertFalse(isValidPegInTx(tx, federation, federationWallet, bridgeConstantsRegtest, activations));
@@ -138,7 +137,7 @@ class PegUtilsLegacyTest {
     void testIsValidPegInTx_sending_50_btc_after_iris() {
         // Tx sending 50 btc to the federation, is a peg-in tx
         Context btcContext = new Context(networkParameters);
-        Federation federation = this.getGenesisFederationForTest(bridgeConstantsRegtest, btcContext);
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         when(activations.isActive(ConsensusRule.RSKIP219)).thenReturn(true);
 
@@ -154,7 +153,7 @@ class PegUtilsLegacyTest {
     void testIsValidPegInTx_value_between_old_and_new_before_iris() {
         // Tx sending btc between old and new value, it is not a peg-in before iris
         Context btcContext = new Context(networkParameters);
-        Federation federation = this.getGenesisFederationForTest(bridgeConstantsRegtest, btcContext);
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         when(activations.isActive(ConsensusRule.RSKIP219)).thenReturn(false);
 
@@ -178,8 +177,7 @@ class PegUtilsLegacyTest {
     void testIsValidPegInTx_value_between_old_and_new_after_iris() {
         // Tx sending btc between old and new value, it is a peg-in after iris
         Context btcContext = new Context(networkParameters);
-        Federation federation = this.getGenesisFederationForTest(bridgeConstantsRegtest, btcContext);
-
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         when(activations.isActive(ConsensusRule.RSKIP219)).thenReturn(true);
 
         BtcTransaction tx = new BtcTransaction(networkParameters);
@@ -485,7 +483,7 @@ class PegUtilsLegacyTest {
         Context btcContext = new Context(networkParameters);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(false);
 
-        Federation activeFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         Script flyoverRedeemScript = FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
             activeFederation.getRedeemScript(),
             Sha256Hash.of(PegTestUtils.createHash(1).getBytes())
@@ -507,7 +505,7 @@ class PegUtilsLegacyTest {
         Context btcContext = new Context(networkParameters);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
 
-        Federation activeFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         Script flyoverRedeemScript = FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
             activeFederation.getRedeemScript(),
             Sha256Hash.of(PegTestUtils.createHash(1).getBytes())
@@ -529,7 +527,7 @@ class PegUtilsLegacyTest {
 
         Context btcContext = new Context(networkParameters);
 
-        Federation activeFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         FederationArgs federationArgs = activeFederation.getArgs();
 
         List<BtcECKey> erpPubKeys = Arrays.asList(
@@ -568,7 +566,7 @@ class PegUtilsLegacyTest {
         Context btcContext = new Context(networkParameters);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
 
-        Federation activeFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         List<BtcECKey> erpFederationKeys = Arrays.asList(
             BtcECKey.fromPrivate(Hex.decode("fa01")),
             BtcECKey.fromPrivate(Hex.decode("fa02"))
@@ -610,7 +608,7 @@ class PegUtilsLegacyTest {
         Context btcContext = new Context(networkParameters);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(false);
 
-        Federation activeFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         List<BtcECKey> erpFederationKeys = Arrays.asList(
             BtcECKey.fromPrivate(Hex.decode("fa01")),
             BtcECKey.fromPrivate(Hex.decode("fa02"))
@@ -648,7 +646,7 @@ class PegUtilsLegacyTest {
         Context btcContext = new Context(networkParameters);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
 
-        Federation activeFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         List<BtcECKey> erpFederationKeys = Arrays.asList(
             BtcECKey.fromPrivate(Hex.decode("fa01")),
             BtcECKey.fromPrivate(Hex.decode("fa02"))
@@ -684,7 +682,7 @@ class PegUtilsLegacyTest {
     @Test
     void testIsValidPegInTx_hasChangeUtxoFromFlyoverRetiredFederation_beforeRskip201_isPegin() {
         Context btcContext = new Context(networkParameters);
-        Federation activeFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(false);
 
         List<BtcECKey> retiredFederationKeys = Arrays.asList(
@@ -734,7 +732,7 @@ class PegUtilsLegacyTest {
     @Test
     void testIsValidPegInTx_hasChangeUtxoFromFlyoverRetiredFederation_afterRskip201_notPegin() {
         Context btcContext = new Context(networkParameters);
-        Federation activeFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
 
         List<BtcECKey> retiredFederationKeys = Arrays.asList(
@@ -784,7 +782,7 @@ class PegUtilsLegacyTest {
     @Test
     void testIsValidPegInTx_hasChangeUtxoFromFlyoverErpRetiredFederation_beforeRskip201_isPegin() {
         Context btcContext = new Context(networkParameters);
-        Federation activeFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(false);
 
         List<BtcECKey> retiredFederationKeys = Arrays.asList(
@@ -838,7 +836,7 @@ class PegUtilsLegacyTest {
     @Test
     void testIsValidPegInTx_hasChangeUtxoFromFlyoverErpRetiredFederation_afterRskip201_notPegin() {
         Context btcContext = new Context(networkParameters);
-        Federation activeFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
 
         List<BtcECKey> retiredFederationKeys = Arrays.asList(
@@ -892,7 +890,7 @@ class PegUtilsLegacyTest {
     @Test
     void testIsValidPegInTx_hasChangeUtxoFromErpRetiredFederation_beforeRskip201_isPegin() {
         Context btcContext = new Context(networkParameters);
-        Federation activeFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         List<BtcECKey> retiredFederationKeys = Arrays.asList(
             BtcECKey.fromPrivate(Hex.decode("fa01")),
@@ -940,7 +938,7 @@ class PegUtilsLegacyTest {
     @Test
     void testIsValidPegInTx_hasChangeUtxoFromErpRetiredFederation_afterRskip201_notPegin() {
         Context btcContext = new Context(networkParameters);
-        Federation activeFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
 
         List<BtcECKey> retiredFederationKeys = Arrays.asList(
@@ -989,7 +987,7 @@ class PegUtilsLegacyTest {
     @Test
     void testIsValidPegInTx_has_multiple_utxos_below_minimum_but_total_amount_is_ok_before_RSKIP293() {
         Context btcContext = new Context(networkParameters);
-        Federation activeFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(false);
 
@@ -1016,7 +1014,7 @@ class PegUtilsLegacyTest {
     @Test
     void testIsValidPegInTx_has_utxos_below_minimum_and_total_amount_as_well_before_RSKIP293() {
         Context btcContext = new Context(networkParameters);
-        Federation activeFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(false);
 
@@ -1043,7 +1041,7 @@ class PegUtilsLegacyTest {
     @Test
     void testIsValidPegInTx_has_utxos_below_minimum_after_RSKIP293() {
         Context btcContext = new Context(networkParameters);
-        Federation activeFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
@@ -1074,7 +1072,7 @@ class PegUtilsLegacyTest {
     @Test
     void testIsValidPegInTx_utxo_equal_to_minimum_after_RSKIP293() {
         Context btcContext = new Context(networkParameters);
-        Federation activeFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
@@ -1097,7 +1095,8 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsValidPegInTx_p2shErpScript_sends_funds_to_federation_address_before_RSKIP353() {
-        Address activeFederationAddress = bridgeConstantsRegtest.getGenesisFederation().getAddress();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Address activeFederationAddress = federation.getAddress();
         testIsValidPegInTx_fromP2shErpScriptSender(
             false,
             false,
@@ -1120,7 +1119,8 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsValidPegInTx_p2shErpScript_sends_funds_to_federation_address_after_RSKIP353() {
-        Address activeFederationAddress = bridgeConstantsRegtest.getGenesisFederation().getAddress();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Address activeFederationAddress = federation.getAddress();
         testIsValidPegInTx_fromP2shErpScriptSender(
             true,
             false,
@@ -1142,7 +1142,8 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsValidPegInTx_flyoverP2shErpScript_sends_funds_to_federation_address_before_RSKIP353() {
-        Address activeFederationAddress = bridgeConstantsRegtest.getGenesisFederation().getAddress();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Address activeFederationAddress = federation.getAddress();
         testIsValidPegInTx_fromP2shErpScriptSender(
             false,
             true,
@@ -1165,7 +1166,8 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsValidPegInTx_flyoverpP2shErpScript_sends_funds_to_federation_address_after_RSKIP353() {
-        Address activeFederationAddress = bridgeConstantsRegtest.getGenesisFederation().getAddress();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Address activeFederationAddress = federation.getAddress();
         testIsValidPegInTx_fromP2shErpScriptSender(
             true,
             true,
@@ -1196,7 +1198,7 @@ class PegUtilsLegacyTest {
         when(activations.isActive(ConsensusRule.RSKIP353)).thenReturn(isRskip353Active);
 
         Context btcContext = new Context(networkParameters);
-        Federation activeFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         FederationArgs activeFederationArgs = activeFederation.getArgs();
 
         List<BtcECKey> emergencyKeys = PegTestUtils.createRandomBtcECKeys(3);
@@ -1791,7 +1793,7 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsPegOutTx() {
-        Federation federation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         List<BtcECKey> activeFederationKeys = Stream.of(
             BtcECKey.fromPrivate(Hex.decode("fa01")),
             BtcECKey.fromPrivate(Hex.decode("fa02")),
@@ -1845,7 +1847,7 @@ class PegUtilsLegacyTest {
             args
         );
 
-        Federation standardFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation standardFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         // Create a tx from the fast bridge fed to a random address
         Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
@@ -1909,7 +1911,7 @@ class PegUtilsLegacyTest {
         erpFederationPublicKeys.sort(BtcECKey.PUBKEY_COMPARATOR);
         ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(federationArgs, erpFederationPublicKeys, 500L, activations);
 
-        Federation standardFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation standardFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         // Create a tx from the erp fed to a random address
         Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
@@ -1975,7 +1977,7 @@ class PegUtilsLegacyTest {
 
         ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(federationArgs, erpFederationPublicKeys, 500L, activations);
 
-        Federation standardFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation standardFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         // Create a tx from the fast bridge erp fed to a random address
         Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
@@ -2020,7 +2022,7 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsPegOutTx_noRedeemScript() {
-        Federation federation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
 
         BtcTransaction pegOutTx1 = new BtcTransaction(networkParameters);
@@ -2038,7 +2040,7 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsPegOutTx_invalidRedeemScript() {
-        Federation federation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
         Script invalidRedeemScript = ScriptBuilder.createRedeemScript(2, Arrays.asList(new BtcECKey(), new BtcECKey()));
 
@@ -2233,7 +2235,7 @@ class PegUtilsLegacyTest {
 
     @Test
     void scriptCorrectlySpends_fromGenesisFederation_ok() {
-        Federation genesisFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         Address destinationAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
 
         BtcTransaction tx = new BtcTransaction(networkParameters);
@@ -2252,7 +2254,7 @@ class PegUtilsLegacyTest {
 
     @Test
     void scriptCorrectlySpends_invalidScript() {
-        Federation genesisFederation = bridgeConstantsRegtest.getGenesisFederation();
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         Address destinationAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
 
         BtcTransaction tx = new BtcTransaction(networkParameters);
@@ -2364,14 +2366,5 @@ class PegUtilsLegacyTest {
         inputScript = ScriptBuilder.updateScriptWithSignature(inputScript, txSig.encodeToBitcoin(), sigIndex, 1, 1);
 
         return inputScript;
-    }
-
-    private Federation getGenesisFederationForTest(BridgeConstants bridgeConstants, Context btcContext){
-        Federation federation = bridgeConstants.getGenesisFederation();
-        Wallet wallet = new BridgeBtcWallet(btcContext, Collections.singletonList(federation));
-        Address federationAddress = federation.getAddress();
-        wallet.addWatchedAddress(federationAddress, federation.getCreationTime().toEpochMilli());
-
-        return federation;
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
@@ -51,10 +51,10 @@ class PegUtilsLegacyTest {
     void testIsValidPegInTx() {
         // Peg-in is for the genesis federation ATM
         Context btcContext = new Context(networkParameters);
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
-        Wallet wallet = new BridgeBtcWallet(btcContext, Collections.singletonList(federation));
-        Address federationAddress = federation.getAddress();
-        wallet.addWatchedAddress(federationAddress, federation.getCreationTime().toEpochMilli());
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Wallet wallet = new BridgeBtcWallet(btcContext, Collections.singletonList(genesisFederation));
+        Address federationAddress = genesisFederation.getAddress();
+        wallet.addWatchedAddress(federationAddress, genesisFederation.getCreationTime().toEpochMilli());
         when(activations.isActive(any(ConsensusRule.class))).thenReturn(false);
 
         // Tx sending less than the minimum allowed, not a peg-in tx
@@ -62,7 +62,7 @@ class PegUtilsLegacyTest {
         BtcTransaction tx = new BtcTransaction(networkParameters);
         tx.addOutput(minimumLockValue.subtract(Coin.CENT), federationAddress);
         tx.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
-        assertFalse(isValidPegInTx(tx, federation, wallet, bridgeConstantsRegtest, activations));
+        assertFalse(isValidPegInTx(tx, genesisFederation, wallet, bridgeConstantsRegtest, activations));
 
         // Tx sending 1 btc to the federation, but also spending from the federation address,
         // the typical peg-out tx, not a peg-in tx.
@@ -75,38 +75,38 @@ class PegUtilsLegacyTest {
             new TransactionOutPoint(networkParameters, 0, Sha256Hash.ZERO_HASH)
         );
         tx2.addInput(txIn);
-        signWithNecessaryKeys(federation, BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS, txIn, tx2);
-        assertFalse(isValidPegInTx(tx2, federation, wallet, bridgeConstantsRegtest, activations));
+        signWithNecessaryKeys(genesisFederation, BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS, txIn, tx2);
+        assertFalse(isValidPegInTx(tx2, genesisFederation, wallet, bridgeConstantsRegtest, activations));
 
         // Tx sending 1 btc to the federation, is a peg-in tx
         BtcTransaction tx3 = new BtcTransaction(networkParameters);
         tx3.addOutput(Coin.COIN, federationAddress);
         tx3.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
-        assertTrue(isValidPegInTx(tx3, federation, wallet, bridgeConstantsRegtest, activations));
+        assertTrue(isValidPegInTx(tx3, genesisFederation, wallet, bridgeConstantsRegtest, activations));
 
         // Tx sending 50 btc to the federation, is a peg-in tx
         BtcTransaction tx4 = new BtcTransaction(networkParameters);
         tx4.addOutput(Coin.FIFTY_COINS, federationAddress);
         tx4.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
-        assertTrue(isValidPegInTx(tx4, federation, wallet, bridgeConstantsRegtest, activations));
+        assertTrue(isValidPegInTx(tx4, genesisFederation, wallet, bridgeConstantsRegtest, activations));
     }
 
     @Test
     void testIsValidPegInTx_less_than_minimum_not_pegin_after_iris() {
         // Tx sending less than the minimum allowed, not a peg-in tx
         Context btcContext = new Context(networkParameters);
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         when(activations.isActive(ConsensusRule.RSKIP219)).thenReturn(true);
         Coin minimumPegInValueAfterIris = bridgeConstantsRegtest.getMinimumPeginTxValue(activations);
 
         // Tx sending less than the minimum allowed, not a peg-in tx
         BtcTransaction tx = new BtcTransaction(networkParameters);
-        tx.addOutput(minimumPegInValueAfterIris.subtract(Coin.CENT), federation.getAddress());
+        tx.addOutput(minimumPegInValueAfterIris.subtract(Coin.CENT), genesisFederation.getAddress());
         tx.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(federation));
-        assertFalse(isValidPegInTx(tx, federation, federationWallet, bridgeConstantsRegtest, activations));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(genesisFederation));
+        assertFalse(isValidPegInTx(tx, genesisFederation, federationWallet, bridgeConstantsRegtest, activations));
     }
 
     @Test
@@ -114,12 +114,12 @@ class PegUtilsLegacyTest {
         // Tx sending 1 btc to the federation, but also spending from the federation address,
         // the typical peg-out tx, not a peg-in tx.
         Context btcContext = new Context(networkParameters);
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         when(activations.isActive(ConsensusRule.RSKIP219)).thenReturn(true);
 
         BtcTransaction tx = new BtcTransaction(networkParameters);
-        tx.addOutput(Coin.COIN, federation.getAddress());
+        tx.addOutput(Coin.COIN, genesisFederation.getAddress());
         TransactionInput txIn = new TransactionInput(
             networkParameters,
             tx,
@@ -127,33 +127,33 @@ class PegUtilsLegacyTest {
             new TransactionOutPoint(networkParameters, 0, Sha256Hash.ZERO_HASH)
         );
         tx.addInput(txIn);
-        signWithNecessaryKeys(federation, BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS, txIn, tx);
+        signWithNecessaryKeys(genesisFederation, BridgeRegTestConstants.REGTEST_FEDERATION_PRIVATE_KEYS, txIn, tx);
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(federation));
-        assertFalse(isValidPegInTx(tx, federation, federationWallet, bridgeConstantsRegtest, activations));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(genesisFederation));
+        assertFalse(isValidPegInTx(tx, genesisFederation, federationWallet, bridgeConstantsRegtest, activations));
     }
 
     @Test
     void testIsValidPegInTx_sending_50_btc_after_iris() {
         // Tx sending 50 btc to the federation, is a peg-in tx
         Context btcContext = new Context(networkParameters);
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         when(activations.isActive(ConsensusRule.RSKIP219)).thenReturn(true);
 
         BtcTransaction tx = new BtcTransaction(networkParameters);
-        tx.addOutput(Coin.FIFTY_COINS, federation.getAddress());
+        tx.addOutput(Coin.FIFTY_COINS, genesisFederation.getAddress());
         tx.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(federation));
-        assertTrue(isValidPegInTx(tx, federation, federationWallet, bridgeConstantsRegtest, activations));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(genesisFederation));
+        assertTrue(isValidPegInTx(tx, genesisFederation, federationWallet, bridgeConstantsRegtest, activations));
     }
 
     @Test
     void testIsValidPegInTx_value_between_old_and_new_before_iris() {
         // Tx sending btc between old and new value, it is not a peg-in before iris
         Context btcContext = new Context(networkParameters);
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
 
         when(activations.isActive(ConsensusRule.RSKIP219)).thenReturn(false);
 
@@ -166,18 +166,18 @@ class PegUtilsLegacyTest {
         assertTrue(valueLock.isLessThan(minimumPegInValueBeforeIris));
         assertTrue(valueLock.isGreaterThan(minimumPegInValueAfterIris));
 
-        tx.addOutput(valueLock, federation.getAddress());
+        tx.addOutput(valueLock, genesisFederation.getAddress());
         tx.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(federation));
-        assertFalse(isValidPegInTx(tx, federation, federationWallet, bridgeConstantsRegtest, activations));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(genesisFederation));
+        assertFalse(isValidPegInTx(tx, genesisFederation, federationWallet, bridgeConstantsRegtest, activations));
     }
 
     @Test
     void testIsValidPegInTx_value_between_old_and_new_after_iris() {
         // Tx sending btc between old and new value, it is a peg-in after iris
         Context btcContext = new Context(networkParameters);
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         when(activations.isActive(ConsensusRule.RSKIP219)).thenReturn(true);
 
         BtcTransaction tx = new BtcTransaction(networkParameters);
@@ -189,11 +189,11 @@ class PegUtilsLegacyTest {
         assertTrue(valueLock.isGreaterThan(minimumPegInValueAfterIris));
         assertTrue(valueLock.isLessThan(minimumPegInValueBeforeIris));
 
-        tx.addOutput(valueLock, federation.getAddress());
+        tx.addOutput(valueLock, genesisFederation.getAddress());
         tx.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(federation));
-        assertTrue(isValidPegInTx(tx, federation, federationWallet, bridgeConstantsRegtest, activations));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(genesisFederation));
+        assertTrue(isValidPegInTx(tx, genesisFederation, federationWallet, bridgeConstantsRegtest, activations));
     }
 
     @Test
@@ -1095,8 +1095,8 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsValidPegInTx_p2shErpScript_sends_funds_to_federation_address_before_RSKIP353() {
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
-        Address activeFederationAddress = federation.getAddress();
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Address activeFederationAddress = genesisFederation.getAddress();
         testIsValidPegInTx_fromP2shErpScriptSender(
             false,
             false,
@@ -1119,8 +1119,8 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsValidPegInTx_p2shErpScript_sends_funds_to_federation_address_after_RSKIP353() {
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
-        Address activeFederationAddress = federation.getAddress();
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Address activeFederationAddress = genesisFederation.getAddress();
         testIsValidPegInTx_fromP2shErpScriptSender(
             true,
             false,
@@ -1142,8 +1142,8 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsValidPegInTx_flyoverP2shErpScript_sends_funds_to_federation_address_before_RSKIP353() {
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
-        Address activeFederationAddress = federation.getAddress();
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Address activeFederationAddress = genesisFederation.getAddress();
         testIsValidPegInTx_fromP2shErpScriptSender(
             false,
             true,
@@ -1166,8 +1166,8 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsValidPegInTx_flyoverpP2shErpScript_sends_funds_to_federation_address_after_RSKIP353() {
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
-        Address activeFederationAddress = federation.getAddress();
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Address activeFederationAddress = activeFederation.getAddress();
         testIsValidPegInTx_fromP2shErpScriptSender(
             true,
             true,
@@ -1793,7 +1793,7 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsPegOutTx() {
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         List<BtcECKey> activeFederationKeys = Stream.of(
             BtcECKey.fromPrivate(Hex.decode("fa01")),
             BtcECKey.fromPrivate(Hex.decode("fa02")),
@@ -1819,14 +1819,14 @@ class PegUtilsLegacyTest {
             new TransactionOutPoint(networkParameters, 0, Sha256Hash.ZERO_HASH)
         );
         pegOutTx1.addInput(pegOutInput1);
-        signWithNecessaryKeys(federation, federationPrivateKeys, pegOutInput1, pegOutTx1);
+        signWithNecessaryKeys(genesisFederation, federationPrivateKeys, pegOutInput1, pegOutTx1);
 
-        assertTrue(isPegOutTx(pegOutTx1, Collections.singletonList(federation), activations));
-        assertTrue(isPegOutTx(pegOutTx1, Arrays.asList(federation, federation2), activations));
+        assertTrue(isPegOutTx(pegOutTx1, Collections.singletonList(genesisFederation), activations));
+        assertTrue(isPegOutTx(pegOutTx1, Arrays.asList(genesisFederation, federation2), activations));
         assertFalse(isPegOutTx(pegOutTx1, Collections.singletonList(federation2), activations));
 
-        assertTrue(isPegOutTx(pegOutTx1, activations, federation.getP2SHScript()));
-        assertTrue(isPegOutTx(pegOutTx1, activations, federation.getP2SHScript(), federation2.getP2SHScript()));
+        assertTrue(isPegOutTx(pegOutTx1, activations, genesisFederation.getP2SHScript()));
+        assertTrue(isPegOutTx(pegOutTx1, activations, genesisFederation.getP2SHScript(), federation2.getP2SHScript()));
         assertFalse(isPegOutTx(pegOutTx1, activations, federation2.getP2SHScript()));
     }
 
@@ -2022,7 +2022,7 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsPegOutTx_noRedeemScript() {
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
 
         BtcTransaction pegOutTx1 = new BtcTransaction(networkParameters);
@@ -2035,12 +2035,12 @@ class PegUtilsLegacyTest {
         );
         pegOutTx1.addInput(pegOutInput1);
 
-        assertFalse(isPegOutTx(pegOutTx1, Collections.singletonList(federation), activations));
+        assertFalse(isPegOutTx(pegOutTx1, Collections.singletonList(genesisFederation), activations));
     }
 
     @Test
     void testIsPegOutTx_invalidRedeemScript() {
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
         Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
         Script invalidRedeemScript = ScriptBuilder.createRedeemScript(2, Arrays.asList(new BtcECKey(), new BtcECKey()));
 
@@ -2054,7 +2054,7 @@ class PegUtilsLegacyTest {
         );
         pegOutTx1.addInput(pegOutInput1);
 
-        assertFalse(isPegOutTx(pegOutTx1, Collections.singletonList(federation), activations));
+        assertFalse(isPegOutTx(pegOutTx1, Collections.singletonList(genesisFederation), activations));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
@@ -136,32 +136,32 @@ class PegUtilsLegacyTest {
     @Test
     void testIsValidPegInTx_sending_50_btc_after_iris() {
         // Tx sending 50 btc to the federation, is a peg-in tx
-        Context btcContext = new Context(networkParameters);
-        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Context btcContext = new Context(bridgeConstantsMainnet.getBtcParams());
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsMainnet);
 
         when(activations.isActive(ConsensusRule.RSKIP219)).thenReturn(true);
 
-        BtcTransaction tx = new BtcTransaction(networkParameters);
+        BtcTransaction tx = new BtcTransaction(bridgeConstantsMainnet.getBtcParams());
         tx.addOutput(Coin.FIFTY_COINS, genesisFederation.getAddress());
         tx.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(genesisFederation));
-        assertTrue(isValidPegInTx(tx, genesisFederation, federationWallet, bridgeConstantsRegtest, activations));
+        assertTrue(isValidPegInTx(tx, genesisFederation, federationWallet, bridgeConstantsMainnet, activations));
     }
 
     @Test
     void testIsValidPegInTx_value_between_old_and_new_before_iris() {
         // Tx sending btc between old and new value, it is not a peg-in before iris
-        Context btcContext = new Context(networkParameters);
-        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Context btcContext = new Context(bridgeConstantsMainnet.getBtcParams());
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsMainnet);
 
         when(activations.isActive(ConsensusRule.RSKIP219)).thenReturn(false);
 
-        BtcTransaction tx = new BtcTransaction(networkParameters);
+        BtcTransaction tx = new BtcTransaction(bridgeConstantsMainnet.getBtcParams());
 
         // Get a value in between pre and post iris minimum
-        Coin minimumPegInValueBeforeIris = bridgeConstantsRegtest.getMinimumPeginTxValue(ActivationConfigsForTest.papyrus200().forBlock(0));
-        Coin minimumPegInValueAfterIris = bridgeConstantsRegtest.getMinimumPeginTxValue(ActivationConfigsForTest.iris300().forBlock(0));
+        Coin minimumPegInValueBeforeIris = bridgeConstantsMainnet.getMinimumPeginTxValue(ActivationConfigsForTest.papyrus200().forBlock(0));
+        Coin minimumPegInValueAfterIris = bridgeConstantsMainnet.getMinimumPeginTxValue(ActivationConfigsForTest.iris300().forBlock(0));
         Coin valueLock = minimumPegInValueAfterIris.plus((minimumPegInValueBeforeIris.subtract(minimumPegInValueAfterIris)).div(2));
         assertTrue(valueLock.isLessThan(minimumPegInValueBeforeIris));
         assertTrue(valueLock.isGreaterThan(minimumPegInValueAfterIris));
@@ -170,21 +170,21 @@ class PegUtilsLegacyTest {
         tx.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(genesisFederation));
-        assertFalse(isValidPegInTx(tx, genesisFederation, federationWallet, bridgeConstantsRegtest, activations));
+        assertFalse(isValidPegInTx(tx, genesisFederation, federationWallet, bridgeConstantsMainnet, activations));
     }
 
     @Test
     void testIsValidPegInTx_value_between_old_and_new_after_iris() {
         // Tx sending btc between old and new value, it is a peg-in after iris
-        Context btcContext = new Context(networkParameters);
-        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Context btcContext = new Context(bridgeConstantsMainnet.getBtcParams());
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsMainnet);
         when(activations.isActive(ConsensusRule.RSKIP219)).thenReturn(true);
 
-        BtcTransaction tx = new BtcTransaction(networkParameters);
+        BtcTransaction tx = new BtcTransaction(bridgeConstantsMainnet.getBtcParams());
 
         // Get a value in between pre and post iris minimum
-        Coin minimumPegInValueBeforeIris = bridgeConstantsRegtest.getMinimumPeginTxValue(ActivationConfigsForTest.papyrus200().forBlock(0));
-        Coin minimumPegInValueAfterIris = bridgeConstantsRegtest.getMinimumPeginTxValue(ActivationConfigsForTest.iris300().forBlock(0));
+        Coin minimumPegInValueBeforeIris = bridgeConstantsMainnet.getMinimumPeginTxValue(ActivationConfigsForTest.papyrus200().forBlock(0));
+        Coin minimumPegInValueAfterIris = bridgeConstantsMainnet.getMinimumPeginTxValue(ActivationConfigsForTest.iris300().forBlock(0));
         Coin valueLock = minimumPegInValueAfterIris.plus((minimumPegInValueBeforeIris.subtract(minimumPegInValueAfterIris)).div(2));
         assertTrue(valueLock.isGreaterThan(minimumPegInValueAfterIris));
         assertTrue(valueLock.isLessThan(minimumPegInValueBeforeIris));
@@ -193,7 +193,7 @@ class PegUtilsLegacyTest {
         tx.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(genesisFederation));
-        assertTrue(isValidPegInTx(tx, genesisFederation, federationWallet, bridgeConstantsRegtest, activations));
+        assertTrue(isValidPegInTx(tx, genesisFederation, federationWallet, bridgeConstantsMainnet, activations));
     }
 
     @Test
@@ -480,45 +480,45 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsValidPegInTx_hasChangeUtxoFromFlyoverFederation_beforeRskip201_isPegin() {
-        Context btcContext = new Context(networkParameters);
+        Context btcContext = new Context(bridgeConstantsMainnet.getBtcParams());
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(false);
 
-        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsMainnet);
         Script flyoverRedeemScript = FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
             activeFederation.getRedeemScript(),
             Sha256Hash.of(PegTestUtils.createHash(1).getBytes())
         );
 
         // Create a tx from the fast bridge fed to the active fed
-        BtcTransaction tx = new BtcTransaction(networkParameters);
+        BtcTransaction tx = new BtcTransaction(bridgeConstantsMainnet.getBtcParams());
         tx.addOutput(Coin.COIN, activeFederation.getAddress());
         tx.addInput(Sha256Hash.ZERO_HASH, 0, flyoverRedeemScript);
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
 
         Assertions.assertTrue(isValidPegInTx(tx, activeFederation, federationWallet,
-            bridgeConstantsRegtest, activations));
+            bridgeConstantsMainnet, activations));
     }
 
     @Test
     void testIsValidPegInTx_hasChangeUtxoFromFlyoverFederation_afterRskip201_notPegin() {
-        Context btcContext = new Context(networkParameters);
+        Context btcContext = new Context(bridgeConstantsMainnet.getBtcParams());
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
 
-        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsMainnet);
         Script flyoverRedeemScript = FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
             activeFederation.getRedeemScript(),
             Sha256Hash.of(PegTestUtils.createHash(1).getBytes())
         );
 
         // Create a tx from the fast bridge fed to the active fed
-        BtcTransaction tx = new BtcTransaction(networkParameters);
+        BtcTransaction tx = new BtcTransaction(bridgeConstantsMainnet.getBtcParams());
         tx.addOutput(Coin.COIN, activeFederation.getAddress());
         tx.addInput(Sha256Hash.ZERO_HASH, 0, flyoverRedeemScript);
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
         Assertions.assertFalse(isValidPegInTx(tx, activeFederation, federationWallet,
-            bridgeConstantsRegtest, activations));
+            bridgeConstantsMainnet, activations));
     }
 
     @Test
@@ -986,14 +986,14 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsValidPegInTx_has_multiple_utxos_below_minimum_but_total_amount_is_ok_before_RSKIP293() {
-        Context btcContext = new Context(networkParameters);
-        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Context btcContext = new Context(bridgeConstantsMainnet.getBtcParams());
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsMainnet);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(false);
 
-        Coin minimumPeginValue = bridgeConstantsRegtest.getMinimumPeginTxValue(activations);
+        Coin minimumPeginValue = bridgeConstantsMainnet.getMinimumPeginTxValue(activations);
         // Create a tx with multiple utxos below the minimum but the sum of each utxos is equal to the minimum
-        BtcTransaction tx = new BtcTransaction(networkParameters);
+        BtcTransaction tx = new BtcTransaction(bridgeConstantsMainnet.getBtcParams());
         tx.addOutput(minimumPeginValue.div(4), activeFederation.getAddress());
         tx.addOutput(minimumPeginValue.div(4), activeFederation.getAddress());
         tx.addOutput(minimumPeginValue.div(4), activeFederation.getAddress());
@@ -1013,14 +1013,14 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsValidPegInTx_has_utxos_below_minimum_and_total_amount_as_well_before_RSKIP293() {
-        Context btcContext = new Context(networkParameters);
-        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Context btcContext = new Context(bridgeConstantsMainnet.getBtcParams());
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsMainnet);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(false);
 
-        Coin minimumPeginValue = bridgeConstantsRegtest.getMinimumPeginTxValue(activations);
+        Coin minimumPeginValue = bridgeConstantsMainnet.getMinimumPeginTxValue(activations);
         // Create a tx with multiple utxos below the minimum, and the sum of each utxos as well is below the minimum
-        BtcTransaction tx = new BtcTransaction(networkParameters);
+        BtcTransaction tx = new BtcTransaction(bridgeConstantsMainnet.getBtcParams());
         tx.addOutput(minimumPeginValue.div(4), activeFederation.getAddress());
         tx.addOutput(minimumPeginValue.div(4), activeFederation.getAddress());
         tx.addOutput(minimumPeginValue.div(4), activeFederation.getAddress());
@@ -1033,24 +1033,24 @@ class PegUtilsLegacyTest {
             Collections.singletonList(activeFederation),
             null,
             federationWallet,
-            bridgeConstantsRegtest.getMinimumPeginTxValue(activations),
+            bridgeConstantsMainnet.getMinimumPeginTxValue(activations),
             activations
         ));
     }
 
     @Test
     void testIsValidPegInTx_has_utxos_below_minimum_after_RSKIP293() {
-        Context btcContext = new Context(networkParameters);
-        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Context btcContext = new Context(bridgeConstantsMainnet.getBtcParams());
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsMainnet);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
-        Coin minimumPeginValue = bridgeConstantsRegtest.getMinimumPeginTxValue(activations);
+        Coin minimumPeginValue = bridgeConstantsMainnet.getMinimumPeginTxValue(activations);
         Coin belowMinimumPeginValue = minimumPeginValue.divide(2);
 
         Coin aboveMinimumPeginValue = minimumPeginValue.add(Coin.COIN);
         // Create a tx with multiple utxos below, one equal to, and one above, the minimum.
-        BtcTransaction tx = new BtcTransaction(networkParameters);
+        BtcTransaction tx = new BtcTransaction(bridgeConstantsMainnet.getBtcParams());
         tx.addOutput(belowMinimumPeginValue, activeFederation.getAddress());
         tx.addOutput(belowMinimumPeginValue, activeFederation.getAddress());
         tx.addOutput(belowMinimumPeginValue, activeFederation.getAddress());
@@ -1071,14 +1071,14 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsValidPegInTx_utxo_equal_to_minimum_after_RSKIP293() {
-        Context btcContext = new Context(networkParameters);
-        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Context btcContext = new Context(bridgeConstantsMainnet.getBtcParams());
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsMainnet);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
         when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(true);
 
-        Coin minimumPeginValue = bridgeConstantsRegtest.getMinimumPeginTxValue(activations);
+        Coin minimumPeginValue = bridgeConstantsMainnet.getMinimumPeginTxValue(activations);
 
-        BtcTransaction tx = new BtcTransaction(networkParameters);
+        BtcTransaction tx = new BtcTransaction(bridgeConstantsMainnet.getBtcParams());
         tx.addOutput(minimumPeginValue, activeFederation.getAddress());
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
@@ -1095,7 +1095,7 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsValidPegInTx_p2shErpScript_sends_funds_to_federation_address_before_RSKIP353() {
-        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsMainnet);
         Address activeFederationAddress = genesisFederation.getAddress();
         testIsValidPegInTx_fromP2shErpScriptSender(
             false,
@@ -1119,7 +1119,7 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsValidPegInTx_p2shErpScript_sends_funds_to_federation_address_after_RSKIP353() {
-        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsMainnet);
         Address activeFederationAddress = genesisFederation.getAddress();
         testIsValidPegInTx_fromP2shErpScriptSender(
             true,
@@ -1142,7 +1142,7 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsValidPegInTx_flyoverP2shErpScript_sends_funds_to_federation_address_before_RSKIP353() {
-        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsMainnet);
         Address activeFederationAddress = genesisFederation.getAddress();
         testIsValidPegInTx_fromP2shErpScriptSender(
             false,
@@ -1166,7 +1166,7 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsValidPegInTx_flyoverpP2shErpScript_sends_funds_to_federation_address_after_RSKIP353() {
-        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsMainnet);
         Address activeFederationAddress = activeFederation.getAddress();
         testIsValidPegInTx_fromP2shErpScriptSender(
             true,
@@ -2022,16 +2022,16 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsPegOutTx_noRedeemScript() {
-        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
-        Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsMainnet);
+        Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(bridgeConstantsMainnet.getBtcParams());
 
-        BtcTransaction pegOutTx1 = new BtcTransaction(networkParameters);
+        BtcTransaction pegOutTx1 = new BtcTransaction(bridgeConstantsMainnet.getBtcParams());
         pegOutTx1.addOutput(Coin.COIN, randomAddress);
         TransactionInput pegOutInput1 = new TransactionInput(
-            networkParameters,
+            bridgeConstantsMainnet.getBtcParams(),
             pegOutTx1,
             new byte[]{},
-            new TransactionOutPoint(networkParameters, 0, Sha256Hash.ZERO_HASH)
+            new TransactionOutPoint(bridgeConstantsMainnet.getBtcParams(), 0, Sha256Hash.ZERO_HASH)
         );
         pegOutTx1.addInput(pegOutInput1);
 
@@ -2040,17 +2040,17 @@ class PegUtilsLegacyTest {
 
     @Test
     void testIsPegOutTx_invalidRedeemScript() {
-        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsRegtest);
-        Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstantsMainnet);
+        Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(bridgeConstantsMainnet.getBtcParams());
         Script invalidRedeemScript = ScriptBuilder.createRedeemScript(2, Arrays.asList(new BtcECKey(), new BtcECKey()));
 
-        BtcTransaction pegOutTx1 = new BtcTransaction(networkParameters);
+        BtcTransaction pegOutTx1 = new BtcTransaction(bridgeConstantsMainnet.getBtcParams());
         pegOutTx1.addOutput(Coin.COIN, randomAddress);
         TransactionInput pegOutInput1 = new TransactionInput(
-            networkParameters,
+            bridgeConstantsMainnet.getBtcParams(),
             pegOutTx1,
             invalidRedeemScript.getProgram(),
-            new TransactionOutPoint(networkParameters, 0, Sha256Hash.ZERO_HASH)
+            new TransactionOutPoint(bridgeConstantsMainnet.getBtcParams(), 0, Sha256Hash.ZERO_HASH)
         );
         pegOutTx1.addInput(pegOutInput1);
 

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsTest.java
@@ -6,7 +6,6 @@ import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.wallet.Wallet;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.constants.BridgeMainNetConstants;
-import co.rsk.peg.constants.BridgeRegTestConstants;
 import co.rsk.peg.constants.BridgeTestNetConstants;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
@@ -32,8 +31,6 @@ import static org.mockito.Mockito.when;
 
 class PegUtilsTest {
     private static final BridgeConstants bridgeMainnetConstants = BridgeMainNetConstants.getInstance();
-    private final BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
-
     private static final NetworkParameters btcMainnetParams = bridgeMainnetConstants.getBtcParams();
     private static final Context context = new Context(bridgeMainnetConstants.getBtcParams());
     private static final ActivationConfig.ForBlock activations = ActivationConfigsForTest.arrowhead600().forBlock(0);
@@ -105,7 +102,7 @@ class PegUtilsTest {
     @Test
     void test_getTransactionType_pegin_below_minimum_active_fed() {
         // Arrange
-        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation activeFederation = FederationTestUtils.getGenesisFederation(bridgeMainnetConstants);
         Wallet liveFederationWallet = new BridgeBtcWallet(context, Collections.singletonList(activeFederation));
 
         Coin minimumPeginTxValue = bridgeMainnetConstants.getMinimumPeginTxValue(activations);
@@ -197,7 +194,7 @@ class PegUtilsTest {
     @Test
     void test_getTransactionType_pegin_output_to_retiring_fed_and_other_addresses() {
         // Arrange
-        Federation retiringFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation retiringFederation = FederationTestUtils.getGenesisFederation(bridgeMainnetConstants);
 
         List<BtcECKey> signers = BitcoinTestUtils.getBtcEcKeysFromSeeds(
             new String[]{"fa01", "fa02", "fa03"}, true
@@ -516,7 +513,7 @@ class PegUtilsTest {
     void test_getTransactionType_migration_from_retired_fed() {
         // Arrange
         Wallet liveFederationWallet = new BridgeBtcWallet(context, Collections.singletonList(activeFederation));
-        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeMainnetConstants);
 
         BtcTransaction btcTransaction = new BtcTransaction(btcMainnetParams);
         btcTransaction.addInput(BitcoinTestUtils.createHash(1), FIRST_OUTPUT_INDEX, genesisFederation.getP2SHScript());
@@ -599,7 +596,7 @@ class PegUtilsTest {
         NetworkParameters btcTestNetParams = bridgeTestNetConstants.getBtcParams();
         Context context = new Context(bridgeTestNetConstants.getBtcParams());
 
-        Federation retiringFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation retiringFederation = FederationTestUtils.getGenesisFederation(bridgeMainnetConstants);
 
         List<BtcECKey> signers = BitcoinTestUtils.getBtcEcKeysFromSeeds(
             new String[]{"fa01", "fa02", "fa03"}, true

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsTest.java
@@ -197,7 +197,7 @@ class PegUtilsTest {
     @Test
     void test_getTransactionType_pegin_output_to_retiring_fed_and_other_addresses() {
         // Arrange
-        Federation retiringFed = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation retiringFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
 
         List<BtcECKey> signers = BitcoinTestUtils.getBtcEcKeysFromSeeds(
             new String[]{"fa01", "fa02", "fa03"}, true
@@ -209,12 +209,12 @@ class PegUtilsTest {
         FederationArgs federationArgs = new FederationArgs(fedMembers, creationTime, 0L, btcMainnetParams);
 
         ErpFederation activeFed = FederationFactory.buildP2shErpFederation(federationArgs, erpPubKeys, activationDelay);
-        Wallet liveFederationWallet = new BridgeBtcWallet(context, Arrays.asList(retiringFed, activeFed));
+        Wallet liveFederationWallet = new BridgeBtcWallet(context, Arrays.asList(retiringFederation, activeFed));
 
         BtcTransaction btcTransaction = new BtcTransaction(btcMainnetParams);
         btcTransaction.addInput(BitcoinTestUtils.createHash(1), FIRST_OUTPUT_INDEX, new Script(new byte[]{}));
         btcTransaction.addOutput(Coin.COIN, userAddress);
-        btcTransaction.addOutput(Coin.COIN, retiringFed.getAddress());
+        btcTransaction.addOutput(Coin.COIN, retiringFederation.getAddress());
         btcTransaction.addOutput(Coin.COIN, BitcoinTestUtils.createP2PKHAddress(btcMainnetParams, "unknown2"));
 
         // Act
@@ -516,20 +516,20 @@ class PegUtilsTest {
     void test_getTransactionType_migration_from_retired_fed() {
         // Arrange
         Wallet liveFederationWallet = new BridgeBtcWallet(context, Collections.singletonList(activeFederation));
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
 
         BtcTransaction btcTransaction = new BtcTransaction(btcMainnetParams);
-        btcTransaction.addInput(BitcoinTestUtils.createHash(1), FIRST_OUTPUT_INDEX, federation.getP2SHScript());
+        btcTransaction.addInput(BitcoinTestUtils.createHash(1), FIRST_OUTPUT_INDEX, genesisFederation.getP2SHScript());
         btcTransaction.addOutput(Coin.COIN, activeFederation.getAddress());
 
-        Script p2SHScript = ScriptBuilder.createP2SHOutputScript(federation.getRedeemScript());
-        Script inputScript = p2SHScript.createEmptyInputScript(null, federation.getRedeemScript());
+        Script p2SHScript = ScriptBuilder.createP2SHOutputScript(genesisFederation.getRedeemScript());
+        Script inputScript = p2SHScript.createEmptyInputScript(null, genesisFederation.getRedeemScript());
 
         btcTransaction.getInput(FIRST_INPUT_INDEX).setScriptSig(inputScript);
 
         Sha256Hash firstInputSigHash = btcTransaction.hashForSignature(
             FIRST_INPUT_INDEX,
-            federation.getRedeemScript(),
+            genesisFederation.getRedeemScript(),
             BtcTransaction.SigHash.ALL,
             false
         );
@@ -599,7 +599,7 @@ class PegUtilsTest {
         NetworkParameters btcTestNetParams = bridgeTestNetConstants.getBtcParams();
         Context context = new Context(bridgeTestNetConstants.getBtcParams());
 
-        Federation retiringFed = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation retiringFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
 
         List<BtcECKey> signers = BitcoinTestUtils.getBtcEcKeysFromSeeds(
             new String[]{"fa01", "fa02", "fa03"}, true
@@ -612,7 +612,7 @@ class PegUtilsTest {
         FederationArgs federationArgs =
             new FederationArgs(fedMembers, creationTime, 0L, btcTestNetParams);
         ErpFederation activeFed = FederationFactory.buildP2shErpFederation(federationArgs, erpPubKeys, activationDelay);
-        Wallet liveFederationWallet = new BridgeBtcWallet(context, Arrays.asList(retiringFed, activeFed));
+        Wallet liveFederationWallet = new BridgeBtcWallet(context, Arrays.asList(retiringFederation, activeFed));
 
         String segwitTxHex = "020000000001011f668117f2ca3314806ade1d99ae400f5413d7e9d4bfcbd11d52645e060e22fb0100000000fdffffff0300000000000000001b6a1952534b5401a27c6f697954357247e78f9900023cfe01a9d49c0412030000000000160014b413f59a7ee6e34321140e83ea661e0484a79bc2988708000000000017a9145e6cf80958803e9b3c81cd90422152520d2a505c870247304402203fce49b39f79581d93720f462b5f33f9174e66dc6efb635d4f41aacb33b08d0302201221aec5db31e269454fcc7a4df2936ccedd566ccf48828d4f97050954f196540121021831c5ba44b739521d635e521560525672087e4d5db053801f4aeb60e782f6d6d0f02400";
         BtcTransaction btcTransaction = new BtcTransaction(btcTestNetParams, Hex.decode(segwitTxHex));

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -69,7 +69,7 @@ class ReleaseTransactionBuilderTest {
     private ActivationConfig.ForBlock activations;
     private Context btcContext;
     private NetworkParameters networkParameters;
-    private BridgeConstants bridgeConstants;
+    private BridgeConstants bridgeRegTestConstants;
     private Federation federation;
 
     @BeforeEach
@@ -77,10 +77,10 @@ class ReleaseTransactionBuilderTest {
         wallet = mock(Wallet.class);
         changeAddress = mockAddress(1000);
         activations = mock(ActivationConfig.ForBlock.class);
-        bridgeConstants = BridgeRegTestConstants.getInstance();
-        networkParameters = bridgeConstants.getBtcParams();
+        bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
+        networkParameters = bridgeRegTestConstants.getBtcParams();
         btcContext = new Context(networkParameters);
-        federation = bridgeConstants.getGenesisFederation();
+        federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
         builder = new ReleaseTransactionBuilder(
             networkParameters,
             wallet,

--- a/rskj-core/src/test/java/co/rsk/peg/constants/BridgeConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/constants/BridgeConstantsTest.java
@@ -7,8 +7,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.time.Instant;
-import java.time.ZonedDateTime;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/rskj-core/src/test/java/co/rsk/peg/constants/BridgeConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/constants/BridgeConstantsTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -157,5 +159,21 @@ class BridgeConstantsTest {
 
         // assert
         assertEquals(expectedValue, pegoutTxIndexGracePeriodInBtcBlocks);
+    }
+
+    private static Stream<Arguments> getGenesisFederationCreationTimeTestProvider() {
+        return Stream.of(
+                Arguments.of(BridgeMainNetConstants.getInstance(), 1514948400L),
+                Arguments.of(BridgeTestNetConstants.getInstance(), 1538967600L),
+                Arguments.of(BridgeRegTestConstants.getInstance(), 1451606400L),
+                Arguments.of(BridgeDevNetConstants.getInstance(),1510617600L)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("getGenesisFederationCreationTimeTestProvider")
+    void getGenesisFederationCreationTimeTest(BridgeConstants bridgeConstants, long expectedGenesisFederationCreationTime){
+        long actualGenesisFederationCreationTime = bridgeConstants.getGenesisFederationCreationTime().getEpochSecond();
+        assertEquals(expectedGenesisFederationCreationTime, actualGenesisFederationCreationTime);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationTestUtils.java
@@ -43,8 +43,6 @@ import org.ethereum.crypto.ECKey;
 
 public final class FederationTestUtils {
 
-    public static final long GENESIS_FEDERATION_CREATION_BLOCK_NUMBER = 1L;
-
     private FederationTestUtils() {
     }
 
@@ -61,6 +59,7 @@ public final class FederationTestUtils {
     }
 
     public static Federation getGenesisFederation(BridgeConstants bridgeConstants) {
+        final long GENESIS_FEDERATION_CREATION_BLOCK_NUMBER = 1L;
         final List<BtcECKey> genesisFederationPublicKeys = bridgeConstants.getGenesisFederationPublicKeys();
         final List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(genesisFederationPublicKeys);
         final Instant genesisFederationCreationTime = bridgeConstants.getGenesisFederationCreationTime();

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationTestUtils.java
@@ -31,14 +31,22 @@ import co.rsk.bitcoinj.crypto.TransactionSignature;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import java.math.BigInteger;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import co.rsk.peg.constants.BridgeConstants;
 import org.ethereum.crypto.ECKey;
 
-public class FederationTestUtils {
+public final class FederationTestUtils {
+
+    public static final long GENESIS_FEDERATION_CREATION_BLOCK_NUMBER = 1L;
+
+    private FederationTestUtils() {
+    }
 
     public static Federation getFederation(Integer... federationMemberPks) {
         FederationArgs federationArgs = new FederationArgs(
@@ -50,6 +58,14 @@ public class FederationTestUtils {
         return FederationFactory.buildStandardMultiSigFederation(
             federationArgs
         );
+    }
+
+    public static Federation getGenesisFederation(BridgeConstants bridgeConstants) {
+        final List<BtcECKey> genesisFederationPublicKeys = bridgeConstants.getGenesisFederationPublicKeys();
+        final List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(genesisFederationPublicKeys);
+        final Instant genesisFederationCreationTime = bridgeConstants.getGenesisFederationCreationTime();
+        final FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationCreationTime, GENESIS_FEDERATION_CREATION_BLOCK_NUMBER, bridgeConstants.getBtcParams());
+        return FederationFactory.buildStandardMultiSigFederation(federationArgs);
     }
 
     public static List<FederationMember> getFederationMembers(int memberCount) {

--- a/rskj-core/src/test/java/co/rsk/peg/federation/P2shErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/P2shErpFederationTest.java
@@ -43,7 +43,6 @@ class P2shErpFederationTest {
     private List<BtcECKey> emergencyKeys;
     private int emergencyThreshold;
     private long activationDelayValue;
-    private final BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
 
     @BeforeEach
     void setup() {
@@ -339,7 +338,7 @@ class P2shErpFederationTest {
             // should add this case because adding erp to mainnet genesis federation
             // throws a validation error, so in that case we use the one set up before each test.
             // if using testnet constants, we can add them with no errors
-            Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+            Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
             defaultKeys = federation.getBtcPublicKeys();
         }
 

--- a/rskj-core/src/test/java/co/rsk/peg/federation/P2shErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/P2shErpFederationTest.java
@@ -338,8 +338,8 @@ class P2shErpFederationTest {
             // should add this case because adding erp to mainnet genesis federation
             // throws a validation error, so in that case we use the one set up before each test.
             // if using testnet constants, we can add them with no errors
-            Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
-            defaultKeys = federation.getBtcPublicKeys();
+            Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+            defaultKeys = genesisFederation.getBtcPublicKeys();
         }
 
         emergencyKeys = bridgeConstants.getErpFedPubKeysList();

--- a/rskj-core/src/test/java/co/rsk/peg/federation/P2shErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/P2shErpFederationTest.java
@@ -338,8 +338,7 @@ class P2shErpFederationTest {
             // should add this case because adding erp to mainnet genesis federation
             // throws a validation error, so in that case we use the one set up before each test.
             // if using testnet constants, we can add them with no errors
-            Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
-            defaultKeys = genesisFederation.getBtcPublicKeys();
+            defaultKeys = bridgeConstants.getGenesisFederationPublicKeys();
         }
 
         emergencyKeys = bridgeConstants.getErpFedPubKeysList();

--- a/rskj-core/src/test/java/co/rsk/peg/federation/P2shErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/P2shErpFederationTest.java
@@ -43,6 +43,7 @@ class P2shErpFederationTest {
     private List<BtcECKey> emergencyKeys;
     private int emergencyThreshold;
     private long activationDelayValue;
+    private final BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
 
     @BeforeEach
     void setup() {
@@ -338,7 +339,8 @@ class P2shErpFederationTest {
             // should add this case because adding erp to mainnet genesis federation
             // throws a validation error, so in that case we use the one set up before each test.
             // if using testnet constants, we can add them with no errors
-            defaultKeys = bridgeConstants.getGenesisFederation().getBtcPublicKeys();
+            Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+            defaultKeys = federation.getBtcPublicKeys();
         }
 
         emergencyKeys = bridgeConstants.getErpFedPubKeysList();

--- a/rskj-core/src/test/java/co/rsk/peg/federation/StandardMultisigFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/StandardMultisigFederationTest.java
@@ -51,13 +51,12 @@ class StandardMultisigFederationTest {
     private List<BtcECKey> keys;
     private List<BtcECKey> sortedPublicKeys;
     private List<byte[]> rskAddresses;
+    private final BridgeConstants bridgeMainNetConstants = BridgeMainNetConstants.getInstance();
 
     @BeforeEach
     void setUp() {
-        BridgeConstants bridgeConstants = BridgeMainNetConstants.getInstance();
-
-        networkParameters = bridgeConstants.getBtcParams();
-        federation = bridgeConstants.getGenesisFederation();
+        networkParameters = bridgeMainNetConstants.getBtcParams();
+        federation = FederationTestUtils.getGenesisFederation(bridgeMainNetConstants);
 
         keys = federation.getBtcPublicKeys();
         sortedPublicKeys = keys.stream()

--- a/rskj-core/src/test/java/co/rsk/peg/performance/ActiveFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/ActiveFederationTest.java
@@ -21,10 +21,7 @@ package co.rsk.peg.performance;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.store.BtcBlockStore;
 import co.rsk.peg.*;
-import co.rsk.peg.federation.Federation;
-import co.rsk.peg.federation.FederationArgs;
-import co.rsk.peg.federation.FederationFactory;
-import co.rsk.peg.federation.FederationMember;
+import co.rsk.peg.federation.*;
 import org.ethereum.TestUtils;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.core.Repository;
@@ -129,7 +126,7 @@ class ActiveFederationTest extends BridgePerformanceTestCase {
                 );
                 provider.setNewFederation(federation);
             } else {
-                federation = bridgeConstants.getGenesisFederation();
+                federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
             }
         };
     }

--- a/rskj-core/src/test/java/co/rsk/peg/performance/AddSignatureTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/AddSignatureTest.java
@@ -34,6 +34,7 @@ import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.PegTestUtils;
+import co.rsk.peg.federation.FederationTestUtils;
 import org.ethereum.TestUtils;
 import org.ethereum.core.Repository;
 import org.ethereum.crypto.HashUtil;
@@ -86,11 +87,13 @@ class AddSignatureTest extends BridgePerformanceTestCase {
     }
 
     private void addSignature_fullySigned(int times, ExecutionStats stats) throws VMException {
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        int numberOfSignaturesRequired = federation.getNumberOfSignaturesRequired();
         executeAndAverage(
                 "addSignature-fullySigned",
                 times,
                 getABIEncoder(),
-                getInitializerFor(bridgeConstants.getGenesisFederation().getNumberOfSignaturesRequired()-1),
+                getInitializerFor(numberOfSignaturesRequired-1),
                 Helper.getZeroValueValueTxBuilderFromFedMember(),
                 Helper.getRandomHeightProvider(10),
                 stats
@@ -112,7 +115,7 @@ class AddSignatureTest extends BridgePerformanceTestCase {
         return (BridgeStorageProvider provider, Repository repository, int executionIndex, BtcBlockStore blockStore) -> {
             releaseTx = new BtcTransaction(networkParameters);
 
-            Federation federation = bridgeConstants.getGenesisFederation();
+            Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
 
             // Receiver and amounts
             BtcECKey to = new BtcECKey();

--- a/rskj-core/src/test/java/co/rsk/peg/performance/AddSignatureTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/AddSignatureTest.java
@@ -87,8 +87,8 @@ class AddSignatureTest extends BridgePerformanceTestCase {
     }
 
     private void addSignature_fullySigned(int times, ExecutionStats stats) throws VMException {
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
-        int numberOfSignaturesRequired = federation.getNumberOfSignaturesRequired();
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        int numberOfSignaturesRequired = genesisFederation.getNumberOfSignaturesRequired();
         executeAndAverage(
                 "addSignature-fullySigned",
                 times,
@@ -115,7 +115,7 @@ class AddSignatureTest extends BridgePerformanceTestCase {
         return (BridgeStorageProvider provider, Repository repository, int executionIndex, BtcBlockStore blockStore) -> {
             releaseTx = new BtcTransaction(networkParameters);
 
-            Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+            Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
 
             // Receiver and amounts
             BtcECKey to = new BtcECKey();
@@ -129,10 +129,10 @@ class AddSignatureTest extends BridgePerformanceTestCase {
             for (int i = 0; i < numInputs; i++) {
                 Coin inputAmount = releaseAmount.divide(numInputs);
                 BtcTransaction inputTx = new BtcTransaction(networkParameters);
-                inputTx.addOutput(inputAmount, federation.getAddress());
+                inputTx.addOutput(inputAmount, genesisFederation.getAddress());
                 releaseTx
                         .addInput(inputTx.getOutput(0))
-                        .setScriptSig(PegTestUtils.createBaseInputScriptThatSpendsFromTheFederation(federation));
+                        .setScriptSig(PegTestUtils.createBaseInputScriptThatSpendsFromTheFederation(genesisFederation));
             }
 
             // Partial signing according to numSignatures asked for

--- a/rskj-core/src/test/java/co/rsk/peg/performance/GetFeePerKbTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/GetFeePerKbTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 
 @Disabled
 class GetFeePerKbTest extends BridgePerformanceTestCase {
-    private Federation federation;
+    private Federation genesisFederation;
 
     @Test
     void getFeePerKb() throws VMException {
@@ -60,7 +60,7 @@ class GetFeePerKbTest extends BridgePerformanceTestCase {
             if (!genesis) {
                 provider.setFeePerKb(Helper.randomCoin(Coin.MILLICOIN, 1, 100));
             } else {
-                federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+                genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
             }
         };
     }

--- a/rskj-core/src/test/java/co/rsk/peg/performance/GetFeePerKbTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/GetFeePerKbTest.java
@@ -23,6 +23,7 @@ import co.rsk.bitcoinj.store.BtcBlockStore;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
 import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationTestUtils;
 import org.ethereum.core.Repository;
 import org.ethereum.vm.exception.VMException;
 import org.junit.jupiter.api.Assertions;
@@ -59,7 +60,7 @@ class GetFeePerKbTest extends BridgePerformanceTestCase {
             if (!genesis) {
                 provider.setFeePerKb(Helper.randomCoin(Coin.MILLICOIN, 1, 100));
             } else {
-                federation = bridgeConstants.getGenesisFederation();
+                federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
             }
         };
     }

--- a/rskj-core/src/test/java/co/rsk/peg/performance/PowpegRedeemScriptTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/PowpegRedeemScriptTest.java
@@ -27,8 +27,8 @@ class PowpegRedeemScriptTest extends BridgePerformanceTestCase {
     void getActivePowpegRedeemScriptTest() throws VMException {
         ExecutionStats stats = new ExecutionStats("getActivePowpegRedeemScript");
         ABIEncoder abiEncoder = (int executionIndex) -> BridgeMethods.GET_ACTIVE_POWPEG_REDEEM_SCRIPT.getFunction().encode();
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
-        Script federationRedeemScript= federation.getRedeemScript();
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        Script federationRedeemScript= genesisFederation.getRedeemScript();
         byte[] federationRedeemScriptProgram = federationRedeemScript.getProgram();
 
 

--- a/rskj-core/src/test/java/co/rsk/peg/performance/PowpegRedeemScriptTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/PowpegRedeemScriptTest.java
@@ -1,7 +1,10 @@
 package co.rsk.peg.performance;
 
+import co.rsk.bitcoinj.script.Script;
 import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeMethods;
+import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationTestUtils;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.vm.exception.VMException;
@@ -24,6 +27,12 @@ class PowpegRedeemScriptTest extends BridgePerformanceTestCase {
     void getActivePowpegRedeemScriptTest() throws VMException {
         ExecutionStats stats = new ExecutionStats("getActivePowpegRedeemScript");
         ABIEncoder abiEncoder = (int executionIndex) -> BridgeMethods.GET_ACTIVE_POWPEG_REDEEM_SCRIPT.getFunction().encode();
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        Script federationRedeemScript= federation.getRedeemScript();
+        byte[] federationRedeemScriptProgram = federationRedeemScript.getProgram();
+
+
+
         executeAndAverage(
             "getActivePowpegRedeemScriptTest",
             10,
@@ -32,12 +41,10 @@ class PowpegRedeemScriptTest extends BridgePerformanceTestCase {
             Helper.getZeroValueRandomSenderTxBuilder(),
             Helper.getRandomHeightProvider(10),
             stats,
-            (environment, executionResult) -> {
-                assertArrayEquals(
-                    constants.getBridgeConstants().getGenesisFederation().getRedeemScript().getProgram(),
-                    getByteFromResult(executionResult)
-                );
-            }
+            (environment, executionResult) -> assertArrayEquals(
+                federationRedeemScriptProgram,
+                getByteFromResult(executionResult)
+            )
         );
         BridgePerformanceTest.addStats(stats);
     }

--- a/rskj-core/src/test/java/co/rsk/peg/performance/RegisterBtcTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/RegisterBtcTransactionTest.java
@@ -25,6 +25,8 @@ import co.rsk.bitcoinj.store.BtcBlockStore;
 import co.rsk.core.RskAddress;
 import co.rsk.peg.*;
 import co.rsk.peg.PegTestUtils;
+import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationTestUtils;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.core.Repository;
 import org.ethereum.crypto.ECKey;
@@ -240,10 +242,13 @@ class RegisterBtcTransactionTest extends BridgePerformanceTestCase {
             BtcTransaction inputTx = new BtcTransaction(networkParameters);
             inputTx.addOutput(fromAmount, fromAddress);
 
+            Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+            Address federationAddress = federation.getAddress();
+
             // Lock tx that uses the input tx
             txToLock = new BtcTransaction(networkParameters);
             txToLock.addInput(inputTx.getOutput(0));
-            txToLock.addOutput(lockAmount, bridgeConstants.getGenesisFederation().getAddress());
+            txToLock.addOutput(lockAmount, federationAddress);
             txToLock.addOutput(changeAmount, fromAddress);
 
             ECKey ecKey = new ECKey();

--- a/rskj-core/src/test/java/co/rsk/peg/performance/RegisterBtcTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/RegisterBtcTransactionTest.java
@@ -242,8 +242,8 @@ class RegisterBtcTransactionTest extends BridgePerformanceTestCase {
             BtcTransaction inputTx = new BtcTransaction(networkParameters);
             inputTx.addOutput(fromAmount, fromAddress);
 
-            Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
-            Address federationAddress = federation.getAddress();
+            Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+            Address federationAddress = genesisFederation.getAddress();
 
             // Lock tx that uses the input tx
             txToLock = new BtcTransaction(networkParameters);

--- a/rskj-core/src/test/java/co/rsk/peg/performance/RegisterFlyoverBtcTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/RegisterFlyoverBtcTransactionTest.java
@@ -10,6 +10,8 @@ import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.peg.*;
 import co.rsk.peg.PegTestUtils;
+import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationTestUtils;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.core.Repository;
@@ -149,9 +151,12 @@ class RegisterFlyoverBtcTransactionTest extends BridgePerformanceTestCase {
 
                 int blocksToGenerate = Helper.randomInRange(minBtcBlocks, maxBtcBlocks);
                 BtcBlock lastBlock = Helper.generateAndAddBlocks(btcBlockChain, blocksToGenerate);
+                Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+                Script federationRedeemScript= federation.getRedeemScript();
 
-                Script flyoverRedeemScript = FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
-                        bridgeConstants.getGenesisFederation().getRedeemScript(),
+
+            Script flyoverRedeemScript = FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
+                        federationRedeemScript,
                         Sha256Hash.wrap(
                                 getFLyoverDerivationHash(
                                         PegTestUtils.createHash3(1),

--- a/rskj-core/src/test/java/co/rsk/peg/performance/RegisterFlyoverBtcTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/RegisterFlyoverBtcTransactionTest.java
@@ -151,8 +151,8 @@ class RegisterFlyoverBtcTransactionTest extends BridgePerformanceTestCase {
 
                 int blocksToGenerate = Helper.randomInRange(minBtcBlocks, maxBtcBlocks);
                 BtcBlock lastBlock = Helper.generateAndAddBlocks(btcBlockChain, blocksToGenerate);
-                Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
-                Script federationRedeemScript= federation.getRedeemScript();
+                Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+                Script federationRedeemScript= genesisFederation.getRedeemScript();
 
 
             Script flyoverRedeemScript = FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(

--- a/rskj-core/src/test/java/co/rsk/peg/performance/RetiringFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/RetiringFederationTest.java
@@ -103,7 +103,7 @@ class RetiringFederationTest extends BridgePerformanceTestCase {
         final int minFederators = 10;
         final int maxFederators = 16;
         Random random = new Random(RetiringFederationTest.class.hashCode());
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         return (BridgeStorageProvider provider, Repository repository, int executionIndex, BtcBlockStore blockStore) -> {
             if (present) {
                 int numFederators = Helper.randomInRange(minFederators, maxFederators);
@@ -116,7 +116,7 @@ class RetiringFederationTest extends BridgePerformanceTestCase {
                 retiringFederation = FederationFactory.buildStandardMultiSigFederation(
                     federationArgs
                 );
-                provider.setNewFederation(federation);
+                provider.setNewFederation(genesisFederation);
                 provider.setOldFederation(retiringFederation);
             } else {
                 retiringFederation = null;

--- a/rskj-core/src/test/java/co/rsk/peg/performance/RetiringFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/RetiringFederationTest.java
@@ -24,6 +24,7 @@ import co.rsk.peg.BridgeStorageProvider;
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.FederationArgs;
 import co.rsk.peg.federation.FederationFactory;
+import co.rsk.peg.federation.FederationTestUtils;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.core.Repository;
 import org.ethereum.vm.exception.VMException;
@@ -102,6 +103,7 @@ class RetiringFederationTest extends BridgePerformanceTestCase {
         final int minFederators = 10;
         final int maxFederators = 16;
         Random random = new Random(RetiringFederationTest.class.hashCode());
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
         return (BridgeStorageProvider provider, Repository repository, int executionIndex, BtcBlockStore blockStore) -> {
             if (present) {
                 int numFederators = Helper.randomInRange(minFederators, maxFederators);
@@ -114,7 +116,7 @@ class RetiringFederationTest extends BridgePerformanceTestCase {
                 retiringFederation = FederationFactory.buildStandardMultiSigFederation(
                     federationArgs
                 );
-                provider.setNewFederation(bridgeConstants.getGenesisFederation());
+                provider.setNewFederation(federation);
                 provider.setOldFederation(retiringFederation);
             } else {
                 retiringFederation = null;

--- a/rskj-core/src/test/java/co/rsk/peg/performance/StateForBtcReleaseClientTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/StateForBtcReleaseClientTest.java
@@ -74,7 +74,7 @@ class StateForBtcReleaseClientTest extends BridgePerformanceTestCase {
             }
 
             int numTxs = Helper.randomInRange(minNumTxs, maxNumTxs);
-            Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
+            Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants);
             for (int i = 0; i < numTxs; i++) {
                 BtcTransaction releaseTx = new BtcTransaction(networkParameters);
 
@@ -89,10 +89,10 @@ class StateForBtcReleaseClientTest extends BridgePerformanceTestCase {
                 for (int j = 0; j < numInputs; j++) {
                     Coin inputAmount = releaseAmount.divide(numInputs);
                     BtcTransaction inputTx = new BtcTransaction(networkParameters);
-                    inputTx.addOutput(inputAmount, federation.getAddress());
+                    inputTx.addOutput(inputAmount, genesisFederation.getAddress());
                     releaseTx
                             .addInput(inputTx.getOutput(0))
-                            .setScriptSig(PegTestUtils.createBaseInputScriptThatSpendsFromTheFederation(federation));
+                            .setScriptSig(PegTestUtils.createBaseInputScriptThatSpendsFromTheFederation(genesisFederation));
                 }
 
 

--- a/rskj-core/src/test/java/co/rsk/peg/performance/StateForBtcReleaseClientTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/StateForBtcReleaseClientTest.java
@@ -28,6 +28,7 @@ import co.rsk.peg.Bridge;
 import co.rsk.peg.BridgeStorageProvider;
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.PegTestUtils;
+import co.rsk.peg.federation.FederationTestUtils;
 import org.ethereum.TestUtils;
 import org.ethereum.core.Repository;
 import org.ethereum.vm.exception.VMException;
@@ -73,10 +74,9 @@ class StateForBtcReleaseClientTest extends BridgePerformanceTestCase {
             }
 
             int numTxs = Helper.randomInRange(minNumTxs, maxNumTxs);
+            Federation federation = FederationTestUtils.getGenesisFederation(bridgeConstants);
             for (int i = 0; i < numTxs; i++) {
                 BtcTransaction releaseTx = new BtcTransaction(networkParameters);
-
-                Federation federation = bridgeConstants.getGenesisFederation();
 
                 // Receiver and amounts
                 Address toAddress = new BtcECKey().toAddress(networkParameters);

--- a/rskj-core/src/test/java/co/rsk/peg/performance/UpdateCollectionsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/UpdateCollectionsTest.java
@@ -188,8 +188,8 @@ class UpdateCollectionsTest extends BridgePerformanceTestCase {
 
             // Generate some utxos
             int numUTXOs = Helper.randomInRange(minUTXOs, maxUTXOs);
-            Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
-            Script federationP2SHScript = federation.getP2SHScript();
+            Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+            Script federationP2SHScript = genesisFederation.getP2SHScript();
 
             for (int i = 0; i < numUTXOs; i++) {
                 Sha256Hash hash = Sha256Hash.wrap(HashUtil.sha256(BigInteger.valueOf(rnd.nextLong()).toByteArray()));
@@ -247,10 +247,10 @@ class UpdateCollectionsTest extends BridgePerformanceTestCase {
                 throw new RuntimeException("Unable to gather release tx set");
             }
 
-            Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+            Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
 
             // Generate some txs waiting for signatures
-            Script genesisFederationScript = federation.getP2SHScript();
+            Script genesisFederationScript = genesisFederation.getP2SHScript();
             for (int i = 0; i < Helper.randomInRange(minTxsWaitingForSigs, maxTxsWaitingForSigs); i++) {
                 Keccak256 rskHash = new Keccak256(HashUtil.keccak256(BigInteger.valueOf(rnd.nextLong()).toByteArray()));
                 BtcTransaction btcTx = new BtcTransaction(networkParameters);
@@ -307,8 +307,8 @@ class UpdateCollectionsTest extends BridgePerformanceTestCase {
 
             // Generate some utxos
             int numUTXOs = Helper.randomInRange(minUTXOs, maxUTXOs);
-            Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
-            Script federationP2SHScript =  federation.getP2SHScript();
+            Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+            Script federationP2SHScript =  genesisFederation.getP2SHScript();
 
             for (int i = 0; i < numUTXOs; i++) {
                 Sha256Hash hash = Sha256Hash.wrap(HashUtil.sha256(BigInteger.valueOf(rnd.nextLong()).toByteArray()));

--- a/rskj-core/src/test/java/co/rsk/peg/performance/UpdateCollectionsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/UpdateCollectionsTest.java
@@ -18,14 +18,10 @@
 
 package co.rsk.peg.performance;
 
-import co.rsk.bitcoinj.core.BtcECKey;
-import co.rsk.bitcoinj.core.BtcTransaction;
-import co.rsk.bitcoinj.core.Coin;
-import co.rsk.bitcoinj.core.NetworkParameters;
-import co.rsk.bitcoinj.core.Sha256Hash;
-import co.rsk.bitcoinj.core.UTXO;
+import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.store.BtcBlockStore;
+import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.constants.BridgeRegTestConstants;
 import co.rsk.crypto.Keccak256;
 import co.rsk.peg.Bridge;
@@ -33,6 +29,8 @@ import co.rsk.peg.BridgeStorageProvider;
 import co.rsk.peg.PegTestUtils;
 import co.rsk.peg.ReleaseRequestQueue;
 import co.rsk.peg.PegoutsWaitingForConfirmations;
+import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationTestUtils;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.core.Repository;
@@ -70,6 +68,8 @@ class UpdateCollectionsTest extends BridgePerformanceTestCase {
     private int maxHeight = 150;
     private int minCentOutput = 1;
     private int maxCentOutput = 100;
+    private final BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
+
 
     @Test
     void updateCollections() throws IOException, VMException {
@@ -188,13 +188,13 @@ class UpdateCollectionsTest extends BridgePerformanceTestCase {
 
             // Generate some utxos
             int numUTXOs = Helper.randomInRange(minUTXOs, maxUTXOs);
-
-            Script federationScript = BridgeRegTestConstants.getInstance().getGenesisFederation().getP2SHScript();
+            Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+            Script federationP2SHScript = federation.getP2SHScript();
 
             for (int i = 0; i < numUTXOs; i++) {
                 Sha256Hash hash = Sha256Hash.wrap(HashUtil.sha256(BigInteger.valueOf(rnd.nextLong()).toByteArray()));
                 Coin value = Coin.MILLICOIN.multiply(Helper.randomInRange(minMilliBtc, maxMilliBtc));
-                utxos.add(new UTXO(hash, 0, value, 1, false, federationScript));
+                utxos.add(new UTXO(hash, 0, value, 1, false, federationP2SHScript));
             }
 
             // Generate some release requests to process
@@ -247,8 +247,10 @@ class UpdateCollectionsTest extends BridgePerformanceTestCase {
                 throw new RuntimeException("Unable to gather release tx set");
             }
 
+            Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+
             // Generate some txs waiting for signatures
-            Script genesisFederationScript = bridgeConstants.getGenesisFederation().getP2SHScript();
+            Script genesisFederationScript = federation.getP2SHScript();
             for (int i = 0; i < Helper.randomInRange(minTxsWaitingForSigs, maxTxsWaitingForSigs); i++) {
                 Keccak256 rskHash = new Keccak256(HashUtil.keccak256(BigInteger.valueOf(rnd.nextLong()).toByteArray()));
                 BtcTransaction btcTx = new BtcTransaction(networkParameters);
@@ -305,13 +307,13 @@ class UpdateCollectionsTest extends BridgePerformanceTestCase {
 
             // Generate some utxos
             int numUTXOs = Helper.randomInRange(minUTXOs, maxUTXOs);
-
-            Script federationScript = BridgeRegTestConstants.getInstance().getGenesisFederation().getP2SHScript();
+            Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+            Script federationP2SHScript =  federation.getP2SHScript();
 
             for (int i = 0; i < numUTXOs; i++) {
                 Sha256Hash hash = Sha256Hash.wrap(HashUtil.sha256(BigInteger.valueOf(rnd.nextLong()).toByteArray()));
                 Coin value = Coin.MILLICOIN.multiply(Helper.randomInRange(minMilliBtc, maxMilliBtc));
-                utxos.add(new UTXO(hash, 0, value, 1, false, federationScript));
+                utxos.add(new UTXO(hash, 0, value, 1, false, federationP2SHScript));
             }
 
             // Generate some release requests to process

--- a/rskj-core/src/test/java/org/ethereum/config/ConstantsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/ConstantsTest.java
@@ -28,6 +28,11 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
+
+import co.rsk.peg.constants.BridgeConstants;
+import co.rsk.peg.constants.BridgeRegTestConstants;
+import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationTestUtils;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.crypto.HashUtil;
@@ -46,6 +51,8 @@ class ConstantsTest {
     private final ActivationConfig activationConfig = mock(ActivationConfig.class);
     private final ActivationConfig.ForBlock preRskip297Config = mock(ActivationConfig.ForBlock.class);
     private final ActivationConfig.ForBlock postRskip297Config = mock(ActivationConfig.ForBlock.class);
+    private final BridgeConstants bridgeRegTestConstants = BridgeRegTestConstants.getInstance();
+
 
     @BeforeEach
     void setUp() {
@@ -55,11 +62,12 @@ class ConstantsTest {
 
     @Test
     void devnetWithFederationTest() {
-        Constants constants = Constants.devnetWithFederation(TEST_FED_KEYS.subList(0, 3));
-        assertThat(constants.getBridgeConstants().getGenesisFederation().hasBtcPublicKey(TEST_FED_KEYS.get(0)), is(true));
-        assertThat(constants.getBridgeConstants().getGenesisFederation().hasBtcPublicKey(TEST_FED_KEYS.get(1)), is(true));
-        assertThat(constants.getBridgeConstants().getGenesisFederation().hasBtcPublicKey(TEST_FED_KEYS.get(2)), is(true));
-        assertThat(constants.getBridgeConstants().getGenesisFederation().hasBtcPublicKey(TEST_FED_KEYS.get(3)), is(false));
+        Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+
+        assertThat(federation.hasBtcPublicKey(TEST_FED_KEYS.get(0)), is(true));
+        assertThat(federation.hasBtcPublicKey(TEST_FED_KEYS.get(1)), is(true));
+        assertThat(federation.hasBtcPublicKey(TEST_FED_KEYS.get(2)), is(true));
+        assertThat(federation.hasBtcPublicKey(TEST_FED_KEYS.get(3)), is(false));
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/config/ConstantsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/ConstantsTest.java
@@ -62,12 +62,12 @@ class ConstantsTest {
 
     @Test
     void devnetWithFederationTest() {
-        Federation federation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeRegTestConstants);
 
-        assertThat(federation.hasBtcPublicKey(TEST_FED_KEYS.get(0)), is(true));
-        assertThat(federation.hasBtcPublicKey(TEST_FED_KEYS.get(1)), is(true));
-        assertThat(federation.hasBtcPublicKey(TEST_FED_KEYS.get(2)), is(true));
-        assertThat(federation.hasBtcPublicKey(TEST_FED_KEYS.get(3)), is(false));
+        assertThat(genesisFederation.hasBtcPublicKey(TEST_FED_KEYS.get(0)), is(true));
+        assertThat(genesisFederation.hasBtcPublicKey(TEST_FED_KEYS.get(1)), is(true));
+        assertThat(genesisFederation.hasBtcPublicKey(TEST_FED_KEYS.get(2)), is(true));
+        assertThat(genesisFederation.hasBtcPublicKey(TEST_FED_KEYS.get(3)), is(false));
     }
 
     @Test


### PR DESCRIPTION
Remove dependency between BridgeConstants and Federation classes

## Description
For the sake of decoupling RSKj, we are applying some changes to remove the dependency between BridgeConstants and Federation classes.


## Motivation and Context
Decouple RSKj

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
