### PR TITLE
LockingCapConstants Test

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/constants/LockingCapConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/constants/LockingCapConstants.java
@@ -13,11 +13,11 @@ public class LockingCapConstants {
         return increaseAuthorizer;
     }
 
-    public int getIncrementsMultiplier() {
-        return incrementsMultiplier;
-    }
-
     public Coin getInitialValue() {
         return initialValue;
+    }
+
+    public int getIncrementsMultiplier() {
+        return incrementsMultiplier;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/constants/LockingCapTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/constants/LockingCapTestNetConstants.java
@@ -24,8 +24,8 @@ public class LockingCapTestNetConstants extends LockingCapConstants {
             AddressBasedAuthorizer.MinimumRequiredCalculation.ONE
         );
 
-        incrementsMultiplier = 2;
         initialValue = Coin.COIN.multiply(200L); // 200 BTC
+        incrementsMultiplier = 2;
     }
 
     public static LockingCapTestNetConstants getInstance() {

--- a/rskj-core/src/test/java/co/rsk/peg/lockingcap/constants/LockingCapConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/lockingcap/constants/LockingCapConstantsTest.java
@@ -1,0 +1,118 @@
+package co.rsk.peg.lockingcap.constants;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.peg.vote.AddressBasedAuthorizer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.ECKey;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class LockingCapConstantsTest {
+
+    @ParameterizedTest
+    @MethodSource("getIncreaseAuthorizerProvider")
+    void getIncreaseAuthorizer(LockingCapConstants lockingCapConstants, AddressBasedAuthorizer expectedIncreaseAuthorizer) {
+        AddressBasedAuthorizer actualIncreaseAuthorizer = lockingCapConstants.getIncreaseAuthorizer();
+        assertEquals(expectedIncreaseAuthorizer, actualIncreaseAuthorizer);
+    }
+
+    private static Stream<Arguments> getIncreaseAuthorizerProvider() {
+        // MainNet
+        List<ECKey> mainNetIncreaseAuthorizedKeys = Arrays.stream(new String[]{
+            "0448f51638348b034995b1fd934fe14c92afde783e69f120a46ee16eb6bdc2e4f6b5e37772094c68c0dea2b1be3d96ea9651a9eebda7304914c8047f4e3e251378",
+            "0484c66f75548baf93e322574adac4e4579b6a53f8d11fab640e14c90118e6983ef24b0de349a3e88f72e81e771ae1c897cef446fd7f4da71778c532aee3b6c41b",
+            "04bb6435dc1ea12da843ebe213893d136c1624acd681fff82551498ae00bf28e9323164b00daf925fa75177463b8254a2aae8a1713e4d851a84ea369c193e9ce51"
+        }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
+
+        AddressBasedAuthorizer mainNetIncreaseAuthorizer = new AddressBasedAuthorizer(
+            mainNetIncreaseAuthorizedKeys,
+            AddressBasedAuthorizer.MinimumRequiredCalculation.ONE
+        );
+
+        // TestNet
+        List<ECKey> testNetIncreaseAuthorizedKeys = Arrays.stream(new String[]{
+            "04701d1d27f8c2ae97912d96fb1f82f10c2395fd320e7a869049268c6b53d2060dfb2e22e3248955332d88cd2ae29a398f8f3858e48dd6d8ffbc37dfd6d1aa4934",
+            "045ef89e4a5645dc68895dbc33b4c966c3a0a52bb837ecdd2ba448604c4f47266456d1191420e1d32bbe8741f8315fde4d1440908d400e5998dbed6549d499559b",
+            "0455db9b3867c14e84a6f58bd2165f13bfdba0703cb84ea85788373a6a109f3717e40483aa1f8ef947f435ccdf10e530dd8b3025aa2d4a7014f12180ee3a301d27"
+        }).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
+
+        AddressBasedAuthorizer testNetIncreaseAuthorizer = new AddressBasedAuthorizer(
+            testNetIncreaseAuthorizedKeys,
+            AddressBasedAuthorizer.MinimumRequiredCalculation.ONE
+        );
+
+        // RegTest
+        ECKey authorizerPublicKey = ECKey.fromPublicOnly(Hex.decode(
+            "04450bbaab83ec48b3cb8fbb077c950ee079733041c039a8c4f1539e5181ca1a27589eeaf0fbf430e49d2909f14c767bf6909ad6845831f683416ee12b832e36ed"
+        ));
+
+        List<ECKey> regTestIncreaseAuthorizedKeys = Collections.singletonList(authorizerPublicKey);
+
+        AddressBasedAuthorizer regTestIncreaseAuthorizer = new AddressBasedAuthorizer(
+            regTestIncreaseAuthorizedKeys,
+            AddressBasedAuthorizer.MinimumRequiredCalculation.ONE
+        );
+
+        return Stream.of(
+            Arguments.of(LockingCapMainNetConstants.getInstance(), mainNetIncreaseAuthorizer),
+            Arguments.of(LockingCapTestNetConstants.getInstance(), testNetIncreaseAuthorizer),
+            Arguments.of(LockingCapRegTestConstants.getInstance(), regTestIncreaseAuthorizer)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("getInitialValueProvider")
+    void getInitialValue(LockingCapConstants lockingCapConstants, Coin expectedInitialValue) {
+        Coin actualInitialValue = lockingCapConstants.getInitialValue();
+        assertEquals(expectedInitialValue, actualInitialValue);
+    }
+
+    private static Stream<Arguments> getInitialValueProvider() {
+        // MainNet
+        Coin mainNetInitialValue = Coin.COIN.multiply(300L);
+
+        // TestNet
+        Coin testNetInitialValue = Coin.COIN.multiply(200L);
+
+        // RegTest
+        Coin regTestInitialValue = Coin.COIN.multiply(1_000L);
+
+        return Stream.of(
+            Arguments.of(LockingCapMainNetConstants.getInstance(), mainNetInitialValue),
+            Arguments.of(LockingCapTestNetConstants.getInstance(), testNetInitialValue),
+            Arguments.of(LockingCapRegTestConstants.getInstance(), regTestInitialValue)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("getIncrementsMultiplierProvider")
+    void getIncrementsMultiplier(LockingCapConstants lockingCapConstants, int expectedIncrementsMultiplier) {
+        int actualIncrementsMultiplier = lockingCapConstants.getIncrementsMultiplier();
+        assertEquals(expectedIncrementsMultiplier, actualIncrementsMultiplier);
+    }
+
+    private static Stream<Arguments> getIncrementsMultiplierProvider() {
+        // MainNet
+        int mainNetIncrementsMultiplier = 2;
+
+        // TestNet
+        int testNetIncrementsMultiplier = 2;
+
+        // RegTest
+        int regTestIncrementsMultiplier = 2;
+
+        return Stream.of(
+            Arguments.of(LockingCapMainNetConstants.getInstance(), mainNetIncrementsMultiplier),
+            Arguments.of(LockingCapTestNetConstants.getInstance(), testNetIncrementsMultiplier),
+            Arguments.of(LockingCapRegTestConstants.getInstance(), regTestIncrementsMultiplier)
+        );
+    }
+}


### PR DESCRIPTION
## Description
Following the Bridge refactors, we already migrated the LockingCapConstants to their classes to break the high coupling LockingCap had with the Bridge objects, however, it’s missing add coverage, so we need to create Unit Tests to get reliability that your new code doesn't break existing functionality when a change is made to the application.

- Create Unit Tests for all methods in LockingCapConstants 

- Create Test Cases for all Networks such as MainNet, TestNet, and RegTest.

## Motivation and Context
This relates to the Bridge Refactor to decouple some objects tied closely to the Bridge.

## How Has This Been Tested?
Unit Tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
