### PR TITLE
Modify ABICallVoteResult

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/abi/ABICallVoteResult.java
+++ b/rskj-core/src/main/java/co/rsk/peg/abi/ABICallVoteResult.java
@@ -27,8 +27,8 @@ package co.rsk.peg.abi;
  * @author Ariel Mendelzon
  */
 public final class ABICallVoteResult {
-    private boolean successful;
-    private Object result;
+    private final boolean successful;
+    private final Object result;
 
     public ABICallVoteResult(boolean successful, Object result) {
         this.successful = successful;


### PR DESCRIPTION
There is an ongoing effort to organize Bridge classes in their package and avoid circular dependencies.
One of the classes we have identified that could be moved to their package are those related to ABI voting.
To capitalize this effort, there are some improvements that can be done in each class.

This PR modifies the ABICallVoteResult:
- Make fields final.