### PR TITLE
Update getCode so it does not make a copy of the array

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/vm/VM.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/VM.java
@@ -775,7 +775,7 @@ public class VM {
         // EXECUTION PHASE
         DataWord codeLength;
         if (op == OpCode.CODESIZE) {
-            codeLength = DataWord.valueOf(program.getCode().length); // during initialization it will return the initialization code size
+            codeLength = DataWord.valueOf(program.getCodeLength()); // during initialization it will return the initialization code size
         } else {
             DataWord address = program.stackPop();
             codeLength = DataWord.valueOf(program.getCodeLengthAt(address));
@@ -879,13 +879,14 @@ public class VM {
         int lengthData = lengthDataDW.intValueSafe(); // amount of bytes to copy
 
         int sizeToBeCopied;
-        if ((long) codeOffset + lengthData > fullCode.length) {
+        int fullCodeLength = fullCode.length;
+        if ((long) codeOffset + lengthData > fullCodeLength) {
             // if user wants to read more info from code what actual code has then..
             // if all code that users wants lies after code has ended..
-            if (codeOffset >=fullCode.length) {
+            if (codeOffset >= fullCodeLength) {
                 sizeToBeCopied=0; // do not copy anything
             } else {
-                sizeToBeCopied = fullCode.length - codeOffset; // copy only the remaining
+                sizeToBeCopied = fullCodeLength - codeOffset; // copy only the remaining
             }
 
         } else
@@ -898,7 +899,7 @@ public class VM {
         // enough space to contain filling also.
         byte[] codeCopy = new byte[lengthData];
 
-        if (codeOffset < fullCode.length) {
+        if (codeOffset < fullCodeLength) {
             System.arraycopy(fullCode, codeOffset, codeCopy, 0, sizeToBeCopied);
         }
 

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -957,7 +957,11 @@ public class Program {
     }
 
     public byte[] getCode() {
-        return Arrays.copyOf(ops, ops.length);
+        return ops;
+    }
+
+    public int getCodeLength() {
+        return ops.length;
     }
 
     public Keccak256 getCodeHashAt(RskAddress addr, boolean standard) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed the call to `Arrays.copyOf()` method and made `getCode()` return the array directly. As per @asoto-iov suggestion the `getCodeLength()` method.

## Motivation and Context
Currently the `doCODESIZE()` and `doCODECOPY()` methods can, under certain conditions, make a call to the `getCode()` method that returns a deep copy of the underlying array which can cause perfomance issues if the code array is too big.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
