### PR TITLE
Rename Minimum Pegout Constants From BridgeConstants

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -915,7 +915,7 @@ public class BridgeSupport {
                 ); // add the gap
 
             // The pegout value should be greater or equals than the max of these two values
-            Coin minValue = Coin.valueOf(Math.max(bridgeConstants.getMinimumPegoutTxValueInSatoshis().value, requireFundsForFee.value));
+            Coin minValue = Coin.valueOf(Math.max(bridgeConstants.getMinimumPegoutTxValue().value, requireFundsForFee.value));
 
             // Since Iris the peg-out the rule is that the minimum is inclusive
             if (value.isLessThan(minValue)) {
@@ -927,7 +927,7 @@ public class BridgeSupport {
             }
         } else {
             // For legacy peg-outs the rule stated that the minimum was exclusive
-            if (!value.isGreaterThan(bridgeConstants.getLegacyMinimumPegoutTxValueInSatoshis())) {
+            if (!value.isGreaterThan(bridgeConstants.getLegacyMinimumPegoutTxValue())) {
                 optionalRejectedPegoutReason = Optional.of(RejectedPegoutReason.LOW_AMOUNT);
             }
         }

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeConstants.java
@@ -42,8 +42,8 @@ public abstract class BridgeConstants {
 
     protected Coin legacyMinimumPeginTxValue;
     protected Coin minimumPeginTxValue;
-    protected Coin legacyMinimumPegoutTxValueInSatoshis;
-    protected Coin minimumPegoutTxValueInSatoshis;
+    protected Coin legacyMinimumPegoutTxValue;
+    protected Coin minimumPegoutTxValue;
 
     protected long federationActivationAge;
     protected long federationActivationAgeLegacy;
@@ -125,9 +125,9 @@ public abstract class BridgeConstants {
         return activations.isActive(ConsensusRule.RSKIP219) ? minimumPeginTxValue : legacyMinimumPeginTxValue;
     }
 
-    public Coin getLegacyMinimumPegoutTxValueInSatoshis() { return legacyMinimumPegoutTxValueInSatoshis; }
+    public Coin getLegacyMinimumPegoutTxValue() { return legacyMinimumPegoutTxValue; }
 
-    public Coin getMinimumPegoutTxValueInSatoshis() { return minimumPegoutTxValueInSatoshis; }
+    public Coin getMinimumPegoutTxValue() { return minimumPegoutTxValue; }
 
     public long getFederationActivationAge(ActivationConfig.ForBlock activations) {
         return activations.isActive(ConsensusRule.RSKIP383)? federationActivationAge: federationActivationAgeLegacy;

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeDevNetConstants.java
@@ -63,9 +63,9 @@ public class BridgeDevNetConstants extends BridgeConstants {
         maxBtcHeadersPerRskBlock = 500;
 
         legacyMinimumPeginTxValue = Coin.valueOf(1_000_000);
-        legacyMinimumPegoutTxValueInSatoshis = Coin.valueOf(500_000);
+        legacyMinimumPegoutTxValue = Coin.valueOf(500_000);
         minimumPeginTxValue = Coin.valueOf(500_000);
-        minimumPegoutTxValueInSatoshis = Coin.valueOf(250_000);
+        minimumPegoutTxValue = Coin.valueOf(250_000);
 
         // Keys generated with GenNodeKey using generators 'auth-a' through 'auth-e'
         List<ECKey> federationChangeAuthorizedKeys = Arrays.stream(new String[]{

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeMainNetConstants.java
@@ -54,9 +54,9 @@ public class BridgeMainNetConstants extends BridgeConstants {
         maxBtcHeadersPerRskBlock = 500;
 
         legacyMinimumPeginTxValue = Coin.valueOf(1_000_000);
-        legacyMinimumPegoutTxValueInSatoshis = Coin.valueOf(800_000);
+        legacyMinimumPegoutTxValue = Coin.valueOf(800_000);
         minimumPeginTxValue = Coin.valueOf(500_000);
-        minimumPegoutTxValueInSatoshis = Coin.valueOf(400_000);
+        minimumPegoutTxValue = Coin.valueOf(400_000);
 
         List<ECKey> federationChangeAuthorizedKeys = Arrays.stream(new String[]{
             "04e593d4cde25137b13f19462bc4c02e97ba2ed5a3860813497abf9b4eeb9259e37e0384d12cfd2d9a7a0ba606b31ee34317a9d7f4a8591c6bcf5dfd5563248b2f",

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
@@ -63,9 +63,9 @@ public class BridgeRegTestConstants extends BridgeConstants {
         maxBtcHeadersPerRskBlock = 500;
 
         legacyMinimumPeginTxValue = Coin.COIN;
-        legacyMinimumPegoutTxValueInSatoshis = Coin.valueOf(500_000);
+        legacyMinimumPegoutTxValue = Coin.valueOf(500_000);
         minimumPeginTxValue = Coin.COIN.div(2);
-        minimumPegoutTxValueInSatoshis = Coin.valueOf(250_000);
+        minimumPegoutTxValue = Coin.valueOf(250_000);
 
         // Keys generated with GenNodeKey using generators 'auth-a' through 'auth-e'
         List<ECKey> federationChangeAuthorizedKeys = Arrays.stream(new String[]{

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeTestNetConstants.java
@@ -68,8 +68,8 @@ public class BridgeTestNetConstants extends BridgeConstants {
 
         legacyMinimumPeginTxValue = Coin.valueOf(1_000_000);
         minimumPeginTxValue = Coin.valueOf(500_000);
-        legacyMinimumPegoutTxValueInSatoshis = Coin.valueOf(500_000);
-        minimumPegoutTxValueInSatoshis = Coin.valueOf(250_000);
+        legacyMinimumPegoutTxValue = Coin.valueOf(500_000);
+        minimumPegoutTxValue = Coin.valueOf(250_000);
 
         // Passphrases are kept private
         List<ECKey> federationChangeAuthorizedKeys = Arrays.stream(new String[]{

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportRegisterBtcTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportRegisterBtcTransactionTest.java
@@ -1624,7 +1624,7 @@ class BridgeSupportRegisterBtcTransactionTest {
             );
         }
 
-        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValueInSatoshis();
+        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValue();
         Coin quarterMinimumPegoutTxValue = minimumPegoutTxValue.div(4);
         for (int i = 0; i < 10; i++) {
             btcTransaction.addOutput(quarterMinimumPegoutTxValue.add(Coin.CENT), BitcoinTestUtils.createP2PKHAddress(btcMainnetParams, "user" + i));
@@ -1705,7 +1705,7 @@ class BridgeSupportRegisterBtcTransactionTest {
             ScriptBuilder.createP2SHMultiSigInputScript(null, activeFederation.getRedeemScript())
         );
 
-        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValueInSatoshis();
+        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValue();
         Coin quarterMinimumPegoutTxValue = minimumPegoutTxValue.div(4);
         for (int i = 0; i < 10; i++) {
             btcTransaction.addOutput(quarterMinimumPegoutTxValue.add(Coin.CENT), BitcoinTestUtils.createP2PKHAddress(btcMainnetParams, "user" + i));
@@ -1788,7 +1788,7 @@ class BridgeSupportRegisterBtcTransactionTest {
             );
         }
 
-        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValueInSatoshis();
+        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValue();
         btcTransaction.addOutput(minimumPegoutTxValue, userAddress);
 
         FederationTestUtils.addSignatures(activeFederation, activeFedSigners, btcTransaction);
@@ -1946,7 +1946,7 @@ class BridgeSupportRegisterBtcTransactionTest {
             );
         }
 
-        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValueInSatoshis();
+        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValue();
         Coin quarterMinimumPegoutTxValue = minimumPegoutTxValue.div(4);
         for (int i = 0; i < 10; i++) {
             btcTransaction.addOutput(quarterMinimumPegoutTxValue.add(Coin.CENT), activeFederation.getAddress());
@@ -2013,7 +2013,7 @@ class BridgeSupportRegisterBtcTransactionTest {
             ScriptBuilder.createP2SHMultiSigInputScript(null, retiringFederation.getRedeemScript())
         );
 
-        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValueInSatoshis();
+        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValue();
         Coin quarterMinimumPegoutTxValue = minimumPegoutTxValue.div(4);
         for (int i = 0; i < 10; i++) {
             btcTransaction.addOutput(quarterMinimumPegoutTxValue.add(Coin.CENT), activeFederation.getAddress());
@@ -2083,7 +2083,7 @@ class BridgeSupportRegisterBtcTransactionTest {
             );
         }
 
-        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValueInSatoshis();
+        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValue();
         btcTransaction.addOutput(minimumPegoutTxValue, activeFederation.getAddress());
 
         FederationTestUtils.addSignatures(retiringFederation, retiringFedSigners, btcTransaction);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -430,10 +430,10 @@ class BridgeSupportReleaseBtcTest {
         bridgeSupport = initBridgeSupport(eventLogger, activationMock);
 
         // Get a value between old and new minimum pegout values
-        Coin middle = bridgeConstants.getLegacyMinimumPegoutTxValueInSatoshis().subtract(bridgeConstants.getMinimumPegoutTxValueInSatoshis()).div(2);
-        Coin value = bridgeConstants.getMinimumPegoutTxValueInSatoshis().add(middle);
-        Assertions.assertTrue(value.isLessThan(bridgeConstants.getLegacyMinimumPegoutTxValueInSatoshis()));
-        Assertions.assertTrue(value.isGreaterThan(bridgeConstants.getMinimumPegoutTxValueInSatoshis()));
+        Coin middle = bridgeConstants.getLegacyMinimumPegoutTxValue().subtract(bridgeConstants.getMinimumPegoutTxValue()).div(2);
+        Coin value = bridgeConstants.getMinimumPegoutTxValue().add(middle);
+        Assertions.assertTrue(value.isLessThan(bridgeConstants.getLegacyMinimumPegoutTxValue()));
+        Assertions.assertTrue(value.isGreaterThan(bridgeConstants.getMinimumPegoutTxValue()));
         bridgeSupport.releaseBtc(buildReleaseRskTx(value));
 
         Transaction rskTx = buildUpdateTx();
@@ -465,10 +465,10 @@ class BridgeSupportReleaseBtcTest {
         bridgeSupport = initBridgeSupport(eventLogger, activationMock);
 
         // Get a value between old and new minimum pegout values
-        Coin middle = bridgeConstants.getLegacyMinimumPegoutTxValueInSatoshis().subtract(bridgeConstants.getMinimumPegoutTxValueInSatoshis()).div(2);
-        Coin value = bridgeConstants.getMinimumPegoutTxValueInSatoshis().add(middle);
-        Assertions.assertTrue(value.isLessThan(bridgeConstants.getLegacyMinimumPegoutTxValueInSatoshis()));
-        Assertions.assertTrue(value.isGreaterThan(bridgeConstants.getMinimumPegoutTxValueInSatoshis()));
+        Coin middle = bridgeConstants.getLegacyMinimumPegoutTxValue().subtract(bridgeConstants.getMinimumPegoutTxValue()).div(2);
+        Coin value = bridgeConstants.getMinimumPegoutTxValue().add(middle);
+        Assertions.assertTrue(value.isLessThan(bridgeConstants.getLegacyMinimumPegoutTxValue()));
+        Assertions.assertTrue(value.isGreaterThan(bridgeConstants.getMinimumPegoutTxValue()));
         bridgeSupport.releaseBtc(buildReleaseRskTx(value));
 
         Transaction rskTx = buildUpdateTx();
@@ -498,10 +498,10 @@ class BridgeSupportReleaseBtcTest {
         bridgeSupport = initBridgeSupport(eventLogger, activationMock);
 
         // Get a value between old and new minimum pegout values
-        Coin middle = bridgeConstants.getLegacyMinimumPegoutTxValueInSatoshis().subtract(bridgeConstants.getMinimumPegoutTxValueInSatoshis()).div(2);
-        Coin value = bridgeConstants.getMinimumPegoutTxValueInSatoshis().add(middle);
-        Assertions.assertTrue(value.isLessThan(bridgeConstants.getLegacyMinimumPegoutTxValueInSatoshis()));
-        Assertions.assertTrue(value.isGreaterThan(bridgeConstants.getMinimumPegoutTxValueInSatoshis()));
+        Coin middle = bridgeConstants.getLegacyMinimumPegoutTxValue().subtract(bridgeConstants.getMinimumPegoutTxValue()).div(2);
+        Coin value = bridgeConstants.getMinimumPegoutTxValue().add(middle);
+        Assertions.assertTrue(value.isLessThan(bridgeConstants.getLegacyMinimumPegoutTxValue()));
+        Assertions.assertTrue(value.isGreaterThan(bridgeConstants.getMinimumPegoutTxValue()));
         bridgeSupport.releaseBtc(buildReleaseRskTx(value));
 
         Transaction rskTx = buildUpdateTx();
@@ -525,7 +525,7 @@ class BridgeSupportReleaseBtcTest {
         bridgeSupport = initBridgeSupport(eventLogger, activationMock);
 
         // Get a value exactly to legacy minimum
-        Coin value = bridgeConstants.getLegacyMinimumPegoutTxValueInSatoshis();
+        Coin value = bridgeConstants.getLegacyMinimumPegoutTxValue();
         bridgeSupport.releaseBtc(buildReleaseRskTx(value));
 
         Transaction rskTx = buildUpdateTx();
@@ -549,7 +549,7 @@ class BridgeSupportReleaseBtcTest {
         bridgeSupport = initBridgeSupport(eventLogger, activationMock);
 
         // Get a value exactly to current minimum
-        Coin value = bridgeConstants.getMinimumPegoutTxValueInSatoshis();
+        Coin value = bridgeConstants.getMinimumPegoutTxValue();
         bridgeSupport.releaseBtc(buildReleaseRskTx(value));
 
         Transaction rskTx = buildUpdateTx();
@@ -580,7 +580,7 @@ class BridgeSupportReleaseBtcTest {
         bridgeSupport = initBridgeSupport(eventLogger, activationMock);
 
         // Get a value exactly to current minimum
-        Coin value = bridgeConstants.getMinimumPegoutTxValueInSatoshis();
+        Coin value = bridgeConstants.getMinimumPegoutTxValue();
         bridgeSupport.releaseBtc(buildReleaseRskTx(value));
 
         Transaction rskTx = buildUpdateTx();
@@ -602,7 +602,7 @@ class BridgeSupportReleaseBtcTest {
 
     @Test
     void release_verify_fee_below_fee_is_rejected() throws IOException {
-        Coin value = bridgeConstants.getMinimumPegoutTxValueInSatoshis().add(Coin.SATOSHI);
+        Coin value = bridgeConstants.getMinimumPegoutTxValue().add(Coin.SATOSHI);
 
         testPegoutMinimumWithFeeVerification(Coin.COIN, value, false);
     }
@@ -633,7 +633,7 @@ class BridgeSupportReleaseBtcTest {
     void release_verify_fee_above_fee_but_below_minimum_is_rejected() throws IOException {
         testPegoutMinimumWithFeeVerification(
             Coin.MILLICOIN,
-            bridgeConstants.getMinimumPegoutTxValueInSatoshis().minus(Coin.SATOSHI),
+            bridgeConstants.getMinimumPegoutTxValue().minus(Coin.SATOSHI),
             false
         );
     }
@@ -1147,7 +1147,7 @@ class BridgeSupportReleaseBtcTest {
         // if shouldPegout true then value should be greater or equals than both required fee plus gap and min pegout value
         // if shouldPegout false then value should be smaller than any of those minimums
         Assertions.assertEquals(!shouldPegout, value.isLessThan(minValueWithGapAboveFee) ||
-            value.isLessThan(bridgeConstants.getMinimumPegoutTxValueInSatoshis()));
+            value.isLessThan(bridgeConstants.getMinimumPegoutTxValue()));
 
         bridgeSupport.releaseBtc(buildReleaseRskTx(value));
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTestIntegration.java
@@ -218,9 +218,9 @@ public class BridgeTestIntegration {
 
     @Test
     void callUpdateCollectionsWithTransactionsWaitingForConfirmation() throws IOException, VMException {
-        BtcTransaction tx1 = createTransaction(2, bridgeRegTestConstants.getMinimumPegoutTxValueInSatoshis());
-        BtcTransaction tx2 = createTransaction(3, bridgeRegTestConstants.getMinimumPegoutTxValueInSatoshis().add(Coin.MILLICOIN));
-        BtcTransaction tx3 = createTransaction(4, bridgeRegTestConstants.getMinimumPegoutTxValueInSatoshis().add(Coin.MILLICOIN).add(Coin.MILLICOIN));
+        BtcTransaction tx1 = createTransaction(2, bridgeRegTestConstants.getMinimumPegoutTxValue());
+        BtcTransaction tx2 = createTransaction(3, bridgeRegTestConstants.getMinimumPegoutTxValue().add(Coin.MILLICOIN));
+        BtcTransaction tx3 = createTransaction(4, bridgeRegTestConstants.getMinimumPegoutTxValue().add(Coin.MILLICOIN).add(Coin.MILLICOIN));
 
         Repository repository = createRepository();
         Repository track = repository.startTracking();
@@ -274,9 +274,9 @@ public class BridgeTestIntegration {
 
     @Test
     void callUpdateCollectionsWithTransactionsWaitingForConfirmationWithEnoughConfirmations() throws IOException, VMException {
-        BtcTransaction tx1 = createTransaction(2, bridgeRegTestConstants.getMinimumPegoutTxValueInSatoshis());
-        BtcTransaction tx2 = createTransaction(3, bridgeRegTestConstants.getMinimumPegoutTxValueInSatoshis().add(Coin.MILLICOIN));
-        BtcTransaction tx3 = createTransaction(4, bridgeRegTestConstants.getMinimumPegoutTxValueInSatoshis().add(Coin.MILLICOIN).add(Coin.MILLICOIN));
+        BtcTransaction tx1 = createTransaction(2, bridgeRegTestConstants.getMinimumPegoutTxValue());
+        BtcTransaction tx2 = createTransaction(3, bridgeRegTestConstants.getMinimumPegoutTxValue().add(Coin.MILLICOIN));
+        BtcTransaction tx3 = createTransaction(4, bridgeRegTestConstants.getMinimumPegoutTxValue().add(Coin.MILLICOIN).add(Coin.MILLICOIN));
 
         Repository repository = createRepository();
         Repository track = repository.startTracking();

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsGetTransactionTypeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsGetTransactionTypeTest.java
@@ -1111,7 +1111,7 @@ class PegUtilsGetTransactionTypeTest {
             );
         }
 
-        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValueInSatoshis();
+        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValue();
         Coin quarterMinimumPegoutTxValue = minimumPegoutTxValue.div(4);
         for (int i = 0; i < 10; i++) {
             btcTransaction.addOutput(quarterMinimumPegoutTxValue.add(Coin.CENT), BitcoinTestUtils.createP2PKHAddress(btcMainnetParams, "user" + i ));
@@ -1170,7 +1170,7 @@ class PegUtilsGetTransactionTypeTest {
             ScriptBuilder.createP2SHMultiSigInputScript(null, activeFederation.getRedeemScript())
         );
 
-        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValueInSatoshis();
+        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValue();
         Coin quarterMinimumPegoutTxValue = minimumPegoutTxValue.div(4);
         for (int i = 0; i < 10; i++) {
             btcTransaction.addOutput(quarterMinimumPegoutTxValue.add(Coin.CENT), BitcoinTestUtils.createP2PKHAddress(btcMainnetParams, "user" + i ));
@@ -1231,7 +1231,7 @@ class PegUtilsGetTransactionTypeTest {
             );
         }
 
-        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValueInSatoshis();
+        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValue();
         btcTransaction.addOutput(minimumPegoutTxValue, userAddress);
 
         FederationTestUtils.addSignatures(activeFederation, activeFedSigners, btcTransaction);
@@ -1434,7 +1434,7 @@ class PegUtilsGetTransactionTypeTest {
             );
         }
 
-        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValueInSatoshis();
+        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValue();
         Coin quarterMinimumPegoutTxValue = minimumPegoutTxValue.div(4);
         for (int i = 0; i < 10; i++) {
             btcTransaction.addOutput(quarterMinimumPegoutTxValue.add(Coin.CENT), activeFederation.getAddress());
@@ -1495,7 +1495,7 @@ class PegUtilsGetTransactionTypeTest {
             ScriptBuilder.createP2SHMultiSigInputScript(null, retiringFederation.getRedeemScript())
         );
 
-        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValueInSatoshis();
+        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValue();
         Coin quarterMinimumPegoutTxValue = minimumPegoutTxValue.div(4);
         for (int i = 0; i < 10; i++) {
             btcTransaction.addOutput(quarterMinimumPegoutTxValue.add(Coin.CENT), activeFederation.getAddress());
@@ -1557,7 +1557,7 @@ class PegUtilsGetTransactionTypeTest {
             );
         }
 
-        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValueInSatoshis();
+        Coin minimumPegoutTxValue = bridgeMainnetConstants.getMinimumPegoutTxValue();
         btcTransaction.addOutput(minimumPegoutTxValue, activeFederation.getAddress());
 
         FederationTestUtils.addSignatures(retiringFederation, retiringFedSigners, btcTransaction);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There are 2 bridge constants related to the minimum pegout value. legacyMinimumPegoutTxValueInSatoshis and minimumPegoutTxValueInSatoshis. These names are not precise, because the data type is actually a Coin object, so it’s not an amount and should not have a unit. For this reason, we renamed both constants to legacyMinimumPegoutTxValue and minimumPegoutTxValue respectively.

## Motivation and Context
To improve naming conventions.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
