### PR TITLE
Add getRetiringFederatorBtcPublicKey tests

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -852,7 +852,7 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         logger.trace("getRetiringFederatorPublicKey");
 
         int index = ((BigInteger) args[0]).intValue();
-        byte[] publicKey = bridgeSupport.getRetiringFederatorPublicKey(index);
+        byte[] publicKey = bridgeSupport.getRetiringFederatorBtcPublicKey(index);
 
         if (publicKey == null) {
             // Empty array is returned when public key is not found or there's no retiring federation

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1955,8 +1955,8 @@ public class BridgeSupport {
      * @param index the retiring federator's index (zero-based)
      * @return the retiring federator's public key, null if no retiring federation exists
      */
-    public byte[] getRetiringFederatorPublicKey(int index) {
-        return federationSupport.getRetiringFederatorPublicKey(index);
+    public byte[] getRetiringFederatorBtcPublicKey(int index) {
+        return federationSupport.getRetiringFederatorBtcPublicKey(index);
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupport.java
@@ -36,7 +36,7 @@ public interface FederationSupport {
     int getRetiringFederationThreshold();
     Instant getRetiringFederationCreationTime();
     long getRetiringFederationCreationBlockNumber();
-    byte[] getRetiringFederatorPublicKey(int index);
+    byte[] getRetiringFederatorBtcPublicKey(int index);
     byte[] getRetiringFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType);
     List<UTXO> getRetiringFederationBtcUTXOs();
 

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupportImpl.java
@@ -276,7 +276,7 @@ public class FederationSupportImpl implements FederationSupport {
     }
 
     @Override
-    public byte[] getRetiringFederatorPublicKey(int index) {
+    public byte[] getRetiringFederatorBtcPublicKey(int index) {
         Federation retiringFederation = getRetiringFederation();
         if (retiringFederation == null) {
             return null;

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
@@ -2191,7 +2191,7 @@ public class BridgeSupportTestIntegration {
 
         assertEquals(-1, bridgeSupport.getRetiringFederationSize().intValue());
         assertEquals(-1, bridgeSupport.getRetiringFederationThreshold().intValue());
-        assertNull(bridgeSupport.getRetiringFederatorPublicKey(0));
+        assertNull(bridgeSupport.getRetiringFederatorBtcPublicKey(0));
         assertNull(bridgeSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC));
         assertNull(bridgeSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK));
         assertNull(bridgeSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.MST));
@@ -2235,7 +2235,7 @@ public class BridgeSupportTestIntegration {
 
         assertEquals(-1, bridgeSupport.getRetiringFederationSize().intValue());
         assertEquals(-1, bridgeSupport.getRetiringFederationThreshold().intValue());
-        assertNull(bridgeSupport.getRetiringFederatorPublicKey(0));
+        assertNull(bridgeSupport.getRetiringFederatorBtcPublicKey(0));
         assertNull(bridgeSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC));
         assertNull(bridgeSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK));
         assertNull(bridgeSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.MST));
@@ -2285,7 +2285,7 @@ public class BridgeSupportTestIntegration {
         assertEquals(mockedOldFederation.getAddress().toString(), bridgeSupport.getRetiringFederationAddress().toString());
         List<FederationMember> members = FederationTestUtils.getFederationMembers(4);
         for (int i = 0; i < 4; i++) {
-            assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getRetiringFederatorPublicKey(i)));
+            assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getRetiringFederatorBtcPublicKey(i)));
             assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
             assertTrue(Arrays.equals(members.get(i).getRskPublicKey().getPubKey(true), bridgeSupport.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
             assertTrue(Arrays.equals(members.get(i).getMstPublicKey().getPubKey(true), bridgeSupport.getRetiringFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -2154,7 +2154,7 @@ class BridgeTest {
             assertThrows(VMException.class, () -> bridge.execute(data));
         } else {
             bridge.execute(data);
-            verify(bridgeSupportMock, times(1)).getRetiringFederatorPublicKey(federatorIndex);
+            verify(bridgeSupportMock, times(1)).getRetiringFederatorBtcPublicKey(federatorIndex);
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTestIntegration.java
@@ -1784,7 +1784,7 @@ public class BridgeTestIntegration {
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         when(bridgeSupportFactoryMock.newInstance(any(), any(), any(), any())).thenReturn(bridgeSupportMock);
-        when(bridgeSupportMock.getRetiringFederatorPublicKey(any(int.class))).then((InvocationOnMock invocation) ->
+        when(bridgeSupportMock.getRetiringFederatorBtcPublicKey(any(int.class))).then((InvocationOnMock invocation) ->
                 BigInteger.valueOf(invocation.<Integer>getArgument(0)).toByteArray());
         bridge.init(mock(Transaction.class), getGenesisBlock(), createRepository().startTracking(), null, null, null);
 
@@ -1820,7 +1820,7 @@ public class BridgeTestIntegration {
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
 
         Assertions.assertNull(bridge.execute(BridgeMethods.GET_RETIRING_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(10)})));
-        verify(bridgeSupportMock, never()).getRetiringFederatorPublicKey(any(int.class));
+        verify(bridgeSupportMock, never()).getRetiringFederatorBtcPublicKey(any(int.class));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
@@ -1204,7 +1204,7 @@ class FederationSupportImplTest {
         }
 
         @ParameterizedTest
-        @Tag("getRetiringFederationCreationBlockNumber")
+        @Tag("getRetiringFederatorBtcPublicKey")
         @MethodSource("newFederationNotActiveActivationArgs")
         void getRetiringFederatorBtcPublicKey_withNewFederationNotActive_returnsNull(
             long currentBlock,

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
@@ -1227,7 +1227,7 @@ class FederationSupportImplTest {
         @ParameterizedTest
         @Tag("getRetiringFederatorBtcPublicKey")
         @MethodSource("newFederationActiveActivationArgs")
-        void getRetiringFederatorBtcPublicKey_withNewFederationActive_returnsOldFederationBtcPublicKey(
+        void getRetiringFederatorBtcPublicKey_withNewFederationActive_returnsFederatorFromOldFederationBtcPublicKey(
             long currentBlock,
             ActivationConfig.ForBlock activations) {
 
@@ -1285,7 +1285,7 @@ class FederationSupportImplTest {
                 int retiringFederationSize = oldFederation.getSize();
                 assertThrows(
                 IndexOutOfBoundsException.class, () ->
-                    federationSupport.getActiveFederatorBtcPublicKey(retiringFederationSize)
+                    federationSupport.getRetiringFederatorBtcPublicKey(retiringFederationSize)
             );
         }
 

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
@@ -1248,7 +1248,7 @@ class FederationSupportImplTest {
         @ParameterizedTest
         @Tag("getRetiringFederatorBtcPublicKey")
         @MethodSource("newFederationActiveActivationArgs")
-        void getRetiringFederatorBtcPublicKey_withNegativeIndex_throwsIndexOutOfBoundsException(
+        void getRetiringFederatorBtcPublicKey_withNewFederationActiveAndNegativeIndex_throwsIndexOutOfBoundsException(
             long currentBlock,
             ActivationConfig.ForBlock activations) {
 
@@ -1268,7 +1268,7 @@ class FederationSupportImplTest {
         @ParameterizedTest
         @Tag("getRetiringFederatorBtcPublicKey")
         @MethodSource("newFederationActiveActivationArgs")
-        void getRetiringFederatorBtcPublicKey_withIndexGreaterThanRetiringFederationSize_throwsIndexOutOfBoundsException(
+        void getRetiringFederatorBtcPublicKey_withNewFederationActiveAndIndexGreaterThanRetiringFederationSize_throwsIndexOutOfBoundsException(
             long currentBlock,
             ActivationConfig.ForBlock activations) {
 


### PR DESCRIPTION
- Add `getRetiringFederatorBtcPublicKey` tests
- Rename `getRetiringFederatorPublicKey` to `getRetiringFederatorBtcPublicKey` in `FederationSupport` and in `BridgeSupport` to be more accurate with what the method does