### PR TITLE
Add getPendingFederatorBtcPublicKey tests

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -995,7 +995,7 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         logger.trace("getPendingFederatorPublicKey");
 
         int index = ((BigInteger) args[0]).intValue();
-        byte[] publicKey = bridgeSupport.getPendingFederatorPublicKey(index);
+        byte[] publicKey = bridgeSupport.getPendingFederatorBtcPublicKey(index);
 
         if (publicKey == null) {
             // Empty array is returned when public key is not found

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -2027,8 +2027,8 @@ public class BridgeSupport {
      * @param index the federator's index (zero-based)
      * @return the pending federation's federator public key
      */
-    public byte[] getPendingFederatorPublicKey(int index) {
-        return federationSupport.getPendingFederatorPublicKey(index);
+    public byte[] getPendingFederatorBtcPublicKey(int index) {
+        return federationSupport.getPendingFederatorBtcPublicKey(index);
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupport.java
@@ -44,7 +44,7 @@ public interface FederationSupport {
 
     Keccak256 getPendingFederationHash();
     int getPendingFederationSize();
-    byte[] getPendingFederatorPublicKey(int index);
+    byte[] getPendingFederatorBtcPublicKey(int index);
     byte[] getPendingFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType);
 
     int voteFederationChange(Transaction tx, ABICallSpec callSpec, SignatureCache signatureCache, BridgeEventLogger eventLogger);

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupportImpl.java
@@ -355,10 +355,6 @@ public class FederationSupportImpl implements FederationSupport {
 
         List<BtcECKey> publicKeys = currentPendingFederation.getBtcPublicKeys();
 
-        if (index < 0 || index >= publicKeys.size()) {
-            throw new IndexOutOfBoundsException(String.format("Federator index must be between 0 and %d", publicKeys.size() - 1));
-        }
-
         return publicKeys.get(index).getPubKey();
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupportImpl.java
@@ -346,7 +346,7 @@ public class FederationSupportImpl implements FederationSupport {
     }
 
     @Override
-    public byte[] getPendingFederatorPublicKey(int index) {
+    public byte[] getPendingFederatorBtcPublicKey(int index) {
         PendingFederation currentPendingFederation = getPendingFederation();
 
         if (currentPendingFederation == null) {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
@@ -2297,7 +2297,7 @@ public class BridgeSupportTestIntegration {
         BridgeSupport bridgeSupport = getBridgeSupportWithMocksForFederationTests(false, null, null, null, null, null, null);
 
         assertEquals(-1, bridgeSupport.getPendingFederationSize().intValue());
-        assertNull(bridgeSupport.getPendingFederatorPublicKey(0));
+        assertNull(bridgeSupport.getPendingFederatorBtcPublicKey(0));
         assertNull(bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC));
         assertNull(bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK));
         assertNull(bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.MST));
@@ -2311,7 +2311,7 @@ public class BridgeSupportTestIntegration {
         assertEquals(5, bridgeSupport.getPendingFederationSize().intValue());
         List<FederationMember> members = FederationTestUtils.getFederationMembers(5);
         for (int i = 0; i < 5; i++) {
-            assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getPendingFederatorPublicKey(i)));
+            assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getPendingFederatorBtcPublicKey(i)));
             assertTrue(Arrays.equals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getPendingFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC)));
             assertTrue(Arrays.equals(members.get(i).getRskPublicKey().getPubKey(true), bridgeSupport.getPendingFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK)));
             assertTrue(Arrays.equals(members.get(i).getMstPublicKey().getPubKey(true), bridgeSupport.getPendingFederatorPublicKeyOfType(i, FederationMember.KeyType.MST)));
@@ -2592,7 +2592,7 @@ public class BridgeSupportTestIntegration {
         mocksProvider.setWinner(mocksProvider.getSpec());
         assertEquals(1, mocksProvider.execute(bridgeSupport));
         assertEquals(1, bridgeSupport.getPendingFederationSize().intValue());
-        assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKey(0)));
+        assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorBtcPublicKey(0)));
         assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC)));
         assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK)));
         assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.MST)));
@@ -2630,12 +2630,12 @@ public class BridgeSupportTestIntegration {
         mocksProvider.setWinner(mocksProvider.getSpec());
         assertEquals(1, mocksProvider.execute(bridgeSupport));
         assertEquals(2, bridgeSupport.getPendingFederationSize().intValue());
-        assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKey(0)));
+        assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorBtcPublicKey(0)));
         assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC)));
         assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK)));
         assertTrue(Arrays.equals(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5"), bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.MST)));
 
-        assertTrue(Arrays.equals(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a"), bridgeSupport.getPendingFederatorPublicKey(1)));
+        assertTrue(Arrays.equals(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a"), bridgeSupport.getPendingFederatorBtcPublicKey(1)));
         assertTrue(Arrays.equals(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a"), bridgeSupport.getPendingFederatorPublicKeyOfType(1, FederationMember.KeyType.BTC)));
         assertTrue(Arrays.equals(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a"), bridgeSupport.getPendingFederatorPublicKeyOfType(1, FederationMember.KeyType.RSK)));
         assertTrue(Arrays.equals(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a"), bridgeSupport.getPendingFederatorPublicKeyOfType(1, FederationMember.KeyType.MST)));

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -1950,7 +1950,7 @@ class BridgeTest {
             assertThrows(VMException.class, () -> bridge.execute(data));
         } else {
             bridge.execute(data);
-            verify(bridgeSupportMock, times(1)).getPendingFederatorPublicKey(federatorIndex);
+            verify(bridgeSupportMock, times(1)).getPendingFederatorBtcPublicKey(federatorIndex);
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTestIntegration.java
@@ -1905,7 +1905,7 @@ public class BridgeTestIntegration {
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         when(bridgeSupportFactoryMock.newInstance(any(), any(), any(), any())).thenReturn(bridgeSupportMock);
-        when(bridgeSupportMock.getPendingFederatorPublicKey(any(int.class))).then((InvocationOnMock invocation) ->
+        when(bridgeSupportMock.getPendingFederatorBtcPublicKey(any(int.class))).then((InvocationOnMock invocation) ->
                 BigInteger.valueOf(invocation.<Integer>getArgument(0)).toByteArray());
         bridge.init(mock(Transaction.class), getGenesisBlock(), createRepository().startTracking(), null, null, null);
 
@@ -1940,7 +1940,7 @@ public class BridgeTestIntegration {
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
 
         Assertions.assertNull(bridge.execute(BridgeMethods.GET_PENDING_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(10)})));
-        verify(bridgeSupportMock, never()).getPendingFederatorPublicKey(any(int.class));
+        verify(bridgeSupportMock, never()).getPendingFederatorBtcPublicKey(any(int.class));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
@@ -1519,6 +1519,13 @@ class FederationSupportImplTest {
             Keccak256 pendingFederationHash = federationSupport.getPendingFederationHash();
             assertThat(pendingFederationHash, is(nullValue()));
         }
+
+        @Test
+        @Tag("getPendingFederatorBtcPublicKey")
+        void getPendingFederatorBtcPublicKey_returnsNull() {
+            byte[] pendingFederatorBtcPublicKey = federationSupport.getPendingFederatorBtcPublicKey(0);
+            assertThat(pendingFederatorBtcPublicKey, is(nullValue()));
+        }
     }
 
     @Nested
@@ -1554,6 +1561,26 @@ class FederationSupportImplTest {
         void getPendingFederationHash_returnsPendingFederationHash() {
             Keccak256 pendingFederationHash = federationSupport.getPendingFederationHash();
             assertThat(pendingFederationHash, is(pendingFederation.getHash()));
+        }
+
+        @Test
+        @Tag("getPendingFederatorBtcPublicKey")
+        void getPendingFederatorBtcPublicKey_returnsFederatorFromPendingFederationBtcPublicKey() {
+            byte[] pendingFederatorBtcPublicKey = federationSupport.getPendingFederatorBtcPublicKey(0);
+            assertThat(pendingFederatorBtcPublicKey, is(pendingFederation.getBtcPublicKeys().get(0).getPubKey()));
+        }
+
+        @Test
+        @Tag("getPendingFederatorBtcPublicKey")
+        void getPendingFederatorBtcPublicKey_withNegativeIndex_throwsIndexOutOfBoundsException() {
+            assertThrows(IndexOutOfBoundsException.class, () -> federationSupport.getPendingFederatorBtcPublicKey(-1));
+        }
+
+        @Test
+        @Tag("getPendingFederatorBtcPublicKey")
+        void getPendingFederatorBtcPublicKey_withIndexGreaterThanPendingFederationSize_throwsIndexOutOfBoundsException() {
+            int pendingFederationSize = pendingFederation.getSize();
+            assertThrows(IndexOutOfBoundsException.class, () -> federationSupport.getPendingFederatorBtcPublicKey(pendingFederationSize));
         }
     }
 


### PR DESCRIPTION
- Add getPendingFederatorBtcPublicKey tests
- Rename `getPendingFederatorPublicKey` to `getPendingFederatorBtcPublicKey` in `BridgeSupport` and `FederationSupport` to be more accurate