### PR TITLE
Whitelist Storage Index Key

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageIndexKey.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageIndexKey.java
@@ -8,8 +8,6 @@ public enum BridgeStorageIndexKey {
     RELEASE_REQUEST_QUEUE("releaseRequestQueue"),
     PEGOUTS_WAITING_FOR_CONFIRMATIONS("releaseTransactionSet"),
     PEGOUTS_WAITING_FOR_SIGNATURES("rskTxsWaitingFS"),
-    LOCK_ONE_OFF_WHITELIST_KEY("lockWhitelist"),
-    LOCK_UNLIMITED_WHITELIST_KEY("unlimitedLockWhitelist"),
     LOCKING_CAP_KEY("lockingCap"),
     RELEASE_REQUEST_QUEUE_WITH_TXHASH("releaseRequestQueueWithTxHash"),
     PEGOUTS_WAITING_FOR_CONFIRMATIONS_WITH_TXHASH_KEY("releaseTransactionSetWithTxHash"),

--- a/rskj-core/src/main/java/co/rsk/peg/whitelist/WhitelistStorageIndexKey.java
+++ b/rskj-core/src/main/java/co/rsk/peg/whitelist/WhitelistStorageIndexKey.java
@@ -1,0 +1,21 @@
+package co.rsk.peg.whitelist;
+
+import org.ethereum.vm.DataWord;
+
+/**
+ *  Enum for Whitelist storage index key.
+ */
+public enum WhitelistStorageIndexKey {
+    LOCK_ONE_OFF("lockWhitelist"),
+    LOCK_UNLIMITED("unlimitedLockWhitelist");
+
+    private final String key;
+
+    WhitelistStorageIndexKey(String key) {
+        this.key = key;
+    }
+
+    public DataWord getKey() {
+        return DataWord.fromString(key);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/whitelist/WhitelistStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/whitelist/WhitelistStorageProviderImpl.java
@@ -1,7 +1,7 @@
 package co.rsk.peg.whitelist;
 
-import static co.rsk.peg.BridgeStorageIndexKey.LOCK_ONE_OFF_WHITELIST_KEY;
-import static co.rsk.peg.BridgeStorageIndexKey.LOCK_UNLIMITED_WHITELIST_KEY;
+import static co.rsk.peg.whitelist.WhitelistStorageIndexKey.LOCK_ONE_OFF;
+import static co.rsk.peg.whitelist.WhitelistStorageIndexKey.LOCK_UNLIMITED;
 import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP87;
 
 import co.rsk.bitcoinj.core.Address;
@@ -41,11 +41,11 @@ public class WhitelistStorageProviderImpl implements WhitelistStorageProvider {
 
         List<OneOffWhiteListEntry> oneOffEntries = lockWhitelist.getAll(OneOffWhiteListEntry.class);
         Pair<List<OneOffWhiteListEntry>, Integer> pairValue = Pair.of(oneOffEntries, lockWhitelist.getDisableBlockHeight());
-        bridgeStorageAccessor.safeSaveToRepository(LOCK_ONE_OFF_WHITELIST_KEY.getKey(), pairValue, BridgeSerializationUtils::serializeOneOffLockWhitelist);
+        bridgeStorageAccessor.safeSaveToRepository(LOCK_ONE_OFF.getKey(), pairValue, BridgeSerializationUtils::serializeOneOffLockWhitelist);
 
         if (activations.isActive(RSKIP87)) {
             List<UnlimitedWhiteListEntry> unlimitedEntries = lockWhitelist.getAll(UnlimitedWhiteListEntry.class);
-            bridgeStorageAccessor.safeSaveToRepository(LOCK_UNLIMITED_WHITELIST_KEY.getKey(), unlimitedEntries, BridgeSerializationUtils::serializeUnlimitedLockWhitelist);
+            bridgeStorageAccessor.safeSaveToRepository(LOCK_UNLIMITED.getKey(), unlimitedEntries, BridgeSerializationUtils::serializeUnlimitedLockWhitelist);
         }
     }
 
@@ -59,7 +59,7 @@ public class WhitelistStorageProviderImpl implements WhitelistStorageProvider {
 
     private LockWhitelist initializeLockWhitelist() {
         Pair<HashMap<Address, OneOffWhiteListEntry>, Integer> oneOffWhitelistAndDisableBlockHeightData =
-            bridgeStorageAccessor.safeGetFromRepository(LOCK_ONE_OFF_WHITELIST_KEY.getKey(),
+            bridgeStorageAccessor.safeGetFromRepository(LOCK_ONE_OFF.getKey(),
                 data -> BridgeSerializationUtils.deserializeOneOffLockWhitelistAndDisableBlockHeight(data, networkParameters));
 
         if (oneOffWhitelistAndDisableBlockHeightData == null) {
@@ -70,7 +70,7 @@ public class WhitelistStorageProviderImpl implements WhitelistStorageProvider {
         Map<Address, LockWhitelistEntry> whitelistedAddresses = new HashMap<>(oneOffWhitelistAndDisableBlockHeightData.getLeft());
 
         if (activations.isActive(RSKIP87)) {
-            whitelistedAddresses.putAll(bridgeStorageAccessor.safeGetFromRepository(LOCK_UNLIMITED_WHITELIST_KEY.getKey(),
+            whitelistedAddresses.putAll(bridgeStorageAccessor.safeGetFromRepository(LOCK_UNLIMITED.getKey(),
                     data -> BridgeSerializationUtils.deserializeUnlimitedLockWhitelistEntries(data, networkParameters)));
         }
 


### PR DESCRIPTION
## Description
Due to multiple storage keys being included in BridgeStorageIndexKey Enum, we need to refactor Whitelist logic to its package and classes, we should also create its own Enum with storage index keys.

Create a new enum called WhitelistStorageIndexKey under co.rsk.peg.whitelist package. Move from BridgeStorageIndexKey to WhitelistStorageIndexKey whitelist constants, and make the respective refactor related.

## Motivation and Context
This relates to the Bridge Refactor to decouple some objects tied closely to the Bridge.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
