### PR TITLE
Fix remaining broken tests

### DIFF
--- a/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/TransactionTest.java
@@ -21,6 +21,7 @@ package co.rsk.core;
 import co.rsk.config.TestSystemProperties;
 import co.rsk.peg.BridgeSupportFactory;
 import co.rsk.peg.RepositoryBtcBlockStoreWithCache;
+import co.rsk.peg.constants.BridgeMainNetConstants;
 import org.bouncycastle.util.BigIntegers;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.Constants;
@@ -448,6 +449,7 @@ class TransactionTest {
         Transaction txInBlock = new ImmutableTransaction(bytes);
 
         Constants constants = Mockito.mock(Constants.class);
+        Mockito.doReturn(BridgeMainNetConstants.getInstance()).when(constants).getBridgeConstants();
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         Mockito.doReturn(false).when(activations).isActive(ConsensusRule.RSKIP400);
 
@@ -460,6 +462,7 @@ class TransactionTest {
         Transaction txInBlock = new ImmutableTransaction(bytes);
 
         Constants constants = Mockito.mock(Constants.class);
+        Mockito.doReturn(BridgeMainNetConstants.getInstance()).when(constants).getBridgeConstants();
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         Mockito.doReturn(true).when(activations).isActive(ConsensusRule.RSKIP400);
 

--- a/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorIntrinsicGasLimitValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/txvalidator/TxValidatorIntrinsicGasLimitValidatorTest.java
@@ -42,9 +42,9 @@ import java.math.BigInteger;
 class TxValidatorIntrinsicGasLimitValidatorTest {
 
     private static final List<BtcECKey> REGTEST_FEDERATION_PRIVATE_KEYS = Arrays.asList(
-        BtcECKey.fromPrivate(Hex.decode("47129ffed2c0273c75d21bb8ba020073bb9a1638df0e04853407461fdd9e8b83")),
-        BtcECKey.fromPrivate(Hex.decode("9f72d27ba603cfab5a0201974a6783ca2476ec3d6b4e2625282c682e0e5f1c35")),
-        BtcECKey.fromPrivate(Hex.decode("e1b17fcd0ef1942465eee61b20561b16750191143d365e71de08b33dd84a9788"))
+        BtcECKey.fromPrivate(Hex.decode("45c5b07fc1a6f58892615b7c31dca6c96db58c4bbc538a6b8a22999aaa860c32")),
+        BtcECKey.fromPrivate(Hex.decode("505334c7745df2fc61486dffb900784505776a898377172ffa77384892749179")),
+        BtcECKey.fromPrivate(Hex.decode("bed0af2ce8aa8cb2bc3f9416c9d518fdee15d1ff15b8ded28376fcb23db6db69"))
     );
 
     private Constants constants;

--- a/rskj-core/src/test/java/org/ethereum/config/ConstantsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/ConstantsTest.java
@@ -29,8 +29,9 @@ import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.FederationTestUtils;
 import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.federation.constants.FederationTestNetConstants;
-import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
@@ -39,12 +40,13 @@ import org.junit.jupiter.api.Test;
 
 class ConstantsTest {
 
-    private static final List<BtcECKey> TEST_FED_KEYS = Arrays.asList(
-        BtcECKey.fromPublicOnly(Hex.decode("039a060badbeb24bee49eb2063f616c0f0f0765d4ca646b20a88ce828f259fcdb9")),
-        BtcECKey.fromPublicOnly(Hex.decode("02afc230c2d355b1a577682b07bc2646041b5d0177af0f98395a46018da699b6da")),
-        BtcECKey.fromPublicOnly(Hex.decode("0344a3c38cd59afcba3edcebe143e025574594b001700dec41e59409bdbd0f2a09")),
-        BtcECKey.fromPublicOnly(Hex.decode("034844a99cd7028aa319476674cc381df006628be71bc5593b8b5fdb32bb42ef85"))
-    );
+    private static final List<BtcECKey> GENESIS_FEDERATION_PUBLIC_KEYS_TESTNET = Stream.of(
+        "039a060badbeb24bee49eb2063f616c0f0f0765d4ca646b20a88ce828f259fcdb9",
+        "02afc230c2d355b1a577682b07bc2646041b5d0177af0f98395a46018da699b6da",
+        "0344a3c38cd59afcba3edcebe143e025574594b001700dec41e59409bdbd0f2a09",
+        "034844a99cd7028aa319476674cc381df006628be71bc5593b8b5fdb32bb42ef85",
+        "032de868a99cf955cc1f9bfe9a869a611ec64707e8ea10709dee52dbfc688626eb" // public key derived from "random" word seed
+    ).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
 
     private final ActivationConfig activationConfig = mock(ActivationConfig.class);
     private final ActivationConfig.ForBlock preRskip297Config = mock(ActivationConfig.ForBlock.class);
@@ -61,10 +63,11 @@ class ConstantsTest {
     void devnetWithFederationTest() {
         Federation genesisFederation = FederationTestUtils.getGenesisFederation(federationConstants);
 
-        assertThat(genesisFederation.hasBtcPublicKey(TEST_FED_KEYS.get(0)), is(true));
-        assertThat(genesisFederation.hasBtcPublicKey(TEST_FED_KEYS.get(1)), is(true));
-        assertThat(genesisFederation.hasBtcPublicKey(TEST_FED_KEYS.get(2)), is(true));
-        assertThat(genesisFederation.hasBtcPublicKey(TEST_FED_KEYS.get(3)), is(false));
+        assertThat(genesisFederation.hasBtcPublicKey(GENESIS_FEDERATION_PUBLIC_KEYS_TESTNET.get(0)), is(true));
+        assertThat(genesisFederation.hasBtcPublicKey(GENESIS_FEDERATION_PUBLIC_KEYS_TESTNET.get(1)), is(true));
+        assertThat(genesisFederation.hasBtcPublicKey(GENESIS_FEDERATION_PUBLIC_KEYS_TESTNET.get(2)), is(true));
+        assertThat(genesisFederation.hasBtcPublicKey(GENESIS_FEDERATION_PUBLIC_KEYS_TESTNET.get(3)), is(true));
+        assertThat(genesisFederation.hasBtcPublicKey(GENESIS_FEDERATION_PUBLIC_KEYS_TESTNET.get(4)), is(false));
     }
 
     @Test


### PR DESCRIPTION
Some tests outside /peg package were failing after the refactor.

This pr fixes them:
- `TransactionTest`, by adding a bridgeConstants mock response to avoid a npe.
- `TxValidatorIntrinsicGasLimitValidatorTest`, by using the regtest federation private keys being now used in regtest.
- `ConstantsTest`, by using the correct genesis federation public keys from `FederationTestNetConstants`.