### PR TITLE
Fix BridgeConstantsTest

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/constants/BridgeConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/constants/BridgeConstantsTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import co.rsk.bitcoinj.core.Coin;
-import java.time.Instant;
 import java.util.stream.Stream;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
@@ -14,95 +13,14 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class BridgeConstantsTest {
-    private static Stream<Arguments> fundsMigrationAgeSinceActivationEndArgsProvider() {
-        return Stream.of(
-            Arguments.of(BridgeMainNetConstants.getInstance(), false),
-            Arguments.of(BridgeTestNetConstants.getInstance(), true),
-            Arguments.of(BridgeRegTestConstants.getInstance(), true)
-        );
-    }
-
-    @ParameterizedTest()
-    @MethodSource("fundsMigrationAgeSinceActivationEndArgsProvider")
-    void test_getFundsMigrationAgeSinceActivationEnd(BridgeConstants bridgeConstants, boolean hasSameValueForBothFields) {
-        // Arrange
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-
-        // Act
-        long fundsMigrationAgeSinceActivationEnd = bridgeConstants.getFundsMigrationAgeSinceActivationEnd(activations);
-
-        // assert
-        assertEquals(fundsMigrationAgeSinceActivationEnd, bridgeConstants.fundsMigrationAgeSinceActivationEnd);
-        assertEquals(hasSameValueForBothFields,  fundsMigrationAgeSinceActivationEnd == bridgeConstants.specialCaseFundsMigrationAgeSinceActivationEnd);
-    }
-
-    @ParameterizedTest()
-    @MethodSource("fundsMigrationAgeSinceActivationEndArgsProvider")
-    void test_getFundsMigrationAgeSinceActivationEnd_post_RSKIP357(BridgeConstants bridgeConstants, boolean hasSameValueForBothMigrationAges) {
-        // Arrange
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
-
-        // Act
-        long fundsMigrationAgeSinceActivationEnd = bridgeConstants.getFundsMigrationAgeSinceActivationEnd(activations);
-
-        // assert
-        assertEquals(fundsMigrationAgeSinceActivationEnd, bridgeConstants.specialCaseFundsMigrationAgeSinceActivationEnd);
-        assertEquals(hasSameValueForBothMigrationAges,  fundsMigrationAgeSinceActivationEnd == bridgeConstants.fundsMigrationAgeSinceActivationEnd);
-    }
-
-    @ParameterizedTest()
-    @MethodSource("fundsMigrationAgeSinceActivationEndArgsProvider")
-    void test_getFundsMigrationAgeSinceActivationEnd_post_RSKIP374(BridgeConstants bridgeConstants, boolean hasSameValueForBothMigrationAges) {
-        // Arrange
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
-        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(true);
-
-        // Act
-        long fundsMigrationAgeSinceActivationEnd = bridgeConstants.getFundsMigrationAgeSinceActivationEnd(activations);
-
-        // assert
-        assertEquals(fundsMigrationAgeSinceActivationEnd, bridgeConstants.fundsMigrationAgeSinceActivationEnd);
-        assertEquals(hasSameValueForBothMigrationAges,  fundsMigrationAgeSinceActivationEnd == bridgeConstants.specialCaseFundsMigrationAgeSinceActivationEnd);
-    }
-
-    private static Stream<Arguments> federationActivationAgeArgProvider() {
-        return Stream.of(
-            Arguments.of(BridgeMainNetConstants.getInstance(), false),
-            Arguments.of(BridgeTestNetConstants.getInstance(), false),
-            Arguments.of(BridgeRegTestConstants.getInstance(), false),
-            Arguments.of(BridgeMainNetConstants.getInstance(), true),
-            Arguments.of(BridgeTestNetConstants.getInstance(), true),
-            Arguments.of(BridgeRegTestConstants.getInstance(), true)
-        );
-    }
-
-    @ParameterizedTest()
-    @MethodSource("federationActivationAgeArgProvider")
-    void test_getFederationActivationAge(BridgeConstants bridgeConstants, boolean isRSKIP383Active) {
-        // Arrange
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP383)).thenReturn(isRSKIP383Active);
-        // Act
-        long federationActivationAge = bridgeConstants.getFederationActivationAge(activations);
-
-        // assert
-        if (isRSKIP383Active){
-            assertEquals(bridgeConstants.federationActivationAge, federationActivationAge);
-        } else {
-            assertEquals(bridgeConstants.federationActivationAgeLegacy, federationActivationAge);
-        }
-    }
-
     private static Stream<Arguments> minimumPeginTxValueArgProvider() {
         return Stream.of(
             Arguments.of(BridgeMainNetConstants.getInstance(), false),
             Arguments.of(BridgeTestNetConstants.getInstance(), false),
-            Arguments.of(BridgeRegTestConstants.getInstance(), false),
+            Arguments.of(new BridgeRegTestConstants(), false),
             Arguments.of(BridgeMainNetConstants.getInstance(), true),
             Arguments.of(BridgeTestNetConstants.getInstance(), true),
-            Arguments.of(BridgeRegTestConstants.getInstance(), true)
+            Arguments.of(new BridgeRegTestConstants(), true)
         );
     }
 
@@ -127,7 +45,7 @@ class BridgeConstantsTest {
         return Stream.of(
             Arguments.of(BridgeMainNetConstants.getInstance(), 837589),
             Arguments.of(BridgeTestNetConstants.getInstance(), 2589553),
-            Arguments.of(BridgeRegTestConstants.getInstance(), 250)
+            Arguments.of(new BridgeRegTestConstants(), 250)
         );
     }
 
@@ -145,7 +63,7 @@ class BridgeConstantsTest {
         return Stream.of(
             Arguments.of(BridgeMainNetConstants.getInstance(), 4_320),
             Arguments.of(BridgeTestNetConstants.getInstance(), 1_440),
-            Arguments.of(BridgeRegTestConstants.getInstance(), 100)
+            Arguments.of(new BridgeRegTestConstants(), 100)
         );
     }
 
@@ -157,21 +75,5 @@ class BridgeConstantsTest {
 
         // assert
         assertEquals(expectedValue, pegoutTxIndexGracePeriodInBtcBlocks);
-    }
-
-    private static Stream<Arguments> getGenesisFederationCreationTimeTestProvider() {
-        return Stream.of(
-            Arguments.of(BridgeMainNetConstants.getInstance(), Instant.ofEpochMilli(1514948400L)),
-            Arguments.of(BridgeTestNetConstants.getInstance(), Instant.ofEpochMilli(1538967600L)),
-            Arguments.of(BridgeRegTestConstants.getInstance(), Instant.ofEpochSecond(1451606400L)),
-            Arguments.of(BridgeDevNetConstants.getInstance(), Instant.ofEpochMilli(1510617600L))
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("getGenesisFederationCreationTimeTestProvider")
-    void getGenesisFederationCreationTimeTest(BridgeConstants bridgeConstants, Instant expectedGenesisFederationCreationTime){
-        Instant actualGenesisFederationCreationTime = bridgeConstants.getGenesisFederationCreationTime();
-        assertEquals(expectedGenesisFederationCreationTime, actualGenesisFederationCreationTime);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/federation/constants/FederationConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/constants/FederationConstantsTest.java
@@ -1,0 +1,114 @@
+package co.rsk.peg.federation.constants;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.stream.Stream;
+
+import co.rsk.peg.constants.*;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class FederationConstantsTest {
+    private static Stream<Arguments> fundsMigrationAgeSinceActivationEndArgsProvider() {
+        return Stream.of(
+            Arguments.of(FederationMainNetConstants.getInstance(), false),
+            Arguments.of(FederationTestNetConstants.getInstance(), true),
+            Arguments.of((new BridgeRegTestConstants()).getFederationConstants(), true)
+        );
+    }
+
+    @ParameterizedTest()
+    @MethodSource("fundsMigrationAgeSinceActivationEndArgsProvider")
+    void test_getFundsMigrationAgeSinceActivationEnd(FederationConstants federationConstants, boolean hasSameValueForBothFields) {
+        // Arrange
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+
+        // Act
+        long fundsMigrationAgeSinceActivationEnd = federationConstants.getFundsMigrationAgeSinceActivationEnd(activations);
+
+        // assert
+        assertEquals(fundsMigrationAgeSinceActivationEnd, federationConstants.fundsMigrationAgeSinceActivationEnd);
+        assertEquals(hasSameValueForBothFields,  fundsMigrationAgeSinceActivationEnd == federationConstants.specialCaseFundsMigrationAgeSinceActivationEnd);
+    }
+
+    @ParameterizedTest()
+    @MethodSource("fundsMigrationAgeSinceActivationEndArgsProvider")
+    void test_getFundsMigrationAgeSinceActivationEnd_post_RSKIP357(FederationConstants federationConstants, boolean hasSameValueForBothMigrationAges) {
+        // Arrange
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
+
+        // Act
+        long fundsMigrationAgeSinceActivationEnd = federationConstants.getFundsMigrationAgeSinceActivationEnd(activations);
+
+        // assert
+        assertEquals(fundsMigrationAgeSinceActivationEnd, federationConstants.specialCaseFundsMigrationAgeSinceActivationEnd);
+        assertEquals(hasSameValueForBothMigrationAges,  fundsMigrationAgeSinceActivationEnd == federationConstants.fundsMigrationAgeSinceActivationEnd);
+    }
+
+    @ParameterizedTest()
+    @MethodSource("fundsMigrationAgeSinceActivationEndArgsProvider")
+    void test_getFundsMigrationAgeSinceActivationEnd_post_RSKIP374(FederationConstants federationConstants, boolean hasSameValueForBothMigrationAges) {
+        // Arrange
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP357)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP374)).thenReturn(true);
+
+        // Act
+        long fundsMigrationAgeSinceActivationEnd = federationConstants.getFundsMigrationAgeSinceActivationEnd(activations);
+
+        // assert
+        assertEquals(fundsMigrationAgeSinceActivationEnd, federationConstants.fundsMigrationAgeSinceActivationEnd);
+        assertEquals(hasSameValueForBothMigrationAges,  fundsMigrationAgeSinceActivationEnd == federationConstants.specialCaseFundsMigrationAgeSinceActivationEnd);
+    }
+
+    private static Stream<Arguments> federationActivationAgeArgProvider() {
+        return Stream.of(
+            Arguments.of(FederationMainNetConstants.getInstance(), false),
+            Arguments.of(FederationTestNetConstants.getInstance(), false),
+            Arguments.of((new BridgeRegTestConstants()).getFederationConstants(), false),
+            Arguments.of(FederationMainNetConstants.getInstance(), true),
+            Arguments.of(FederationTestNetConstants.getInstance(), true),
+            Arguments.of((new BridgeRegTestConstants()).getFederationConstants(), true)
+        );
+    }
+
+    @ParameterizedTest()
+    @MethodSource("federationActivationAgeArgProvider")
+    void test_getFederationActivationAge(FederationConstants federationConstants, boolean isRSKIP383Active) {
+        // Arrange
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        when(activations.isActive(ConsensusRule.RSKIP383)).thenReturn(isRSKIP383Active);
+        // Act
+        long federationActivationAge = federationConstants.getFederationActivationAge(activations);
+
+        // assert
+        if (isRSKIP383Active){
+            assertEquals(federationConstants.federationActivationAge, federationActivationAge);
+        } else {
+            assertEquals(federationConstants.federationActivationAgeLegacy, federationActivationAge);
+        }
+    }
+
+    private static Stream<Arguments> getGenesisFederationCreationTimeTestProvider() {
+        return Stream.of(
+            Arguments.of(BridgeMainNetConstants.getInstance(), Instant.ofEpochMilli(1514948400L)),
+            Arguments.of(BridgeTestNetConstants.getInstance(), Instant.ofEpochMilli(1538967600L)),
+            Arguments.of(new BridgeRegTestConstants(), Instant.ofEpochSecond(1451606400L)),
+            Arguments.of(BridgeDevNetConstants.getInstance(), Instant.ofEpochMilli(1510617600L))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("getGenesisFederationCreationTimeTestProvider")
+    void getGenesisFederationCreationTimeTest(FederationConstants federationConstants, Instant expectedGenesisFederationCreationTime){
+        Instant actualGenesisFederationCreationTime = federationConstants.getGenesisFederationCreationTime();
+        assertEquals(expectedGenesisFederationCreationTime, actualGenesisFederationCreationTime);
+    }
+}


### PR DESCRIPTION
- Fix `BridgeConstantsTest` by moving federation constants related tests from it.
- Create `FederationConstantsTest` class inside new `/federation/constants` package to have those tests.