### PR TITLE
Whitelist Response Code Enum

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -20,10 +20,9 @@ package co.rsk.peg;
 import static co.rsk.peg.BridgeUtils.getRegularPegoutTxSize;
 import static co.rsk.peg.ReleaseTransactionBuilder.BTC_TX_VERSION_2;
 import static co.rsk.peg.pegin.RejectedPeginReason.INVALID_AMOUNT;
-
-import static co.rsk.peg.whitelist.WhitelistResponseCode.ALREADY_EXISTS_ERROR;
+import static co.rsk.peg.whitelist.WhitelistResponseCode.ADDRESS_ALREADY_WHITELISTED;
 import static co.rsk.peg.whitelist.WhitelistResponseCode.GENERIC_ERROR;
-import static co.rsk.peg.whitelist.WhitelistResponseCode.INVALID_ADDRESS_FORMAT_ERROR;
+import static co.rsk.peg.whitelist.WhitelistResponseCode.INVALID_ADDRESS_FORMAT;
 import static co.rsk.peg.whitelist.WhitelistResponseCode.SUCCESS;
 import static co.rsk.peg.whitelist.WhitelistResponseCode.UNKNOWN_ERROR;
 import static org.ethereum.config.blockchain.upgrades.ConsensusRule.*;
@@ -2081,7 +2080,7 @@ public class BridgeSupport {
             return this.addLockWhitelistAddress(tx, new OneOffWhiteListEntry(address, maxTransferValueCoin));
         } catch (AddressFormatException e) {
             logger.warn(INVALID_ADDRESS_FORMAT_MESSAGE, e);
-            return INVALID_ADDRESS_FORMAT_ERROR.getCode();
+            return INVALID_ADDRESS_FORMAT.getCode();
         }
     }
 
@@ -2091,7 +2090,7 @@ public class BridgeSupport {
             return this.addLockWhitelistAddress(tx, new UnlimitedWhiteListEntry(address));
         } catch (AddressFormatException e) {
             logger.warn(INVALID_ADDRESS_FORMAT_MESSAGE, e);
-            return INVALID_ADDRESS_FORMAT_ERROR.getCode();
+            return INVALID_ADDRESS_FORMAT.getCode();
         }
     }
 
@@ -2104,7 +2103,7 @@ public class BridgeSupport {
 
         try {
             if (whitelist.isWhitelisted(entry.address())) {
-                return ALREADY_EXISTS_ERROR.getCode();
+                return ADDRESS_ALREADY_WHITELISTED.getCode();
             }
             whitelist.put(entry.address(), entry);
             return SUCCESS.getCode();

--- a/rskj-core/src/main/java/co/rsk/peg/whitelist/WhitelistResponseCode.java
+++ b/rskj-core/src/main/java/co/rsk/peg/whitelist/WhitelistResponseCode.java
@@ -2,8 +2,8 @@ package co.rsk.peg.whitelist;
 
 public enum WhitelistResponseCode {
     GENERIC_ERROR(-10),
-    INVALID_ADDRESS_FORMAT_ERROR(-2),
-    ALREADY_EXISTS_ERROR(-1),
+    INVALID_ADDRESS_FORMAT(-2),
+    ADDRESS_ALREADY_WHITELISTED(-1),
     UNKNOWN_ERROR(0),
     SUCCESS(1);
 

--- a/rskj-core/src/main/java/co/rsk/peg/whitelist/WhitelistResponseCode.java
+++ b/rskj-core/src/main/java/co/rsk/peg/whitelist/WhitelistResponseCode.java
@@ -1,0 +1,19 @@
+package co.rsk.peg.whitelist;
+
+public enum WhitelistResponseCode {
+    GENERIC_ERROR(-10),
+    INVALID_ADDRESS_FORMAT_ERROR(-2),
+    ALREADY_EXISTS_ERROR(-1),
+    UNKNOWN_ERROR(0),
+    SUCCESS(1);
+
+    private final int code;
+
+    WhitelistResponseCode(int code) {
+        this.code = code;
+    }
+
+    public int getCode() {
+        return code;
+    }
+}


### PR DESCRIPTION
## Description
New enum WhitelistResponseCode that contains the response codes for Whitelist. Currently, they are part of BridgeSupport, and we are going to remove them and put them all in the new object.

Remove the LOCK_WHITELIST prefix, and _CODE suffix since don't add any value.

## Motivation and Context
This is related to the Bridge Refactor to decouple some objects that are tied closely to the Bridge.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
