### PR TITLE
Modify ABICallSpec

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/abi/ABICallSpec.java
+++ b/rskj-core/src/main/java/co/rsk/peg/abi/ABICallSpec.java
@@ -34,18 +34,12 @@ import java.util.Objects;
  * @author Ariel Mendelzon
  */
 public final class ABICallSpec {
-    public static final Comparator<ABICallSpec> byBytesComparator = new Comparator<ABICallSpec>() {
-        @Override
-        public int compare(ABICallSpec specA, ABICallSpec specB) {
-            return SignedBytes.lexicographicalComparator().compare(
-                    specA.getEncoded(),
-                    specB.getEncoded()
-            );
-        }
-    };
+    public static final Comparator<ABICallSpec> byBytesComparator = Comparator.comparing(
+        spec -> SignedBytes.lexicographicalComparator().compare(spec.getEncoded(), spec.getEncoded())
+    );
 
-    private String function;
-    private byte[][] arguments;
+    private final String function;
+    private final byte[][] arguments;
 
     public ABICallSpec(String function, byte[][] arguments) {
         this.function = function;
@@ -100,7 +94,12 @@ public final class ABICallSpec {
 
     @Override
     public int hashCode() {
-        int[] argumentsHashes = Arrays.stream(arguments).map(argument -> Arrays.hashCode(argument)).mapToInt(Integer::intValue).toArray();
+        int[] argumentsHashes = Arrays
+                                .stream(arguments)
+                                .map(Arrays::hashCode)
+                                .mapToInt(Integer::intValue)
+                                .toArray();
+
         return Objects.hash(function, Arrays.hashCode(argumentsHashes));
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/abi/ABICallSpec.java
+++ b/rskj-core/src/main/java/co/rsk/peg/abi/ABICallSpec.java
@@ -34,9 +34,8 @@ import java.util.Objects;
  * @author Ariel Mendelzon
  */
 public final class ABICallSpec {
-    public static final Comparator<ABICallSpec> byBytesComparator = Comparator.comparing(
-        spec -> SignedBytes.lexicographicalComparator().compare(spec.getEncoded(), spec.getEncoded())
-    );
+    public static final Comparator<ABICallSpec> byBytesComparator = (specA, specB)
+        -> SignedBytes.lexicographicalComparator().compare(specA.getEncoded(), specB.getEncoded());
 
     private final String function;
     private final byte[][] arguments;


### PR DESCRIPTION
There is an ongoing effort to organize Bridge classes in their package and avoid circular dependencies.
One of the classes we have identified that could be moved to their package are those related to ABI voting.
To capitalize this effort, there are some improvements that can be done in each class.

This PR modifies the ABICallSpec:
- Refactor methods to make them mode readable.
- Make fields final.
