### PR TITLE
Extract federation constants from BridgeConstants

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -23,6 +23,7 @@ import co.rsk.bitcoinj.script.Script;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
+import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.vote.ABICallElection;
 import co.rsk.peg.vote.ABICallSpec;
 import co.rsk.peg.bitcoin.CoinbaseInformation;
@@ -327,8 +328,9 @@ public class BridgeSerializationUtils {
         );
 
         FederationArgs federationArgs = federation.getArgs();
-        List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
-        long activationDelay = bridgeConstants.getErpFedActivationDelay();
+        FederationConstants federationConstants = bridgeConstants.getFederationConstants();
+        List<BtcECKey> erpPubKeys = federationConstants.getErpFedPubKeysList();
+        long activationDelay = federationConstants.getErpFedActivationDelay();
 
         return FederationFactory.buildNonStandardErpFederation(federationArgs, erpPubKeys, activationDelay, activations);
     }
@@ -344,8 +346,9 @@ public class BridgeSerializationUtils {
         );
 
         FederationArgs federationArgs = federation.getArgs();
-        List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
-        long activationDelay = bridgeConstants.getErpFedActivationDelay();
+        FederationConstants federationConstants = bridgeConstants.getFederationConstants();
+        List<BtcECKey> erpPubKeys = federationConstants.getErpFedPubKeysList();
+        long activationDelay = federationConstants.getErpFedActivationDelay();
 
         return FederationFactory.buildP2shErpFederation(federationArgs, erpPubKeys, activationDelay);
     }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -39,6 +39,7 @@ import co.rsk.peg.bitcoin.RskAllowUnconfirmedCoinSelector;
 import co.rsk.peg.btcLockSender.BtcLockSender.TxSenderAddressType;
 import co.rsk.peg.btcLockSender.BtcLockSenderProvider;
 import co.rsk.peg.federation.*;
+import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.feeperkb.FeePerKbSupport;
 import co.rsk.peg.flyover.FlyoverFederationInformation;
 import co.rsk.peg.flyover.FlyoverTxResponseCodes;
@@ -1006,18 +1007,22 @@ public class BridgeSupport {
     }
 
     private boolean federationIsInMigrationAge(Federation federation) {
-        long federationActivationAge = bridgeConstants.getFederationActivationAge(activations);
+        FederationConstants federationConstants = bridgeConstants.getFederationConstants();
+
+        long federationActivationAge = federationConstants.getFederationActivationAge(activations);
         long federationAge = rskExecutionBlock.getNumber() - federation.getCreationBlockNumber();
-        long ageBegin = federationActivationAge + bridgeConstants.getFundsMigrationAgeSinceActivationBegin();
-        long ageEnd = federationActivationAge + bridgeConstants.getFundsMigrationAgeSinceActivationEnd(activations);
+        long ageBegin = federationActivationAge + federationConstants.getFundsMigrationAgeSinceActivationBegin();
+        long ageEnd = federationActivationAge + federationConstants.getFundsMigrationAgeSinceActivationEnd(activations);
 
         return federationAge > ageBegin && federationAge < ageEnd;
     }
 
     private boolean federationIsPastMigrationAge(Federation federation) {
+        FederationConstants federationConstants = bridgeConstants.getFederationConstants();
+
         long federationAge = rskExecutionBlock.getNumber() - federation.getCreationBlockNumber();
-        long ageEnd = bridgeConstants.getFederationActivationAge(activations) +
-            bridgeConstants.getFundsMigrationAgeSinceActivationEnd(activations);
+        long ageEnd = federationConstants.getFederationActivationAge(activations) +
+            federationConstants.getFundsMigrationAgeSinceActivationEnd(activations);
 
         return federationAge >= ageEnd;
     }
@@ -1341,6 +1346,8 @@ public class BridgeSupport {
     }
 
     private void updateFederationCreationBlockHeights() {
+        FederationConstants federationConstants = bridgeConstants.getFederationConstants();
+
         if (!activations.isActive(RSKIP186)) {
             return;
         }
@@ -1350,7 +1357,7 @@ public class BridgeSupport {
             long nextFederationCreationBlockHeight = nextFederationCreationBlockHeightOpt.get();
             long curBlockHeight = rskExecutionBlock.getNumber();
 
-            if (curBlockHeight >= nextFederationCreationBlockHeight + bridgeConstants.getFederationActivationAge(activations)) {
+            if (curBlockHeight >= nextFederationCreationBlockHeight + federationConstants.getFederationActivationAge(activations)) {
                 provider.setActiveFederationCreationBlockHeight(nextFederationCreationBlockHeight);
                 provider.clearNextFederationCreationBlockHeight();
             }
@@ -2077,7 +2084,8 @@ public class BridgeSupport {
         provider.setPendingFederation(currentPendingFederation);
 
         // Clear votes on election
-        provider.getFederationElection(bridgeConstants.getFederationChangeAuthorizer()).clear();
+        FederationConstants federationConstants = bridgeConstants.getFederationConstants();
+        provider.getFederationElection(federationConstants.getFederationChangeAuthorizer()).clear();
 
         return 1;
     }
@@ -2172,7 +2180,8 @@ public class BridgeSupport {
         provider.setPendingFederation(null);
 
         // Clear votes on election
-        provider.getFederationElection(bridgeConstants.getFederationChangeAuthorizer()).clear();
+        FederationConstants federationConstants = bridgeConstants.getFederationConstants();
+        provider.getFederationElection(federationConstants.getFederationChangeAuthorizer()).clear();
 
         if (activations.isActive(RSKIP186)) {
             // Preserve federation change info
@@ -2209,7 +2218,8 @@ public class BridgeSupport {
         provider.setPendingFederation(null);
 
         // Clear votes on election
-        provider.getFederationElection(bridgeConstants.getFederationChangeAuthorizer()).clear();
+        FederationConstants federationConstants = bridgeConstants.getFederationConstants();
+        provider.getFederationElection(federationConstants.getFederationChangeAuthorizer()).clear();
 
         return 1;
     }
@@ -2220,7 +2230,8 @@ public class BridgeSupport {
             return FEDERATION_CHANGE_GENERIC_ERROR_CODE;
         }
 
-        AddressBasedAuthorizer authorizer = bridgeConstants.getFederationChangeAuthorizer();
+        FederationConstants federationConstants = bridgeConstants.getFederationConstants();
+        AddressBasedAuthorizer authorizer = federationConstants.getFederationChangeAuthorizer();
 
         // Must be authorized to vote (checking for signature)
         if (!authorizer.isAuthorized(tx, signatureCache)) {
@@ -2684,6 +2695,8 @@ public class BridgeSupport {
     }
 
     public long getActiveFederationCreationBlockHeight() {
+        FederationConstants federationConstants = bridgeConstants.getFederationConstants();
+
         if (!activations.isActive(RSKIP186)) {
             return 0L;
         }
@@ -2692,7 +2705,7 @@ public class BridgeSupport {
         if (nextFederationCreationBlockHeightOpt.isPresent()) {
             long nextFederationCreationBlockHeight = nextFederationCreationBlockHeightOpt.get();
             long curBlockHeight = rskExecutionBlock.getNumber();
-            if (curBlockHeight >= nextFederationCreationBlockHeight + bridgeConstants.getFederationActivationAge(activations)) {
+            if (curBlockHeight >= nextFederationCreationBlockHeight + federationConstants.getFederationActivationAge(activations)) {
                 return nextFederationCreationBlockHeight;
             }
         }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -398,6 +398,7 @@ public final class BridgeUtils {
         }
 
         BridgeConstants bridgeConstants = constants.getBridgeConstants();
+        FederationConstants federationConstants = bridgeConstants.getFederationConstants();
         RskAddress senderAddress = rskTx.getSender(signatureCache);
 
         // Temporary assumption: if areBridgeTxsFree() is true then the current federation
@@ -407,7 +408,7 @@ public final class BridgeUtils {
            !activations.isActive(ConsensusRule.ARE_BRIDGE_TXS_PAID) &&
            rskTx.acceptTransactionSignature(constants.getChainId()) &&
            (
-               isFromGenesisFederation(senderAddress, bridgeConstants.getGenesisFederationPublicKeys()) ||
+               isFromGenesisFederation(senderAddress, federationConstants.getGenesisFederationPublicKeys()) ||
                isFromAuthorizedSender(rskTx, bridgeConstants, signatureCache)
            );
     }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -30,6 +30,7 @@ import co.rsk.core.RskAddress;
 import co.rsk.peg.bitcoin.RskAllowUnconfirmedCoinSelector;
 import co.rsk.peg.btcLockSender.BtcLockSender.TxSenderAddressType;
 import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.feeperkb.constants.FeePerKbConstants;
 import co.rsk.peg.flyover.FlyoverTxResponseCodes;
 import co.rsk.peg.utils.BtcTransactionFormatUtils;
@@ -460,7 +461,8 @@ public final class BridgeUtils {
     }
 
     private static boolean isFromFederationChangeAuthorizedSender(Transaction rskTx, BridgeConstants bridgeConfiguration, SignatureCache signatureCache) {
-        AddressBasedAuthorizer authorizer = bridgeConfiguration.getFederationChangeAuthorizer();
+        FederationConstants federationConstants = bridgeConfiguration.getFederationConstants();
+        AddressBasedAuthorizer authorizer = federationConstants.getFederationChangeAuthorizer();
         return authorizer.isAuthorized(rskTx, signatureCache);
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -415,8 +415,9 @@ public final class BridgeUtils {
 
     private static boolean isFromAuthorizedSender(Transaction rskTx, BridgeConstants bridgeConstants, SignatureCache signatureCache) {
         FeePerKbConstants feePerKbConstants = bridgeConstants.getFeePerKbConstants();
+        FederationConstants federationConstants = bridgeConstants.getFederationConstants();
 
-        return isFromFederationChangeAuthorizedSender(rskTx, bridgeConstants, signatureCache) ||
+        return isFromFederationChangeAuthorizedSender(rskTx, federationConstants, signatureCache) ||
             isFromLockWhitelistChangeAuthorizedSender(rskTx, bridgeConstants, signatureCache) ||
             isFromFeePerKbChangeAuthorizedSender(rskTx, feePerKbConstants, signatureCache);
     }
@@ -461,8 +462,7 @@ public final class BridgeUtils {
         }
     }
 
-    private static boolean isFromFederationChangeAuthorizedSender(Transaction rskTx, BridgeConstants bridgeConfiguration, SignatureCache signatureCache) {
-        FederationConstants federationConstants = bridgeConfiguration.getFederationConstants();
+    private static boolean isFromFederationChangeAuthorizedSender(Transaction rskTx, FederationConstants federationConstants, SignatureCache signatureCache) {
         AddressBasedAuthorizer authorizer = federationConstants.getFederationChangeAuthorizer();
         return authorizer.isAuthorized(rskTx, signatureCache);
     }

--- a/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
@@ -24,6 +24,7 @@ import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.FederationArgs;
 import co.rsk.peg.federation.FederationFactory;
 import co.rsk.peg.federation.FederationMember;
+import co.rsk.peg.federation.constants.FederationConstants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.Block;
 
@@ -234,7 +235,8 @@ public class FederationSupport {
 
     private boolean shouldFederationBeActive(Federation federation) {
         long federationAge = executionBlock.getNumber() - federation.getCreationBlockNumber();
-        return federationAge >= bridgeConstants.getFederationActivationAge(activations);
+        FederationConstants federationConstants = bridgeConstants.getFederationConstants();
+        return federationAge >= federationConstants.getFederationActivationAge(activations);
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FederationSupport.java
@@ -246,9 +246,10 @@ public class FederationSupport {
      */
     private Federation getGenesisFederation() {
         final long GENESIS_FEDERATION_CREATION_BLOCK_NUMBER = 1L;
-        final List<BtcECKey> genesisFederationPublicKeys = bridgeConstants.getGenesisFederationPublicKeys();
+        FederationConstants federationConstants = bridgeConstants.getFederationConstants();
+        final List<BtcECKey> genesisFederationPublicKeys = federationConstants.getGenesisFederationPublicKeys();
         final List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(genesisFederationPublicKeys);
-        final Instant genesisFederationCreationTime = bridgeConstants.getGenesisFederationCreationTime();
+        final Instant genesisFederationCreationTime = federationConstants.getGenesisFederationCreationTime();
         final FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationCreationTime, GENESIS_FEDERATION_CREATION_BLOCK_NUMBER, bridgeConstants.getBtcParams());
         return FederationFactory.buildStandardMultiSigFederation(federationArgs);
     }

--- a/rskj-core/src/main/java/co/rsk/peg/PegUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/PegUtils.java
@@ -17,6 +17,7 @@ import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.bitcoin.BitcoinUtils;
 import co.rsk.peg.btcLockSender.BtcLockSender.TxSenderAddressType;
 import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.pegin.PeginEvaluationResult;
 import co.rsk.peg.pegin.PeginProcessAction;
 import co.rsk.peg.pegininstructions.PeginInstructionsException;
@@ -117,9 +118,10 @@ public class PegUtils {
             );
         } else {
             Coin minimumPeginTxValue = bridgeConstants.getMinimumPeginTxValue(activations);
+            FederationConstants federationConstants = bridgeConstants.getFederationConstants();
             Address oldFederationAddress = Address.fromBase58(
                 bridgeConstants.getBtcParams(),
-                bridgeConstants.getOldFederationAddress()
+                federationConstants.getOldFederationAddress()
             );
             Script retiredFederationP2SHScript = provider.getLastRetiredFederationP2SHScript().orElse(null);
 

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeConstants.java
@@ -18,25 +18,20 @@
 
 package co.rsk.peg.constants;
 
-import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
-import java.util.List;
 
 import co.rsk.peg.feeperkb.constants.FeePerKbConstants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 
-import java.time.Instant;
-
 public abstract class BridgeConstants {
     protected String btcParamsString;
 
     protected FeePerKbConstants feePerKbConstants;
-    protected List<BtcECKey> genesisFederationPublicKeys;
-    protected Instant genesisFederationCreationTime;
+
     protected FederationConstants federationConstants;
 
     protected int btc2RskMinimumAcceptableConfirmations;
@@ -87,14 +82,6 @@ public abstract class BridgeConstants {
 
     public String getBtcParamsString() {
         return btcParamsString;
-    }
-
-    public List<BtcECKey> getGenesisFederationPublicKeys() {
-        return genesisFederationPublicKeys;
-    }
-
-    public Instant getGenesisFederationCreationTime() {
-        return genesisFederationCreationTime;
     }
 
     public int getBtc2RskMinimumAcceptableConfirmations() {

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeConstants.java
@@ -21,6 +21,7 @@ package co.rsk.peg.constants;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
 import java.util.List;
 
@@ -34,9 +35,9 @@ public abstract class BridgeConstants {
     protected String btcParamsString;
 
     protected FeePerKbConstants feePerKbConstants;
-
     protected List<BtcECKey> genesisFederationPublicKeys;
     protected Instant genesisFederationCreationTime;
+    protected FederationConstants federationConstants;
 
     protected int btc2RskMinimumAcceptableConfirmations;
     protected int btc2RskMinimumAcceptableConfirmationsOnRsk;
@@ -50,13 +51,6 @@ public abstract class BridgeConstants {
     protected Coin minimumPeginTxValue;
     protected Coin legacyMinimumPegoutTxValue;
     protected Coin minimumPegoutTxValue;
-
-    protected long federationActivationAge;
-    protected long federationActivationAgeLegacy;
-
-    protected long fundsMigrationAgeSinceActivationBegin;
-    protected long fundsMigrationAgeSinceActivationEnd;
-    protected long specialCaseFundsMigrationAgeSinceActivationEnd;
 
     protected AddressBasedAuthorizer federationChangeAuthorizer;
 
@@ -74,11 +68,6 @@ public abstract class BridgeConstants {
 
     protected int maxDepthBlockchainAccepted;
 
-    protected long erpFedActivationDelay;
-    protected List<BtcECKey> erpFedPubKeysList;
-
-    protected String oldFederationAddress;
-
     protected int minimumPegoutValuePercentageToReceiveAfterFee;
 
     protected int maxInputsPerPegoutTransaction;
@@ -93,6 +82,8 @@ public abstract class BridgeConstants {
     }
 
     public FeePerKbConstants getFeePerKbConstants() { return feePerKbConstants; }
+
+    public FederationConstants getFederationConstants() { return federationConstants; }
 
     public String getBtcParamsString() {
         return btcParamsString;
@@ -130,24 +121,6 @@ public abstract class BridgeConstants {
 
     public Coin getMinimumPegoutTxValue() { return minimumPegoutTxValue; }
 
-    public long getFederationActivationAge(ActivationConfig.ForBlock activations) {
-        return activations.isActive(ConsensusRule.RSKIP383)? federationActivationAge: federationActivationAgeLegacy;
-    }
-
-    public long getFundsMigrationAgeSinceActivationBegin() {
-        return fundsMigrationAgeSinceActivationBegin;
-    }
-
-    public long getFundsMigrationAgeSinceActivationEnd(ActivationConfig.ForBlock activations) {
-        if (activations.isActive(ConsensusRule.RSKIP357) && !activations.isActive(ConsensusRule.RSKIP374)){
-            return specialCaseFundsMigrationAgeSinceActivationEnd;
-        }
-
-        return fundsMigrationAgeSinceActivationEnd;
-    }
-
-    public AddressBasedAuthorizer getFederationChangeAuthorizer() { return federationChangeAuthorizer; }
-
     public AddressBasedAuthorizer getLockWhitelistChangeAuthorizer() { return lockWhitelistChangeAuthorizer; }
 
     public AddressBasedAuthorizer getIncreaseLockingCapAuthorizer() { return increaseLockingCapAuthorizer; }
@@ -161,18 +134,6 @@ public abstract class BridgeConstants {
     public int getBtcHeightWhenBlockIndexActivates() { return btcHeightWhenBlockIndexActivates; }
 
     public int getMaxDepthToSearchBlocksBelowIndexActivation() { return maxDepthToSearchBlocksBelowIndexActivation; }
-
-    public long getErpFedActivationDelay() {
-        return erpFedActivationDelay;
-    }
-
-    public List<BtcECKey> getErpFedPubKeysList() {
-        return erpFedPubKeysList;
-    }
-
-    public String getOldFederationAddress() {
-        return oldFederationAddress;
-    }
 
     public long getMinSecondsBetweenCallsToReceiveHeader() { return minSecondsBetweenCallsReceiveHeader; }
 

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeDevNetConstants.java
@@ -92,13 +92,6 @@ public class BridgeDevNetConstants extends BridgeConstants {
             AddressBasedAuthorizer.MinimumRequiredCalculation.ONE
         );
 
-        federationActivationAgeLegacy = 10L;
-        federationActivationAge = 20L;
-
-        fundsMigrationAgeSinceActivationBegin = 15L;
-        fundsMigrationAgeSinceActivationEnd = 100L;
-        specialCaseFundsMigrationAgeSinceActivationEnd = 100L;
-
         // Key generated with GenNodeKey using generator 'auth-increase_locking_cap'
         List<ECKey> increaseLockingCapAuthorizedKeys = Arrays.stream(new String[]{
             "04450bbaab83ec48b3cb8fbb077c950ee079733041c039a8c4f1539e5181ca1a27589eeaf0fbf430e49d2909f14c767bf6909ad6845831f683416ee12b832e36ed"
@@ -115,23 +108,6 @@ public class BridgeDevNetConstants extends BridgeConstants {
 
         btcHeightWhenBlockIndexActivates = 700_000;
         maxDepthToSearchBlocksBelowIndexActivation = 4_320; // 30 days in BTC blocks (considering 1 block every 10 minutes)
-
-        erpFedActivationDelay = 52_560; // 1 year in BTC blocks (considering 1 block every 10 minutes)
-
-        // Keys generated with GenNodeKey using generators 'erp-fed-01' through 'erp-fed-05'
-        erpFedPubKeysList = Arrays.stream(new String[] {
-            "03b9fc46657cf72a1afa007ecf431de1cd27ff5cc8829fa625b66ca47b967e6b24",
-            "029cecea902067992d52c38b28bf0bb2345bda9b21eca76b16a17c477a64e43301",
-            "03284178e5fbcc63c54c3b38e3ef88adf2da6c526313650041b0ef955763634ebd",
-            "03776b1fd8f86da3c1db3d69699e8250a15877d286734ea9a6da8e9d8ad25d16c1",
-            "03ab0e2cd7ed158687fc13b88019990860cdb72b1f5777b58513312550ea1584bc"
-        }).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
-
-        // Multisig address created in bitcoind with the following private keys:
-        // 47129ffed2c0273c75d21bb8ba020073bb9a1638df0e04853407461fdd9e8b83
-        // 9f72d27ba603cfab5a0201974a6783ca2476ec3d6b4e2625282c682e0e5f1c35
-        // e1b17fcd0ef1942465eee61b20561b16750191143d365e71de08b33dd84a9788
-        oldFederationAddress = "2N7ZgQyhFKm17RbaLqygYbS7KLrQfapyZzu";
 
         minSecondsBetweenCallsReceiveHeader = 300;  // 5 minutes
 

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeDevNetConstants.java
@@ -22,7 +22,6 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
-import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -49,9 +48,6 @@ public class BridgeDevNetConstants extends BridgeConstants {
 
     public BridgeDevNetConstants(List<BtcECKey> federationPublicKeys) {
         btcParamsString = NetworkParameters.ID_TESTNET;
-
-        genesisFederationPublicKeys = federationPublicKeys;
-        genesisFederationCreationTime = ZonedDateTime.parse("1970-01-18T11:36:57.600Z").toInstant();
 
         btc2RskMinimumAcceptableConfirmations = 1;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 10;

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeMainNetConstants.java
@@ -1,12 +1,10 @@
 package co.rsk.peg.constants;
 
-import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
-import co.rsk.peg.feeperkb.constants.FeePerKbMainNetConstants;
+import co.rsk.peg.federation.constants.FederationMainNetConstants;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
-import com.google.common.collect.Lists;
-import java.time.ZonedDateTime;
+import co.rsk.peg.feeperkb.constants.FeePerKbMainNetConstants;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -19,31 +17,7 @@ public class BridgeMainNetConstants extends BridgeConstants {
     private BridgeMainNetConstants() {
         btcParamsString = NetworkParameters.ID_MAINNET;
         feePerKbConstants = FeePerKbMainNetConstants.getInstance();
-
-        BtcECKey federator0PublicKey = BtcECKey.fromPublicOnly(Hex.decode("03b53899c390573471ba30e5054f78376c5f797fda26dde7a760789f02908cbad2"));
-        BtcECKey federator1PublicKey = BtcECKey.fromPublicOnly(Hex.decode("027319afb15481dbeb3c426bcc37f9a30e7f51ceff586936d85548d9395bcc2344"));
-        BtcECKey federator2PublicKey = BtcECKey.fromPublicOnly(Hex.decode("0355a2e9bf100c00fc0a214afd1bf272647c7824eb9cb055480962f0c382596a70"));
-        BtcECKey federator3PublicKey = BtcECKey.fromPublicOnly(Hex.decode("02566d5ded7c7db1aa7ee4ef6f76989fb42527fcfdcddcd447d6793b7d869e46f7"));
-        BtcECKey federator4PublicKey = BtcECKey.fromPublicOnly(Hex.decode("0294c817150f78607566e961b3c71df53a22022a80acbb982f83c0c8baac040adc"));
-        BtcECKey federator5PublicKey = BtcECKey.fromPublicOnly(Hex.decode("0372cd46831f3b6afd4c044d160b7667e8ebf659d6cb51a825a3104df6ee0638c6"));
-        BtcECKey federator6PublicKey = BtcECKey.fromPublicOnly(Hex.decode("0340df69f28d69eef60845da7d81ff60a9060d4da35c767f017b0dd4e20448fb44"));
-        BtcECKey federator7PublicKey = BtcECKey.fromPublicOnly(Hex.decode("02ac1901b6fba2c1dbd47d894d2bd76c8ba1d296d65f6ab47f1c6b22afb53e73eb"));
-        BtcECKey federator8PublicKey = BtcECKey.fromPublicOnly(Hex.decode("031aabbeb9b27258f98c2bf21f36677ae7bae09eb2d8c958ef41a20a6e88626d26"));
-        BtcECKey federator9PublicKey = BtcECKey.fromPublicOnly(Hex.decode("0245ef34f5ee218005c9c21227133e8568a4f3f11aeab919c66ff7b816ae1ffeea"));
-        BtcECKey federator10PublicKey = BtcECKey.fromPublicOnly(Hex.decode("02550cc87fa9061162b1dd395a16662529c9d8094c0feca17905a3244713d65fe8"));
-        BtcECKey federator11PublicKey = BtcECKey.fromPublicOnly(Hex.decode("02481f02b7140acbf3fcdd9f72cf9a7d9484d8125e6df7c9451cfa55ba3b077265"));
-        BtcECKey federator12PublicKey = BtcECKey.fromPublicOnly(Hex.decode("03f909ae15558c70cc751aff9b1f495199c325b13a9e5b934fd6299cd30ec50be8"));
-        BtcECKey federator13PublicKey = BtcECKey.fromPublicOnly(Hex.decode("02c6018fcbd3e89f3cf9c7f48b3232ea3638eb8bf217e59ee290f5f0cfb2fb9259"));
-        BtcECKey federator14PublicKey = BtcECKey.fromPublicOnly(Hex.decode("03b65694ccccda83cbb1e56b31308acd08e993114c33f66a456b627c2c1c68bed6"));
-
-        genesisFederationPublicKeys = Lists.newArrayList(
-            federator0PublicKey, federator1PublicKey, federator2PublicKey,
-            federator3PublicKey, federator4PublicKey, federator5PublicKey,
-            federator6PublicKey, federator7PublicKey, federator8PublicKey,
-            federator9PublicKey, federator10PublicKey, federator11PublicKey,
-            federator12PublicKey, federator13PublicKey, federator14PublicKey
-        );
-        genesisFederationCreationTime = ZonedDateTime.parse("1970-01-18T12:49:08.400Z").toInstant();
+        federationConstants = FederationMainNetConstants.getInstance();
 
         btc2RskMinimumAcceptableConfirmations = 100;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 1000;
@@ -58,17 +32,6 @@ public class BridgeMainNetConstants extends BridgeConstants {
         minimumPeginTxValue = Coin.valueOf(500_000);
         minimumPegoutTxValue = Coin.valueOf(400_000);
 
-        List<ECKey> federationChangeAuthorizedKeys = Arrays.stream(new String[]{
-            "04e593d4cde25137b13f19462bc4c02e97ba2ed5a3860813497abf9b4eeb9259e37e0384d12cfd2d9a7a0ba606b31ee34317a9d7f4a8591c6bcf5dfd5563248b2f",
-            "045e7f2563e73d44d149c19cffca36e1898597dc759d76166b8104103c0d3f351a8a48e3a224544e9a649ad8ebcfdbd6c39744ddb85925f19c7e3fd48f07fc1c06",
-            "0441945e4e272936106f6200b36162f3510e8083535c15e175ac82deaf828da955b85fd72b7534f2a34cedfb45fa63b728cc696a2bd3c5d39ec799ec2618e9aa9f"
-        }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
-
-        federationChangeAuthorizer = new AddressBasedAuthorizer(
-            federationChangeAuthorizedKeys,
-            AddressBasedAuthorizer.MinimumRequiredCalculation.MAJORITY
-        );
-
         List<ECKey> lockWhitelistAuthorizedKeys = Arrays.stream(new String[]{
             "041a2449e9d63409c5a8ea3a21c4109b1a6634ee88fd57176d45ea46a59713d5e0b688313cf252128a3e49a0b2effb4b413e5a2525a6fa5894d059f815c9d9efa6"
         }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
@@ -77,13 +40,6 @@ public class BridgeMainNetConstants extends BridgeConstants {
             lockWhitelistAuthorizedKeys,
             AddressBasedAuthorizer.MinimumRequiredCalculation.ONE
         );
-
-        federationActivationAgeLegacy = 18500L;
-        federationActivationAge = 40320L;
-
-        fundsMigrationAgeSinceActivationBegin = 0L;
-        fundsMigrationAgeSinceActivationEnd = 10585L;
-        specialCaseFundsMigrationAgeSinceActivationEnd = 172_800L; // 60 days, considering 1 block every 30 seconds
 
         List<ECKey> increaseLockingCapAuthorizedKeys = Arrays.stream(new String[]{
             "0448f51638348b034995b1fd934fe14c92afde783e69f120a46ee16eb6bdc2e4f6b5e37772094c68c0dea2b1be3d96ea9651a9eebda7304914c8047f4e3e251378",
@@ -101,17 +57,6 @@ public class BridgeMainNetConstants extends BridgeConstants {
 
         btcHeightWhenBlockIndexActivates = 696_022;
         maxDepthToSearchBlocksBelowIndexActivation = 4_320; // 30 days in BTC blocks (considering 1 block every 10 minutes)
-
-        erpFedActivationDelay = 52_560; // 1 year in BTC blocks (considering 1 block every 10 minutes)
-
-        erpFedPubKeysList = Arrays.stream(new String[] {
-            "0257c293086c4d4fe8943deda5f890a37d11bebd140e220faa76258a41d077b4d4",
-            "03c2660a46aa73078ee6016dee953488566426cf55fc8011edd0085634d75395f9",
-            "03cd3e383ec6e12719a6c69515e5559bcbe037d0aa24c187e1e26ce932e22ad7b3",
-            "02370a9838e4d15708ad14a104ee5606b36caaaaf739d833e67770ce9fd9b3ec80"
-        }).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
-
-        oldFederationAddress = "35JUi1FxabGdhygLhnNUEFG4AgvpNMgxK1";
 
         minSecondsBetweenCallsReceiveHeader = 300;  // 5 minutes in seconds
         maxDepthBlockchainAccepted = 25;

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
@@ -52,7 +52,7 @@ public class BridgeRegTestConstants extends BridgeConstants {
     public BridgeRegTestConstants(List<BtcECKey> federationPublicKeys) {
         btcParamsString = NetworkParameters.ID_REGTEST;
         feePerKbConstants = FeePerKbRegTestConstants.getInstance();
-        federationConstants = FederationRegTestConstants.getInstance(federationPublicKeys);
+        federationConstants = new FederationRegTestConstants(federationPublicKeys);
 
         btc2RskMinimumAcceptableConfirmations = 3;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 5;

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
@@ -34,7 +34,6 @@ import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 
 public class BridgeRegTestConstants extends BridgeConstants {
-    private static final BridgeRegTestConstants instance = new BridgeRegTestConstants();
 
     public BridgeRegTestConstants() {
         this(getDefaultFederationPublicKeys());
@@ -53,7 +52,7 @@ public class BridgeRegTestConstants extends BridgeConstants {
     public BridgeRegTestConstants(List<BtcECKey> federationPublicKeys) {
         btcParamsString = NetworkParameters.ID_REGTEST;
         feePerKbConstants = FeePerKbRegTestConstants.getInstance();
-        federationConstants = new FederationRegTestConstants(federationPublicKeys);
+        federationConstants = FederationRegTestConstants.getInstance(federationPublicKeys);
 
         btc2RskMinimumAcceptableConfirmations = 3;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 5;
@@ -107,9 +106,5 @@ public class BridgeRegTestConstants extends BridgeConstants {
 
         btcHeightWhenPegoutTxIndexActivates = 250;
         pegoutTxIndexGracePeriodInBtcBlocks = 100;
-    }
-
-    public static BridgeRegTestConstants getInstance() {
-        return instance;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
@@ -23,16 +23,32 @@ import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.federation.constants.FederationRegTestConstants;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import co.rsk.peg.feeperkb.constants.FeePerKbRegTestConstants;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.ECKey;
+import org.ethereum.crypto.HashUtil;
 
 public class BridgeRegTestConstants extends BridgeConstants {
+    private static final BridgeRegTestConstants instance = new BridgeRegTestConstants();
 
-    private static final BridgeRegTestConstants instance = new BridgeRegTestConstants(FederationRegTestConstants.defaultFederationPublicKeys);
+    public BridgeRegTestConstants() {
+        this(getDefaultFederationPublicKeys());
+    }
+    private static List<BtcECKey> getDefaultFederationPublicKeys() {
+        BtcECKey federator0PrivateKey = BtcECKey.fromPrivate(HashUtil.keccak256("federator1".getBytes(StandardCharsets.UTF_8)));
+        BtcECKey federator1PrivateKey = BtcECKey.fromPrivate(HashUtil.keccak256("federator2".getBytes(StandardCharsets.UTF_8)));
+        BtcECKey federator2PrivateKey = BtcECKey.fromPrivate(HashUtil.keccak256("federator3".getBytes(StandardCharsets.UTF_8)));
+        List<BtcECKey> defaultFederationPrivateKeys = Collections.unmodifiableList(Arrays.asList(federator0PrivateKey, federator1PrivateKey, federator2PrivateKey));
+
+        return Collections.unmodifiableList(defaultFederationPrivateKeys.stream()
+                .map(key -> BtcECKey.fromPublicOnly(key.getPubKey()))
+                .collect(Collectors.toList()));
+    }
 
     public BridgeRegTestConstants(List<BtcECKey> federationPublicKeys) {
         btcParamsString = NetworkParameters.ID_REGTEST;

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
@@ -21,38 +21,23 @@ package co.rsk.peg.constants;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.peg.federation.constants.FederationRegTestConstants;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
-import java.nio.charset.StandardCharsets;
-import java.time.ZonedDateTime;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import co.rsk.peg.feeperkb.constants.FeePerKbRegTestConstants;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.ECKey;
-import org.ethereum.crypto.HashUtil;
 
 public class BridgeRegTestConstants extends BridgeConstants {
-    // IMPORTANT: BTC, RSK and MST keys are the same.
-    // Change upon implementation of the <INSERT FORK NAME HERE> fork.
-    public static final List<BtcECKey> REGTEST_FEDERATION_PRIVATE_KEYS = Collections.unmodifiableList(Arrays.asList(
-        BtcECKey.fromPrivate(HashUtil.keccak256("federator1".getBytes(StandardCharsets.UTF_8))),
-        BtcECKey.fromPrivate(HashUtil.keccak256("federator2".getBytes(StandardCharsets.UTF_8))),
-        BtcECKey.fromPrivate(HashUtil.keccak256("federator3".getBytes(StandardCharsets.UTF_8)))
-    ));
-    public static final List<BtcECKey> REGTEST_FEDERATION_PUBLIC_KEYS = Collections.unmodifiableList(REGTEST_FEDERATION_PRIVATE_KEYS.stream()
-        .map(key -> BtcECKey.fromPublicOnly(key.getPubKey()))
-        .collect(Collectors.toList()));
 
-    private static final BridgeRegTestConstants instance = new BridgeRegTestConstants(REGTEST_FEDERATION_PUBLIC_KEYS);
+    private static final BridgeRegTestConstants instance = new BridgeRegTestConstants(FederationRegTestConstants.defaultGenesisFederationPublicKeys);
 
     public BridgeRegTestConstants(List<BtcECKey> federationPublicKeys) {
         btcParamsString = NetworkParameters.ID_REGTEST;
         feePerKbConstants = FeePerKbRegTestConstants.getInstance();
-
-        genesisFederationPublicKeys = federationPublicKeys;
-        genesisFederationCreationTime = ZonedDateTime.parse("2016-01-01T00:00:00Z").toInstant();
+        federationConstants = new FederationRegTestConstants(federationPublicKeys);
 
         btc2RskMinimumAcceptableConfirmations = 3;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 5;
@@ -66,27 +51,6 @@ public class BridgeRegTestConstants extends BridgeConstants {
         legacyMinimumPegoutTxValue = Coin.valueOf(500_000);
         minimumPeginTxValue = Coin.COIN.div(2);
         minimumPegoutTxValue = Coin.valueOf(250_000);
-
-        // Keys generated with GenNodeKey using generators 'auth-a' through 'auth-e'
-        List<ECKey> federationChangeAuthorizedKeys = Arrays.stream(new String[]{
-            "04dde17c5fab31ffc53c91c2390136c325bb8690dc135b0840075dd7b86910d8ab9e88baad0c32f3eea8833446a6bc5ff1cd2efa99ecb17801bcb65fc16fc7d991",
-            "04af886c67231476807e2a8eee9193878b9d94e30aa2ee469a9611d20e1e1c1b438e5044148f65e6e61bf03e9d72e597cb9cdea96d6fc044001b22099f9ec403e2",
-            "045d4dedf9c69ab3ea139d0f0da0ad00160b7663d01ce7a6155cd44a3567d360112b0480ab6f31cac7345b5f64862205ea7ccf555fcf218f87fa0d801008fecb61",
-            "04709f002ac4642b6a87ea0a9dc76eeaa93f71b3185985817ec1827eae34b46b5d869320efb5c5cbe2a5c13f96463fe0210710b53352a4314188daffe07bd54154",
-            "04aff62315e9c18004392a5d9e39496ff5794b2d9f43ab4e8ade64740d7fdfe896969be859b43f26ef5aa4b5a0d11808277b4abfa1a07cc39f2839b89cc2bc6b4c"
-        }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
-
-        federationChangeAuthorizer = new AddressBasedAuthorizer(
-            federationChangeAuthorizedKeys,
-            AddressBasedAuthorizer.MinimumRequiredCalculation.MAJORITY
-        );
-
-        federationActivationAgeLegacy = 10L;
-        federationActivationAge = 20L;
-
-        fundsMigrationAgeSinceActivationBegin = 15L;
-        fundsMigrationAgeSinceActivationEnd = 150L;
-        specialCaseFundsMigrationAgeSinceActivationEnd = 150L;
 
         // Key generated with GenNodeKey using generator 'auth-lock-whitelist'
         List<ECKey> lockWhitelistAuthorizedKeys = Arrays.stream(new String[]{
@@ -118,23 +82,6 @@ public class BridgeRegTestConstants extends BridgeConstants {
 
         btcHeightWhenBlockIndexActivates = 10;
         maxDepthToSearchBlocksBelowIndexActivation = 5;
-
-        erpFedActivationDelay = 500;
-
-        // Keys generated with GenNodeKey using generators 'erp-fed-01' through 'erp-fed-05'
-        erpFedPubKeysList = Arrays.stream(new String[] {
-            "03b9fc46657cf72a1afa007ecf431de1cd27ff5cc8829fa625b66ca47b967e6b24",
-            "029cecea902067992d52c38b28bf0bb2345bda9b21eca76b16a17c477a64e43301",
-            "03284178e5fbcc63c54c3b38e3ef88adf2da6c526313650041b0ef955763634ebd",
-            "03776b1fd8f86da3c1db3d69699e8250a15877d286734ea9a6da8e9d8ad25d16c1",
-            "03ab0e2cd7ed158687fc13b88019990860cdb72b1f5777b58513312550ea1584bc"
-        }).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
-
-        // Multisig address created in bitcoind with the following private keys:
-        // 47129ffed2c0273c75d21bb8ba020073bb9a1638df0e04853407461fdd9e8b83
-        // 9f72d27ba603cfab5a0201974a6783ca2476ec3d6b4e2625282c682e0e5f1c35
-        // e1b17fcd0ef1942465eee61b20561b16750191143d365e71de08b33dd84a9788
-        oldFederationAddress = "2N7ZgQyhFKm17RbaLqygYbS7KLrQfapyZzu";
 
         minimumPegoutValuePercentageToReceiveAfterFee = 20;
 

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
@@ -32,7 +32,7 @@ import org.ethereum.crypto.ECKey;
 
 public class BridgeRegTestConstants extends BridgeConstants {
 
-    private static final BridgeRegTestConstants instance = new BridgeRegTestConstants(FederationRegTestConstants.defaultGenesisFederationPublicKeys);
+    private static final BridgeRegTestConstants instance = new BridgeRegTestConstants(FederationRegTestConstants.defaultFederationPublicKeys);
 
     public BridgeRegTestConstants(List<BtcECKey> federationPublicKeys) {
         btcParamsString = NetworkParameters.ID_REGTEST;

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeTestNetConstants.java
@@ -18,11 +18,10 @@
 
 package co.rsk.peg.constants;
 
-import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.peg.federation.constants.FederationTestNetConstants;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
-import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -36,28 +35,7 @@ public class BridgeTestNetConstants extends BridgeConstants {
     BridgeTestNetConstants() {
         btcParamsString = NetworkParameters.ID_TESTNET;
         feePerKbConstants = FeePerKbTestNetConstants.getInstance();
-
-        BtcECKey federator0PublicKey = BtcECKey.fromPublicOnly(
-            Hex.decode("039a060badbeb24bee49eb2063f616c0f0f0765d4ca646b20a88ce828f259fcdb9")
-        );
-        BtcECKey federator1PublicKey = BtcECKey.fromPublicOnly(
-            Hex.decode("02afc230c2d355b1a577682b07bc2646041b5d0177af0f98395a46018da699b6da")
-        );
-        BtcECKey federator2PublicKey = BtcECKey.fromPublicOnly(
-            Hex.decode("0344a3c38cd59afcba3edcebe143e025574594b001700dec41e59409bdbd0f2a09")
-        );
-        BtcECKey federator3PublicKey = BtcECKey.fromPublicOnly(
-            Hex.decode("034844a99cd7028aa319476674cc381df006628be71bc5593b8b5fdb32bb42ef85")
-        );
-
-        genesisFederationPublicKeys = Arrays.asList(
-            federator0PublicKey,
-            federator1PublicKey,
-            federator2PublicKey,
-            federator3PublicKey
-        );
-
-        genesisFederationCreationTime = ZonedDateTime.parse("1970-01-18T19:29:27.600Z").toInstant();
+        federationConstants = FederationTestNetConstants.getInstance();
 
         btc2RskMinimumAcceptableConfirmations = 10;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 10;
@@ -73,18 +51,6 @@ public class BridgeTestNetConstants extends BridgeConstants {
         minimumPegoutTxValue = Coin.valueOf(250_000);
 
         // Passphrases are kept private
-        List<ECKey> federationChangeAuthorizedKeys = Arrays.stream(new String[]{
-            "04d9052c2022f6f35da53f04f02856ff5e59f9836eec03daad0328d12c5c66140205da540498e46cd05bf63c1201382dd84c100f0d52a10654159965aea452c3f2",
-            "04bf889f2035c8c441d7d1054b6a449742edd04d202f44a29348b4140b34e2a81ce66e388f40046636fd012bd7e3cecd9b951ffe28422334722d20a1cf6c7926fb",
-            "047e707e4f67655c40c539363fb435d89574b8fe400971ba0290de9c2adbb2bd4e1e5b35a2188b9409ff2cc102292616efc113623483056bb8d8a02bf7695670ea"
-        }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
-
-        federationChangeAuthorizer = new AddressBasedAuthorizer(
-            federationChangeAuthorizedKeys,
-            AddressBasedAuthorizer.MinimumRequiredCalculation.MAJORITY
-        );
-
-        // Passphrases are kept private
         List<ECKey> lockWhitelistAuthorizedKeys = Arrays.stream(new String[]{
             "04bf7e3bca7f7c58326382ed9c2516a8773c21f1b806984bb1c5c33bd18046502d97b28c0ea5b16433fbb2b23f14e95b36209f304841e814017f1ede1ecbdcfce3"
         }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
@@ -93,13 +59,6 @@ public class BridgeTestNetConstants extends BridgeConstants {
             lockWhitelistAuthorizedKeys,
             AddressBasedAuthorizer.MinimumRequiredCalculation.ONE
         );
-
-        federationActivationAgeLegacy = 60L;
-        federationActivationAge = 120L;
-
-        fundsMigrationAgeSinceActivationBegin = 60L;
-        fundsMigrationAgeSinceActivationEnd = 900L;
-        specialCaseFundsMigrationAgeSinceActivationEnd = 900L;
 
         List<ECKey> increaseLockingCapAuthorizedKeys = Arrays.stream(new String[]{
             "04701d1d27f8c2ae97912d96fb1f82f10c2395fd320e7a869049268c6b53d2060dfb2e22e3248955332d88cd2ae29a398f8f3858e48dd6d8ffbc37dfd6d1aa4934",
@@ -117,20 +76,6 @@ public class BridgeTestNetConstants extends BridgeConstants {
 
         btcHeightWhenBlockIndexActivates = 2_039_594;
         maxDepthToSearchBlocksBelowIndexActivation = 4_320; // 30 days in BTC blocks (considering 1 block every 10 minutes)
-
-        erpFedActivationDelay = 52_560; // 1 year in BTC blocks (considering 1 block every 10 minutes)
-
-        erpFedPubKeysList = Arrays.stream(new String[] {
-            "0216c23b2ea8e4f11c3f9e22711addb1d16a93964796913830856b568cc3ea21d3",
-            "034db69f2112f4fb1bb6141bf6e2bd6631f0484d0bd95b16767902c9fe219d4a6f",
-            "0275562901dd8faae20de0a4166362a4f82188db77dbed4ca887422ea1ec185f14"
-        }).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
-
-        // Multisig address created in bitcoind with the following private keys:
-        // 47129ffed2c0273c75d21bb8ba020073bb9a1638df0e04853407461fdd9e8b83
-        // 9f72d27ba603cfab5a0201974a6783ca2476ec3d6b4e2625282c682e0e5f1c35
-        // e1b17fcd0ef1942465eee61b20561b16750191143d365e71de08b33dd84a9788
-        oldFederationAddress = "2N7ZgQyhFKm17RbaLqygYbS7KLrQfapyZzu";
 
         minSecondsBetweenCallsReceiveHeader = 300;  // 5 minutes
         maxDepthBlockchainAccepted = 25;

--- a/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/PendingFederation.java
@@ -22,6 +22,7 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.crypto.Keccak256;
+import co.rsk.peg.federation.constants.FederationConstants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.crypto.HashUtil;
@@ -115,8 +116,9 @@ public final class PendingFederation {
         }
 
         // should build an erp federation due to activations
-        List<BtcECKey> erpPubKeys = bridgeConstants.getErpFedPubKeysList();
-        long activationDelay = bridgeConstants.getErpFedActivationDelay();
+        FederationConstants federationConstants = bridgeConstants.getFederationConstants();
+        List<BtcECKey> erpPubKeys = federationConstants.getErpFedPubKeysList();
+        long activationDelay = federationConstants.getErpFedActivationDelay();
 
         if (shouldBuildNonStandardErpFederation(activations)) {
             logger.info("[buildFederation] Going to create a Non-Standard ERP Federation");

--- a/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationConstants.java
@@ -1,0 +1,63 @@
+package co.rsk.peg.federation.constants;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.peg.vote.AddressBasedAuthorizer;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
+
+import java.time.Instant;
+import java.util.List;
+
+public class FederationConstants {
+    protected List<BtcECKey> genesisFederationPublicKeys;
+    protected Instant genesisFederationCreationTime;
+
+    protected AddressBasedAuthorizer federationChangeAuthorizer;
+    protected String oldFederationAddress;
+    protected long federationActivationAge;
+    protected long federationActivationAgeLegacy;
+    protected long fundsMigrationAgeSinceActivationBegin;
+    protected long fundsMigrationAgeSinceActivationEnd;
+    protected long specialCaseFundsMigrationAgeSinceActivationEnd;
+
+    protected long erpFedActivationDelay;
+    protected List<BtcECKey> erpFedPubKeysList;
+
+
+    public List<BtcECKey> getGenesisFederationPublicKeys() {
+        return genesisFederationPublicKeys;
+    }
+
+    public Instant getGenesisFederationCreationTime() {
+        return genesisFederationCreationTime;
+    }
+
+    public long getFederationActivationAge(ActivationConfig.ForBlock activations) {
+        return activations.isActive(ConsensusRule.RSKIP383) ? federationActivationAge  : federationActivationAgeLegacy;
+    }
+
+    public long getFundsMigrationAgeSinceActivationBegin() {
+        return fundsMigrationAgeSinceActivationBegin;
+    }
+    public long getFundsMigrationAgeSinceActivationEnd(ActivationConfig.ForBlock activations) {
+        if (activations.isActive(ConsensusRule.RSKIP357) && !activations.isActive(ConsensusRule.RSKIP374)){
+            return specialCaseFundsMigrationAgeSinceActivationEnd;
+        }
+
+        return fundsMigrationAgeSinceActivationEnd;
+    }
+
+    public AddressBasedAuthorizer getFederationChangeAuthorizer() { return federationChangeAuthorizer; }
+
+    public long getErpFedActivationDelay() {
+        return erpFedActivationDelay;
+    }
+
+    public List<BtcECKey> getErpFedPubKeysList() {
+        return erpFedPubKeysList;
+    }
+
+    public String getOldFederationAddress() {
+        return oldFederationAddress;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationConstants.java
@@ -23,7 +23,6 @@ public class FederationConstants {
     protected long erpFedActivationDelay;
     protected List<BtcECKey> erpFedPubKeysList;
 
-
     public List<BtcECKey> getGenesisFederationPublicKeys() {
         return genesisFederationPublicKeys;
     }
@@ -39,6 +38,7 @@ public class FederationConstants {
     public long getFundsMigrationAgeSinceActivationBegin() {
         return fundsMigrationAgeSinceActivationBegin;
     }
+
     public long getFundsMigrationAgeSinceActivationEnd(ActivationConfig.ForBlock activations) {
         if (activations.isActive(ConsensusRule.RSKIP357) && !activations.isActive(ConsensusRule.RSKIP374)){
             return specialCaseFundsMigrationAgeSinceActivationEnd;

--- a/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationMainNetConstants.java
@@ -1,0 +1,70 @@
+package co.rsk.peg.federation.constants;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.peg.vote.AddressBasedAuthorizer;
+import com.google.common.collect.Lists;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.ECKey;
+
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class FederationMainNetConstants extends FederationConstants {
+
+    private static final FederationMainNetConstants instance = new FederationMainNetConstants();
+
+    private FederationMainNetConstants() {
+        BtcECKey federator0PublicKey = BtcECKey.fromPublicOnly(Hex.decode("03b53899c390573471ba30e5054f78376c5f797fda26dde7a760789f02908cbad2"));
+        BtcECKey federator1PublicKey = BtcECKey.fromPublicOnly(Hex.decode("027319afb15481dbeb3c426bcc37f9a30e7f51ceff586936d85548d9395bcc2344"));
+        BtcECKey federator2PublicKey = BtcECKey.fromPublicOnly(Hex.decode("0355a2e9bf100c00fc0a214afd1bf272647c7824eb9cb055480962f0c382596a70"));
+        BtcECKey federator3PublicKey = BtcECKey.fromPublicOnly(Hex.decode("02566d5ded7c7db1aa7ee4ef6f76989fb42527fcfdcddcd447d6793b7d869e46f7"));
+        BtcECKey federator4PublicKey = BtcECKey.fromPublicOnly(Hex.decode("0294c817150f78607566e961b3c71df53a22022a80acbb982f83c0c8baac040adc"));
+        BtcECKey federator5PublicKey = BtcECKey.fromPublicOnly(Hex.decode("0372cd46831f3b6afd4c044d160b7667e8ebf659d6cb51a825a3104df6ee0638c6"));
+        BtcECKey federator6PublicKey = BtcECKey.fromPublicOnly(Hex.decode("0340df69f28d69eef60845da7d81ff60a9060d4da35c767f017b0dd4e20448fb44"));
+        BtcECKey federator7PublicKey = BtcECKey.fromPublicOnly(Hex.decode("02ac1901b6fba2c1dbd47d894d2bd76c8ba1d296d65f6ab47f1c6b22afb53e73eb"));
+        BtcECKey federator8PublicKey = BtcECKey.fromPublicOnly(Hex.decode("031aabbeb9b27258f98c2bf21f36677ae7bae09eb2d8c958ef41a20a6e88626d26"));
+        BtcECKey federator9PublicKey = BtcECKey.fromPublicOnly(Hex.decode("0245ef34f5ee218005c9c21227133e8568a4f3f11aeab919c66ff7b816ae1ffeea"));
+        BtcECKey federator10PublicKey = BtcECKey.fromPublicOnly(Hex.decode("02550cc87fa9061162b1dd395a16662529c9d8094c0feca17905a3244713d65fe8"));
+        BtcECKey federator11PublicKey = BtcECKey.fromPublicOnly(Hex.decode("02481f02b7140acbf3fcdd9f72cf9a7d9484d8125e6df7c9451cfa55ba3b077265"));
+        BtcECKey federator12PublicKey = BtcECKey.fromPublicOnly(Hex.decode("03f909ae15558c70cc751aff9b1f495199c325b13a9e5b934fd6299cd30ec50be8"));
+        BtcECKey federator13PublicKey = BtcECKey.fromPublicOnly(Hex.decode("02c6018fcbd3e89f3cf9c7f48b3232ea3638eb8bf217e59ee290f5f0cfb2fb9259"));
+        BtcECKey federator14PublicKey = BtcECKey.fromPublicOnly(Hex.decode("03b65694ccccda83cbb1e56b31308acd08e993114c33f66a456b627c2c1c68bed6"));
+        genesisFederationPublicKeys = Lists.newArrayList(
+            federator0PublicKey, federator1PublicKey, federator2PublicKey,
+            federator3PublicKey, federator4PublicKey, federator5PublicKey,
+            federator6PublicKey, federator7PublicKey, federator8PublicKey,
+            federator9PublicKey, federator10PublicKey, federator11PublicKey,
+            federator12PublicKey, federator13PublicKey, federator14PublicKey
+        );
+        genesisFederationCreationTime = ZonedDateTime.parse("1970-01-18T12:49:08.400Z").toInstant();
+
+        List<ECKey> federationChangeAuthorizedKeys =  Arrays.stream(new String[]{
+            "04e593d4cde25137b13f19462bc4c02e97ba2ed5a3860813497abf9b4eeb9259e37e0384d12cfd2d9a7a0ba606b31ee34317a9d7f4a8591c6bcf5dfd5563248b2f",
+            "045e7f2563e73d44d149c19cffca36e1898597dc759d76166b8104103c0d3f351a8a48e3a224544e9a649ad8ebcfdbd6c39744ddb85925f19c7e3fd48f07fc1c06",
+            "0441945e4e272936106f6200b36162f3510e8083535c15e175ac82deaf828da955b85fd72b7534f2a34cedfb45fa63b728cc696a2bd3c5d39ec799ec2618e9aa9f"
+        }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
+        federationChangeAuthorizer = new AddressBasedAuthorizer(federationChangeAuthorizedKeys, AddressBasedAuthorizer.MinimumRequiredCalculation.MAJORITY);
+
+        federationActivationAgeLegacy = 18500L;
+        federationActivationAge = 40320L;
+
+        fundsMigrationAgeSinceActivationBegin = 0L;
+        fundsMigrationAgeSinceActivationEnd = 10585L;
+        specialCaseFundsMigrationAgeSinceActivationEnd = 172_800L; // 60 days, considering 1 block every 30 seconds
+
+        String erpFederator0StringPubKey = "0257c293086c4d4fe8943deda5f890a37d11bebd140e220faa76258a41d077b4d4";
+        String erpFederator1StringPubKey = "03c2660a46aa73078ee6016dee953488566426cf55fc8011edd0085634d75395f9";
+        String erpFederator2StringPubKey = "03cd3e383ec6e12719a6c69515e5559bcbe037d0aa24c187e1e26ce932e22ad7b3";
+        String erpFederator3StringPubKey = "02370a9838e4d15708ad14a104ee5606b36caaaaf739d833e67770ce9fd9b3ec80";
+        erpFedPubKeysList = Arrays.stream(new String[]
+            {erpFederator0StringPubKey, erpFederator1StringPubKey, erpFederator2StringPubKey, erpFederator3StringPubKey})
+            .map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
+        erpFedActivationDelay = 52_560; // 1 year in BTC blocks (considering 1 block every 10 minutes)
+
+        oldFederationAddress = "35JUi1FxabGdhygLhnNUEFG4AgvpNMgxK1";
+    }
+
+    public static FederationMainNetConstants getInstance() { return instance; }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationMainNetConstants.java
@@ -66,5 +66,7 @@ public class FederationMainNetConstants extends FederationConstants {
         oldFederationAddress = "35JUi1FxabGdhygLhnNUEFG4AgvpNMgxK1";
     }
 
-    public static FederationMainNetConstants getInstance() { return instance; }
+    public static FederationMainNetConstants getInstance() {
+        return instance;
+    }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationRegTestConstants.java
@@ -15,18 +15,19 @@ import java.util.stream.Collectors;
 
 public class FederationRegTestConstants extends FederationConstants {
 
-    public static final List<BtcECKey> defaultGenesisFederationPublicKeys =
-        Collections.unmodifiableList(getDefaultGenesisFederationPrivateKeys().stream()
+    public static final List<BtcECKey> defaultFederationPublicKeys =
+        Collections.unmodifiableList(getDefaultFederationPrivateKeys().stream()
         .map(key -> BtcECKey.fromPublicOnly(key.getPubKey()))
         .collect(Collectors.toList()));
-    private static List<BtcECKey> getDefaultGenesisFederationPrivateKeys() {
+
+    private static List<BtcECKey> getDefaultFederationPrivateKeys() {
         BtcECKey federator0PrivateKey = BtcECKey.fromPrivate(HashUtil.keccak256("federator1".getBytes(StandardCharsets.UTF_8)));
         BtcECKey federator1PrivateKey = BtcECKey.fromPrivate(HashUtil.keccak256("federator2".getBytes(StandardCharsets.UTF_8)));
         BtcECKey federator2PrivateKey = BtcECKey.fromPrivate(HashUtil.keccak256("federator3".getBytes(StandardCharsets.UTF_8)));
         return Collections.unmodifiableList(Arrays.asList(federator0PrivateKey, federator1PrivateKey, federator2PrivateKey));
     }
 
-    private static final FederationRegTestConstants instance = new FederationRegTestConstants(defaultGenesisFederationPublicKeys);
+    private static final FederationRegTestConstants instance = new FederationRegTestConstants(defaultFederationPublicKeys);
 
     public FederationRegTestConstants(List<BtcECKey> federationPublicKeys) {
         // IMPORTANT: BTC, RSK and MST keys are the same.

--- a/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationRegTestConstants.java
@@ -11,9 +11,7 @@ import java.util.stream.Collectors;
 
 public class FederationRegTestConstants extends FederationConstants {
 
-    private static FederationRegTestConstants instance;
-
-    private FederationRegTestConstants(List<BtcECKey> federationPublicKeys) {
+    public FederationRegTestConstants(List<BtcECKey> federationPublicKeys) {
         // IMPORTANT: BTC, RSK and MST keys are the same.
         // Change upon implementation of the <INSERT FORK NAME HERE> fork.
         genesisFederationPublicKeys = federationPublicKeys;
@@ -51,13 +49,5 @@ public class FederationRegTestConstants extends FederationConstants {
         // 9f72d27ba603cfab5a0201974a6783ca2476ec3d6b4e2625282c682e0e5f1c35
         // e1b17fcd0ef1942465eee61b20561b16750191143d365e71de08b33dd84a9788
         oldFederationAddress = "2N7ZgQyhFKm17RbaLqygYbS7KLrQfapyZzu";
-    }
-
-    public static FederationRegTestConstants getInstance(List<BtcECKey> federationPublicKeys) {
-        if (instance == null) {
-            instance = new FederationRegTestConstants(federationPublicKeys);
-        }
-
-        return instance;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationRegTestConstants.java
@@ -11,7 +11,9 @@ import java.util.stream.Collectors;
 
 public class FederationRegTestConstants extends FederationConstants {
 
-    public FederationRegTestConstants(List<BtcECKey> federationPublicKeys) {
+    private static FederationRegTestConstants instance;
+
+    private FederationRegTestConstants(List<BtcECKey> federationPublicKeys) {
         // IMPORTANT: BTC, RSK and MST keys are the same.
         // Change upon implementation of the <INSERT FORK NAME HERE> fork.
         genesisFederationPublicKeys = federationPublicKeys;
@@ -49,5 +51,13 @@ public class FederationRegTestConstants extends FederationConstants {
         // 9f72d27ba603cfab5a0201974a6783ca2476ec3d6b4e2625282c682e0e5f1c35
         // e1b17fcd0ef1942465eee61b20561b16750191143d365e71de08b33dd84a9788
         oldFederationAddress = "2N7ZgQyhFKm17RbaLqygYbS7KLrQfapyZzu";
+    }
+
+    public static FederationRegTestConstants getInstance(List<BtcECKey> federationPublicKeys) {
+        if (instance == null) {
+            instance = new FederationRegTestConstants(federationPublicKeys);
+        }
+
+        return instance;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationRegTestConstants.java
@@ -4,30 +4,12 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.ECKey;
-import org.ethereum.crypto.HashUtil;
-
-import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class FederationRegTestConstants extends FederationConstants {
-
-    public static final List<BtcECKey> defaultFederationPublicKeys =
-        Collections.unmodifiableList(getDefaultFederationPrivateKeys().stream()
-        .map(key -> BtcECKey.fromPublicOnly(key.getPubKey()))
-        .collect(Collectors.toList()));
-
-    private static List<BtcECKey> getDefaultFederationPrivateKeys() {
-        BtcECKey federator0PrivateKey = BtcECKey.fromPrivate(HashUtil.keccak256("federator1".getBytes(StandardCharsets.UTF_8)));
-        BtcECKey federator1PrivateKey = BtcECKey.fromPrivate(HashUtil.keccak256("federator2".getBytes(StandardCharsets.UTF_8)));
-        BtcECKey federator2PrivateKey = BtcECKey.fromPrivate(HashUtil.keccak256("federator3".getBytes(StandardCharsets.UTF_8)));
-        return Collections.unmodifiableList(Arrays.asList(federator0PrivateKey, federator1PrivateKey, federator2PrivateKey));
-    }
-
-    private static final FederationRegTestConstants instance = new FederationRegTestConstants(defaultFederationPublicKeys);
 
     public FederationRegTestConstants(List<BtcECKey> federationPublicKeys) {
         // IMPORTANT: BTC, RSK and MST keys are the same.
@@ -68,6 +50,4 @@ public class FederationRegTestConstants extends FederationConstants {
         // e1b17fcd0ef1942465eee61b20561b16750191143d365e71de08b33dd84a9788
         oldFederationAddress = "2N7ZgQyhFKm17RbaLqygYbS7KLrQfapyZzu";
     }
-
-    public static FederationRegTestConstants getInstance() { return instance; }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationRegTestConstants.java
@@ -1,0 +1,72 @@
+package co.rsk.peg.federation.constants;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.peg.vote.AddressBasedAuthorizer;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.crypto.HashUtil;
+
+import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class FederationRegTestConstants extends FederationConstants {
+
+    public static final List<BtcECKey> defaultGenesisFederationPublicKeys =
+        Collections.unmodifiableList(getDefaultGenesisFederationPrivateKeys().stream()
+        .map(key -> BtcECKey.fromPublicOnly(key.getPubKey()))
+        .collect(Collectors.toList()));
+    private static List<BtcECKey> getDefaultGenesisFederationPrivateKeys() {
+        BtcECKey federator0PrivateKey = BtcECKey.fromPrivate(HashUtil.keccak256("federator1".getBytes(StandardCharsets.UTF_8)));
+        BtcECKey federator1PrivateKey = BtcECKey.fromPrivate(HashUtil.keccak256("federator2".getBytes(StandardCharsets.UTF_8)));
+        BtcECKey federator2PrivateKey = BtcECKey.fromPrivate(HashUtil.keccak256("federator3".getBytes(StandardCharsets.UTF_8)));
+        return Collections.unmodifiableList(Arrays.asList(federator0PrivateKey, federator1PrivateKey, federator2PrivateKey));
+    }
+
+    private static final FederationRegTestConstants instance = new FederationRegTestConstants(defaultGenesisFederationPublicKeys);
+
+    public FederationRegTestConstants(List<BtcECKey> federationPublicKeys) {
+        // IMPORTANT: BTC, RSK and MST keys are the same.
+        // Change upon implementation of the <INSERT FORK NAME HERE> fork.
+        genesisFederationPublicKeys = federationPublicKeys;
+        genesisFederationCreationTime = ZonedDateTime.parse("2016-01-01T00:00:00Z").toInstant();
+
+        // Keys generated with GenNodeKey using generators 'auth-a' through 'auth-e'
+        List<ECKey> federationChangeAuthorizedKeys = Arrays.stream(new String[]{
+            "04dde17c5fab31ffc53c91c2390136c325bb8690dc135b0840075dd7b86910d8ab9e88baad0c32f3eea8833446a6bc5ff1cd2efa99ecb17801bcb65fc16fc7d991",
+            "04af886c67231476807e2a8eee9193878b9d94e30aa2ee469a9611d20e1e1c1b438e5044148f65e6e61bf03e9d72e597cb9cdea96d6fc044001b22099f9ec403e2",
+            "045d4dedf9c69ab3ea139d0f0da0ad00160b7663d01ce7a6155cd44a3567d360112b0480ab6f31cac7345b5f64862205ea7ccf555fcf218f87fa0d801008fecb61",
+            "04709f002ac4642b6a87ea0a9dc76eeaa93f71b3185985817ec1827eae34b46b5d869320efb5c5cbe2a5c13f96463fe0210710b53352a4314188daffe07bd54154",
+            "04aff62315e9c18004392a5d9e39496ff5794b2d9f43ab4e8ade64740d7fdfe896969be859b43f26ef5aa4b5a0d11808277b4abfa1a07cc39f2839b89cc2bc6b4c"
+        }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
+        federationChangeAuthorizer = new AddressBasedAuthorizer(federationChangeAuthorizedKeys, AddressBasedAuthorizer.MinimumRequiredCalculation.MAJORITY);
+
+        federationActivationAgeLegacy = 10L;
+        federationActivationAge = 20L;
+
+        fundsMigrationAgeSinceActivationBegin = 15L;
+        fundsMigrationAgeSinceActivationEnd = 150L;
+        specialCaseFundsMigrationAgeSinceActivationEnd = 150L;
+
+        // Keys generated with GenNodeKey using generators 'erp-fed-01' through 'erp-fed-05'
+        erpFedPubKeysList = Arrays.stream(new String[] {
+            "03b9fc46657cf72a1afa007ecf431de1cd27ff5cc8829fa625b66ca47b967e6b24",
+            "029cecea902067992d52c38b28bf0bb2345bda9b21eca76b16a17c477a64e43301",
+            "03284178e5fbcc63c54c3b38e3ef88adf2da6c526313650041b0ef955763634ebd",
+            "03776b1fd8f86da3c1db3d69699e8250a15877d286734ea9a6da8e9d8ad25d16c1",
+            "03ab0e2cd7ed158687fc13b88019990860cdb72b1f5777b58513312550ea1584bc"
+        }).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
+        erpFedActivationDelay = 500;
+
+        // Multisig address created in bitcoind with the following private keys:
+        // 47129ffed2c0273c75d21bb8ba020073bb9a1638df0e04853407461fdd9e8b83
+        // 9f72d27ba603cfab5a0201974a6783ca2476ec3d6b4e2625282c682e0e5f1c35
+        // e1b17fcd0ef1942465eee61b20561b16750191143d365e71de08b33dd84a9788
+        oldFederationAddress = "2N7ZgQyhFKm17RbaLqygYbS7KLrQfapyZzu";
+    }
+
+    public static FederationRegTestConstants getInstance() { return instance; }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationTestNetConstants.java
@@ -1,0 +1,55 @@
+package co.rsk.peg.federation.constants;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.peg.vote.AddressBasedAuthorizer;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.ECKey;
+
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class FederationTestNetConstants extends FederationConstants {
+
+    private static final FederationTestNetConstants instance = new FederationTestNetConstants();
+
+    private FederationTestNetConstants() {
+        BtcECKey federator0PublicKey = BtcECKey.fromPublicOnly(Hex.decode("039a060badbeb24bee49eb2063f616c0f0f0765d4ca646b20a88ce828f259fcdb9"));
+        BtcECKey federator1PublicKey = BtcECKey.fromPublicOnly(Hex.decode("02afc230c2d355b1a577682b07bc2646041b5d0177af0f98395a46018da699b6da"));
+        BtcECKey federator2PublicKey = BtcECKey.fromPublicOnly(Hex.decode("0344a3c38cd59afcba3edcebe143e025574594b001700dec41e59409bdbd0f2a09"));
+        BtcECKey federator3PublicKey = BtcECKey.fromPublicOnly(Hex.decode("034844a99cd7028aa319476674cc381df006628be71bc5593b8b5fdb32bb42ef85"));
+        genesisFederationPublicKeys = Arrays.asList(federator0PublicKey, federator1PublicKey, federator2PublicKey, federator3PublicKey);
+        genesisFederationCreationTime = ZonedDateTime.parse("1970-01-18T19:29:27.600Z").toInstant();
+
+        // Passphrases are kept private
+        List<ECKey> federationChangeAuthorizedKeys = Arrays.stream(new String[]{
+            "04d9052c2022f6f35da53f04f02856ff5e59f9836eec03daad0328d12c5c66140205da540498e46cd05bf63c1201382dd84c100f0d52a10654159965aea452c3f2",
+            "04bf889f2035c8c441d7d1054b6a449742edd04d202f44a29348b4140b34e2a81ce66e388f40046636fd012bd7e3cecd9b951ffe28422334722d20a1cf6c7926fb",
+            "047e707e4f67655c40c539363fb435d89574b8fe400971ba0290de9c2adbb2bd4e1e5b35a2188b9409ff2cc102292616efc113623483056bb8d8a02bf7695670ea"
+        }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
+        federationChangeAuthorizer = new AddressBasedAuthorizer(federationChangeAuthorizedKeys, AddressBasedAuthorizer.MinimumRequiredCalculation.MAJORITY);
+
+        federationActivationAgeLegacy = 60L;
+        federationActivationAge = 120L;
+
+        fundsMigrationAgeSinceActivationBegin = 60L;
+        fundsMigrationAgeSinceActivationEnd = 900L;
+        specialCaseFundsMigrationAgeSinceActivationEnd = 900L;
+
+        erpFedPubKeysList = Arrays.stream(new String[] {
+            "0216c23b2ea8e4f11c3f9e22711addb1d16a93964796913830856b568cc3ea21d3",
+            "034db69f2112f4fb1bb6141bf6e2bd6631f0484d0bd95b16767902c9fe219d4a6f",
+            "0275562901dd8faae20de0a4166362a4f82188db77dbed4ca887422ea1ec185f14"
+        }).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
+        erpFedActivationDelay = 52_560; // 1 year in BTC blocks (considering 1 block every 10 minutes)
+
+        // Multisig address created in bitcoind with the following private keys:
+        // 47129ffed2c0273c75d21bb8ba020073bb9a1638df0e04853407461fdd9e8b83
+        // 9f72d27ba603cfab5a0201974a6783ca2476ec3d6b4e2625282c682e0e5f1c35
+        // e1b17fcd0ef1942465eee61b20561b16750191143d365e71de08b33dd84a9788
+        oldFederationAddress = "2N7ZgQyhFKm17RbaLqygYbS7KLrQfapyZzu";
+    }
+
+    public static FederationTestNetConstants getInstance() { return instance; }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/feeperkb/constants/FeePerKbMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/feeperkb/constants/FeePerKbMainNetConstants.java
@@ -20,15 +20,15 @@ public class FeePerKbMainNetConstants extends FeePerKbConstants {
             "04bb6435dc1ea12da843ebe213893d136c1624acd681fff82551498ae00bf28e9323164b00daf925fa75177463b8254a2aae8a1713e4d851a84ea369c193e9ce51"
         }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
 
-            feePerKbChangeAuthorizer = new AddressBasedAuthorizer(
-                feePerKbAuthorizedKeys,
-                AddressBasedAuthorizer.MinimumRequiredCalculation.MAJORITY
-            );
+        feePerKbChangeAuthorizer = new AddressBasedAuthorizer(
+            feePerKbAuthorizedKeys,
+            AddressBasedAuthorizer.MinimumRequiredCalculation.MAJORITY
+        );
 
-            genesisFeePerKb = Coin.MILLICOIN.multiply(5);
+        genesisFeePerKb = Coin.MILLICOIN.multiply(5);
 
-            maxFeePerKb = Coin.valueOf(5_000_000L);
-        }
+        maxFeePerKb = Coin.valueOf(5_000_000L);
+    }
 
     public static FeePerKbMainNetConstants getInstance() {
         return instance;

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -119,7 +119,7 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
         byte[] newFederationFlatPubKeys = flatKeysAsByteArray(newFederation.getBtcPublicKeys());
         String newFederationBtcAddress = newFederation.getAddress().toBase58();
 
-        FederationConstants federationConstants = this.bridgeConstants.getFederationConstants();
+        FederationConstants federationConstants = bridgeConstants.getFederationConstants();
         long newFedActivationBlockNumber = executionBlock.getNumber() + federationConstants.getFederationActivationAge(activations);
 
         CallTransaction.Function event = BridgeEvents.COMMIT_FEDERATION.getEvent();

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -24,6 +24,7 @@ import co.rsk.crypto.Keccak256;
 import co.rsk.peg.BridgeEvents;
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.FederationMember;
+import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.pegin.RejectedPeginReason;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
@@ -117,7 +118,9 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
         String oldFederationBtcAddress = oldFederation.getAddress().toBase58();
         byte[] newFederationFlatPubKeys = flatKeysAsByteArray(newFederation.getBtcPublicKeys());
         String newFederationBtcAddress = newFederation.getAddress().toBase58();
-        long newFedActivationBlockNumber = executionBlock.getNumber() + this.bridgeConstants.getFederationActivationAge(activations);
+
+        FederationConstants federationConstants = this.bridgeConstants.getFederationConstants();
+        long newFedActivationBlockNumber = executionBlock.getNumber() + federationConstants.getFederationActivationAge(activations);
 
         CallTransaction.Function event = BridgeEvents.COMMIT_FEDERATION.getEvent();
         byte[][] encodedTopicsInBytes = event.encodeEventTopics();

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BrigeEventLoggerLegacyImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BrigeEventLoggerLegacyImpl.java
@@ -24,6 +24,7 @@ import co.rsk.peg.Bridge;
 import co.rsk.peg.DeprecatedMethodCallException;
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.FederationMember;
+import co.rsk.peg.federation.constants.FederationConstants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.Block;
@@ -120,7 +121,8 @@ public class BrigeEventLoggerLegacyImpl implements BridgeEventLogger {
         byte[] newFedFlatPubKeys = flatKeysAsRlpCollection(newFederation.getBtcPublicKeys());
         byte[] newFedData = RLP.encodeList(RLP.encodeElement(newFederation.getAddress().getHash160()), RLP.encodeList(newFedFlatPubKeys));
 
-        long newFedActivationBlockNumber = executionBlock.getNumber() + this.bridgeConstants.getFederationActivationAge(activations);
+        FederationConstants federationConstants = this.bridgeConstants.getFederationConstants();
+        long newFedActivationBlockNumber = executionBlock.getNumber() + federationConstants.getFederationActivationAge(activations);
 
         byte[] data = RLP.encodeList(oldFedData, newFedData, RLP.encodeString(Long.toString(newFedActivationBlockNumber)));
 

--- a/rskj-core/src/main/java/org/ethereum/config/Constants.java
+++ b/rskj-core/src/main/java/org/ethereum/config/Constants.java
@@ -277,7 +277,7 @@ public class Constants {
                 BlockDifficulty.ZERO,
                 BigInteger.valueOf(2048),
                 0,
-                BridgeRegTestConstants.getInstance(),
+                new BridgeRegTestConstants(),
                 new BlockDifficulty(new BigInteger("550000000"))
         );
     }

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -185,11 +185,10 @@ public abstract class SystemProperties {
                     );
                     break;
                 case "regtest":
-                    if (getGenesisFederationPublicKeys().isPresent()) {
-                        constants = Constants.regtestWithFederation(getGenesisFederationPublicKeys().get());
-                    } else {
-                        constants = Constants.regtest();
-                    }
+                    Optional<List<BtcECKey>> genesisFederationPublicKeysOptional = getGenesisFederationPublicKeys();
+                    constants = genesisFederationPublicKeysOptional
+                        .map(Constants::regtestWithFederation)
+                        .orElseGet(Constants::regtest);
                     break;
                 default:
                     throw new RuntimeException(String.format("Unknown network name '%s'", netName()));

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -185,8 +185,7 @@ public abstract class SystemProperties {
                     );
                     break;
                 case "regtest":
-                    Optional<List<BtcECKey>> genesisFederationPublicKeysOptional = getGenesisFederationPublicKeys();
-                    constants = genesisFederationPublicKeysOptional
+                    constants = getGenesisFederationPublicKeys()
                         .map(Constants::regtestWithFederation)
                         .orElseGet(Constants::regtest);
                     break;

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -22,7 +22,6 @@ package org.ethereum.config;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.peg.constants.BridgeDevNetConstants;
 import co.rsk.config.ConfigLoader;
-import co.rsk.peg.federation.constants.FederationRegTestConstants;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigObject;
 import com.typesafe.config.ConfigRenderOptions;
@@ -186,9 +185,11 @@ public abstract class SystemProperties {
                     );
                     break;
                 case "regtest":
-                    constants = Constants.regtestWithFederation(
-                            getGenesisFederationPublicKeys().orElse(FederationRegTestConstants.defaultFederationPublicKeys)
-                    );
+                    if (getGenesisFederationPublicKeys().isPresent()) {
+                        constants = Constants.regtestWithFederation(getGenesisFederationPublicKeys().get());
+                    } else {
+                        constants = Constants.regtest();
+                    }
                     break;
                 default:
                     throw new RuntimeException(String.format("Unknown network name '%s'", netName()));

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -21,8 +21,8 @@ package org.ethereum.config;
 
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.peg.constants.BridgeDevNetConstants;
-import co.rsk.peg.constants.BridgeRegTestConstants;
 import co.rsk.config.ConfigLoader;
+import co.rsk.peg.federation.constants.FederationRegTestConstants;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigObject;
 import com.typesafe.config.ConfigRenderOptions;
@@ -187,7 +187,7 @@ public abstract class SystemProperties {
                     break;
                 case "regtest":
                     constants = Constants.regtestWithFederation(
-                            getGenesisFederationPublicKeys().orElse(BridgeRegTestConstants.REGTEST_FEDERATION_PUBLIC_KEYS)
+                            getGenesisFederationPublicKeys().orElse(FederationRegTestConstants.defaultGenesisFederationPublicKeys)
                     );
                     break;
                 default:

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -187,7 +187,7 @@ public abstract class SystemProperties {
                     break;
                 case "regtest":
                     constants = Constants.regtestWithFederation(
-                            getGenesisFederationPublicKeys().orElse(FederationRegTestConstants.defaultGenesisFederationPublicKeys)
+                            getGenesisFederationPublicKeys().orElse(FederationRegTestConstants.defaultFederationPublicKeys)
                     );
                     break;
                 default:


### PR DESCRIPTION
Extract federation constants from BridgeConstants to their own classes.
Create /federation package to have all federation-related classes.
Move new classes to /federation/constants package.

Fix now broken use of BridgeConstants