### PR TITLE
Add tests for BridgeSupport methods that call FederationSupport

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -792,7 +792,7 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         logger.trace("getFederatorPublicKey");
 
         int index = ((BigInteger) args[0]).intValue();
-        return bridgeSupport.getActiveFederatorPublicKey(index);
+        return bridgeSupport.getActiveFederatorBtcPublicKey(index);
     }
 
     public byte[] getFederatorPublicKeyOfType(Object[] args) throws VMException {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -934,6 +934,10 @@ public class BridgeSupport {
 
         processConfirmedPegouts(rskTx);
 
+        updateFederationCreationBlockHeights();
+    }
+
+    protected void updateFederationCreationBlockHeights() {
         federationSupport.updateFederationCreationBlockHeights();
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1896,7 +1896,7 @@ public class BridgeSupport {
      * @param index the federator's index (zero-based)
      * @return the federator's public key
      */
-    public byte[] getActiveFederatorPublicKey(int index) {
+    public byte[] getActiveFederatorBtcPublicKey(int index) {
         return federationSupport.getActiveFederatorBtcPublicKey(index);
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupportImpl.java
@@ -312,7 +312,6 @@ public class FederationSupportImpl implements FederationSupport {
         }
     }
 
-
     @Override
     public List<UTXO> getNewFederationBtcUTXOs() {
         return provider.getNewFederationBtcUTXOs(constants.getBtcParams(), activations);

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupportImpl.java
@@ -766,6 +766,7 @@ public class FederationSupportImpl implements FederationSupport {
         return currentBlockHeight < nextFederationCreationBlockHeight + constants.getFederationActivationAge(activations);
     }
 
+    @Override
     public void save() {
         provider.save(constants.getBtcParams(), activations);
     }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupportImpl.java
@@ -111,11 +111,11 @@ public class FederationSupportImpl implements FederationSupport {
     }
 
     private Federation getGenesisFederation() {
-        long GENESIS_FEDERATION_CREATION_BLOCK_NUMBER = 1L;
+        long genesisFederationCreationBlockNumber = 1L;
         List<BtcECKey> genesisFederationPublicKeys = constants.getGenesisFederationPublicKeys();
         List<FederationMember> federationMembers = FederationMember.getFederationMembersFromKeys(genesisFederationPublicKeys);
         Instant genesisFederationCreationTime = constants.getGenesisFederationCreationTime();
-        FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationCreationTime, GENESIS_FEDERATION_CREATION_BLOCK_NUMBER, constants.getBtcParams());
+        FederationArgs federationArgs = new FederationArgs(federationMembers, genesisFederationCreationTime, genesisFederationCreationBlockNumber, constants.getBtcParams());
         return FederationFactory.buildStandardMultiSigFederation(federationArgs);
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -267,6 +267,14 @@ class BridgeSupportTest {
         }
 
         @Test
+        void getActiveFederationBtcUTXOs() {
+            List<UTXO> utxos = BitcoinTestUtils.createUTXOs(2, federation.getAddress());
+
+            when(federationSupport.getActiveFederationBtcUTXOs()).thenReturn(utxos);
+            assertThat(bridgeSupport.getActiveFederationBtcUTXOs(), is(utxos));
+        }
+
+        @Test
         void getRetiringFederation() {
             when(federationSupport.getRetiringFederation()).thenReturn(federation);
             assertThat(bridgeSupport.getRetiringFederation(), is(federation));
@@ -338,6 +346,22 @@ class BridgeSupportTest {
         }
 
         @Test
+        void getRetiringFederationBtcUTXOs() {
+            List<UTXO> utxos = BitcoinTestUtils.createUTXOs(2, federation.getAddress());
+
+            when(federationSupport.getRetiringFederationBtcUTXOs()).thenReturn(utxos);
+            assertThat(bridgeSupport.getRetiringFederationBtcUTXOs(), is(utxos));
+        }
+
+        @Test
+        void getNewFederationBtcUTXOs() {
+            List<UTXO> utxos = BitcoinTestUtils.createUTXOs(2, federation.getAddress());
+
+            when(federationSupport.getNewFederationBtcUTXOs()).thenReturn(utxos);
+            assertThat(bridgeSupport.getNewFederationBtcUTXOs(), is(utxos));
+        }
+
+        @Test
         void getPendingFederationHash() {
             PendingFederation pendingFederation = new PendingFederationBuilder().build();
             Keccak256 hash = pendingFederation.getHash();
@@ -387,6 +411,20 @@ class BridgeSupportTest {
 
             when(federationSupport.voteFederationChange(any(), any(), any(), any())).thenReturn(result);
             assertThat(bridgeSupport.voteFederationChange(tx, callSpec), is(result));
+        }
+
+        @Test
+        void clearRetiredFederation_callsFederationSupportClearRetiredFederation() {
+            bridgeSupport.clearRetiredFederation();
+            verify(federationSupport).clearRetiredFederation();
+        }
+
+        @Test
+        void getLastRetiredFederationP2SHScript() {
+            Script script = federation.getP2SHScript();
+
+            when(federationSupport.getLastRetiredFederationP2SHScript()).thenReturn(Optional.ofNullable(script));
+            assertThat(bridgeSupport.getLastRetiredFederationP2SHScript(), is(script));
         }
 
         @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -256,14 +256,6 @@ class BridgeSupportTest {
             when(federationSupport.getActiveFederatorPublicKeyOfType(0, FederationMember.KeyType.MST)).thenReturn(mstKey.getPubKey());
             assertThat(bridgeSupport.getActiveFederatorPublicKeyOfType(0, FederationMember.KeyType.MST), is(mstKey.getPubKey()));
         }
-
-        @Test
-        void getActiveFederationBtcUTXOs() {
-            int threshold = federation.getNumberOfSignaturesRequired();
-
-            when(federationSupport.getActiveFederationThreshold()).thenReturn(threshold);
-            assertThat(bridgeSupport.getActiveFederationThreshold(), is(threshold));
-        }
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -207,6 +207,63 @@ class BridgeSupportTest {
             when(federationSupport.getActiveFederationSize()).thenReturn(size);
             assertThat(bridgeSupport.getActiveFederationSize(), is(size));
         }
+
+        @Test
+        void getActiveFederationThreshold() {
+            int threshold = federation.getNumberOfSignaturesRequired();
+
+            when(federationSupport.getActiveFederationThreshold()).thenReturn(threshold);
+            assertThat(bridgeSupport.getActiveFederationThreshold(), is(threshold));
+        }
+
+        @Test
+        void getActiveFederationCreationTime() {
+            Instant creationTime = federation.getCreationTime();
+
+            when(federationSupport.getActiveFederationCreationTime()).thenReturn(creationTime);
+            assertThat(bridgeSupport.getActiveFederationCreationTime(), is(creationTime));
+        }
+
+        @Test
+        void getActiveFederationCreationBlockNumber() {
+            long creationBlockNumber = federation.getCreationBlockNumber();
+
+            when(federationSupport.getActiveFederationCreationBlockNumber()).thenReturn(creationBlockNumber);
+            assertThat(bridgeSupport.getActiveFederationCreationBlockNumber(), is(creationBlockNumber));
+        }
+
+        @Test
+        void getActiveFederatorBtcPublicKey() {
+            BtcECKey publicKey = federation.getBtcPublicKeys().get(0);
+
+            when(federationSupport.getActiveFederatorBtcPublicKey(0)).thenReturn(publicKey.getPubKey());
+            assertThat(bridgeSupport.getActiveFederatorPublicKey(0), is(publicKey.getPubKey()));
+        }
+
+        @Test
+        void getActiveFederatorPublicKeyOfType() {
+            FederationMember member = federation.getMembers().get(0);
+            BtcECKey btcKey = member.getBtcPublicKey();
+            ECKey rskKey = member.getRskPublicKey();
+            ECKey mstKey = member.getMstPublicKey();
+
+            when(federationSupport.getActiveFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC)).thenReturn(btcKey.getPubKey());
+            assertThat(bridgeSupport.getActiveFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC), is(btcKey.getPubKey()));
+
+            when(federationSupport.getActiveFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK)).thenReturn(rskKey.getPubKey());
+            assertThat(bridgeSupport.getActiveFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK), is(rskKey.getPubKey()));
+
+            when(federationSupport.getActiveFederatorPublicKeyOfType(0, FederationMember.KeyType.MST)).thenReturn(mstKey.getPubKey());
+            assertThat(bridgeSupport.getActiveFederatorPublicKeyOfType(0, FederationMember.KeyType.MST), is(mstKey.getPubKey()));
+        }
+
+        @Test
+        void getActiveFederationBtcUTXOs() {
+            int threshold = federation.getNumberOfSignaturesRequired();
+
+            when(federationSupport.getActiveFederationThreshold()).thenReturn(threshold);
+            assertThat(bridgeSupport.getActiveFederationThreshold(), is(threshold));
+        }
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -428,19 +428,6 @@ class BridgeSupportTest {
     }
 
     @Test
-    void getActivePowpegRedeemScript_before_RSKIP293_activation() {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP293)).thenReturn(false);
-
-        BridgeSupport bridgeSupport = bridgeSupportBuilder
-            .withBridgeConstants(bridgeConstantsRegtest)
-            .withActivations(activations)
-            .build();
-
-        assertEquals(Optional.empty(), bridgeSupport.getActiveFederationRedeemScript());
-    }
-
-    @Test
     void increaseLockingCap_unauthorized() {
         AddressBasedAuthorizer authorizer = mock(AddressBasedAuthorizer.class);
         when(authorizer.isAuthorized(any(Transaction.class), any())).thenReturn(false);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -179,7 +179,7 @@ class BridgeSupportTest {
         }
 
         @Test
-            void getActiveFederation() {
+        void getActiveFederation() {
             when(federationSupport.getActiveFederation()).thenReturn(federation);
             assertThat(bridgeSupport.getActiveFederation(), is(federation));
         }
@@ -237,7 +237,7 @@ class BridgeSupportTest {
             BtcECKey publicKey = federation.getBtcPublicKeys().get(0);
 
             when(federationSupport.getActiveFederatorBtcPublicKey(0)).thenReturn(publicKey.getPubKey());
-            assertThat(bridgeSupport.getActiveFederatorPublicKey(0), is(publicKey.getPubKey()));
+            assertThat(bridgeSupport.getActiveFederatorBtcPublicKey(0), is(publicKey.getPubKey()));
         }
 
         @Test
@@ -255,6 +255,77 @@ class BridgeSupportTest {
 
             when(federationSupport.getActiveFederatorPublicKeyOfType(0, FederationMember.KeyType.MST)).thenReturn(mstKey.getPubKey());
             assertThat(bridgeSupport.getActiveFederatorPublicKeyOfType(0, FederationMember.KeyType.MST), is(mstKey.getPubKey()));
+        }
+
+        @Test
+        void getRetiringFederation() {
+            when(federationSupport.getRetiringFederation()).thenReturn(federation);
+            assertThat(bridgeSupport.getRetiringFederation(), is(federation));
+        }
+
+        @Test
+        void getRetiringFederationAddress() {
+            Address address = federation.getAddress();
+
+            when(federationSupport.getRetiringFederationAddress()).thenReturn(address);
+            assertThat(bridgeSupport.getRetiringFederationAddress(), is(address));
+        }
+
+        @Test
+        void getRetiringFederationSize() {
+            int size = federation.getSize();
+
+            when(federationSupport.getRetiringFederationSize()).thenReturn(size);
+            assertThat(bridgeSupport.getRetiringFederationSize(), is(size));
+        }
+
+        @Test
+        void getRetiringFederationThreshold() {
+            int threshold = federation.getNumberOfSignaturesRequired();
+
+            when(federationSupport.getRetiringFederationThreshold()).thenReturn(threshold);
+            assertThat(bridgeSupport.getRetiringFederationThreshold(), is(threshold));
+        }
+
+        @Test
+        void getRetiringFederationCreationTime() {
+            Instant creationTime = federation.getCreationTime();
+
+            when(federationSupport.getRetiringFederationCreationTime()).thenReturn(creationTime);
+            assertThat(bridgeSupport.getRetiringFederationCreationTime(), is(creationTime));
+        }
+
+        @Test
+        void getRetiringFederationCreationBlockNumber() {
+            long creationBlockNumber = federation.getCreationBlockNumber();
+
+            when(federationSupport.getRetiringFederationCreationBlockNumber()).thenReturn(creationBlockNumber);
+            assertThat(bridgeSupport.getRetiringFederationCreationBlockNumber(), is(creationBlockNumber));
+        }
+
+        @Test
+        void getRetiringFederatorBtcPublicKey() {
+            BtcECKey publicKey = federation.getBtcPublicKeys().get(0);
+
+            when(federationSupport.getRetiringFederatorBtcPublicKey(0)).thenReturn(publicKey.getPubKey());
+            assertThat(bridgeSupport.getRetiringFederatorBtcPublicKey(0), is(publicKey.getPubKey()));
+        }
+
+        @Test
+        void getRetiringFederatorPublicKeyOfType() {
+            FederationMember member = federation.getMembers().get(0);
+            BtcECKey btcKey = member.getBtcPublicKey();
+            ECKey rskKey = member.getRskPublicKey();
+            ECKey mstKey = member.getMstPublicKey();
+
+            when(federationSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC)).thenReturn(btcKey.getPubKey());
+            assertThat(bridgeSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC), is(btcKey.getPubKey()));
+
+            when(federationSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK)).thenReturn(rskKey.getPubKey());
+            assertThat(bridgeSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK), is(rskKey.getPubKey()));
+
+            when(federationSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.MST)).thenReturn(mstKey.getPubKey());
+            assertThat(bridgeSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.MST), is(mstKey.getPubKey()));
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -267,14 +267,6 @@ class BridgeSupportTest {
         }
 
         @Test
-        void getActiveFederationBtcUTXOs() {
-            List<UTXO> utxos = BitcoinTestUtils.createUTXOs(2, federation.getAddress());
-
-            when(federationSupport.getActiveFederationBtcUTXOs()).thenReturn(utxos);
-            assertThat(bridgeSupport.getActiveFederationBtcUTXOs(), is(utxos));
-        }
-
-        @Test
         void getRetiringFederation() {
             when(federationSupport.getRetiringFederation()).thenReturn(federation);
             assertThat(bridgeSupport.getRetiringFederation(), is(federation));
@@ -346,22 +338,6 @@ class BridgeSupportTest {
         }
 
         @Test
-        void getRetiringFederationBtcUTXOs() {
-            List<UTXO> utxos = BitcoinTestUtils.createUTXOs(2, federation.getAddress());
-
-            when(federationSupport.getRetiringFederationBtcUTXOs()).thenReturn(utxos);
-            assertThat(bridgeSupport.getRetiringFederationBtcUTXOs(), is(utxos));
-        }
-
-        @Test
-        void getNewFederationBtcUTXOs() {
-            List<UTXO> utxos = BitcoinTestUtils.createUTXOs(2, federation.getAddress());
-
-            when(federationSupport.getNewFederationBtcUTXOs()).thenReturn(utxos);
-            assertThat(bridgeSupport.getNewFederationBtcUTXOs(), is(utxos));
-        }
-
-        @Test
         void getPendingFederationHash() {
             PendingFederation pendingFederation = new PendingFederationBuilder().build();
             Keccak256 hash = pendingFederation.getHash();
@@ -411,20 +387,6 @@ class BridgeSupportTest {
 
             when(federationSupport.voteFederationChange(any(), any(), any(), any())).thenReturn(result);
             assertThat(bridgeSupport.voteFederationChange(tx, callSpec), is(result));
-        }
-
-        @Test
-        void clearRetiredFederation_callsFederationSupportClearRetiredFederation() {
-            bridgeSupport.clearRetiredFederation();
-            verify(federationSupport).clearRetiredFederation();
-        }
-
-        @Test
-        void getLastRetiredFederationP2SHScript() {
-            Script script = federation.getP2SHScript();
-
-            when(federationSupport.getLastRetiredFederationP2SHScript()).thenReturn(Optional.ofNullable(script));
-            assertThat(bridgeSupport.getLastRetiredFederationP2SHScript(), is(script));
         }
 
         @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -44,6 +44,7 @@ import co.rsk.peg.utils.BridgeEventLogger;
 import co.rsk.peg.utils.MerkleTreeUtils;
 import co.rsk.peg.pegin.RejectedPeginReason;
 import co.rsk.peg.utils.UnrefundablePeginReason;
+import co.rsk.peg.vote.ABICallSpec;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
 import co.rsk.peg.whitelist.LockWhitelist;
 import co.rsk.peg.whitelist.OneOffWhiteListEntry;
@@ -233,6 +234,14 @@ class BridgeSupportTest {
         }
 
         @Test
+        void getActiveFederationCreationBlockHeight() {
+            long creationBlockHeight = 100L;
+
+            when(federationSupport.getActiveFederationCreationBlockHeight()).thenReturn(creationBlockHeight);
+            assertThat(bridgeSupport.getActiveFederationCreationBlockHeight(), is(creationBlockHeight));
+        }
+
+        @Test
         void getActiveFederatorBtcPublicKey() {
             BtcECKey publicKey = federation.getBtcPublicKeys().get(0);
 
@@ -326,6 +335,70 @@ class BridgeSupportTest {
 
             when(federationSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.MST)).thenReturn(mstKey.getPubKey());
             assertThat(bridgeSupport.getRetiringFederatorPublicKeyOfType(0, FederationMember.KeyType.MST), is(mstKey.getPubKey()));
+        }
+
+        @Test
+        void getPendingFederationHash() {
+            PendingFederation pendingFederation = new PendingFederationBuilder().build();
+            Keccak256 hash = pendingFederation.getHash();
+
+            when(federationSupport.getPendingFederationHash()).thenReturn(hash);
+            assertThat(bridgeSupport.getPendingFederationHash(), is(hash));
+        }
+
+        @Test
+        void getPendingFederationSize() {
+            int size = federation.getSize();
+
+            when(federationSupport.getPendingFederationSize()).thenReturn(size);
+            assertThat(bridgeSupport.getPendingFederationSize(), is(size));
+        }
+
+        @Test
+        void getPendingFederatorBtcPublicKey() {
+            BtcECKey publicKey = federation.getBtcPublicKeys().get(0);
+
+            when(federationSupport.getPendingFederatorBtcPublicKey(0)).thenReturn(publicKey.getPubKey());
+            assertThat(bridgeSupport.getPendingFederatorBtcPublicKey(0), is(publicKey.getPubKey()));
+        }
+
+        @Test
+        void getPendingFederatorPublicKeyOfType() {
+            FederationMember member = federation.getMembers().get(0);
+            BtcECKey btcKey = member.getBtcPublicKey();
+            ECKey rskKey = member.getRskPublicKey();
+            ECKey mstKey = member.getMstPublicKey();
+
+            when(federationSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC)).thenReturn(btcKey.getPubKey());
+            assertThat(bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.BTC), is(btcKey.getPubKey()));
+
+            when(federationSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK)).thenReturn(rskKey.getPubKey());
+            assertThat(bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.RSK), is(rskKey.getPubKey()));
+
+            when(federationSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.MST)).thenReturn(mstKey.getPubKey());
+            assertThat(bridgeSupport.getPendingFederatorPublicKeyOfType(0, FederationMember.KeyType.MST), is(mstKey.getPubKey()));
+        }
+
+        @Test
+        void voteFederationChange() throws BridgeIllegalArgumentException {
+            Transaction tx = mock(Transaction.class);
+            ABICallSpec callSpec = mock(ABICallSpec.class);
+            int result = 1;
+
+            when(federationSupport.voteFederationChange(any(), any(), any(), any())).thenReturn(result);
+            assertThat(bridgeSupport.voteFederationChange(tx, callSpec), is(result));
+        }
+
+        @Test
+        void updateFederationCreationBlockHeights_callsFederationSupportUpdateFederationCreationBlockHeights() {
+            bridgeSupport.updateFederationCreationBlockHeights();
+            verify(federationSupport).updateFederationCreationBlockHeights();
+        }
+
+        @Test
+        void save_callsFederationSupportSave() throws IOException {
+            bridgeSupport.save();
+            verify(federationSupport).save();
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestIntegration.java
@@ -2043,7 +2043,7 @@ public class BridgeSupportTestIntegration {
 
         List<FederationMember> members = genesisFederation.getMembers();
         for (int i = 0; i < 6; i++) {
-            Assertions.assertArrayEquals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getActiveFederatorPublicKey(i));
+            Assertions.assertArrayEquals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getActiveFederatorBtcPublicKey(i));
             Assertions.assertArrayEquals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getActiveFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC));
             Assertions.assertArrayEquals(members.get(i).getRskPublicKey().getPubKey(true), bridgeSupport.getActiveFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK));
             Assertions.assertArrayEquals(members.get(i).getMstPublicKey().getPubKey(true), bridgeSupport.getActiveFederatorPublicKeyOfType(i, FederationMember.KeyType.MST));
@@ -2084,7 +2084,7 @@ public class BridgeSupportTestIntegration {
         assertEquals(activeFederation.getAddress().toString(), bridgeSupport.getActiveFederationAddress().toString());
         List<FederationMember> members = FederationTestUtils.getFederationMembers(3);
         for (int i = 0; i < 3; i++) {
-            Assertions.assertArrayEquals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getActiveFederatorPublicKey(i));
+            Assertions.assertArrayEquals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getActiveFederatorBtcPublicKey(i));
             Assertions.assertArrayEquals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getActiveFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC));
             Assertions.assertArrayEquals(members.get(i).getRskPublicKey().getPubKey(true), bridgeSupport.getActiveFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK));
             Assertions.assertArrayEquals(members.get(i).getMstPublicKey().getPubKey(true), bridgeSupport.getActiveFederatorPublicKeyOfType(i, FederationMember.KeyType.MST));
@@ -2130,7 +2130,7 @@ public class BridgeSupportTestIntegration {
         assertEquals(newFederation.getAddress().toString(), bridgeSupport.getActiveFederationAddress().toString());
         List<FederationMember> members = FederationTestUtils.getFederationMembers(3);
         for (int i = 0; i < 3; i++) {
-            Assertions.assertArrayEquals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getActiveFederatorPublicKey(i));
+            Assertions.assertArrayEquals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getActiveFederatorBtcPublicKey(i));
             Assertions.assertArrayEquals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getActiveFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC));
             Assertions.assertArrayEquals(members.get(i).getRskPublicKey().getPubKey(true), bridgeSupport.getActiveFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK));
             Assertions.assertArrayEquals(members.get(i).getMstPublicKey().getPubKey(true), bridgeSupport.getActiveFederatorPublicKeyOfType(i, FederationMember.KeyType.MST));
@@ -2177,7 +2177,7 @@ public class BridgeSupportTestIntegration {
         assertEquals(oldFederation.getAddress().toString(), bridgeSupport.getActiveFederationAddress().toString());
         List<FederationMember> members = FederationTestUtils.getFederationMembers(6);
         for (int i = 0; i < 6; i++) {
-            Assertions.assertArrayEquals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getActiveFederatorPublicKey(i));
+            Assertions.assertArrayEquals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getActiveFederatorBtcPublicKey(i));
             Assertions.assertArrayEquals(members.get(i).getBtcPublicKey().getPubKey(), bridgeSupport.getActiveFederatorPublicKeyOfType(i, FederationMember.KeyType.BTC));
             Assertions.assertArrayEquals(members.get(i).getRskPublicKey().getPubKey(true), bridgeSupport.getActiveFederatorPublicKeyOfType(i, FederationMember.KeyType.RSK));
             Assertions.assertArrayEquals(members.get(i).getMstPublicKey().getPubKey(true), bridgeSupport.getActiveFederatorPublicKeyOfType(i, FederationMember.KeyType.MST));

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -1679,7 +1679,7 @@ class BridgeTest {
             assertThrows(VMException.class, () -> bridge.execute(data));
         } else {
             bridge.execute(data);
-            verify(bridgeSupportMock, times(1)).getActiveFederatorPublicKey(federatorIndex);
+            verify(bridgeSupportMock, times(1)).getActiveFederatorBtcPublicKey(federatorIndex);
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTestIntegration.java
@@ -1622,7 +1622,7 @@ public class BridgeTestIntegration {
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
         when(bridgeSupportFactoryMock.newInstance(any(), any(), any(), any())).thenReturn(bridgeSupportMock);
 
-        when(bridgeSupportMock.getActiveFederatorPublicKey(any(int.class))).then((InvocationOnMock invocation) ->
+        when(bridgeSupportMock.getActiveFederatorBtcPublicKey(any(int.class))).then((InvocationOnMock invocation) ->
                 BigInteger.valueOf(invocation.<Integer>getArgument(0)).toByteArray());
         bridge.init(mock(Transaction.class), getGenesisBlock(), null, null, null, null);
 
@@ -1655,7 +1655,7 @@ public class BridgeTestIntegration {
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
 
         Assertions.assertNull(bridge.execute(BridgeMethods.GET_FEDERATOR_PUBLIC_KEY.getFunction().encode(new Object[]{BigInteger.valueOf(10)})));
-        verify(bridgeSupportMock, never()).getActiveFederatorPublicKey(any(int.class));
+        verify(bridgeSupportMock, never()).getActiveFederatorBtcPublicKey(any(int.class));
     }
 
     @Test


### PR DESCRIPTION
-Add tests that add coverage to those `BridgeSupport` methods that simply pass the call to `FederationSupport` ones.
-Refactor / rename some methods in `BridgeSupport`.
-Remove tests from `BridgeSupportTest` that are now part of `FederationSupportImplTest` class.