### PR TITLE
Use original values for genesisFederationCreationTime

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeConstants.java
@@ -60,7 +60,6 @@ public abstract class BridgeConstants {
     protected AddressBasedAuthorizer feePerKbChangeAuthorizer;
 
     protected Coin genesisFeePerKb;
-
     protected Coin maxFeePerKb;
 
     protected AddressBasedAuthorizer increaseLockingCapAuthorizer;
@@ -76,7 +75,6 @@ public abstract class BridgeConstants {
     protected int maxDepthBlockchainAccepted;
 
     protected long erpFedActivationDelay;
-
     protected List<BtcECKey> erpFedPubKeysList;
 
     protected String oldFederationAddress;

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeDevNetConstants.java
@@ -49,9 +49,8 @@ public class BridgeDevNetConstants extends BridgeConstants {
     public BridgeDevNetConstants(List<BtcECKey> federationPublicKeys) {
         btcParamsString = NetworkParameters.ID_TESTNET;
 
-        this.genesisFederationPublicKeys = federationPublicKeys;
-
-        genesisFederationCreationTime = ZonedDateTime.parse("2017-11-14T00:00:00Z").toInstant();
+        genesisFederationPublicKeys = federationPublicKeys;
+        genesisFederationCreationTime = ZonedDateTime.parse("1970-01-18T11:36:57.600Z").toInstant();
 
         btc2RskMinimumAcceptableConfirmations = 1;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 10;
@@ -110,7 +109,6 @@ public class BridgeDevNetConstants extends BridgeConstants {
         );
 
         genesisFeePerKb = Coin.MILLICOIN;
-
         maxFeePerKb = Coin.valueOf(5_000_000L);
 
         // Key generated with GenNodeKey using generator 'auth-increase_locking_cap'

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeMainNetConstants.java
@@ -41,8 +41,7 @@ public class BridgeMainNetConstants extends BridgeConstants {
             federator9PublicKey, federator10PublicKey, federator11PublicKey,
             federator12PublicKey, federator13PublicKey, federator14PublicKey
         );
-
-        genesisFederationCreationTime = ZonedDateTime.parse("2018-01-03T03:00:00Z").toInstant();
+        genesisFederationCreationTime = ZonedDateTime.parse("1970-01-18T12:49:08.400Z").toInstant();
 
         btc2RskMinimumAcceptableConfirmations = 100;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 1000;
@@ -96,7 +95,6 @@ public class BridgeMainNetConstants extends BridgeConstants {
         );
 
         genesisFeePerKb = Coin.MILLICOIN.multiply(5);
-
         maxFeePerKb = Coin.valueOf(5_000_000L);
 
         List<ECKey> increaseLockingCapAuthorizedKeys = Arrays.stream(new String[]{

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
@@ -49,8 +49,7 @@ public class BridgeRegTestConstants extends BridgeConstants {
     public BridgeRegTestConstants(List<BtcECKey> federationPublicKeys) {
         btcParamsString = NetworkParameters.ID_REGTEST;
 
-        this.genesisFederationPublicKeys = federationPublicKeys;
-
+        genesisFederationPublicKeys = federationPublicKeys;
         genesisFederationCreationTime = ZonedDateTime.parse("2016-01-01T00:00:00Z").toInstant();
 
         btc2RskMinimumAcceptableConfirmations = 3;

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeTestNetConstants.java
@@ -55,7 +55,7 @@ public class BridgeTestNetConstants extends BridgeConstants {
             federator3PublicKey
         );
 
-        genesisFederationCreationTime = ZonedDateTime.parse("2018-10-08T03:00:00Z").toInstant();
+        genesisFederationCreationTime = ZonedDateTime.parse("1970-01-18T19:29:27.600Z").toInstant();
 
         btc2RskMinimumAcceptableConfirmations = 10;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 10;
@@ -111,7 +111,6 @@ public class BridgeTestNetConstants extends BridgeConstants {
         );
 
         genesisFeePerKb = Coin.MILLICOIN;
-
         maxFeePerKb = Coin.valueOf(5_000_000L);
 
         List<ECKey> increaseLockingCapAuthorizedKeys = Arrays.stream(new String[]{

--- a/rskj-core/src/test/java/co/rsk/peg/constants/BridgeConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/constants/BridgeConstantsTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import co.rsk.bitcoinj.core.Coin;
+import java.time.Instant;
 import java.util.stream.Stream;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
@@ -160,17 +161,17 @@ class BridgeConstantsTest {
 
     private static Stream<Arguments> getGenesisFederationCreationTimeTestProvider() {
         return Stream.of(
-                Arguments.of(BridgeMainNetConstants.getInstance(), 1514948400L),
-                Arguments.of(BridgeTestNetConstants.getInstance(), 1538967600L),
-                Arguments.of(BridgeRegTestConstants.getInstance(), 1451606400L),
-                Arguments.of(BridgeDevNetConstants.getInstance(),1510617600L)
+            Arguments.of(BridgeMainNetConstants.getInstance(), Instant.ofEpochMilli(1514948400L)),
+            Arguments.of(BridgeTestNetConstants.getInstance(), Instant.ofEpochMilli(1538967600L)),
+            Arguments.of(BridgeRegTestConstants.getInstance(), Instant.ofEpochSecond(1451606400L)),
+            Arguments.of(BridgeDevNetConstants.getInstance(), Instant.ofEpochMilli(1510617600L))
         );
     }
 
     @ParameterizedTest
     @MethodSource("getGenesisFederationCreationTimeTestProvider")
-    void getGenesisFederationCreationTimeTest(BridgeConstants bridgeConstants, long expectedGenesisFederationCreationTime){
-        long actualGenesisFederationCreationTime = bridgeConstants.getGenesisFederationCreationTime().getEpochSecond();
+    void getGenesisFederationCreationTimeTest(BridgeConstants bridgeConstants, Instant expectedGenesisFederationCreationTime){
+        Instant actualGenesisFederationCreationTime = bridgeConstants.getGenesisFederationCreationTime();
         assertEquals(expectedGenesisFederationCreationTime, actualGenesisFederationCreationTime);
     }
 }


### PR DESCRIPTION
Update Bridge constants to use a ZonedDateTime object to indicate the `genesisFederationCreationTime` value instead of an Instant object.