### PR TITLE
chore(snap): refactor code to use blocking queues with threads for SNAP messages processing

### DIFF
--- a/rskj-core/src/integrationTest/java/co/rsk/util/OkHttpClientTestFixture.java
+++ b/rskj-core/src/integrationTest/java/co/rsk/util/OkHttpClientTestFixture.java
@@ -30,10 +30,10 @@ import java.security.cert.X509Certificate;
 
 public class OkHttpClientTestFixture {
 
-    public static final String GET_BEST_BLOCK_CONTENT = "[{\n" +
+    public static final String GET_BLOCK_CONTENT = "[{\n" +
             "    \"method\": \"eth_getBlockByNumber\",\n" +
             "    \"params\": [\n" +
-            "        \"latest\",\n" +
+            "        \"<BLOCK_NUM_OR_TAG>\",\n" +
             "        true\n" +
             "    ],\n" +
             "    \"id\": 1,\n" +
@@ -94,11 +94,15 @@ public class OkHttpClientTestFixture {
     }
 
     public static Response sendJsonRpcGetBestBlockMessage(int port) throws IOException {
-        return sendJsonRpcMessage(GET_BEST_BLOCK_CONTENT, port);
+        return sendJsonRpcGetBlockMessage(port, "latest");
     }
 
-    public static JsonNode getJsonResponseForGetBestBlockMessage(int port) throws IOException {
-        Response response = sendJsonRpcGetBestBlockMessage(port);
+    public static Response sendJsonRpcGetBlockMessage(int port, String blockNumOrTag) throws IOException {
+        return sendJsonRpcMessage(GET_BLOCK_CONTENT.replace("<BLOCK_NUM_OR_TAG>", blockNumOrTag), port);
+    }
+
+    public static JsonNode getJsonResponseForGetBestBlockMessage(int port, String blockNumOrTag) throws IOException {
+        Response response = sendJsonRpcGetBlockMessage(port, blockNumOrTag);
         return new ObjectMapper().readTree(response.body().string());
     }
 }

--- a/rskj-core/src/integrationTest/java/co/rsk/util/cli/ConnectBlocksCommandLine.java
+++ b/rskj-core/src/integrationTest/java/co/rsk/util/cli/ConnectBlocksCommandLine.java
@@ -30,7 +30,7 @@ public class ConnectBlocksCommandLine extends RskjCommandLineBase {
 
     public ConnectBlocksCommandLine(String filePath, Path dbDir) {
         super("co.rsk.cli.tools.ConnectBlocks",
-                new String[]{},
+                new String[]{ "-Dlogging.dir=./build/tmp" },
                 makeArgs(filePath, dbDir));
     }
 

--- a/rskj-core/src/integrationTest/resources/snap-sync-client-rskj.conf
+++ b/rskj-core/src/integrationTest/resources/snap-sync-client-rskj.conf
@@ -70,9 +70,11 @@ rpc.providers.web.http.port=<CLIENT_RPC_HTTP_PORT>
 rpc.providers.web.ws.port=<CLIENT_RPC_WS_PORT>
 
 sync {
-  enabled = true
-  snapshot.enabled = true
-  snapshot.chunkSize = 200
-  snapshot.parallel = true
-  snapshot.limit = 20
+    enabled = true
+    snapshot.client = {
+        enabled = true
+        chunkSize = 200
+        parallel = true
+        limit = 2000
+    }
 }

--- a/rskj-core/src/integrationTest/resources/snap-sync-server-rskj.conf
+++ b/rskj-core/src/integrationTest/resources/snap-sync-server-rskj.conf
@@ -78,9 +78,6 @@ wallet {
 }
 
 sync {
-    enabled = false
-    snapshot.enabled = true
-    snapshot.chunkSize = 200
-    snapshot.parallel = true
-    snapshot.limit = 10
+    enabled = true
+    snapshot.server.enabled = true
 }

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1010,6 +1010,9 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         if (getRskSystemProperties().isSyncEnabled()) {
             internalServices.add(getSyncPool());
+            if (getSyncConfiguration().isServerSnapSyncEnabled()) {
+                internalServices.add(getSnapshotProcessor());
+            }
         }
 
         if (getRskSystemProperties().isMinerServerEnabled()) {
@@ -1464,7 +1467,8 @@ public class RskContext implements NodeContext, NodeBootstrapper {
                 rskSystemProperties.getMaxRequestedBodies(),
                 rskSystemProperties.getLongSyncLimit(),
                 rskSystemProperties.getTopBest(),
-                rskSystemProperties.isSnapshotSyncEnabled(),
+                rskSystemProperties.isServerSnapshotSyncEnabled(),
+                rskSystemProperties.isClientSnapshotSyncEnabled(),
                 rskSystemProperties.getSnapshotChunkTimeout(),
                 rskSystemProperties.getSnapshotSyncLimit());
     }

--- a/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
+++ b/rskj-core/src/main/java/co/rsk/config/RskSystemProperties.java
@@ -407,17 +407,18 @@ public class RskSystemProperties extends SystemProperties {
         return configFromFiles.getInt("sync.longSyncLimit");
     }
 
-    public boolean isSnapshotSyncEnabled() { return configFromFiles.getBoolean("sync.snapshot.enabled");}
+    public boolean isServerSnapshotSyncEnabled() { return configFromFiles.getBoolean("sync.snapshot.server.enabled");}
+    public boolean isClientSnapshotSyncEnabled() { return configFromFiles.getBoolean("sync.snapshot.client.enabled");}
 
     public int getSnapshotChunkTimeout() {
-        return configFromFiles.getInt("sync.snapshot.chunkRequestTimeout");
+        return configFromFiles.getInt("sync.snapshot.client.chunkRequestTimeout");
     }
 
-    public boolean isSnapshotParallelEnabled() { return configFromFiles.getBoolean("sync.snapshot.parallel");}
+    public boolean isSnapshotParallelEnabled() { return configFromFiles.getBoolean("sync.snapshot.client.parallel");}
 
-    public int getSnapshotChunkSize() { return configFromFiles.getInt("sync.snapshot.chunkSize");}
+    public int getSnapshotChunkSize() { return configFromFiles.getInt("sync.snapshot.client.chunkSize");}
 
-    public int getSnapshotSyncLimit() { return configFromFiles.getInt("sync.snapshot.limit");}
+    public int getSnapshotSyncLimit() { return configFromFiles.getInt("sync.snapshot.client.limit");}
 
     // its fixed, cannot be set by config file
     public int getChunkSize() {

--- a/rskj-core/src/main/java/co/rsk/net/SnapshotProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/SnapshotProcessor.java
@@ -21,10 +21,7 @@ package co.rsk.net;
 import co.rsk.config.InternalService;
 import co.rsk.core.BlockDifficulty;
 import co.rsk.net.messages.*;
-import co.rsk.net.sync.BlockConnectorHelper;
-import co.rsk.net.sync.PeersInformation;
-import co.rsk.net.sync.SnapSyncState;
-import co.rsk.net.sync.SyncMessageHandler;
+import co.rsk.net.sync.*;
 import co.rsk.trie.TrieDTO;
 import co.rsk.trie.TrieDTOInOrderIterator;
 import co.rsk.trie.TrieDTOInOrderRecoverer;
@@ -456,7 +453,7 @@ public class SnapshotProcessor implements InternalService {
         long from = 0;
         logger.debug("Generating chunk request tasks...");
         while (from < state.getRemoteTrieSize()) {
-            SnapSyncState.ChunkTask task = new SnapSyncState.ChunkTask(state.getLastBlock().getNumber(), from);
+            ChunkTask task = new ChunkTask(state.getLastBlock().getNumber(), from);
             state.getChunkTaskQueue().add(task);
             from += chunkSize * 1024L;
         }
@@ -471,9 +468,9 @@ public class SnapshotProcessor implements InternalService {
     }
 
     private void executeNextChunkRequestTask(SnapSyncState state, Peer peer) {
-        Queue<SnapSyncState.ChunkTask> taskQueue = state.getChunkTaskQueue();
+        Queue<ChunkTask> taskQueue = state.getChunkTaskQueue();
         if (!taskQueue.isEmpty()) {
-            SnapSyncState.ChunkTask task = taskQueue.poll();
+            ChunkTask task = taskQueue.poll();
 
             requestStateChunk(peer, task.getFrom(), task.getBlockNumber(), chunkSize);
         } else {

--- a/rskj-core/src/main/java/co/rsk/net/SyncProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/SyncProcessor.java
@@ -78,9 +78,6 @@ public class SyncProcessor implements SyncEventsHandler {
     private SyncState syncState;
     private long lastRequestId;
 
-    // TODO(snap-poc) tmp field until we can spot from DB (stateRoot?) if further Snap sync is required
-    private boolean snapSyncFinished;
-
     @VisibleForTesting
     public SyncProcessor(Blockchain blockchain,
                          BlockStore blockStore,
@@ -227,6 +224,18 @@ public class SyncProcessor implements SyncEventsHandler {
         }
     }
 
+    public void processSnapStatusResponse(Peer sender, SnapStatusResponseMessage responseMessage) {
+        syncState.onSnapStatus(sender, responseMessage);
+    }
+
+    public void processSnapBlocksResponse(Peer sender, SnapBlocksResponseMessage responseMessage) {
+        syncState.onSnapBlocks(sender, responseMessage);
+    }
+
+    public void processStateChunkResponse(Peer peer, SnapStateChunkResponseMessage responseMessage) {
+        syncState.onSnapStateChunk(peer, responseMessage);
+    }
+
     @Override
     public void sendSkeletonRequest(Peer peer, long height) {
         logger.debug("Send skeleton request to node {} height {}", peer.getPeerNodeID(), height);
@@ -280,19 +289,9 @@ public class SyncProcessor implements SyncEventsHandler {
     }
 
     @Override
-    public void startSnapSync(PeersInformation peers) {
-        logger.info("Start Snap syncing with #{} nodes", peers.getBestPeerCandidates());
-        setSyncState(new SnapSyncState(this, snapshotProcessor, syncConfiguration, peers));
-    }
-
-    @Override
-    public void snapSyncFinished() {
-        this.snapSyncFinished = true;
-    }
-
-    @Override
-    public boolean isSnapSyncFinished() {
-        return snapSyncFinished;
+    public void startSnapSync() {
+        logger.info("Start Snap syncing");
+        setSyncState(new SnapSyncState(this, snapshotProcessor, syncConfiguration));
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/net/messages/MessageVisitor.java
+++ b/rskj-core/src/main/java/co/rsk/net/messages/MessageVisitor.java
@@ -150,10 +150,6 @@ public class MessageVisitor {
         this.blockProcessor.processBlockHeadersRequest(sender, message.getId(), hash, count);
     }
 
-    public void apply(SnapStateChunkRequestMessage message) {
-        this.snapshotProcessor.processStateChunkRequest(sender, message);
-    }
-
     public void apply(BlockHashRequestMessage message) {
         this.blockProcessor.processBlockHashRequest(sender, message.getId(), message.getHeight());
     }
@@ -191,30 +187,34 @@ public class MessageVisitor {
         blockProcessor.processNewBlockHashesMessage(sender, message);
     }
 
-    public void apply(SnapStateChunkResponseMessage message) {
-        logger.debug("snapshot chunk response : {}", message.getId());
-        this.snapshotProcessor.processStateChunkResponse(sender, message);
-    }
-
     public void apply(SnapStatusRequestMessage message) {
         logger.debug("snapshot status request message apply");
-
-        this.snapshotProcessor.processSnapStatusRequest(sender);
+        this.snapshotProcessor.processSnapStatusRequest(sender, message);
     }
 
     public void apply(SnapStatusResponseMessage message)  {
         logger.debug("snapshot status response message apply blocks[{}] - trieSize[{}]", message.getBlocks().size(), message.getTrieSize());
-        this.snapshotProcessor.processSnapStatusResponse(sender, message);
+        this.syncProcessor.processSnapStatusResponse(sender, message);
     }
 
-    public void apply(SnapBlocksRequestMessage snapBlocksRequestMessage) {
-        logger.debug("snapshot blocks request message apply : {}", snapBlocksRequestMessage);
-        this.snapshotProcessor.processSnapBlocksRequest(sender, snapBlocksRequestMessage);
+    public void apply(SnapBlocksRequestMessage message) {
+        logger.debug("snapshot blocks request message apply : {}", message);
+        this.snapshotProcessor.processSnapBlocksRequest(sender, message);
     }
 
-    public void apply(SnapBlocksResponseMessage snapBlocksResponseMessage) {
-        logger.debug("snapshot blocks response message apply : {}", snapBlocksResponseMessage);
-        this.snapshotProcessor.processSnapBlocksResponse(sender, snapBlocksResponseMessage);
+    public void apply(SnapBlocksResponseMessage message) {
+        logger.debug("snapshot blocks response message apply : {}", message);
+        this.syncProcessor.processSnapBlocksResponse(sender, message);
+    }
+
+    public void apply(SnapStateChunkRequestMessage message) {
+        logger.debug("snapshot chunk request : {}", message.getId());
+        this.snapshotProcessor.processStateChunkRequest(sender, message);
+    }
+
+    public void apply(SnapStateChunkResponseMessage message) {
+        logger.debug("snapshot chunk response : {}", message.getId());
+        this.syncProcessor.processStateChunkResponse(sender, message);
     }
 
     public void apply(TransactionsMessage message) {

--- a/rskj-core/src/main/java/co/rsk/net/sync/BaseSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/BaseSyncState.java
@@ -19,6 +19,9 @@ package co.rsk.net.sync;
 
 import co.rsk.net.Peer;
 import co.rsk.net.messages.BodyResponseMessage;
+import co.rsk.net.messages.SnapBlocksResponseMessage;
+import co.rsk.net.messages.SnapStateChunkResponseMessage;
+import co.rsk.net.messages.SnapStatusResponseMessage;
 import com.google.common.annotations.VisibleForTesting;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.BlockIdentifier;
@@ -51,30 +54,34 @@ public abstract class BaseSyncState implements SyncState {
         }
     }
 
-    protected void onMessageTimeOut() {
-    }
+    protected void onMessageTimeOut() { /* empty */ }
 
     @Override
-    public void newBlockHeaders(List<BlockHeader> chunk) {
-    }
+    public void newBlockHeaders(List<BlockHeader> chunk) { /* empty */ }
 
     @Override
-    public void newBody(BodyResponseMessage message, Peer peer) {
-    }
+    public void newBody(BodyResponseMessage message, Peer peer) { /* empty */ }
 
     @Override
-    public void newConnectionPointData(byte[] hash) {
-    }
+    public void newConnectionPointData(byte[] hash) { /* empty */ }
 
     @Override
-    public void newPeerStatus() { }
+    public void newPeerStatus() { /* empty */ }
 
     @Override
-    public void newSkeleton(List<BlockIdentifier> skeleton, Peer peer) {
-    }
+    public void newSkeleton(List<BlockIdentifier> skeleton, Peer peer) { /* empty */ }
 
     @Override
-    public void onEnter() { }
+    public void onSnapStatus(Peer sender, SnapStatusResponseMessage responseMessage) { /* empty */ }
+
+    @Override
+    public void onSnapBlocks(Peer sender, SnapBlocksResponseMessage responseMessage) { /* empty */ }
+
+    @Override
+    public void onSnapStateChunk(Peer peer, SnapStateChunkResponseMessage responseMessage) { /* empty */ }
+
+    @Override
+    public void onEnter() { /* empty */ }
 
     @VisibleForTesting
     public void messageSent() {

--- a/rskj-core/src/main/java/co/rsk/net/sync/ChunkTask.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/ChunkTask.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2024 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.net.sync;
+
+public class ChunkTask {
+    private final long blockNumber;
+    private final long from;
+
+    public ChunkTask(long blockNumber, long from) {
+        this.blockNumber = blockNumber;
+        this.from = from;
+    }
+
+    public long getBlockNumber() {
+        return blockNumber;
+    }
+
+    public long getFrom() {
+        return from;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/net/sync/PeerAndModeDecidingSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/PeerAndModeDecidingSyncState.java
@@ -87,7 +87,7 @@ public class PeerAndModeDecidingSyncState extends BaseSyncState {
     }
 
     private boolean tryStartSnapshotSync() {
-        if (!syncConfiguration.isSnapSyncEnabled()) {
+        if (!syncConfiguration.isClientSnapSyncEnabled()) {
             logger.trace("Snap syncing disabled");
             return false;
         }
@@ -111,17 +111,11 @@ public class PeerAndModeDecidingSyncState extends BaseSyncState {
             return false;
         }
 
-        // TODO(snap-poc) tmp naive approach until we can spot from DB (stateRoot?) if further Snap sync is required
-        if (syncEventsHandler.isSnapSyncFinished()) {
-            logger.debug("Snap syncing not required (local state is ok)");
-            return false;
-        }
-
         // we consider Snap as part of the Long Sync
         syncEventsHandler.onLongSyncUpdate(true, peerBestBlockNumOpt.get());
 
         // send the LIST
-        syncEventsHandler.startSnapSync(peersInformation);
+        syncEventsHandler.startSnapSync();
         return true;
     }
 
@@ -170,7 +164,7 @@ public class PeerAndModeDecidingSyncState extends BaseSyncState {
 
     private boolean shouldSnapSync(long peerBestBlockNumber) {
         long distanceToTip = peerBestBlockNumber - blockStore.getBestBlock().getNumber();
-        return distanceToTip > syncConfiguration.getSnapshotSyncLimit() && syncConfiguration.isSnapSyncEnabled();
+        return distanceToTip > syncConfiguration.getSnapshotSyncLimit() && syncConfiguration.isClientSnapSyncEnabled();
     }
 
     private Optional<Long> getPeerBestBlockNumber(Peer peer) {

--- a/rskj-core/src/main/java/co/rsk/net/sync/SnapSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SnapSyncState.java
@@ -256,21 +256,5 @@ public class SnapSyncState extends BaseSyncState {
         isRunning = true;
     }
 
-    public static class ChunkTask {
-        private final long blockNumber;
-        private final long from;
 
-        public ChunkTask(long blockNumber, long from) {
-            this.blockNumber = blockNumber;
-            this.from = from;
-        }
-
-        public long getBlockNumber() {
-            return blockNumber;
-        }
-
-        public long getFrom() {
-            return from;
-        }
-    }
 }

--- a/rskj-core/src/main/java/co/rsk/net/sync/SyncConfiguration.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SyncConfiguration.java
@@ -25,10 +25,10 @@ import java.time.Duration;
 @Immutable
 public final class SyncConfiguration {
     @VisibleForTesting
-    public static final SyncConfiguration DEFAULT = new SyncConfiguration(5, 60, 30, 5, 20, 192, 20, 10, 0, false, 60, 0);
+    public static final SyncConfiguration DEFAULT = new SyncConfiguration(5, 60, 30, 5, 20, 192, 20, 10, 0, false, false, 60, 0);
 
     @VisibleForTesting
-    public static final SyncConfiguration IMMEDIATE_FOR_TESTING = new SyncConfiguration(1, 1, 3, 1, 5, 192, 20, 10, 0, false, 60, 0);
+    public static final SyncConfiguration IMMEDIATE_FOR_TESTING = new SyncConfiguration(1, 1, 3, 1, 5, 192, 20, 10, 0, false, false, 60, 0);
 
     private final int expectedPeers;
     private final Duration timeoutWaitingPeers;
@@ -39,7 +39,8 @@ public final class SyncConfiguration {
     private final int longSyncLimit;
     private final int maxRequestedBodies;
     private final double topBest;
-    private final boolean isSnapSyncEnabled;
+    private final boolean isServerSnapSyncEnabled;
+    private final boolean isClientSnapSyncEnabled;
 
     private final Duration timeoutWaitingSnapChunk;
 
@@ -55,9 +56,10 @@ public final class SyncConfiguration {
      * @param maxRequestedBodies       Amount of bodies to request at the same time when synchronizing backwards.
      * @param longSyncLimit            Distance to the tip of the peer's blockchain to enable long synchronization.
      * @param topBest                  % of top best nodes that  will be considered for random selection.
-     * @param isSnapSyncEnabled        flag to indicate if snap sync is enabled
-     * @param timeoutWaitingSnapChunk  specific request timeout for snap sync
-     * @param snapshotSyncLimit       Distance to the tip of the peer's blockchain to enable snap synchronization.
+     * @param isServerSnapSyncEnabled  Flag that indicates if server-side snap sync is enabled
+     * @param isClientSnapSyncEnabled  Flag that indicates if client-side snap sync is enabled
+     * @param timeoutWaitingSnapChunk  Specific request timeout for snap sync
+     * @param snapshotSyncLimit        Distance to the tip of the peer's blockchain to enable snap synchronization.
      */
     public SyncConfiguration(
             int expectedPeers,
@@ -69,7 +71,8 @@ public final class SyncConfiguration {
             int maxRequestedBodies,
             int longSyncLimit,
             double topBest,
-            boolean isSnapSyncEnabled,
+            boolean isServerSnapSyncEnabled,
+            boolean isClientSnapSyncEnabled,
             int timeoutWaitingSnapChunk, 
             int snapshotSyncLimit) {
         this.expectedPeers = expectedPeers;
@@ -81,7 +84,8 @@ public final class SyncConfiguration {
         this.maxRequestedBodies = maxRequestedBodies;
         this.longSyncLimit = longSyncLimit;
         this.topBest = topBest;
-        this.isSnapSyncEnabled = isSnapSyncEnabled;
+        this.isServerSnapSyncEnabled = isServerSnapSyncEnabled;
+        this.isClientSnapSyncEnabled = isClientSnapSyncEnabled;
         // TODO(snap-poc) re-visit the need of this specific timeout as the algorithm evolves
         this.timeoutWaitingSnapChunk = Duration.ofSeconds(timeoutWaitingSnapChunk);
         this.snapshotSyncLimit = snapshotSyncLimit;
@@ -123,8 +127,12 @@ public final class SyncConfiguration {
        return topBest;
     }
 
-    public boolean isSnapSyncEnabled() {
-        return isSnapSyncEnabled;
+    public boolean isServerSnapSyncEnabled() {
+        return isServerSnapSyncEnabled;
+    }
+
+    public boolean isClientSnapSyncEnabled() {
+        return isClientSnapSyncEnabled;
     }
 
     public Duration getTimeoutWaitingSnapChunk() {

--- a/rskj-core/src/main/java/co/rsk/net/sync/SyncEventsHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SyncEventsHandler.java
@@ -59,9 +59,5 @@ public interface SyncEventsHandler {
 
     void backwardSyncing(Peer peer);
 
-    void startSnapSync(PeersInformation peers);
-
-    void snapSyncFinished();
-
-    boolean isSnapSyncFinished();
+    void startSnapSync();
 }

--- a/rskj-core/src/main/java/co/rsk/net/sync/SyncMessageHandler.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SyncMessageHandler.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2024 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.net.sync;
+
+import co.rsk.net.Peer;
+import co.rsk.net.messages.Message;
+import co.rsk.util.FormatUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.BlockingQueue;
+
+public abstract class SyncMessageHandler implements Runnable {
+
+    private static final Logger logger = LoggerFactory.getLogger("syncprocessor");
+
+    private final String name;
+
+    private final BlockingQueue<Job> jobQueue;
+
+    protected SyncMessageHandler(String name, BlockingQueue<Job> jobQueue) {
+        this.name = name;
+        this.jobQueue = jobQueue;
+    }
+
+    public abstract boolean isRunning();
+
+    @Override
+    public void run() {
+        logger.debug("Starting processing queue of messages for: [{}]", name);
+
+        Job job = null;
+        Instant jobStart = Instant.MIN;
+        while (isRunning()) {
+            try {
+                job = jobQueue.take();
+
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Processing msg: [{}] from: [{}] for: [{}]", job.getMsg().getMessageType(), job.getSender(), name);
+                    jobStart = Instant.now();
+                }
+
+                job.run();
+
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Finished processing of msg: [{}] from: [{}] for: [{}] after [{}] seconds.",
+                            job.getMsg().getMessageType(), job.getSender(), name,
+                            FormatUtils.formatNanosecondsToSeconds(Duration.between(jobStart, Instant.now()).toNanos()));
+                }
+            } catch (InterruptedException e) {
+                logger.warn("Queue processing was interrupted for: [{}]", name, e);
+            } catch (Exception e) {
+                logger.error("Unexpected error processing msg: '[{}]' for: [{}]", job, name, e);
+            }
+        }
+
+        logger.debug("Finished processing queue of messages for: [{}]", name);
+    }
+
+    public static abstract class Job implements Runnable {
+        private final Peer sender;
+
+        private final Message msg;
+
+        public Job(Peer sender, Message msg) {
+            this.sender = sender;
+            this.msg = msg;
+        }
+
+        public Peer getSender() {
+            return sender;
+        }
+
+        public Message getMsg() {
+            return msg;
+        }
+
+        @Override
+        public String toString() {
+            return "SyncMessageHandler{" +
+                    "sender=" + sender +
+                    ", msgType=" + msg.getMessageType() +
+                    '}';
+        }
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/net/sync/SyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SyncState.java
@@ -19,6 +19,9 @@ package co.rsk.net.sync;
 
 import co.rsk.net.Peer;
 import co.rsk.net.messages.BodyResponseMessage;
+import co.rsk.net.messages.SnapBlocksResponseMessage;
+import co.rsk.net.messages.SnapStateChunkResponseMessage;
+import co.rsk.net.messages.SnapStatusResponseMessage;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.BlockIdentifier;
 
@@ -39,6 +42,12 @@ public interface SyncState {
     void newPeerStatus();
 
     void newSkeleton(List<BlockIdentifier> skeletonChunk, Peer peer);
+
+    void onSnapStatus(Peer sender, SnapStatusResponseMessage responseMessage);
+
+    void onSnapBlocks(Peer sender, SnapBlocksResponseMessage responseMessage);
+
+    void onSnapStateChunk(Peer peer, SnapStateChunkResponseMessage responseMessage);
 
     void onEnter();
 

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -252,11 +252,16 @@ sync = {
     waitForSync = <bool>
     topBest = <percentage number>
     snapshot = {
-        enabled = <bool>
-        parallel = <bool>
-        chunkSize = <chunkSize>
-        chunkRequestTimeout = <chunkRequestTimeout>
-        limit = <limit>
+        server = {
+            enabled = <bool>
+        }
+        client = {
+            enabled = <bool>
+            parallel = <bool>
+            chunkSize = <chunkSize>
+            chunkRequestTimeout = <chunkRequestTimeout>
+            limit = <limit>
+        }
     }
 }
 rpc = {

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -333,17 +333,24 @@ sync {
     # X % of top best nodes will be considered when for random selection
     topBest = 0
 
+    # (experimental, OFF by default for both client and server)
     snapshot = {
-        # Client / snapshot sync enabled (Server is always enabled)
-        enabled = false
-        # Server / chunk size
-        chunkSize = 100
-        # Request timeout
-        chunkRequestTimeout = 120
-        # Distance to the tip of the blockchain to start snapshot sync
-        limit = 1000000
-        # Parallel requests (true, false
-        parallel = false
+        server = {
+            # Server / snapshot sync enabled
+            enabled = false
+        }
+        client = {
+            # Client / snapshot sync enabled
+            enabled = false
+            # Server / chunk size
+            chunkSize = 100
+            # Request timeout (in seconds)
+            chunkRequestTimeout = 120
+            # Distance to the tip of the blockchain to start snapshot sync
+            limit = 1000000
+            # Parallel requests (true, false
+            parallel = false
+        }
     }
 }
 

--- a/rskj-core/src/test/java/co/rsk/net/SnapshotProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/SnapshotProcessorTest.java
@@ -231,10 +231,7 @@ public class SnapshotProcessorTest {
         Peer peer = mock(Peer.class);
         SnapStatusRequestMessage msg = mock(SnapStatusRequestMessage.class);
         CountDownLatch latch = new CountDownLatch(2);
-        doAnswer(invocation -> {
-            latch.countDown();
-            return null;
-        }).when(listener).onQueueEmpty();
+        doCountDownOnQueueEmpty(listener, latch);
         underTest = new SnapshotProcessor(
                 blockchain,
                 trieStore,
@@ -270,10 +267,7 @@ public class SnapshotProcessorTest {
         Peer peer = mock(Peer.class);
         SnapBlocksRequestMessage msg = mock(SnapBlocksRequestMessage.class);
         CountDownLatch latch = new CountDownLatch(2);
-        doAnswer(invocation -> {
-            latch.countDown();
-            return null;
-        }).when(listener).onQueueEmpty();
+        doCountDownOnQueueEmpty(listener, latch);
         underTest = new SnapshotProcessor(
                 blockchain,
                 trieStore,
@@ -309,10 +303,7 @@ public class SnapshotProcessorTest {
         Peer peer = mock(Peer.class);
         SnapStateChunkRequestMessage msg = mock(SnapStateChunkRequestMessage.class);
         CountDownLatch latch = new CountDownLatch(2);
-        doAnswer(invocation -> {
-            latch.countDown();
-            return null;
-        }).when(listener).onQueueEmpty();
+        doCountDownOnQueueEmpty(listener, latch);
         underTest = new SnapshotProcessor(
                 blockchain,
                 trieStore,
@@ -359,4 +350,10 @@ public class SnapshotProcessorTest {
         return mockedPeer;
     }
 
+    private static void doCountDownOnQueueEmpty(SyncMessageHandler.Listener listener, CountDownLatch latch) {
+        doAnswer(invocation -> {
+            latch.countDown();
+            return null;
+        }).when(listener).onQueueEmpty();
+    }
 }

--- a/rskj-core/src/test/java/co/rsk/net/ThreeAsyncNodeUsingSyncProcessorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/ThreeAsyncNodeUsingSyncProcessorTest.java
@@ -190,7 +190,7 @@ class ThreeAsyncNodeUsingSyncProcessorTest {
 
         SimpleAsyncNode node1 = SimpleAsyncNode.createDefaultNode(b1);
         SimpleAsyncNode node2 = SimpleAsyncNode.createDefaultNode(b1);
-        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192, 20, 10, 0, false, 60, 0);
+        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192, 20, 10, 0, false, false, 60, 0);
         SimpleAsyncNode node3 = SimpleAsyncNode.createNode(b2, syncConfiguration);
 
         Assertions.assertEquals(50, node1.getBestBlock().getNumber());
@@ -231,7 +231,7 @@ class ThreeAsyncNodeUsingSyncProcessorTest {
 
         SimpleAsyncNode node1 = SimpleAsyncNode.createDefaultNode(b1);
         SimpleAsyncNode node2 = SimpleAsyncNode.createDefaultNode(b1);
-        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192, 20, 10, 0, false, 60, 0);
+        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192, 20, 10, 0, false, false, 60, 0);
         SimpleAsyncNode node3 = SimpleAsyncNode.createNode(b2, syncConfiguration);
 
         Assertions.assertEquals(200, node1.getBestBlock().getNumber());
@@ -272,7 +272,7 @@ class ThreeAsyncNodeUsingSyncProcessorTest {
 
         SimpleAsyncNode node1 = SimpleAsyncNode.createDefaultNode(b1);
         SimpleAsyncNode node2 = SimpleAsyncNode.createDefaultNode(b1);
-        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,0,1,20,192, 20, 10, 0, false, 60, 0);
+        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,0,1,20,192, 20, 10, 0, false, false, 60, 0);
         SimpleAsyncNode node3 = SimpleAsyncNode.createNode(b2, syncConfiguration);
 
         Assertions.assertEquals(200, node1.getBestBlock().getNumber());
@@ -319,7 +319,7 @@ class ThreeAsyncNodeUsingSyncProcessorTest {
 
         SimpleAsyncNode node1 = SimpleAsyncNode.createDefaultNode(b1);
         SimpleAsyncNode node2 = SimpleAsyncNode.createDefaultNode(b2);
-        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192, 20, 10, 0, false, 60, 0);
+        SyncConfiguration syncConfiguration = new SyncConfiguration(2,1,1,1,20,192, 20, 10, 0, false, false, 60, 0);
         SimpleAsyncNode node3 = SimpleAsyncNode.createNode(b3, syncConfiguration);
 
         Assertions.assertEquals(193, node1.getBestBlock().getNumber());
@@ -363,7 +363,7 @@ class ThreeAsyncNodeUsingSyncProcessorTest {
         SimpleAsyncNode node1 = SimpleAsyncNode.createDefaultNode(b2);
         SimpleAsyncNode node2 = SimpleAsyncNode.createDefaultNode(b2);
         SimpleAsyncNode node3 = SimpleAsyncNode.createDefaultNode(b3);
-        SyncConfiguration syncConfiguration = new SyncConfiguration(3,1,10,100,20,192, 20, 10, 0, false, 60, 0);
+        SyncConfiguration syncConfiguration = new SyncConfiguration(3,1,10,100,20,192, 20, 10, 0, false, false, 60, 0);
         SimpleAsyncNode node4 = SimpleAsyncNode.createNode(b1, syncConfiguration);
 
         Assertions.assertEquals(200, node1.getBestBlock().getNumber());

--- a/rskj-core/src/test/java/co/rsk/net/sync/SimpleSyncEventsHandler.java
+++ b/rskj-core/src/test/java/co/rsk/net/sync/SimpleSyncEventsHandler.java
@@ -104,20 +104,6 @@ public class SimpleSyncEventsHandler implements SyncEventsHandler {
         return stopSyncingWasCalled_;
     }
 
-
     @Override
-    public void startSnapSync(PeersInformation peers) {
-
-    }
-
-    @Override
-    public void snapSyncFinished() {
-
-    }
-
-    @Override
-    public boolean isSnapSyncFinished() {
-        return false;
-    }
-
+    public void startSnapSync() { }
 }

--- a/rskj-core/src/test/java/co/rsk/net/sync/SnapSyncStateTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/sync/SnapSyncStateTest.java
@@ -159,10 +159,7 @@ class SnapSyncStateTest {
         Peer peer = mock(Peer.class);
         SnapStatusResponseMessage msg = mock(SnapStatusResponseMessage.class);
         CountDownLatch latch = new CountDownLatch(1);
-        doAnswer(invocation -> {
-            latch.countDown();
-            return null;
-        }).when(listener).onQueueEmpty();
+        doCountDownOnQueueEmpty(listener, latch);
         underTest.onEnter();
 
         //when
@@ -184,10 +181,7 @@ class SnapSyncStateTest {
         Peer peer = mock(Peer.class);
         SnapBlocksResponseMessage msg = mock(SnapBlocksResponseMessage.class);
         CountDownLatch latch = new CountDownLatch(1);
-        doAnswer(invocation -> {
-            latch.countDown();
-            return null;
-        }).when(listener).onQueueEmpty();
+        doCountDownOnQueueEmpty(listener, latch);
         underTest.onEnter();
 
         //when
@@ -209,10 +203,7 @@ class SnapSyncStateTest {
         Peer peer = mock(Peer.class);
         SnapStateChunkResponseMessage msg = mock(SnapStateChunkResponseMessage.class);
         CountDownLatch latch = new CountDownLatch(1);
-        doAnswer(invocation -> {
-            latch.countDown();
-            return null;
-        }).when(listener).onQueueEmpty();
+        doCountDownOnQueueEmpty(listener, latch);
         underTest.onEnter();
 
         //when
@@ -226,5 +217,12 @@ class SnapSyncStateTest {
 
         assertEquals(peer, jobArg.getValue().getSender());
         assertEquals(msg, jobArg.getValue().getMsg());
+    }
+
+    private static void doCountDownOnQueueEmpty(SyncMessageHandler.Listener listener, CountDownLatch latch) {
+        doAnswer(invocation -> {
+            latch.countDown();
+            return null;
+        }).when(listener).onQueueEmpty();
     }
 }

--- a/rskj-core/src/test/java/co/rsk/net/sync/SyncMessageHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/sync/SyncMessageHandlerTest.java
@@ -1,0 +1,146 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2024 RSK Labs Ltd.
+ * (derived from ethereumJ library, Copyright (c) 2016 <ether.camp>)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.net.sync;
+
+import co.rsk.net.Peer;
+import co.rsk.net.messages.Message;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+class SyncMessageHandlerTest {
+
+    private static final long THREAD_JOIN_TIMEOUT = 10_000; // 10 secs
+
+    private BlockingQueue<SyncMessageHandler.Job> jobQueue;
+    private Thread thread;
+    private volatile Boolean isRunning;
+
+    private final SyncMessageHandler.Listener listener = mock(SyncMessageHandler.Listener.class);
+
+    @BeforeEach
+    void setUp() {
+        jobQueue = new LinkedBlockingQueue<>();
+        thread = new Thread(new SyncMessageHandler("SNAP requests", jobQueue, listener) {
+
+            @Override
+            public boolean isRunning() {
+                return isRunning;
+            }
+        }, "snap sync request handler");
+    }
+
+    @Test
+    void run_processOneJob() throws InterruptedException {
+        //given
+        final AtomicBoolean jobCalled = new AtomicBoolean();
+
+        isRunning = Boolean.TRUE;
+        doAnswer(invocation -> {
+            isRunning = Boolean.FALSE;
+            return null;
+        }).when(listener).onQueueEmpty();
+
+        thread.start();
+
+        //when
+        jobQueue.put(new SyncMessageHandler.Job(mock(Peer.class), mock(Message.class)) {
+            @Override
+            public void run() {
+                jobCalled.set(true);
+            }
+        });
+
+        //then
+        thread.join(THREAD_JOIN_TIMEOUT);
+
+        assertTrue(jobCalled.get());
+        verify(listener, times(1)).onStart();
+        verify(listener, times(1)).onQueueEmpty();
+        verify(listener, never()).onInterrupted();
+        verify(listener, never()).onException(any());
+        verify(listener, times(1)).onComplete();
+    }
+
+    @Test
+    void run_processSuccessfulJobAfterFailedOne() throws InterruptedException {
+        //given
+        final AtomicBoolean jobCalled = new AtomicBoolean();
+        RuntimeException exception = new RuntimeException("Failed job");
+
+        isRunning = Boolean.TRUE;
+        doAnswer(invocation -> {
+            isRunning = Boolean.FALSE;
+            return null;
+        }).when(listener).onQueueEmpty();
+
+        thread.start();
+
+        //when
+        jobQueue.put(new SyncMessageHandler.Job(mock(Peer.class), mock(Message.class)) {
+            @Override
+            public void run() {
+                throw exception;
+            }
+        });
+        jobQueue.put(new SyncMessageHandler.Job(mock(Peer.class), mock(Message.class)) {
+            @Override
+            public void run() {
+                jobCalled.set(true);
+            }
+        });
+
+        //then
+        thread.join(THREAD_JOIN_TIMEOUT);
+
+        assertTrue(jobCalled.get());
+        verify(listener, times(1)).onStart();
+        verify(listener, times(1)).onQueueEmpty();
+        verify(listener, never()).onInterrupted();
+        verify(listener, times(1)).onException(exception);
+        verify(listener, times(1)).onComplete();
+    }
+
+    @Test
+    void run_processIsInterrupted() throws InterruptedException {
+        //given-when
+        isRunning = Boolean.TRUE;
+        doAnswer(invocation -> {
+            new Thread(() -> thread.interrupt()).start();
+            return null;
+        }).when(listener).onStart();
+
+        thread.start();
+
+        //then
+        thread.join(THREAD_JOIN_TIMEOUT);
+
+        verify(listener, times(1)).onStart();
+        verify(listener, times(0)).onQueueEmpty();
+        verify(listener, times(1)).onInterrupted();
+        verify(listener, never()).onException(any());
+        verify(listener, times(1)).onComplete();
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
changes:
- client SNAP sync state migrated from `SnapshotProcessor` to `SnapSyncState`
- processing of SNAP requests and responses is being queued in appropriate blocking queue and then executed in a dedicated thread 
- now there are two separate snap configs for client and server
- updated a bit snap integration test

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
