### PR TITLE
Modify ABICallElection

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -2302,8 +2302,9 @@ public class BridgeSupport {
         }
 
         // If enough votes have been reached, then actually execute the function
-        ABICallSpec winnerSpec = election.getWinner();
-        if (winnerSpec != null) {
+        Optional<ABICallSpec> winnerSpecOptional = election.getWinner();
+        if (winnerSpecOptional.isPresent()) {
+            ABICallSpec winnerSpec = winnerSpecOptional.get();
             try {
                 result = executeVoteFederationChangeFunction(false, winnerSpec);
             } catch (IOException e) {
@@ -2605,12 +2606,13 @@ public class BridgeSupport {
             return -1;
         }
 
-        ABICallSpec winner = feePerKbElection.getWinner();
-        if (winner == null) {
+        Optional<ABICallSpec> winnerOptional = feePerKbElection.getWinner();
+        if (!winnerOptional.isPresent()) {
             logger.info("Successful fee per kb vote for {}", feePerKb);
             return 1;
         }
 
+        ABICallSpec winner = winnerOptional.get();
         Coin winnerFee;
         try {
             winnerFee = BridgeSerializationUtils.deserializeCoin(winner.getArguments()[0]);

--- a/rskj-core/src/main/java/co/rsk/peg/UnauthorizedVoterException.java
+++ b/rskj-core/src/main/java/co/rsk/peg/UnauthorizedVoterException.java
@@ -1,0 +1,7 @@
+package co.rsk.peg;
+
+public class UnauthorizedVoterException extends RuntimeException {
+
+    public UnauthorizedVoterException(String message) { super(message); }
+
+}

--- a/rskj-core/src/main/java/co/rsk/peg/vote/ABICallElection.java
+++ b/rskj-core/src/main/java/co/rsk/peg/vote/ABICallElection.java
@@ -64,6 +64,8 @@ public class ABICallElection {
      * @return whether the voting succeeded
      */
     public boolean vote(ABICallSpec callSpec, RskAddress voter) {
+        logger.info("[vote] Trying to register voter's {} vote ", voter);
+
         if (!authorizer.isAuthorized(voter)) {
             logger.info("[vote] Voter is not authorized.");
             return false;

--- a/rskj-core/src/main/java/co/rsk/peg/vote/ABICallElection.java
+++ b/rskj-core/src/main/java/co/rsk/peg/vote/ABICallElection.java
@@ -83,11 +83,11 @@ public class ABICallElection {
     }
 
     /**
-     * Returns the election winner abi call spec, or null if there's none
+     * Returns the election winner abi call spec, or empty if there's none
      * The vote authorizer determines the number of participants,
      * whereas this class determines the number of votes that
      * conforms a win
-     * @return the winner abi call spec
+     * @return the (optional) winner abi call spec
      */
     public Optional<ABICallSpec> getWinner() {
         for (Map.Entry<ABICallSpec, List<RskAddress>> specVotes : votes.entrySet()) {

--- a/rskj-core/src/main/java/co/rsk/peg/vote/ABICallElection.java
+++ b/rskj-core/src/main/java/co/rsk/peg/vote/ABICallElection.java
@@ -22,7 +22,6 @@ import co.rsk.core.RskAddress;
 
 import java.util.*;
 
-import co.rsk.peg.UnauthorizedVoterException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/rskj-core/src/main/java/co/rsk/peg/vote/UnauthorizedVoterException.java
+++ b/rskj-core/src/main/java/co/rsk/peg/vote/UnauthorizedVoterException.java
@@ -1,4 +1,4 @@
-package co.rsk.peg;
+package co.rsk.peg.vote;
 
 public class UnauthorizedVoterException extends RuntimeException {
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -71,7 +71,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static co.rsk.peg.federation.FederationFormatVersion.*;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static co.rsk.peg.BridgeStorageIndexKey.*;
@@ -1850,7 +1849,7 @@ class BridgeStorageProviderTest {
 
         ABICallElection result = storageProvider.getFeePerKbElection(authorizerMock);
         MatcherAssert.assertThat(result.getVotes().isEmpty(), is(true));
-        MatcherAssert.assertThat(result.getWinner(), nullValue());
+        Assertions.assertFalse(result.getWinner().isPresent());
     }
 
     @Test
@@ -1882,7 +1881,7 @@ class BridgeStorageProviderTest {
 
         ABICallElection result = storageProvider.getFeePerKbElection(authorizerMock);
         MatcherAssert.assertThat(result.getVotes(), is(electionVotes));
-        MatcherAssert.assertThat(result.getWinner(), is(expectedWinner));
+        Assertions.assertEquals(expectedWinner, result.getWinner().get());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
@@ -22,16 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import co.rsk.bitcoinj.core.Address;
 import co.rsk.bitcoinj.core.AddressFormatException;
@@ -2152,6 +2143,7 @@ public class BridgeSupportTestIntegration {
             when(election.getWinner()).then((InvocationOnMock m) -> this.getWinner());
         }
 
+
         public RskAddress getVoter() {
             return voter;
         }
@@ -2168,8 +2160,12 @@ public class BridgeSupportTestIntegration {
             return tx;
         }
 
-        public ABICallSpec getWinner() {
-            return winner;
+        public Optional<ABICallSpec> getWinner() {
+            if (winner == null) {
+                return Optional.empty();
+            }
+
+            return Optional.of(winner);
         }
 
         public void setWinner(ABICallSpec winner) {
@@ -3990,15 +3986,15 @@ public class BridgeSupportTestIntegration {
 
             return holder.getFederationElection();
         });
-        Mockito.doAnswer((InvocationOnMock m) -> {
+        doAnswer((InvocationOnMock m) -> {
             holder.setActiveFederation(m.<Federation>getArgument(0));
             return null;
         }).when(providerMock).setNewFederation(any());
-        Mockito.doAnswer((InvocationOnMock m) -> {
+        doAnswer((InvocationOnMock m) -> {
             holder.setRetiringFederation(m.<Federation>getArgument(0));
             return null;
         }).when(providerMock).setOldFederation(any());
-        Mockito.doAnswer((InvocationOnMock m) -> {
+        doAnswer((InvocationOnMock m) -> {
             holder.setPendingFederation(m.<PendingFederation>getArgument(0));
             return null;
         }).when(providerMock).setPendingFederation(any());

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
@@ -2143,7 +2143,6 @@ public class BridgeSupportTestIntegration {
             when(election.getWinner()).then((InvocationOnMock m) -> this.getWinner());
         }
 
-
         public RskAddress getVoter() {
             return voter;
         }

--- a/rskj-core/src/test/java/co/rsk/peg/vote/ABICallElectionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/vote/ABICallElectionTest.java
@@ -126,13 +126,13 @@ class ABICallElectionTest {
 
     @Test
     void getWinnerAndClearWinners_existingFn() {
-        Assertions.assertNull(election.getWinner());
+        Assertions.assertFalse(election.getWinner().isPresent());
         Assertions.assertTrue(election.vote(spec_fnb, createVoter("ee")));
-        Assertions.assertEquals(spec_fnb, election.getWinner());
+        Assertions.assertEquals(spec_fnb, election.getWinner().get());
 
         election.clearWinners();
 
-        Assertions.assertNull(election.getWinner());
+        Assertions.assertFalse(election.getWinner().isPresent());
         Assertions.assertEquals(1, election.getVotes().size());
         Assertions.assertEquals(Collections.emptyList(), election.getVotes().get(spec_fna));
     }
@@ -140,17 +140,17 @@ class ABICallElectionTest {
     @Test
     void getWinnerAndClearWinners_newFn() {
         ABICallSpec spec_fnc = new ABICallSpec("fn-c", new byte[][]{ Hex.decode("44") });
-        Assertions.assertNull(election.getWinner());
+        Assertions.assertFalse(election.getWinner().isPresent());
         Assertions.assertTrue(election.vote(spec_fnc, createVoter("ee")));
-        Assertions.assertNull(election.getWinner());
+        Assertions.assertFalse(election.getWinner().isPresent());
         Assertions.assertTrue(election.vote(spec_fnc, createVoter("cc")));
-        Assertions.assertNull(election.getWinner());
+        Assertions.assertFalse(election.getWinner().isPresent());
         Assertions.assertTrue(election.vote(spec_fnc, createVoter("aa")));
-        Assertions.assertEquals(spec_fnc, election.getWinner());
+        Assertions.assertEquals(spec_fnc, election.getWinner().get());
 
         election.clearWinners();
 
-        Assertions.assertNull(election.getWinner());
+        Assertions.assertFalse(election.getWinner().isPresent());
         Assertions.assertEquals(2, election.getVotes().size());
         Assertions.assertEquals(Collections.emptyList(), election.getVotes().get(spec_fna));
         Assertions.assertEquals(Arrays.asList(createVoter("aa"), createVoter("bb")), election.getVotes().get(spec_fnb));


### PR DESCRIPTION
There is an ongoing effort to organize Bridge classes in their package and avoid circular dependencies.
One of the classes we have identified that could be moved to their package are those related to ABI voting.
To capitalize this effort, there are some improvements that can be done in each class.


This PR modifies the ABICallElection:
- Make getWinner return Optional instead of null. 
- Add logs.
- Make validate method throw a new UnauthorizedVoterException.
