### PR TITLE
Add UTs for verifyLockSenderIsWhitelisted in WhitelistSupportImplTest

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/whitelist/WhitelistSupportImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/whitelist/WhitelistSupportImplTest.java
@@ -2,7 +2,9 @@ package co.rsk.peg.whitelist;
 
 import static co.rsk.peg.whitelist.WhitelistStorageIndexKey.LOCK_ONE_OFF;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import co.rsk.bitcoinj.core.Address;
@@ -260,6 +262,33 @@ class WhitelistSupportImplTest {
         int actualResult = whitelistSupport.setLockWhitelistDisableBlockDelay(tx, BigInteger.ZERO, 0);
 
         assertEquals(WhitelistResponseCode.DISABLE_BLOCK_DELAY_INVALID.getCode(), actualResult);
+    }
+
+    @Test
+    void verifyLockSenderIsWhitelisted_whenOneOffLockWhitelistAddressIsWhitelisted_shouldReturnTrue() {
+        Transaction tx = TransactionUtils.getTransactionFromCaller(signatureCache, WhitelistCaller.AUTHORIZED.getRskAddress());
+        whitelistSupport.addOneOffLockWhitelistAddress(tx, btcAddress.toString(), BigInteger.TEN);
+
+        boolean actualResult = whitelistSupport.verifyLockSenderIsWhitelisted(btcAddress, Coin.SATOSHI, 0);
+
+        assertTrue(actualResult);
+    }
+
+    @Test
+    void verifyLockSenderIsWhitelisted_whenUnlimitedLockWhitelistAddressIsWhitelisted_shouldReturnTrue() {
+        Transaction tx = TransactionUtils.getTransactionFromCaller(signatureCache, WhitelistCaller.AUTHORIZED.getRskAddress());
+        whitelistSupport.addUnlimitedLockWhitelistAddress(tx, btcAddress.toString());
+
+        boolean actualResult = whitelistSupport.verifyLockSenderIsWhitelisted(btcAddress, Coin.SATOSHI, 0);
+
+        assertTrue(actualResult);
+    }
+
+    @Test
+    void verifyLockSenderIsWhitelisted_whenAddressIsNotWhitelisted_shouldReturnFalse() {
+        boolean actualResult = whitelistSupport.verifyLockSenderIsWhitelisted(btcAddress, Coin.SATOSHI, 0);
+
+        assertFalse(actualResult);
     }
 
     private void saveInMemoryStorageOneOffWhiteListEntry() {

--- a/rskj-core/src/test/java/co/rsk/peg/whitelist/WhitelistSupportImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/whitelist/WhitelistSupportImplTest.java
@@ -268,9 +268,11 @@ class WhitelistSupportImplTest {
     void verifyLockSenderIsWhitelisted_whenOneOffLockWhitelistAddressIsWhitelisted_shouldReturnTrue() {
         Transaction tx = TransactionUtils.getTransactionFromCaller(signatureCache, WhitelistCaller.AUTHORIZED.getRskAddress());
         whitelistSupport.addOneOffLockWhitelistAddress(tx, btcAddress.toString(), BigInteger.TEN);
+        LockWhitelistEntry lockWhitelistEntry = whitelistSupport.getLockWhitelistEntryByAddress(btcAddress.toString());
 
         boolean actualResult = whitelistSupport.verifyLockSenderIsWhitelisted(btcAddress, Coin.SATOSHI, 0);
 
+        assertTrue(lockWhitelistEntry.isConsumed());
         assertTrue(actualResult);
     }
 


### PR DESCRIPTION
## Description
As part of Bridge refactors, this is time to work on the Whitelist process, so we need to extract this from the Bridge and create its objects to decouple the process.

Create UTs for verifyLockSenderIsWhitelisted to increase coverage on WhitelistSupportImplTest.

## Motivation and Context
Increase coverage.

## How Has This Been Tested?
Unit Tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
