### PR TITLE
Add to field in trace responses

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -778,7 +778,7 @@ public class Program {
             TransferInvoke invoke = new TransferInvoke(callerAddress, ownerAddress, msg.getGas().longValue(), transferValue);
             ProgramResult result = new ProgramResult();
 
-            ProgramSubtrace subtrace = ProgramSubtrace.newCallSubtrace(CallType.fromMsgType(msg.getType()), invoke, result, null, Collections.emptyList());
+            ProgramSubtrace subtrace = ProgramSubtrace.newCallSubtrace(CallType.fromMsgType(msg.getType()), invoke, result, msg.getCodeAddress(), Collections.emptyList());
 
             getTrace().addSubTrace(subtrace);
 

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -437,7 +437,7 @@ rpc {
         },
         trace {
             version: "1.0",
-            enabled: "true"
+            enabled: "false"
         },
         rsk {
             version: "1.0",

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -437,7 +437,7 @@ rpc {
         },
         trace {
             version: "1.0",
-            enabled: "false"
+            enabled: "true"
         },
         rsk {
             version: "1.0",

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceModuleImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceModuleImplTest.java
@@ -750,6 +750,44 @@ class TraceModuleImplTest {
         Assertions.assertEquals("\"create2\"", oresult.get("action").get("creationMethod").toString());
     }
 
+    @Test
+    void executedContractWithDelegateCallToNonExistentContract() throws Exception {
+        DslParser parser = DslParser.fromResource("dsl/delegatecall02.txt");
+        ReceiptStore receiptStore = new ReceiptStoreImpl(new HashMapDB());
+        World world = new World(receiptStore);
+
+        WorldDslProcessor processor = new WorldDslProcessor(world);
+        processor.processCommands(parser);
+
+        Account delegateCallAccount = world.getAccountByName("delegatecall");
+        Account delegatedAccount = world.getAccountByName("delegated");
+
+        Assertions.assertNotNull(delegateCallAccount);
+        Assertions.assertNotNull(delegatedAccount);
+
+        Transaction transaction = world.getTransactionByName("tx01");
+
+        TraceModuleImpl traceModule = new TraceModuleImpl(world.getBlockChain(), world.getBlockStore(), receiptStore, world.getBlockExecutor(), null, world.getBlockTxSignatureCache());
+
+        JsonNode result = traceModule.traceTransaction(transaction.getHash().toJsonString());
+
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isArray());
+
+        ArrayNode aresult = (ArrayNode)result;
+
+        Assertions.assertEquals(2, aresult.size());
+        Assertions.assertTrue(result.get(0).isObject());
+
+        ObjectNode oresult = (ObjectNode)result.get(1);
+
+        Assertions.assertNotNull(oresult.get("action"));
+        Assertions.assertNotNull(oresult.get("action").get("callType"));
+        Assertions.assertEquals("\"delegatecall\"", oresult.get("action").get("callType").toString());
+        Assertions.assertEquals("\"" + delegatedAccount.getAddress().toJsonString() + "\"", oresult.get("action").get("to").toString());
+        Assertions.assertEquals("\"" + delegateCallAccount.getAddress().toJsonString() + "\"", oresult.get("action").get("from").toString());
+    }
+
     private static World executeMultiContract(ReceiptStore receiptStore) throws DslProcessorException, FileNotFoundException {
         DslParser parser = DslParser.fromResource("dsl/contracts08.txt");
         World world = new World(receiptStore);

--- a/rskj-core/src/test/resources/dsl/delegatecall02.txt
+++ b/rskj-core/src/test/resources/dsl/delegatecall02.txt
@@ -1,0 +1,40 @@
+
+account_new acc1 10000000
+
+# account with no contract code
+
+account_new delegated 0
+
+# contract account with delegate call
+
+# code
+# PUSH1 0x00    (output data size)
+# PUSH1 0x00    (output data offset)
+# PUSH1 0x00    (input data size)
+# PUSH1 0x00    (input data offset)
+# PUSH20 <delegated contract address>
+# PUSH2 0x1000   (gas to use)
+# DELEGATECALL
+# STOP
+
+account_new delegatecall 0 600060006000600073[delegated]611000f400
+
+# invoke delegatecall contract
+
+transaction_build tx01
+    sender acc1
+    receiver delegatecall
+    value 0
+    gas 1200000
+    build
+
+block_build b01
+    parent g00
+    transactions tx01
+    build
+
+block_connect b01
+
+# Assert best block
+assert_best b01
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Pass `codeAddress` instead of `null`  if the contract code is empty when creating a new call sub trace.

## Motivation and Context
This is a reported [bug](https://github.com/rsksmart/rskj/issues/2346). Traces generated from any `trace_` api method do not include the `to` property in an `action` when in cases when `action` in question is a `delegatecall` to a non existent contract.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
