### PR TITLE
Fix log message in BridgeSupport releaseBtc Method

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -834,11 +834,12 @@ public class BridgeSupport {
      * @throws IOException
      */
     public void releaseBtc(Transaction rskTx) throws IOException {
-        Coin pegoutValue = rskTx.getValue().toBitcoin();
+        final co.rsk.core.Coin pegoutValueInWeis = rskTx.getValue();
+        final Coin pegoutValueInSatoshis = pegoutValueInWeis.toBitcoin();
         final RskAddress senderAddress = rskTx.getSender(signatureCache);
         logger.debug(
             "[releaseBtc] Releasing {} RBTC from RSK address {} in tx {}",
-            pegoutValue,
+            pegoutValueInWeis,
             senderAddress,
             rskTx.getHash()
         );
@@ -850,7 +851,7 @@ public class BridgeSupport {
                 senderAddress
             );
             if (activations.isActive(ConsensusRule.RSKIP185)) {
-                emitRejectEvent(pegoutValue, senderAddress, RejectedPegoutReason.CALLER_CONTRACT);
+                emitRejectEvent(pegoutValueInSatoshis, senderAddress, RejectedPegoutReason.CALLER_CONTRACT);
                 return;
             } else {
                 String message = "Contract calling releaseBTC";
@@ -864,7 +865,7 @@ public class BridgeSupport {
         Address btcDestinationAddress = BridgeUtils.recoverBtcAddressFromEthTransaction(rskTx, btcParams);
         logger.debug("[releaseBtc] BTC destination address: {}", btcDestinationAddress);
 
-        requestRelease(btcDestinationAddress, pegoutValue, rskTx);
+        requestRelease(btcDestinationAddress, pegoutValueInSatoshis, rskTx);
     }
 
     private void refundAndEmitRejectEvent(Coin value, RskAddress senderAddress, RejectedPegoutReason reason) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -838,7 +838,7 @@ public class BridgeSupport {
         final Coin pegoutValueInSatoshis = pegoutValueInWeis.toBitcoin();
         final RskAddress senderAddress = rskTx.getSender(signatureCache);
         logger.debug(
-            "[releaseBtc] Releasing {} RBTC from RSK address {} in tx {}",
+            "[releaseBtc] Releasing {} weis from RSK address {} in tx {}",
             pegoutValueInWeis,
             senderAddress,
             rskTx.getHash()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
releaseBtc method is printing a message showing the wrong unit. We changed the log message to print Weis as the unit instead of Satoshis getting the value in Weis from the Rsk transaction before converting it to satoshis with rskTx.getValue().

## Motivation and Context
This improves the traceability of the project.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
