### PR TITLE
Remove unrealistic test cases. Rename tag to be more accurate

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
@@ -161,7 +161,7 @@ class FederationSupportImplTest {
     }
 
     @Nested
-    @Tag("one null federation")
+    @Tag("null old federation, non null new federation")
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ActiveFederationTestsWithOneNullFederation {
         @BeforeAll
@@ -274,7 +274,6 @@ class FederationSupportImplTest {
 
         private Stream<Arguments> expectedSizeArgs() {
             return Stream.of(
-                Arguments.of(oldFederation, null, genesisFederation.getSize()),
                 Arguments.of(null, newFederation, newFederation.getSize())
             );
         }
@@ -292,7 +291,6 @@ class FederationSupportImplTest {
 
         private Stream<Arguments> expectedThresholdArgs() {
             return Stream.of(
-                Arguments.of(oldFederation, null, genesisFederation.getNumberOfSignaturesRequired()),
                 Arguments.of(null, newFederation, newFederation.getNumberOfSignaturesRequired())
             );
         }
@@ -310,7 +308,6 @@ class FederationSupportImplTest {
 
         private Stream<Arguments> expectedCreationTimeArgs() {
             return Stream.of(
-                Arguments.of(oldFederation, null, genesisFederation.getCreationTime()),
                 Arguments.of(null, newFederation, newFederation.getCreationTime())
             );
         }
@@ -328,7 +325,6 @@ class FederationSupportImplTest {
 
         private Stream<Arguments> expectedCreationBlockNumberArgs() {
             return Stream.of(
-                Arguments.of(oldFederation, null, genesisFederation.getCreationBlockNumber()),
                 Arguments.of(null, newFederation, newFederation.getCreationBlockNumber())
             );
         }

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
@@ -74,7 +74,7 @@ class FederationSupportImplTest {
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     @Tag("null federations")
     class ActiveFederationTestsWithNullFederations {
-        @BeforeAll
+        @BeforeEach
         void setUp() {
             StorageAccessor storageAccessor = new InMemoryStorage();
             storageProvider = new FederationStorageProviderImpl(storageAccessor);
@@ -164,7 +164,7 @@ class FederationSupportImplTest {
     @Tag("null old federation, non null new federation")
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ActiveFederationTestsWithNullOldFederation {
-        @BeforeAll
+        @BeforeEach
         void setUp() {
             StorageAccessor storageAccessor = new InMemoryStorage();
             storageProvider = new FederationStorageProviderImpl(storageAccessor);
@@ -265,38 +265,32 @@ class FederationSupportImplTest {
         // old federation should be active if we are before the activation block number
         // activation block number is smaller for hop than for fingerroot
 
+        // create old and new federations
+        long oldFederationCreationBlockNumber = 20;
+        long newFederationCreationBlockNumber = 65;
+        Federation oldFederation = new P2shErpFederationBuilder()
+            .withCreationBlockNumber(oldFederationCreationBlockNumber)
+            .build();
+        List<BtcECKey> newFederationKeys = BitcoinTestUtils.getBtcEcKeysFromSeeds(
+            new String[]{"fa01", "fa02", "fa03", "fa04", "fa05", "fa06", "fa07", "fa08", "fa09"}, true
+        );
+        Federation newFederation = new P2shErpFederationBuilder()
+            .withMembersBtcPublicKeys(newFederationKeys)
+            .withCreationBlockNumber(newFederationCreationBlockNumber)
+            .build();
+
+        // get block number activations for hop and fingerroot
         ActivationConfig.ForBlock hopActivations = ActivationConfigsForTest.hop400().forBlock(0);
-        long blockNumberFederationActivationHop;
+        long newFederationActivationAgeHop = federationMainnetConstants.getFederationActivationAge(hopActivations);
+        long blockNumberFederationActivationHop = newFederationCreationBlockNumber + newFederationActivationAgeHop;
         ActivationConfig.ForBlock fingerrootActivations = ActivationConfigsForTest.fingerroot500().forBlock(0);
-        long blockNumberFederationActivationFingerroot;
+        long newFederationActivationAgeFingerroot = federationMainnetConstants.getFederationActivationAge(fingerrootActivations);
+        long blockNumberFederationActivationFingerroot = newFederationCreationBlockNumber + newFederationActivationAgeFingerroot;
+
         FederationStorageProvider storageProvider;
 
-        @BeforeAll
+        @BeforeEach
         void setUp() {
-            long oldFederationCreationBlockNumber = 20;
-            long newFederationCreationBlockNumber = 65;
-
-            // get block number activation for hop
-            long newFederationActivationAgeHop = federationMainnetConstants.getFederationActivationAge(hopActivations);
-            blockNumberFederationActivationHop = newFederationCreationBlockNumber + newFederationActivationAgeHop;
-
-            // get block number activation for fingerroot
-            long newFederationActivationAgeFingerroot = federationMainnetConstants.getFederationActivationAge(fingerrootActivations);
-            blockNumberFederationActivationFingerroot = newFederationCreationBlockNumber + newFederationActivationAgeFingerroot;
-
-            // create old and new federations
-            P2shErpFederationBuilder p2shErpFederationBuilder = new P2shErpFederationBuilder();
-            oldFederation = p2shErpFederationBuilder
-                .withCreationBlockNumber(oldFederationCreationBlockNumber)
-                .build();
-            List<BtcECKey> newFederationKeys = BitcoinTestUtils.getBtcEcKeysFromSeeds(
-                new String[]{"fa01", "fa02", "fa03", "fa04", "fa05", "fa06", "fa07", "fa08", "fa09"}, true
-            );
-            newFederation = p2shErpFederationBuilder
-                .withMembersBtcPublicKeys(newFederationKeys)
-                .withCreationBlockNumber(newFederationCreationBlockNumber)
-                .build();
-
             // save federations in storage
             StorageAccessor storageAccessor = new InMemoryStorage();
             storageProvider = new FederationStorageProviderImpl(storageAccessor);

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
@@ -53,7 +53,6 @@ class FederationSupportImplTest {
 
     private static final FederationConstants federationMainnetConstants = FederationMainNetConstants.getInstance();
     private final Federation genesisFederation = FederationTestUtils.getGenesisFederation(federationMainnetConstants);
-    private Federation oldFederation;
     private Federation newFederation;
     private FederationStorageProvider storageProvider;
     private final FederationSupportBuilder federationSupportBuilder = new FederationSupportBuilder();


### PR DESCRIPTION
- Remove unrealistic test cases with non null `oldFederation` and null `newFederation`
- Rename the tag where these tests were removed to be more accurate

Also,
- Replace `BeforeAll` with `BeforeEach` for inner test classes to better align with unit tests practices.
This change required that the variables declared in the `setUp()` of the `ActiveFederationTestsWithNonNullFederations` class be made global, so they can be used by the method sources.