### PR TITLE
Fix PowpegMigrationTest

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupportImpl.java
@@ -604,7 +604,7 @@ public class FederationSupportImpl implements FederationSupport {
      * @return 1 upon success, -1 if there was no pending federation, -2 if the pending federation was incomplete,
      * -3 if the given hash doesn't match the current pending federation's hash.
      */
-    private Integer commitFederation(boolean dryRun, Keccak256 hash, BridgeEventLogger eventLogger) {
+    protected Integer commitFederation(boolean dryRun, Keccak256 hash, BridgeEventLogger eventLogger) {
         PendingFederation currentPendingFederation = provider.getPendingFederation();
 
         if (currentPendingFederation == null) {


### PR DESCRIPTION
- Fix `PowpegMigrationTest`
- Move `PowpegMigrationTest` to `/federation` package.
- Make `commitFederation` method in `FederationSupportImpl` protected instead of private to test