### PR TITLE
Initialize storageVersionEntries as new hashmap

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
@@ -41,6 +41,7 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
 
     public FederationStorageProviderImpl(StorageAccessor bridgeStorageAccessor) {
         this.bridgeStorageAccessor = bridgeStorageAccessor;
+        this.storageVersionEntries = new HashMap<>();
     }
 
     @Override
@@ -122,19 +123,19 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
     }
 
     private Optional<Integer> getStorageVersion(DataWord versionKey) {
-        if (!storageVersionEntries.containsKey(versionKey)) {
-            Optional<Integer> version = bridgeStorageAccessor.safeGetFromRepository(versionKey, data -> {
-                if (data == null || data.length == 0) {
-                    return Optional.empty();
-                }
-
-                return Optional.of(BridgeSerializationUtils.deserializeInteger(data));
-            });
-
-            storageVersionEntries.put(versionKey, version);
-            return version;
+        if (storageVersionEntries.containsKey(versionKey)) {
+            return storageVersionEntries.get(versionKey);
         }
-        return storageVersionEntries.get(versionKey);
+
+        Optional<Integer> version = bridgeStorageAccessor.safeGetFromRepository(versionKey, data -> {
+            if (data == null || data.length == 0) {
+                return Optional.empty();
+            }
+
+            return Optional.of(BridgeSerializationUtils.deserializeInteger(data));
+        });
+        storageVersionEntries.put(versionKey, version);
+        return version;
     }
 
     @Override


### PR DESCRIPTION
- Add the initialization to `FederationStorageProviderImpl`, since the field is now part of it.
_Context:_ `storageVersionEntries` was being initialized when belong to `BridgeStorageProvider`. See [here](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java#L126).
This got lost during the refactor.
- Refactor the method `getStorageVersion` method following a Sonar suggestion