### PR TITLE
LockingCapConstants Refactor

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeConstants.java
@@ -63,12 +63,6 @@ public abstract class BridgeConstants {
 
     protected AddressBasedAuthorizer federationChangeAuthorizer;
 
-    protected AddressBasedAuthorizer increaseLockingCapAuthorizer;
-
-    protected Coin initialLockingCap;
-
-    protected int lockingCapIncrementsMultiplier;
-
     protected int btcHeightWhenBlockIndexActivates;
     protected int maxDepthToSearchBlocksBelowIndexActivation;
     protected long minSecondsBetweenCallsReceiveHeader;
@@ -151,12 +145,6 @@ public abstract class BridgeConstants {
     }
 
     public AddressBasedAuthorizer getFederationChangeAuthorizer() { return federationChangeAuthorizer; }
-
-    public AddressBasedAuthorizer getIncreaseLockingCapAuthorizer() { return increaseLockingCapAuthorizer; }
-
-    public int getLockingCapIncrementsMultiplier() { return lockingCapIncrementsMultiplier; }
-
-    public Coin getInitialLockingCap() { return initialLockingCap; }
 
     public Coin getMaxRbtc() { return Coin.valueOf(21_000_000, 0); }
 

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeDevNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeDevNetConstants.java
@@ -88,20 +88,6 @@ public class BridgeDevNetConstants extends BridgeConstants {
         fundsMigrationAgeSinceActivationEnd = 100L;
         specialCaseFundsMigrationAgeSinceActivationEnd = 100L;
 
-        // Key generated with GenNodeKey using generator 'auth-increase_locking_cap'
-        List<ECKey> increaseLockingCapAuthorizedKeys = Arrays.stream(new String[]{
-            "04450bbaab83ec48b3cb8fbb077c950ee079733041c039a8c4f1539e5181ca1a27589eeaf0fbf430e49d2909f14c767bf6909ad6845831f683416ee12b832e36ed"
-        }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
-
-        increaseLockingCapAuthorizer = new AddressBasedAuthorizer(
-            increaseLockingCapAuthorizedKeys,
-            AddressBasedAuthorizer.MinimumRequiredCalculation.ONE
-        );
-
-        initialLockingCap = Coin.COIN.multiply(1_000L); // 1_000 BTC
-
-        lockingCapIncrementsMultiplier = 2;
-
         btcHeightWhenBlockIndexActivates = 700_000;
         maxDepthToSearchBlocksBelowIndexActivation = 4_320; // 30 days in BTC blocks (considering 1 block every 10 minutes)
 

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeMainNetConstants.java
@@ -78,20 +78,6 @@ public class BridgeMainNetConstants extends BridgeConstants {
         fundsMigrationAgeSinceActivationEnd = 10585L;
         specialCaseFundsMigrationAgeSinceActivationEnd = 172_800L; // 60 days, considering 1 block every 30 seconds
 
-        List<ECKey> increaseLockingCapAuthorizedKeys = Arrays.stream(new String[]{
-            "0448f51638348b034995b1fd934fe14c92afde783e69f120a46ee16eb6bdc2e4f6b5e37772094c68c0dea2b1be3d96ea9651a9eebda7304914c8047f4e3e251378",
-            "0484c66f75548baf93e322574adac4e4579b6a53f8d11fab640e14c90118e6983ef24b0de349a3e88f72e81e771ae1c897cef446fd7f4da71778c532aee3b6c41b",
-            "04bb6435dc1ea12da843ebe213893d136c1624acd681fff82551498ae00bf28e9323164b00daf925fa75177463b8254a2aae8a1713e4d851a84ea369c193e9ce51"
-        }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
-
-        increaseLockingCapAuthorizer = new AddressBasedAuthorizer(
-            increaseLockingCapAuthorizedKeys,
-            AddressBasedAuthorizer.MinimumRequiredCalculation.ONE
-        );
-
-        lockingCapIncrementsMultiplier = 2;
-        initialLockingCap = Coin.COIN.multiply(300); // 300 BTC
-
         btcHeightWhenBlockIndexActivates = 696_022;
         maxDepthToSearchBlocksBelowIndexActivation = 4_320; // 30 days in BTC blocks (considering 1 block every 10 minutes)
 

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
@@ -90,23 +90,9 @@ public class BridgeRegTestConstants extends BridgeConstants {
         fundsMigrationAgeSinceActivationEnd = 150L;
         specialCaseFundsMigrationAgeSinceActivationEnd = 150L;
 
-        initialLockingCap = Coin.COIN.multiply(1_000L); // 1_000 BTC
-
-        lockingCapIncrementsMultiplier = 2;
-
         minSecondsBetweenCallsReceiveHeader = 300;  // 5 minutes in seconds
 
         maxDepthBlockchainAccepted = 25;
-
-        // Key generated with GenNodeKey using generator 'auth-increase_locking_cap'
-        List<ECKey> increaseLockingCapAuthorizedKeys = Arrays.stream(new String[]{
-            "04450bbaab83ec48b3cb8fbb077c950ee079733041c039a8c4f1539e5181ca1a27589eeaf0fbf430e49d2909f14c767bf6909ad6845831f683416ee12b832e36ed"
-        }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
-
-        increaseLockingCapAuthorizer = new AddressBasedAuthorizer(
-            increaseLockingCapAuthorizedKeys,
-            AddressBasedAuthorizer.MinimumRequiredCalculation.ONE
-        );
 
         btcHeightWhenBlockIndexActivates = 10;
         maxDepthToSearchBlocksBelowIndexActivation = 5;

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeTestNetConstants.java
@@ -93,20 +93,6 @@ public class BridgeTestNetConstants extends BridgeConstants {
         fundsMigrationAgeSinceActivationEnd = 900L;
         specialCaseFundsMigrationAgeSinceActivationEnd = 900L;
 
-        List<ECKey> increaseLockingCapAuthorizedKeys = Arrays.stream(new String[]{
-            "04701d1d27f8c2ae97912d96fb1f82f10c2395fd320e7a869049268c6b53d2060dfb2e22e3248955332d88cd2ae29a398f8f3858e48dd6d8ffbc37dfd6d1aa4934",
-            "045ef89e4a5645dc68895dbc33b4c966c3a0a52bb837ecdd2ba448604c4f47266456d1191420e1d32bbe8741f8315fde4d1440908d400e5998dbed6549d499559b",
-            "0455db9b3867c14e84a6f58bd2165f13bfdba0703cb84ea85788373a6a109f3717e40483aa1f8ef947f435ccdf10e530dd8b3025aa2d4a7014f12180ee3a301d27"
-        }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
-
-        increaseLockingCapAuthorizer = new AddressBasedAuthorizer(
-            increaseLockingCapAuthorizedKeys,
-            AddressBasedAuthorizer.MinimumRequiredCalculation.ONE
-        );
-
-        lockingCapIncrementsMultiplier = 2;
-        initialLockingCap = Coin.COIN.multiply(200); // 200 BTC
-
         btcHeightWhenBlockIndexActivates = 2_039_594;
         maxDepthToSearchBlocksBelowIndexActivation = 4_320; // 30 days in BTC blocks (considering 1 block every 10 minutes)
 

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/constants/LockingCapConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/constants/LockingCapConstants.java
@@ -1,0 +1,23 @@
+package co.rsk.peg.lockingcap.constants;
+
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.peg.vote.AddressBasedAuthorizer;
+
+public class LockingCapConstants {
+
+    protected AddressBasedAuthorizer increaseAuthorizer;
+    protected Coin initialValue;
+    protected int incrementsMultiplier;
+
+    public AddressBasedAuthorizer getIncreaseAuthorizer() {
+        return increaseAuthorizer;
+    }
+
+    public int getIncrementsMultiplier() {
+        return incrementsMultiplier;
+    }
+
+    public Coin getInitialValue() {
+        return initialValue;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/constants/LockingCapMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/constants/LockingCapMainNetConstants.java
@@ -2,9 +2,10 @@ package co.rsk.peg.lockingcap.constants;
 
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.ECKey;
 
@@ -13,11 +14,11 @@ public class LockingCapMainNetConstants extends LockingCapConstants {
     private static final LockingCapMainNetConstants instance = new LockingCapMainNetConstants();
 
     private LockingCapMainNetConstants() {
-        List<ECKey> increaseAuthorizedKeys = Arrays.stream(new String[]{
+        List<ECKey> increaseAuthorizedKeys = Collections.unmodifiableList(Stream.of(
             "0448f51638348b034995b1fd934fe14c92afde783e69f120a46ee16eb6bdc2e4f6b5e37772094c68c0dea2b1be3d96ea9651a9eebda7304914c8047f4e3e251378",
             "0484c66f75548baf93e322574adac4e4579b6a53f8d11fab640e14c90118e6983ef24b0de349a3e88f72e81e771ae1c897cef446fd7f4da71778c532aee3b6c41b",
             "04bb6435dc1ea12da843ebe213893d136c1624acd681fff82551498ae00bf28e9323164b00daf925fa75177463b8254a2aae8a1713e4d851a84ea369c193e9ce51"
-        }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
+        ).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList()));
 
         increaseAuthorizer = new AddressBasedAuthorizer(
             increaseAuthorizedKeys,

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/constants/LockingCapMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/constants/LockingCapMainNetConstants.java
@@ -1,0 +1,34 @@
+package co.rsk.peg.lockingcap.constants;
+
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.peg.vote.AddressBasedAuthorizer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.ECKey;
+
+public class LockingCapMainNetConstants extends LockingCapConstants {
+
+    private static final LockingCapMainNetConstants instance = new LockingCapMainNetConstants();
+
+    private LockingCapMainNetConstants() {
+        List<ECKey> increaseAuthorizedKeys = Arrays.stream(new String[]{
+            "0448f51638348b034995b1fd934fe14c92afde783e69f120a46ee16eb6bdc2e4f6b5e37772094c68c0dea2b1be3d96ea9651a9eebda7304914c8047f4e3e251378",
+            "0484c66f75548baf93e322574adac4e4579b6a53f8d11fab640e14c90118e6983ef24b0de349a3e88f72e81e771ae1c897cef446fd7f4da71778c532aee3b6c41b",
+            "04bb6435dc1ea12da843ebe213893d136c1624acd681fff82551498ae00bf28e9323164b00daf925fa75177463b8254a2aae8a1713e4d851a84ea369c193e9ce51"
+        }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
+
+        increaseAuthorizer = new AddressBasedAuthorizer(
+            increaseAuthorizedKeys,
+            AddressBasedAuthorizer.MinimumRequiredCalculation.ONE
+        );
+
+        initialValue = Coin.COIN.multiply(300L); // 300 BTC
+        incrementsMultiplier = 2;
+    }
+
+    public static LockingCapMainNetConstants getInstance() {
+        return instance;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/constants/LockingCapRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/constants/LockingCapRegTestConstants.java
@@ -1,0 +1,33 @@
+package co.rsk.peg.lockingcap.constants;
+
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.peg.vote.AddressBasedAuthorizer;
+import java.util.Collections;
+import java.util.List;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.ECKey;
+
+public class LockingCapRegTestConstants extends LockingCapConstants {
+
+    private static final LockingCapRegTestConstants instance = new LockingCapRegTestConstants();
+
+    private LockingCapRegTestConstants() {
+        ECKey authorizerPublicKey = ECKey.fromPublicOnly(Hex.decode(
+            "04450bbaab83ec48b3cb8fbb077c950ee079733041c039a8c4f1539e5181ca1a27589eeaf0fbf430e49d2909f14c767bf6909ad6845831f683416ee12b832e36ed"
+        ));
+
+        List<ECKey> increaseAuthorizedKeys = Collections.singletonList(authorizerPublicKey);
+
+        increaseAuthorizer = new AddressBasedAuthorizer(
+            increaseAuthorizedKeys,
+            AddressBasedAuthorizer.MinimumRequiredCalculation.ONE
+        );
+
+        initialValue = Coin.COIN.multiply(1_000L); // 1000 BTC
+        incrementsMultiplier = 2;
+    }
+
+    public static LockingCapRegTestConstants getInstance() {
+        return instance;
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/constants/LockingCapTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/constants/LockingCapTestNetConstants.java
@@ -2,9 +2,10 @@ package co.rsk.peg.lockingcap.constants;
 
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.ECKey;
 
@@ -13,11 +14,11 @@ public class LockingCapTestNetConstants extends LockingCapConstants {
     private static final LockingCapTestNetConstants instance = new LockingCapTestNetConstants();
 
     private LockingCapTestNetConstants() {
-        List<ECKey> increaseAuthorizedKeys = Arrays.stream(new String[]{
+        List<ECKey> increaseAuthorizedKeys = Collections.unmodifiableList(Stream.of(
             "04701d1d27f8c2ae97912d96fb1f82f10c2395fd320e7a869049268c6b53d2060dfb2e22e3248955332d88cd2ae29a398f8f3858e48dd6d8ffbc37dfd6d1aa4934",
             "045ef89e4a5645dc68895dbc33b4c966c3a0a52bb837ecdd2ba448604c4f47266456d1191420e1d32bbe8741f8315fde4d1440908d400e5998dbed6549d499559b",
             "0455db9b3867c14e84a6f58bd2165f13bfdba0703cb84ea85788373a6a109f3717e40483aa1f8ef947f435ccdf10e530dd8b3025aa2d4a7014f12180ee3a301d27"
-        }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
+        ).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList()));
 
         increaseAuthorizer = new AddressBasedAuthorizer(
             increaseAuthorizedKeys,

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/constants/LockingCapTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/constants/LockingCapTestNetConstants.java
@@ -1,0 +1,34 @@
+package co.rsk.peg.lockingcap.constants;
+
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.peg.vote.AddressBasedAuthorizer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.ECKey;
+
+public class LockingCapTestNetConstants extends LockingCapConstants {
+
+    private static final LockingCapTestNetConstants instance = new LockingCapTestNetConstants();
+
+    private LockingCapTestNetConstants() {
+        List<ECKey> increaseAuthorizedKeys = Arrays.stream(new String[]{
+            "04701d1d27f8c2ae97912d96fb1f82f10c2395fd320e7a869049268c6b53d2060dfb2e22e3248955332d88cd2ae29a398f8f3858e48dd6d8ffbc37dfd6d1aa4934",
+            "045ef89e4a5645dc68895dbc33b4c966c3a0a52bb837ecdd2ba448604c4f47266456d1191420e1d32bbe8741f8315fde4d1440908d400e5998dbed6549d499559b",
+            "0455db9b3867c14e84a6f58bd2165f13bfdba0703cb84ea85788373a6a109f3717e40483aa1f8ef947f435ccdf10e530dd8b3025aa2d4a7014f12180ee3a301d27"
+        }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
+
+        increaseAuthorizer = new AddressBasedAuthorizer(
+            increaseAuthorizedKeys,
+            AddressBasedAuthorizer.MinimumRequiredCalculation.ONE
+        );
+
+        incrementsMultiplier = 2;
+        initialValue = Coin.COIN.multiply(200L); // 200 BTC
+    }
+
+    public static LockingCapTestNetConstants getInstance() {
+        return instance;
+    }
+}


### PR DESCRIPTION
## Description
Following with the Bridge refactors, it is now time to refactor and remove the locking cap business logic from the Bridge.

Create its package `lockingcap` with a Support, StorageProvider, and Constants classes. Since it will have its classes, should be removed from the variable names, `lockingCap`, to avoid being redundant.

## Motivation and Context
This relates to the Bridge Refactor to decouple some objects tied closely to the Bridge.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
