### PR TITLE
Modify AdressBasedAuthorizer

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/AddressBasedAuthorizer.java
+++ b/rskj-core/src/main/java/co/rsk/peg/AddressBasedAuthorizer.java
@@ -33,13 +33,13 @@ import java.util.stream.Collectors;
  * @author Ariel Mendelzon
  */
 public class AddressBasedAuthorizer {
-    public enum MinimumRequiredCalculation { ONE, MAJORITY, ALL };
+    public enum MinimumRequiredCalculation { ONE, MAJORITY, ALL }
 
     protected List<byte[]> authorizedAddresses;
     protected MinimumRequiredCalculation requiredCalculation;
 
     public AddressBasedAuthorizer(List<ECKey> authorizedKeys, MinimumRequiredCalculation requiredCalculation) {
-        this.authorizedAddresses = authorizedKeys.stream().map(key -> key.getAddress()).collect(Collectors.toList());
+        this.authorizedAddresses = authorizedKeys.stream().map(ECKey::getAddress).collect(Collectors.toList());
         this.requiredCalculation = requiredCalculation;
     }
 


### PR DESCRIPTION
There is an ongoing effort to organize Bridge classes in their package and avoid circular dependencies.
One of the classes we have identified that could be moved to their package are those related to ABI voting.
To capitalize this effort, there are some improvements that can be done in each class.

This PR modifies the ABICallVoteResult:
- Refactor using lambda expression.