### PR TITLE
Create FederationSupport interface

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupport.java
@@ -18,7 +18,7 @@ public interface FederationSupport {
     Optional<Script> getActiveFederationRedeemScript();
     Address getActiveFederationAddress();
     int getActiveFederationSize();
-    Integer getActiveFederationThreshold();
+    int getActiveFederationThreshold();
     Instant getActiveFederationCreationTime();
     long getActiveFederationCreationBlockNumber();
     byte[] getActiveFederatorBtcPublicKey(int index);
@@ -28,8 +28,8 @@ public interface FederationSupport {
     @Nullable
     Federation getRetiringFederation();
     Address getRetiringFederationAddress();
-    Integer getRetiringFederationSize();
-    Integer getRetiringFederationThreshold();
+    int getRetiringFederationSize();
+    int getRetiringFederationThreshold();
     Instant getRetiringFederationCreationTime();
     long getRetiringFederationCreationBlockNumber();
     byte[] getRetiringFederatorPublicKey(int index);
@@ -39,10 +39,10 @@ public interface FederationSupport {
     @Nullable
     PendingFederation getPendingFederation();
     byte[] getPendingFederationHash();
-    Integer getPendingFederationSize();
+    int getPendingFederationSize();
     byte[] getPendingFederatorPublicKey(int index);
     byte[] getPendingFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType);
 
-    Integer voteFederationChange(Transaction tx, ABICallSpec callSpec, SignatureCache signatureCache);
+    int voteFederationChange(Transaction tx, ABICallSpec callSpec, SignatureCache signatureCache);
     long getActiveFederationCreationBlockHeight();
 }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupport.java
@@ -1,0 +1,48 @@
+package co.rsk.peg.federation;
+
+import co.rsk.bitcoinj.core.Address;
+import co.rsk.bitcoinj.core.UTXO;
+import co.rsk.bitcoinj.script.Script;
+import co.rsk.peg.vote.ABICallSpec;
+import org.ethereum.core.SignatureCache;
+import org.ethereum.core.Transaction;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+public interface FederationSupport {
+
+    Federation getActiveFederation();
+    Optional<Script> getActiveFederationRedeemScript();
+    Address getActiveFederationAddress();
+    int getActiveFederationSize();
+    Integer getActiveFederationThreshold();
+    Instant getActiveFederationCreationTime();
+    long getActiveFederationCreationBlockNumber();
+    byte[] getActiveFederatorBtcPublicKey(int index);
+    byte[] getActiveFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType);
+    List<UTXO> getActiveFederationBtcUTXOs();
+
+    @Nullable
+    Federation getRetiringFederation();
+    Address getRetiringFederationAddress();
+    Integer getRetiringFederationSize();
+    Integer getRetiringFederationThreshold();
+    Instant getRetiringFederationCreationTime();
+    long getRetiringFederationCreationBlockNumber();
+    byte[] getRetiringFederatorPublicKey(int index);
+    byte[] getRetiringFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType);
+    List<UTXO> getRetiringFederationBtcUTXOs();
+
+    @Nullable
+    PendingFederation getPendingFederation();
+    byte[] getPendingFederationHash();
+    Integer getPendingFederationSize();
+    byte[] getPendingFederatorPublicKey(int index);
+    byte[] getPendingFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType);
+
+    Integer voteFederationChange(Transaction tx, ABICallSpec callSpec, SignatureCache signatureCache);
+    long getActiveFederationCreationBlockHeight();
+}


### PR DESCRIPTION
Create FederationSupport interface in /federation package with all federation-related methods

_Disclaimer:_ added `getPendingFederation` method to replace that the pending federation is being get directly from the provider.