### PR TITLE
Feat/create new storage accessor method with data input

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationChangeFunction.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationChangeFunction.java
@@ -1,6 +1,6 @@
 package co.rsk.peg.federation;
 
-public enum FederationChangeFunctions {
+public enum FederationChangeFunction {
     CREATE("create"),
     ADD("add"),
     ADD_MULTI("add-multi"),
@@ -10,7 +10,7 @@ public enum FederationChangeFunctions {
 
     private final String key;
 
-    FederationChangeFunctions(String key) { this.key = key; }
+    FederationChangeFunction(String key) { this.key = key; }
 
     public String getKey() { return key; }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationChangeFunctions.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationChangeFunctions.java
@@ -1,0 +1,16 @@
+package co.rsk.peg.federation;
+
+public enum FederationChangeFunctions {
+    CREATE("create"),
+    ADD("add"),
+    ADD_MULTI("add-multi"),
+    COMMIT("commit"),
+    ROLLBACK("rollback")
+    ;
+
+    private final String key;
+
+    FederationChangeFunctions(String key) { this.key = key; }
+
+    public String getKey() { return key; }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
@@ -54,17 +54,36 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
     }
 
     private DataWord getStorageKeyForNewFederationBtcUtxos(NetworkParameters networkParameters, ActivationConfig.ForBlock activations) {
-        DataWord key = NEW_FEDERATION_BTC_UTXOS_KEY.getKey();
-        if (networkParameters.getId().equals(NetworkParameters.ID_TESTNET)) {
-            if (activations.isActive(RSKIP284)) {
-                key = NEW_FEDERATION_BTC_UTXOS_KEY_FOR_TESTNET_PRE_HOP.getKey();
-            }
-            if (activations.isActive(RSKIP293)) {
-                key = NEW_FEDERATION_BTC_UTXOS_KEY_FOR_TESTNET_POST_HOP.getKey();
-            }
+
+        if (networkIsTestnet(networkParameters)) {
+            return getNewFederationBtcUtxosKeyForTestnet(activations);
         }
 
-        return key;
+        return NEW_FEDERATION_BTC_UTXOS_KEY.getKey();
+    }
+
+    private boolean networkIsTestnet(NetworkParameters networkParameters) {
+        return networkParameters.getId().equals(NetworkParameters.ID_TESTNET);
+    }
+
+    private DataWord getNewFederationBtcUtxosKeyForTestnet(ActivationConfig.ForBlock activations) {
+        if (shouldUseGeneralKeyForTestnet(activations)) {
+            return NEW_FEDERATION_BTC_UTXOS_KEY.getKey();
+        }
+
+        if (shouldUsePreHopKeyForTestnet(activations)) {
+            return NEW_FEDERATION_BTC_UTXOS_KEY_FOR_TESTNET_PRE_HOP.getKey();
+        }
+
+        return NEW_FEDERATION_BTC_UTXOS_KEY_FOR_TESTNET_POST_HOP.getKey();
+    }
+
+    private boolean shouldUseGeneralKeyForTestnet(ActivationConfig.ForBlock activations) {
+        return !activations.isActive(RSKIP284);
+    }
+
+    private boolean shouldUsePreHopKeyForTestnet(ActivationConfig.ForBlock activations) {
+        return !activations.isActive(RSKIP293);
     }
 
     @Override
@@ -291,17 +310,17 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
             return;
         }
 
-        StorageAccessor.RepositorySerializer<Federation> serializer = BridgeSerializationUtils::serializeFederationOnlyBtcKeys;
-
-        if (activations.isActive(RSKIP123)) {
-            saveStorageVersion(
-                NEW_FEDERATION_FORMAT_VERSION.getKey(),
-                newFederation.getFormatVersion()
-            );
-            serializer = BridgeSerializationUtils::serializeFederation;
+        if (!activations.isActive(RSKIP123)) {
+            bridgeStorageAccessor.safeSaveToRepository(NEW_FEDERATION_KEY.getKey(), newFederation, BridgeSerializationUtils::serializeFederationOnlyBtcKeys);
+            return;
         }
 
-        bridgeStorageAccessor.safeSaveToRepository(NEW_FEDERATION_KEY.getKey(), newFederation, serializer);
+        saveNewFederationFormatVersion();
+        bridgeStorageAccessor.safeSaveToRepository(NEW_FEDERATION_KEY.getKey(), newFederation, BridgeSerializationUtils::serializeFederation);
+    }
+
+    private void saveNewFederationFormatVersion() {
+        saveStorageVersion(NEW_FEDERATION_FORMAT_VERSION.getKey(), newFederation.getFormatVersion());
     }
 
     private void saveOldFederation(ActivationConfig.ForBlock activations) {
@@ -309,39 +328,47 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
             return;
         }
 
-        StorageAccessor.RepositorySerializer<Federation> serializer = BridgeSerializationUtils::serializeFederationOnlyBtcKeys;
-
-        if (activations.isActive(RSKIP123)) {
-            if (oldFederation != null) {
-                saveStorageVersion(
-                    OLD_FEDERATION_FORMAT_VERSION.getKey(),
-                    oldFederation.getFormatVersion()
-                );
-            } else {
-                // assume it is a standard federation to keep backwards compatibility
-                saveStorageVersion(
-                    OLD_FEDERATION_FORMAT_VERSION.getKey(),
-                    STANDARD_MULTISIG_FEDERATION.getFormatVersion()
-                );
-            }
-            serializer = BridgeSerializationUtils::serializeFederation;
+        if (!activations.isActive(RSKIP123)) {
+            bridgeStorageAccessor.safeSaveToRepository(OLD_FEDERATION_KEY.getKey(), oldFederation, BridgeSerializationUtils::serializeFederationOnlyBtcKeys);
+            return;
         }
 
-        bridgeStorageAccessor.safeSaveToRepository(OLD_FEDERATION_KEY.getKey(), oldFederation, serializer);
+        saveOldFederationFormatVersion();
+        bridgeStorageAccessor.safeSaveToRepository(OLD_FEDERATION_KEY.getKey(), oldFederation, BridgeSerializationUtils::serializeFederation);
     }
 
-    // TODO
-/*    private void savePendingFederation() throws IOException {
-        if (shouldSavePendingFederation) {
-            if (activations.isActive(RSKIP123)) {
-                // we only need to save the standard part of the fed since the emergency part is constant
-                saveStorageVersion(
-                    PENDING_FEDERATION_FORMAT_VERSION.getKey(),
-                    STANDARD_MULTISIG_FEDERATION.getFormatVersion()
-                );
-            }
-            savePendingFederationToRepository(pendingFederation);
+    private void saveOldFederationFormatVersion() {
+        int oldFederationFormatVersion = getOldFederationFormatVersion();
+        saveStorageVersion(OLD_FEDERATION_FORMAT_VERSION.getKey(), oldFederationFormatVersion);
+    }
+
+    private int getOldFederationFormatVersion() {
+        if (oldFederation == null) {
+            // assume it is a standard federation to keep backwards compatibility
+            return STANDARD_MULTISIG_FEDERATION.getFormatVersion();
         }
+
+        return oldFederation.getFormatVersion();
+    }
+
+    // TODO: revisar
+/*    private void savePendingFederation(ActivationConfig.ForBlock activations) {
+
+        if (!shouldSavePendingFederation) {
+            return;
+        }
+
+        if (!activations.isActive(RSKIP123)) {
+            bridgeStorageAccessor.safeSaveToRepository(PENDING_FEDERATION_KEY.getKey(), pendingFederation, BridgeSerializationUtils::serializePendingFederationOnlyBtcKeys);
+            return;
+        }
+
+        savePendingFederationFormatVersion();
+        bridgeStorageAccessor.safeSaveToRepository(PENDING_FEDERATION_KEY.getKey(), pendingFederation, BridgeSerializationUtils::serializePendingFederation);
+    }
+    private void savePendingFederationFormatVersion() {
+        // we only need to save the standard part of the fed since the emergency part is constant
+        saveStorageVersion(PENDING_FEDERATION_FORMAT_VERSION.getKey(), STANDARD_MULTISIG_FEDERATION.getFormatVersion());
     }*/
 
     private void saveFederationElection() {
@@ -367,9 +394,10 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
 
         if (nextFederationCreationBlockHeight == -1L) {
             bridgeStorageAccessor.safeSaveToRepository(NEXT_FEDERATION_CREATION_BLOCK_HEIGHT_KEY.getKey(), null, BridgeSerializationUtils::serializeLong);
-        } else {
-            bridgeStorageAccessor.safeSaveToRepository(NEXT_FEDERATION_CREATION_BLOCK_HEIGHT_KEY.getKey(), nextFederationCreationBlockHeight, BridgeSerializationUtils::serializeLong);
+            return;
         }
+
+        bridgeStorageAccessor.safeSaveToRepository(NEXT_FEDERATION_CREATION_BLOCK_HEIGHT_KEY.getKey(), nextFederationCreationBlockHeight, BridgeSerializationUtils::serializeLong);
     }
 
     private void saveLastRetiredFederationP2SHScript(ActivationConfig.ForBlock activations) {

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupport.java
@@ -18,7 +18,7 @@ public interface FederationSupport {
     Optional<Script> getActiveFederationRedeemScript();
     Address getActiveFederationAddress();
     int getActiveFederationSize();
-    Integer getActiveFederationThreshold();
+    int getActiveFederationThreshold();
     Instant getActiveFederationCreationTime();
     long getActiveFederationCreationBlockNumber();
     byte[] getActiveFederatorBtcPublicKey(int index);
@@ -28,8 +28,8 @@ public interface FederationSupport {
     @Nullable
     Federation getRetiringFederation();
     Address getRetiringFederationAddress();
-    Integer getRetiringFederationSize();
-    Integer getRetiringFederationThreshold();
+    int getRetiringFederationSize();
+    int getRetiringFederationThreshold();
     Instant getRetiringFederationCreationTime();
     long getRetiringFederationCreationBlockNumber();
     byte[] getRetiringFederatorPublicKey(int index);
@@ -39,10 +39,10 @@ public interface FederationSupport {
     @Nullable
     PendingFederation getPendingFederation();
     byte[] getPendingFederationHash();
-    Integer getPendingFederationSize();
+    int getPendingFederationSize();
     byte[] getPendingFederatorPublicKey(int index);
     byte[] getPendingFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType);
 
-    Integer voteFederationChange(Transaction tx, ABICallSpec callSpec, SignatureCache signatureCache);
+    int voteFederationChange(Transaction tx, ABICallSpec callSpec, SignatureCache signatureCache);
     long getActiveFederationCreationBlockHeight();
 }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupport.java
@@ -1,0 +1,48 @@
+package co.rsk.peg.federation;
+
+import co.rsk.bitcoinj.core.Address;
+import co.rsk.bitcoinj.core.UTXO;
+import co.rsk.bitcoinj.script.Script;
+import co.rsk.peg.vote.ABICallSpec;
+import org.ethereum.core.SignatureCache;
+import org.ethereum.core.Transaction;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+public interface FederationSupport {
+
+    Federation getActiveFederation();
+    Optional<Script> getActiveFederationRedeemScript();
+    Address getActiveFederationAddress();
+    int getActiveFederationSize();
+    Integer getActiveFederationThreshold();
+    Instant getActiveFederationCreationTime();
+    long getActiveFederationCreationBlockNumber();
+    byte[] getActiveFederatorBtcPublicKey(int index);
+    byte[] getActiveFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType);
+    List<UTXO> getActiveFederationBtcUTXOs();
+
+    @Nullable
+    Federation getRetiringFederation();
+    Address getRetiringFederationAddress();
+    Integer getRetiringFederationSize();
+    Integer getRetiringFederationThreshold();
+    Instant getRetiringFederationCreationTime();
+    long getRetiringFederationCreationBlockNumber();
+    byte[] getRetiringFederatorPublicKey(int index);
+    byte[] getRetiringFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType);
+    List<UTXO> getRetiringFederationBtcUTXOs();
+
+    @Nullable
+    PendingFederation getPendingFederation();
+    byte[] getPendingFederationHash();
+    Integer getPendingFederationSize();
+    byte[] getPendingFederatorPublicKey(int index);
+    byte[] getPendingFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType);
+
+    Integer voteFederationChange(Transaction tx, ABICallSpec callSpec, SignatureCache signatureCache);
+    long getActiveFederationCreationBlockHeight();
+}

--- a/rskj-core/src/main/java/co/rsk/peg/storage/BridgeStorageAccessorImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/storage/BridgeStorageAccessorImpl.java
@@ -33,17 +33,25 @@ public class BridgeStorageAccessorImpl implements StorageAccessor {
     @Override
     public <T> void safeSaveToRepository(DataWord addressKey, T object, RepositorySerializer<T> serializer) {
         try {
-            saveToRepository(addressKey, object, serializer);
+            byte[] serializedData = getSerializedData(object, serializer);
+            safeSaveToRepository(addressKey, serializedData);
         } catch (IOException ioe) {
             throw new StorageAccessException("Unable to save to repository: " + addressKey, ioe);
         }
     }
 
-    private <T> void saveToRepository(DataWord addressKey, T object, RepositorySerializer<T> serializer) throws IOException {
+    private <T> byte[] getSerializedData(T object, RepositorySerializer<T> serializer) throws IOException {
         byte[] data = null;
         if (object != null) {
             data = serializer.serialize(object);
         }
-        repository.addStorageBytes(CONTRACT_ADDRESS, addressKey, data);
+
+        return data;
     }
+
+    @Override
+    public void safeSaveToRepository(DataWord addressKey, byte[] serializedData) {
+        repository.addStorageBytes(CONTRACT_ADDRESS, addressKey, serializedData);
+    }
+
 }

--- a/rskj-core/src/main/java/co/rsk/peg/storage/StorageAccessor.java
+++ b/rskj-core/src/main/java/co/rsk/peg/storage/StorageAccessor.java
@@ -8,6 +8,7 @@ public interface StorageAccessor {
     <T> T safeGetFromRepository(DataWord keyAddress, RepositoryDeserializer<T> deserializer);
 
     <T> void safeSaveToRepository(DataWord addressKey, T object, RepositorySerializer<T> serializer);
+    void safeSaveToRepository(DataWord addressKey, byte[] data);
 
     interface RepositoryDeserializer<T> {
         T deserialize(byte[] data) throws IOException;


### PR DESCRIPTION
- Refactor some methods for readability
- Create federation change functions enum inside /federation package
- Create FederationSupport interface in /federation package with all federation-related methods
- Create FederationSupport implementation
- Create a new method in StorageAccessor to be able to save to repository already serialized data. Refactor `savePendingFederation` method using it.
