### PR TITLE
fix(ci): persist test reports for sonar

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -56,10 +56,12 @@ jobs:
             rskj-core/build
 
   smell-test:
-    needs: build-rskj
+    needs: unit-tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Java JDK
         uses: actions/setup-java@v3
@@ -92,27 +94,36 @@ jobs:
           path: |
             rskj-core/build
 
-      - name: Sonarqube for PRs
+      - name: Download test reports
+        uses: actions/download-artifact@v4
+        with:
+          name: test-report
+          path: |
+            rskj-core/build/test-results/
+            rskj-core/build/reports/
+
+      - name: Prepare PR flags for SonarQube analysis
         if: github.event_name == 'pull_request'
         run: |
-          pr_number=${{ github.event.pull_request.number }}
+          pr_number="${{ github.event.pull_request.number }}"
           extra_flags="-Dsonar.pullrequest.base=${{ github.base_ref }} \
           -Dsonar.pullrequest.branch=${{ github.head_ref }} \
           -Dsonar.pullrequest.key=$pr_number"
+          echo EXTRA_FLAGS="$extra_flags" >> $GITHUB_ENV
+
+      - name: Prepare push flags for SonarQube analysis
+        if: github.event_name != 'pull_request'
+        run: |
+          echo EXTRA_FLAGS="-Dsonar.branch.name=${{ github.ref }}" >> $GITHUB_ENV
+          
+      - name: Run SonarQube analysis
+        run: |
+          extra_flags="${{ env.EXTRA_FLAGS }}"
           ./gradlew sonarqube --no-daemon -x build -x test \
           $extra_flags \
           -Dsonar.organization=rsksmart \
           -Dsonar.host.url="https://sonarcloud.io" \
           -Dsonar.token="${{ secrets.SONAR_TOKEN }}"
-
-      - name: Sonarqube for master
-        if: github.event_name != 'pull_request'
-        run: |
-          ./gradlew sonarqube --no-daemon -x build -x test \
-            -Dsonar.branch.name="${{ github.ref }}" \
-            -Dsonar.organization=rsksmart \
-            -Dsonar.host.url="https://sonarcloud.io" \
-            -Dsonar.token="${{ secrets.SONAR_TOKEN }}"
 
   mining-tests:
     needs: build-rskj
@@ -253,6 +264,14 @@ jobs:
       - name: Run tests
         run: |
           ./gradlew --no-daemon --stacktrace test
+
+      - name: Persist test reports for sonar
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: |
+            rskj-core/build/test-results/
+            rskj-core/build/reports/
 
   integration-tests:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -8,12 +8,3 @@ subprojects {
     version = config.modifier?.trim() ? config.versionNumber + "-" + config.modifier : config.versionNumber
 }
 
-sonarqube {
-    properties {
-        property "sonar.java.binaries", "rskj-core/build/classes/java/main"
-        property "sonar.scm.provider", "git"
-        property "sonar.projectBaseDir", project.projectDir
-        property "sonar.projectKey", "rskj"
-        property "sonar.organization", "rsksmart"
-    }
-}


### PR DESCRIPTION
The Sonarqube seems to consume some test reports generated by JaCoCo gradle plugin

This PR persists these and ensures that the sonar gradle script has access to all branches
