### PR TITLE
fix(ci): moves vars to step env

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -102,28 +102,33 @@ jobs:
             rskj-core/build/test-results/
             rskj-core/build/reports/
 
-      - name: Prepare PR flags for SonarQube analysis
-        if: github.event_name == 'pull_request'
-        run: |
-          pr_number="${{ github.event.pull_request.number }}"
-          extra_flags="-Dsonar.pullrequest.base=${{ github.base_ref }} \
-          -Dsonar.pullrequest.branch=${{ github.head_ref }} \
-          -Dsonar.pullrequest.key=$pr_number"
-          echo EXTRA_FLAGS="$extra_flags" >> $GITHUB_ENV
-
-      - name: Prepare push flags for SonarQube analysis
-        if: github.event_name != 'pull_request'
-        run: |
-          echo EXTRA_FLAGS="-Dsonar.branch.name=${{ github.ref }}" >> $GITHUB_ENV
-          
       - name: Run SonarQube analysis
+        env:
+          GH_EVENT: ${{ github.event_name }}
+          GH_PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_PR_BASE_REF: ${{ github.base_ref }}
+          GH_PR_HEAD_REF: ${{ github.head_ref }}
+          GH_REF: ${{ github.ref }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          extra_flags="${{ env.EXTRA_FLAGS }}"
-          ./gradlew sonarqube --no-daemon -x build -x test \
-          $extra_flags \
-          -Dsonar.organization=rsksmart \
-          -Dsonar.host.url="https://sonarcloud.io" \
-          -Dsonar.token="${{ secrets.SONAR_TOKEN }}"
+          if [ "$GH_EVENT" = pull_request ]; then
+            ./gradlew sonarqube --no-daemon -x build -x test \
+              -Dsonar.pullrequest.base="$GH_PR_BASE_REF" \
+              -Dsonar.pullrequest.branch="$GH_PR_HEAD_REF" \
+              -Dsonar.pullrequest.key="$GH_PR_NUMBER" \
+              -Dsonar.organization=rsksmart \
+              -Dsonar.projectKey=rskj \
+              -Dsonar.host.url="https://sonarcloud.io" \
+              -Dsonar.token="$SONAR_TOKEN"
+          else
+            ./gradlew sonarqube --no-daemon -x build -x test \
+              -Dsonar.branch.name="$GH_REF" \
+              -Dsonar.organization=rsksmart \
+              -Dsonar.projectKey=rskj \
+              -Dsonar.host.url="https://sonarcloud.io" \
+              -Dsonar.token="$SONAR_TOKEN"
+          fi
+
 
   mining-tests:
     needs: build-rskj


### PR DESCRIPTION
# Security Bugfix

Moves untrusted input of github variables to the step env var definition to prevent RCE. https://securitylab.github.com/research/github-actions-untrusted-input/


