### PR TITLE
Adding the effectiveGasPrice to the eth_getTransactionReceipt

### DIFF
--- a/doc/rpc/components/schemas/Receipt.json
+++ b/doc/rpc/components/schemas/Receipt.json
@@ -15,7 +15,8 @@
       "to",
       "transactionHash",
       "transactionIndex",
-      "type"
+      "type",
+      "effectiveGasPrice"
     ],
     "properties": {
       "blockHash": {
@@ -78,6 +79,11 @@
         "title": "ReceiptType",
         "description": "is a positive unsigned 8-bit number that represents the type of the transaction.",
         "type": "string"
+      },
+      "effectiveGasPrice": {
+        "title": "ReceiptEffectiveGasPrice",
+        "description": "The actual value per gas deducted on the transaction.",
+        "$ref": "#/components/schemas/IntegerHex"
       },
       "root": {
         "title": "Receipt Root",

--- a/doc/rpc/methods/eth_getTransactionReceipt.json
+++ b/doc/rpc/methods/eth_getTransactionReceipt.json
@@ -58,7 +58,8 @@
             ],
             "logsBloom": "0x00...0",
             "status": "0x1",
-            "type": "0x0"
+            "type": "0x0",
+            "effectiveGasPrice": "0x1"
           }
         ]
       }

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionReceiptDTO.java
@@ -46,6 +46,8 @@ public class TransactionReceiptDTO {
     private String status;               // either 1 (success) or 0 (failure)
     private String logsBloom;            // Bloom filter for light clients to quickly retrieve related logs.
     private String type = TRANSACTION_TYPE;     // is a positive unsigned 8-bit number that represents the type of the transaction.
+    private String effectiveGasPrice;   // The actual value per gas deducted on the transaction.
+
 
     public TransactionReceiptDTO(Block block, TransactionInfo txInfo, SignatureCache signatureCache) {
         TransactionReceipt receipt = txInfo.getReceipt();
@@ -74,6 +76,7 @@ public class TransactionReceiptDTO {
         transactionHash = receipt.getTransaction().getHash().toJsonString();
         transactionIndex = HexUtils.toQuantityJsonHex(txInfo.getIndex());
         logsBloom = HexUtils.toUnformattedJsonHex(txInfo.getReceipt().getBloomFilter().getData());
+        effectiveGasPrice = HexUtils.toQuantityJsonHex(txInfo.getReceipt().getTransaction().getGasPrice().getBytes());
     }
 
     public String getTransactionHash() {
@@ -126,5 +129,9 @@ public class TransactionReceiptDTO {
 
     public String getType() {
         return type;
+    }
+
+    public String getEffectiveGasPrice() {
+        return effectiveGasPrice;
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -99,6 +99,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.*;
 import java.util.function.Function;
@@ -819,6 +820,9 @@ class Web3ImplTest {
 
         String blockNumberAsHex = "0x" + Long.toHexString(block1.getNumber());
         assertEquals(blockNumberAsHex, tr.getBlockNumber());
+
+        String effectiveGasPrice = "0x" + tx.getGasPrice().asBigInteger();
+        assertEquals(effectiveGasPrice, tr.getEffectiveGasPrice());
 
         String rawTransactionReceipt = web3.rsk_getRawTransactionReceiptByHash(hashString);
         String expectedRawTxReceipt = "0xf9010c01825208b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c082520801";

--- a/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionReceiptDTOTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionReceiptDTOTest.java
@@ -17,6 +17,7 @@
  */
 package org.ethereum.rpc.dto;
 
+import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import org.ethereum.core.*;
@@ -36,10 +37,11 @@ class TransactionReceiptDTOTest {
 
     @Test
     void testOkStatusField() {
+        //given
         RskAddress rskAddress = RskAddress.nullAddress();
         Keccak256 hash = Keccak256.ZERO_HASH;
         Bloom bloom = new Bloom();
-
+        Coin gasPrice = Coin.valueOf(100);
         Block block = mock(Block.class);
         when(block.getHash()).thenReturn(hash);
 
@@ -47,6 +49,7 @@ class TransactionReceiptDTOTest {
         when(transaction.getHash()).thenReturn(hash);
         when(transaction.getSender(any(SignatureCache.class))).thenReturn(rskAddress);
         when(transaction.getReceiveAddress()).thenReturn(rskAddress);
+        when(transaction.getGasPrice()).thenReturn(gasPrice);
 
         TransactionReceipt txReceipt = mock(TransactionReceipt.class);
         when(txReceipt.getTransaction()).thenReturn(transaction);
@@ -58,17 +61,21 @@ class TransactionReceiptDTOTest {
 
         TransactionReceiptDTO transactionReceiptDTO = new TransactionReceiptDTO(block, txInfo, new BlockTxSignatureCache(new ReceivedTxSignatureCache()));
 
+        //when
         String actualStatus = transactionReceiptDTO.getStatus();
 
+        //then
         assertNotNull(actualStatus);
         assertEquals("0x1", actualStatus);
     }
 
     @Test
     void testErrorStatusField() {
+        //given
         RskAddress rskAddress = RskAddress.nullAddress();
         Keccak256 hash = Keccak256.ZERO_HASH;
         Bloom bloom = new Bloom();
+        Coin gasPrice = Coin.valueOf(100);
 
         Block block = mock(Block.class);
         when(block.getHash()).thenReturn(hash);
@@ -77,6 +84,7 @@ class TransactionReceiptDTOTest {
         when(transaction.getHash()).thenReturn(hash);
         when(transaction.getSender(any(SignatureCache.class))).thenReturn(rskAddress);
         when(transaction.getReceiveAddress()).thenReturn(rskAddress);
+        when(transaction.getGasPrice()).thenReturn(gasPrice);
 
         TransactionReceipt txReceipt = mock(TransactionReceipt.class);
         when(txReceipt.getTransaction()).thenReturn(transaction);
@@ -88,17 +96,21 @@ class TransactionReceiptDTOTest {
 
         TransactionReceiptDTO transactionReceiptDTO = new TransactionReceiptDTO(block, txInfo, new BlockTxSignatureCache(new ReceivedTxSignatureCache()));
 
+        //when
         String actualStatus = transactionReceiptDTO.getStatus();
 
+        //then
         assertNotNull(actualStatus);
         assertEquals("0x0", actualStatus);
     }
 
     @Test
     void testErrorStatusFieldUsingEmptyByteArray() {
+        //given
         RskAddress rskAddress = RskAddress.nullAddress();
         Keccak256 hash = Keccak256.ZERO_HASH;
         Bloom bloom = new Bloom();
+        Coin gasPrice = Coin.valueOf(100);
 
         Block block = mock(Block.class);
         when(block.getHash()).thenReturn(hash);
@@ -107,6 +119,7 @@ class TransactionReceiptDTOTest {
         when(transaction.getHash()).thenReturn(hash);
         when(transaction.getSender(any(SignatureCache.class))).thenReturn(rskAddress);
         when(transaction.getReceiveAddress()).thenReturn(rskAddress);
+        when(transaction.getGasPrice()).thenReturn(gasPrice);
 
         TransactionReceipt txReceipt = mock(TransactionReceipt.class);
         when(txReceipt.getTransaction()).thenReturn(transaction);
@@ -118,17 +131,21 @@ class TransactionReceiptDTOTest {
 
         TransactionReceiptDTO transactionReceiptDTO = new TransactionReceiptDTO(block, txInfo, new BlockTxSignatureCache(new ReceivedTxSignatureCache()));
 
+        //when
         String actualStatus = transactionReceiptDTO.getStatus();
 
+        //then
         assertNotNull(actualStatus);
         assertEquals("0x0", actualStatus);
     }
 
     @Test
     void testErrorStatusFieldUsingNullByteArray() {
+        //given
         RskAddress rskAddress = RskAddress.nullAddress();
         Keccak256 hash = Keccak256.ZERO_HASH;
         Bloom bloom = new Bloom();
+        Coin gasPrice = Coin.valueOf(100);
 
         Block block = mock(Block.class);
         when(block.getHash()).thenReturn(hash);
@@ -137,26 +154,33 @@ class TransactionReceiptDTOTest {
         when(transaction.getHash()).thenReturn(hash);
         when(transaction.getSender(any(SignatureCache.class))).thenReturn(rskAddress);
         when(transaction.getReceiveAddress()).thenReturn(rskAddress);
+        when(transaction.getGasPrice()).thenReturn(gasPrice);
 
         TransactionReceipt txReceipt = mock(TransactionReceipt.class);
         when(txReceipt.getTransaction()).thenReturn(transaction);
         when(txReceipt.getLogInfoList()).thenReturn(Collections.emptyList());
         when(txReceipt.getBloomFilter()).thenReturn(bloom);
         when(txReceipt.getStatus()).thenReturn(null);
+        when(txReceipt.getStatus()).thenReturn(null);
+
 
         TransactionInfo txInfo = new TransactionInfo(txReceipt, hash.getBytes(), 0);
 
         TransactionReceiptDTO transactionReceiptDTO = new TransactionReceiptDTO(block, txInfo, new BlockTxSignatureCache(new ReceivedTxSignatureCache()));
 
+        //when
         String actualStatus = transactionReceiptDTO.getStatus();
 
+        //then
         assertNotNull(actualStatus);
         assertEquals("0x0", actualStatus);
     }
     @Test
     void testTypeField() {
+        //given
         RskAddress rskAddress = RskAddress.nullAddress();
         Keccak256 hash = Keccak256.ZERO_HASH;
+        Coin gasPrice = Coin.valueOf(100);
         Bloom bloom = new Bloom();
 
         Block block = mock(Block.class);
@@ -166,6 +190,7 @@ class TransactionReceiptDTOTest {
         when(transaction.getHash()).thenReturn(hash);
         when(transaction.getSender(any(SignatureCache.class))).thenReturn(rskAddress);
         when(transaction.getReceiveAddress()).thenReturn(rskAddress);
+        when(transaction.getGasPrice()).thenReturn(gasPrice);
 
         TransactionReceipt txReceipt = mock(TransactionReceipt.class);
         when(txReceipt.getTransaction()).thenReturn(transaction);
@@ -177,8 +202,10 @@ class TransactionReceiptDTOTest {
 
         TransactionReceiptDTO transactionReceiptDTO = new TransactionReceiptDTO(block, txInfo, new BlockTxSignatureCache(new ReceivedTxSignatureCache()));
 
+        //when
         String actualType = transactionReceiptDTO.getType();
 
+        //then
         assertNotNull(actualType);
         assertEquals("0x0", actualType);
     }


### PR DESCRIPTION
In order to let the transactionReceipt compatible with the Ethereum one, we are adding the field effectiveGasPrice, that it's the same value of the gasPrice on the transaction.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
