### PR TITLE
Create LockingCapStorageIndexKey Enum

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageIndexKey.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageIndexKey.java
@@ -15,7 +15,6 @@ public enum BridgeStorageIndexKey {
     OLD_FEDERATION_KEY("oldFederation"),
     PENDING_FEDERATION_KEY("pendingFederation"),
     FEDERATION_ELECTION_KEY("federationElection"),
-    LOCKING_CAP_KEY("lockingCap"),
     RELEASE_REQUEST_QUEUE_WITH_TXHASH("releaseRequestQueueWithTxHash"),
     PEGOUTS_WAITING_FOR_CONFIRMATIONS_WITH_TXHASH_KEY("releaseTransactionSetWithTxHash"),
     RECEIVE_HEADERS_TIMESTAMP("receiveHeadersLastTimestamp"),

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapStorageIndexKey.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapStorageIndexKey.java
@@ -1,0 +1,17 @@
+package co.rsk.peg.lockingcap;
+
+import org.ethereum.vm.DataWord;
+
+public enum LockingCapStorageIndexKey {
+    LOCKING_CAP("lockingCap");
+
+    private final String key;
+
+    LockingCapStorageIndexKey(String key) {
+        this.key = key;
+    }
+
+    public DataWord getKey() {
+        return DataWord.fromString(key);
+    }
+}


### PR DESCRIPTION
## Description
Create the package lockingcap with an enum to hold the storage index key for locking cap value, create a new enum LockingCapStorageIndexKey to contain the index key for the locking cap value in storage, remove it from BridgeStorageIndexKey, remove the. _KEY suffix, and rename to LOCKING_CAP.

## Motivation and Context
This relates to the Bridge Refactor to decouple some objects tied closely to the Bridge.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
