### PR TITLE
Add save test

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
@@ -2074,8 +2074,8 @@ class FederationSupportImplTest {
             .withFederationStorageProvider(storageProvider)
             .withActivations(activations)
             .build();
-        federationSupport.save();
 
+        federationSupport.save();
         verify(storageProvider).save(federationMainnetConstants.getBtcParams(), activations);
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
@@ -23,8 +23,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import co.rsk.RskTestUtils;
 import co.rsk.bitcoinj.core.Address;
@@ -2063,6 +2062,21 @@ class FederationSupportImplTest {
         // check the old federation was removed
         oldFederation = storageProvider.getOldFederation(federationMainnetConstants, activations);
         assertThat(oldFederation, is(nullValue()));
+    }
+
+    @Test
+    @Tag("save")
+    void save_callsStorageProviderSave() {
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
+        storageProvider = mock(FederationStorageProviderImpl.class);
+        federationSupport = federationSupportBuilder
+            .withFederationConstants(federationMainnetConstants)
+            .withFederationStorageProvider(storageProvider)
+            .withActivations(activations)
+            .build();
+        federationSupport.save();
+
+        verify(storageProvider).save(federationMainnetConstants.getBtcParams(), activations);
     }
 
     private List<ECKey> getRskPublicKeysFromFederationMembers(List<FederationMember> members) {


### PR DESCRIPTION
-Add `save()` test

_Disclaimer_
since the `save()` method from the `federationSupport` is just calling the one from its provider, this test ensures that this happens correctly. That's why the provider had to be mocked.
Checking the internal logic of the federationStorageProvider's `save()` is out of scope of this test, it should be part of `FederationStorageProviderTests`