### PR TITLE
Make Value Field In the KeyType Enum Final

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationMember.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationMember.java
@@ -60,7 +60,7 @@ public final class FederationMember {
         RSK("rsk"),
         MST("mst");
 
-        private String value;
+        private final String value;
 
         KeyType(String value) {
             this.value = value;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The FederationMember class contains a KeyType enum. This enum has a Value field that must be declared with the final keyword.

## Motivation and Context
This is part of a tech debt and improves good practices on the project. The Final keyword will make this attribute immutable, which is a good practice for handling concurrent transactions and avoiding state modification after creation.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
