### PR TITLE
Fix getPendingFederationHash bridge's method to avoid npe 

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -972,7 +972,7 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         );
     }
 
-    public byte[] getPendingFederationHashBytes(Object[] args) {
+    public byte[] getPendingFederationHashSerialized(Object[] args) {
         logger.trace("getPendingFederationHash");
 
         Keccak256 hash = bridgeSupport.getPendingFederationHash();

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -972,17 +972,17 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         );
     }
 
-    public byte[] getPendingFederationHash(Object[] args) {
+    public byte[] getPendingFederationHashBytes(Object[] args) {
         logger.trace("getPendingFederationHash");
 
-        byte[] hash = bridgeSupport.getPendingFederationHash().getBytes();
+        Keccak256 hash = bridgeSupport.getPendingFederationHash();
 
         if (hash == null) {
             // Empty array is returned when pending federation is not present
             return new byte[]{};
         }
 
-        return hash;
+        return hash.getBytes();
     }
 
     public Integer getPendingFederationSize(Object[] args) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
@@ -331,7 +331,7 @@ public enum BridgeMethods {
             new String[]{"bytes"}
         ),
         fixedCost(3000L),
-        (BridgeMethodExecutorTyped) Bridge::getPendingFederationHash,
+        (BridgeMethodExecutorTyped) Bridge::getPendingFederationHashBytes,
         fixedPermission(true),
         CallTypeHelper.ALLOW_STATIC_CALL
     ),

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
@@ -331,7 +331,7 @@ public enum BridgeMethods {
             new String[]{"bytes"}
         ),
         fixedCost(3000L),
-        (BridgeMethodExecutorTyped) Bridge::getPendingFederationHashBytes,
+        (BridgeMethodExecutorTyped) Bridge::getPendingFederationHashSerialized,
         fixedPermission(true),
         CallTypeHelper.ALLOW_STATIC_CALL
     ),


### PR DESCRIPTION
In the federation support refactor, the bridge support's method `getPendingFederationHash` [was modified](https://github.com/rsksmart/rskj/blob/federation-support-refactor-integration/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java#L1996) to return a `Keccak256 hash` [instead of](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java#L2348) `bytes`, and therefore, the same bridge's method [was modified](https://github.com/rsksmart/rskj/blob/federation-support-refactor-integration/rskj-core/src/main/java/co/rsk/peg/Bridge.java#L978) to get the bytes from the hash [instead of](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/co/rsk/peg/Bridge.java#L977) getting the bytes directly.

This pr refactors the bridge method to avoid a npe when pending federation hash returns null.
Also, the method's name have been renamed to be more accurate