### PR TITLE
Chainwork fix

### DIFF
--- a/rskj-core/build.gradle
+++ b/rskj-core/build.gradle
@@ -123,7 +123,7 @@ ext {
             jaxwsRtVer             : '2.3.5',
             picocliVer             : '4.6.3',
 
-            bitcoinjThinVer: '0.14.4-rsk-14',
+            bitcoinjThinVer: '0.14.4-rsk-15-SNAPSHOT',
             rskjNativeVer: '1.3.0',
     ]
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -211,12 +211,12 @@ public class BridgeSupport {
         Context.propagate(btcContext);
         this.ensureBtcBlockChain();
         for (BtcBlock header : headers) {
-            StoredBlock previousBlock = btcBlockStore.get(header.getPrevBlockHash()); // we assume previous block was already saved
-            if (cannotProcessNextBlock(previousBlock)) {
-                logger.warn("[receiveHeaders] Header {} has too much work to be processed", header.getHash());
-                break;
-            }
             try {
+                StoredBlock previousBlock = btcBlockStore.get(header.getPrevBlockHash());
+                if (cannotProcessNextBlock(previousBlock)) {
+                    logger.warn("[receiveHeaders] Header {} has too much work to be processed", header.getHash());
+                    break;
+                }
                 btcBlockChain.add(header);
             } catch (Exception e) {
                 // If we try to add an orphan header bitcoinj throws an exception

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeConstants.java
@@ -87,6 +87,7 @@ public abstract class BridgeConstants {
 
     protected int btcHeightWhenPegoutTxIndexActivates;
     protected int pegoutTxIndexGracePeriodInBtcBlocks;
+    protected int blockWithTooMuchChainWorkHeight;
 
     public NetworkParameters getBtcParams() {
         return NetworkParameters.fromID(btcParamsString);
@@ -197,4 +198,6 @@ public abstract class BridgeConstants {
     public int getPegoutTxIndexGracePeriodInBtcBlocks() {
         return pegoutTxIndexGracePeriodInBtcBlocks;
     }
+
+    public int getBlockWithTooMuchChainWorkHeight() { return blockWithTooMuchChainWorkHeight; }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeMainNetConstants.java
@@ -124,6 +124,8 @@ public class BridgeMainNetConstants extends BridgeConstants {
 
         btcHeightWhenPegoutTxIndexActivates = 837_589; // Estimated date Wed, 03 Apr 2024 15:00:00 GMT. 832,430 was the block number at time of calculation
         pegoutTxIndexGracePeriodInBtcBlocks = 4_320; // 30 days in BTC blocks (considering 1 block every 10 minutes)
+
+        blockWithTooMuchChainWorkHeight = 849_138;
     }
 
     public static BridgeMainNetConstants getInstance() {

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
@@ -144,6 +144,8 @@ public class BridgeRegTestConstants extends BridgeConstants {
 
         btcHeightWhenPegoutTxIndexActivates = 250;
         pegoutTxIndexGracePeriodInBtcBlocks = 100;
+
+        blockWithTooMuchChainWorkHeight = Integer.MAX_VALUE;
     }
 
     public static BridgeRegTestConstants getInstance() {

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeTestNetConstants.java
@@ -143,6 +143,8 @@ public class BridgeTestNetConstants extends BridgeConstants {
 
         btcHeightWhenPegoutTxIndexActivates = 2_589_553; // Estimated date Wed, 20 Mar 2024 15:00:00 GMT. 2,579,823 was the block number at time of calculation
         pegoutTxIndexGracePeriodInBtcBlocks = 1_440; // 10 days in BTC blocks (considering 1 block every 10 minutes)
+
+        blockWithTooMuchChainWorkHeight = Integer.MAX_VALUE;
     }
 
     public static BridgeTestNetConstants getInstance() {

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -94,6 +94,7 @@ public enum ConsensusRule {
     RSKIP415("rskip415"),
     RSKIP417("rskip417"),
     RSKIP428("rskip428"),
+    RSKIP434("rskip434")
     ;
 
     private String configKey;

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/NetworkUpgrade.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/NetworkUpgrade.java
@@ -32,6 +32,7 @@ public enum NetworkUpgrade {
     HOP401("hop401"),
     FINGERROOT500("fingerroot500"),
     ARROWHEAD600("arrowhead600"),
+    ARROWHEAD631("arrowhead631"),
     LOVELL700("lovell700");
 
     private String name;

--- a/rskj-core/src/main/resources/config/main.conf
+++ b/rskj-core/src/main/resources/config/main.conf
@@ -13,10 +13,8 @@ blockchain.config {
         hop401 = 4976300,
         fingerroot500 = 5468000,
         arrowhead600 = 6223700,
+        arrowhead631 = -1,
         lovell700 = -1
-    },
-    consensusRules = {
-        rskip434 = -1
     }
 }
 

--- a/rskj-core/src/main/resources/config/main.conf
+++ b/rskj-core/src/main/resources/config/main.conf
@@ -14,6 +14,9 @@ blockchain.config {
         fingerroot500 = 5468000,
         arrowhead600 = 6223700,
         lovell700 = -1
+    },
+    consensusRules = {
+        rskip434 = -1
     }
 }
 

--- a/rskj-core/src/main/resources/config/regtest.conf
+++ b/rskj-core/src/main/resources/config/regtest.conf
@@ -13,12 +13,12 @@ blockchain.config {
         hop401 = 0,
         fingerroot500 = 0,
         arrowhead600 = 0,
+        arrowhead631 = -1,
         lovell700 = 0
     },
     consensusRules = {
         rskip97 = -1 # disable orchid difficulty drop
-        rskipUMM = 1,
-        rskip434 = -1
+        rskipUMM = 1
     }
 }
 

--- a/rskj-core/src/main/resources/config/regtest.conf
+++ b/rskj-core/src/main/resources/config/regtest.conf
@@ -17,7 +17,8 @@ blockchain.config {
     },
     consensusRules = {
         rskip97 = -1 # disable orchid difficulty drop
-        rskipUMM = 1
+        rskipUMM = 1,
+        rskip434 = -1
     }
 }
 

--- a/rskj-core/src/main/resources/config/testnet.conf
+++ b/rskj-core/src/main/resources/config/testnet.conf
@@ -19,7 +19,8 @@ blockchain.config {
         rskip97 = -1, # disable orchid difficulty drop
         rskip132 = 43550, # enable recalculted receive headers cost
         rskip284 = 2581800,
-        rskip290 = 2581800
+        rskip290 = 2581800,
+        rskip434 = -1
     }
 }
 

--- a/rskj-core/src/main/resources/config/testnet.conf
+++ b/rskj-core/src/main/resources/config/testnet.conf
@@ -13,14 +13,14 @@ blockchain.config {
         hop401 = 3362200,
         fingerroot500 = 4015800,
         arrowhead600 = 4927100,
+        arrowhead631 = -1,
         lovell700 = -1
     },
     consensusRules = {
         rskip97 = -1, # disable orchid difficulty drop
         rskip132 = 43550, # enable recalculted receive headers cost
         rskip284 = 2581800,
-        rskip290 = 2581800,
-        rskip434 = -1
+        rskip290 = 2581800
     }
 }
 

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -16,6 +16,7 @@ blockchain = {
             hop401 = <height>
             fingerroot500 = <height>
             arrowhead600 = <height>
+            arrowhead631 = <height>
             lovell700 = <height>
         }
         consensusRules = {
@@ -94,6 +95,7 @@ blockchain = {
              rskip415 = <hardforkName>
              rskip417 = <hardforkName>
              rskip428 = <hardforkName>
+             rskip434 = <hardforkName>
          }
     }
     gc = {

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -80,6 +80,7 @@ blockchain = {
             rskip415 = arrowhead600
             rskip417 = arrowhead600
             rskip428 = lovell700
+            rskip434 = arrowhead631
         }
     }
     gc = {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -6234,8 +6234,6 @@ class BridgeSupportTest {
     class ChainWorkTests {
         Repository repository;
         BtcBlockStoreWithCache.Factory btcBlockStoreFactory;
-        BridgeStorageProvider bridgeStorageProviderPreRSKIP434;
-        BridgeStorageProvider bridgeStorageProviderPostRSKIP434;
         BtcBlockStoreWithCache btcBlockStoreWithCachePreRSKIP434;
         BtcBlockStoreWithCache btcBlockStoreWithCachePostRSKIP434;
 
@@ -6260,7 +6258,7 @@ class BridgeSupportTest {
             btcBlockStoreFactory = new RepositoryBtcBlockStoreWithCache.Factory(bridgeMainnetConstants.getBtcParams(), 100, 100);
 
             // recreate context pre rskip 434 for mainnet
-            bridgeStorageProviderPreRSKIP434 = new BridgeStorageProvider(
+            BridgeStorageProvider bridgeStorageProviderPreRSKIP434 = new BridgeStorageProvider(
                 repository,
                 PrecompiledContracts.BRIDGE_ADDR,
                 bridgeMainnetConstants,
@@ -6277,7 +6275,7 @@ class BridgeSupportTest {
                 btcBlockStoreFactory.newInstance(repository, bridgeMainnetConstants, bridgeStorageProviderPreRSKIP434, activationsPreRSKIP434);
 
             // recreate context post rskip 434 for mainnet
-            bridgeStorageProviderPostRSKIP434 = new BridgeStorageProvider(
+            BridgeStorageProvider bridgeStorageProviderPostRSKIP434 = new BridgeStorageProvider(
                 repository,
                 PrecompiledContracts.BRIDGE_ADDR,
                 bridgeMainnetConstants,

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -6232,6 +6232,8 @@ class BridgeSupportTest {
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     @Tag("test chain work before and after rskip 434")
     class ChainWorkTests {
+        ActivationConfig.ForBlock activationsPreRSKIP434 = ActivationConfigsForTest.arrowhead600().forBlock(0);
+        ActivationConfig.ForBlock activationsPostRSKIP434 = ActivationConfigsForTest.arrowhead631().forBlock(0);
         Repository repository;
         BtcBlockStoreWithCache.Factory btcBlockStoreFactory;
         BtcBlockStoreWithCache btcBlockStoreWithCachePreRSKIP434;
@@ -6251,9 +6253,6 @@ class BridgeSupportTest {
         @BeforeEach
         void setUp() {
             BridgeConstants bridgeMainnetConstants = BridgeMainNetConstants.getInstance();
-            ActivationConfig.ForBlock activationsPreRSKIP434 = ActivationConfigsForTest.allBut(ConsensusRule.RSKIP434).forBlock(0);
-            ActivationConfig.ForBlock activationsPostRSKIP434 = ActivationConfigsForTest.all().forBlock(0);
-
             repository = createRepository();
             btcBlockStoreFactory = new RepositoryBtcBlockStoreWithCache.Factory(bridgeMainnetConstants.getBtcParams(), 100, 100);
 
@@ -6470,18 +6469,15 @@ class BridgeSupportTest {
         }
 
         private Stream<Arguments> notMainnetAndActivationsArgs() {
-            ActivationConfig.ForBlock activationsPreRSKIP434 = ActivationConfigsForTest.allBut(ConsensusRule.RSKIP434).forBlock(0);
-            ActivationConfig.ForBlock activationsPostRSKIP434 = ActivationConfigsForTest.all().forBlock(0);
-
             BridgeConstants testnet = BridgeTestNetConstants.getInstance();
             BridgeConstants regtest = BridgeRegTestConstants.getInstance();
 
             return Stream.of(
-                    Arguments.of(activationsPreRSKIP434, testnet),
-                    Arguments.of(activationsPostRSKIP434, testnet),
-                    Arguments.of(activationsPreRSKIP434, regtest),
-                    Arguments.of(activationsPostRSKIP434, regtest)
-                );
+                Arguments.of(activationsPreRSKIP434, testnet),
+                Arguments.of(activationsPostRSKIP434, testnet),
+                Arguments.of(activationsPreRSKIP434, regtest),
+                Arguments.of(activationsPostRSKIP434, regtest)
+            );
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
@@ -938,10 +938,29 @@ public class BridgeSupportTestIntegration {
         BridgeSupport bridgeSupport = getBridgeSupport(provider, track, mockFactory, activations);
         BtcBlockChain btcBlockChain = new SimpleBlockChain(btcContext, btcBlockStore);
         TestUtils.setInternalState(bridgeSupport, "btcBlockChain", btcBlockChain);
+
+        Sha256Hash merkleRoot = PegTestUtils.createHash(2);
+
+        co.rsk.bitcoinj.core.BtcBlock prevBlock = new co.rsk.bitcoinj.core.BtcBlock(
+            btcParams,
+            1,
+            PegTestUtils.createHash(1), // hash from its previous block
+            merkleRoot,
+            1,
+            1,
+            1,
+            new ArrayList<>()
+        );
+        BigInteger prevBlockChainWork = new BigInteger("ffffffffffffffff", 16);
+        StoredBlock prevStoredBlock = new StoredBlock(prevBlock, prevBlockChainWork, 1);
+        // save previous block in storage, so we are able to build next block from it
+        btcBlockStore.put(prevStoredBlock);
+        track.save();
+
         co.rsk.bitcoinj.core.BtcBlock block = new co.rsk.bitcoinj.core.BtcBlock(
                 btcParams,
                 1,
-                PegTestUtils.createHash(1),
+                prevBlock.getHash(),
                 PegTestUtils.createHash(2),
                 1,
                 1,

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -43,6 +43,7 @@ class ActivationConfigTest {
             "    hop401: 0",
             "    fingerroot500: 0",
             "    arrowhead600: 0",
+            "    arrowhead631: 0",
             "    lovell700: 0",
             "},",
             "consensusRules: {",
@@ -120,6 +121,7 @@ class ActivationConfigTest {
             "    rskip412: arrowhead600",
             "    rskip415: arrowhead600",
             "    rskip417: arrowhead600",
+            "    rskip434: arrowhead631",
             "    rskip428: lovell700",
             "}"
     ));

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
@@ -191,6 +191,15 @@ public class ActivationConfigsForTest {
         return rskips;
     }
 
+    private static List<ConsensusRule> getArrowhead631Rskips() {
+        List<ConsensusRule> rskips = new ArrayList<>();
+        rskips.addAll(Collections.singletonList(
+            ConsensusRule.RSKIP434
+        ));
+
+        return rskips;
+    }
+
     private static List<ConsensusRule> getLovell700Rskips() {
         List<ConsensusRule> rskips = new ArrayList<>();
         rskips.addAll(Arrays.asList(
@@ -341,6 +350,29 @@ public class ActivationConfigsForTest {
         return enableTheseDisableThose(rskips, except);
     }
 
+    public static ActivationConfig arrowhead631() {
+        return arrowhead631(Collections.emptyList());
+    }
+
+    public static ActivationConfig arrowhead631(List<ConsensusRule> except) {
+        List<ConsensusRule> rskips = new ArrayList<>();
+        rskips.addAll(getPaidBridgeTxsRskip());
+        rskips.addAll(getOrchidRskips());
+        rskips.addAll(getOrchid060Rskips());
+        rskips.addAll(getWasabi100Rskips());
+        rskips.addAll(getBahamasRskips());
+        rskips.addAll(getTwoToThreeRskips());
+        rskips.addAll(getPapyrus200Rskips());
+        rskips.addAll(getIris300Rskips());
+        rskips.addAll(getHop400Rskips());
+        rskips.addAll(getHop401Rskips());
+        rskips.addAll(getFingerroot500Rskips());
+        rskips.addAll(getArrowhead600Rskips());
+        rskips.addAll(getArrowhead631Rskips());
+
+        return enableTheseDisableThose(rskips, except);
+    }
+
     public static ActivationConfig lovell700(List<ConsensusRule> except) {
         List<ConsensusRule> rskips = new ArrayList<>();
         rskips.addAll(getPaidBridgeTxsRskip());
@@ -355,6 +387,7 @@ public class ActivationConfigsForTest {
         rskips.addAll(getHop401Rskips());
         rskips.addAll(getFingerroot500Rskips());
         rskips.addAll(getArrowhead600Rskips());
+        rskips.addAll(getArrowhead631Rskips());
         rskips.addAll(getLovell700Rskips());
 
         return enableTheseDisableThose(rskips, except);


### PR DESCRIPTION
Related to https://blog.rootstock.io/noticia/incident-report-rootstock-peg-in-peg-out-service-outage-on-june-24th/

Only register in the Bridge Bitcoin blocks past 849,137 height if RSKIP434 is active.

Relates to
- https://github.com/rsksmart/bitcoinj/pull/17
- https://github.com/rsksmart/bitcoinj-thin/pull/78

*ci:rc631-modifier*
*fed:ARROWHEAD-6.3.1-rc*
*rit:ARROWHEAD-6.3.1-rc*