### PR TITLE
Rename and move FederationSupportTest

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package co.rsk.peg;
+package co.rsk.peg.federation;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -47,7 +47,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class FederationSupportTest {
+class FederationSupportImplTest {
 
     private FederationSupport federationSupport;
     private FederationConstants federationMainnetConstants;

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.when;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.bitcoin.BitcoinTestUtils;
-import co.rsk.peg.federation.*;
 import co.rsk.peg.federation.FederationMember.KeyType;
 import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.federation.constants.FederationMainNetConstants;


### PR DESCRIPTION
- Rename `FederationSupportTest` to `FederationSupportImplTest`
- Move the class to the `/federation` package