### PR TITLE
Adapt BridgeSupport Methods for LockingCap Refactor

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -187,7 +187,7 @@ public class BridgeSupport {
         feePerKbSupport.save();
         whitelistSupport.save();
         federationSupport.save();
-        // TODO: save lockingCapSupport.save();
+        lockingCapSupport.save(activations);
     }
 
     /**
@@ -2113,14 +2113,7 @@ public class BridgeSupport {
     }
 
     public Coin getLockingCap() {
-        // Before returning the locking cap, check if it was already set
-        if (activations.isActive(ConsensusRule.RSKIP134) && this.provider.getLockingCap() == null) {
-            // Set the initial locking cap value
-            logger.debug("Setting initial locking cap value");
-            this.provider.setLockingCap(bridgeConstants.getInitialLockingCap());
-        }
-
-        return this.provider.getLockingCap();
+        return lockingCapSupport.getLockingCap().get();
     }
 
     /**
@@ -2132,29 +2125,8 @@ public class BridgeSupport {
         return federationSupport.getActiveFederationRedeemScript();
     }
 
-    public boolean increaseLockingCap(Transaction tx, Coin newCap) {
-        // Only pre-configured addresses can modify locking cap
-        AddressBasedAuthorizer authorizer = bridgeConstants.getIncreaseLockingCapAuthorizer();
-        if (!authorizer.isAuthorized(tx, signatureCache)) {
-            logger.warn("not authorized address tried to increase locking cap. Address: {}", tx.getSender(signatureCache));
-            return false;
-        }
-        // new locking cap must be bigger than current locking cap
-        Coin currentLockingCap = this.getLockingCap();
-        if (newCap.compareTo(currentLockingCap) < 0) {
-            logger.warn("attempted value doesn't increase locking cap. Attempted: {}", newCap.value);
-            return false;
-        }
-        Coin maxLockingCap = currentLockingCap.multiply(bridgeConstants.getLockingCapIncrementsMultiplier());
-        if (newCap.compareTo(maxLockingCap) > 0) {
-            logger.warn("attempted value increases locking cap above its limit. Attempted: {}", newCap.value);
-            return false;
-        }
-
-        logger.info("increased locking cap: {}", newCap.value);
-        this.provider.setLockingCap(newCap);
-
-        return true;
+    public boolean increaseLockingCap(Transaction tx, Coin newLockingCap) {
+        return lockingCapSupport.increaseLockingCap(tx, newLockingCap);
     }
 
     public void registerBtcCoinbaseTransaction(byte[] btcTxSerialized, Sha256Hash blockHash, byte[] pmtSerialized, Sha256Hash witnessMerkleRoot, byte[] witnessReservedValue) throws VMException {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -2740,16 +2740,16 @@ public class BridgeSupport {
     }
 
     private boolean verifyLockDoesNotSurpassLockingCap(BtcTransaction btcTx, Coin totalAmount) {
-        if (!activations.isActive(ConsensusRule.RSKIP134)) {
+        Optional<Coin> lockingCap = lockingCapSupport.getLockingCap();
+        if (!lockingCap.isPresent()) {
             return true;
         }
 
         Coin fedCurrentFunds = getBtcLockedInFederation();
-        Optional<Coin> lockingCap = lockingCapSupport.getLockingCap();
         logger.trace("Evaluating locking cap for: TxId {}. Value to lock {}. Current funds {}. Current locking cap {}", btcTx.getHash(true), totalAmount, fedCurrentFunds, lockingCap);
         Coin fedUTXOsAfterThisLock = fedCurrentFunds.add(totalAmount);
         // If the federation funds (including this new UTXO) are smaller than or equals to the current locking cap, we are fine.
-        if (lockingCap.isPresent() && fedUTXOsAfterThisLock.compareTo(lockingCap.get()) <= 0) {
+        if (fedUTXOsAfterThisLock.compareTo(lockingCap.get()) <= 0) {
             return true;
         }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -2113,7 +2113,7 @@ public class BridgeSupport {
     }
 
     public Coin getLockingCap() {
-        return lockingCapSupport.getLockingCap().get();
+        return lockingCapSupport.getLockingCap();
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -187,7 +187,7 @@ public class BridgeSupport {
         feePerKbSupport.save();
         whitelistSupport.save();
         federationSupport.save();
-        lockingCapSupport.save(activations);
+        lockingCapSupport.save();
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -2113,7 +2113,7 @@ public class BridgeSupport {
     }
 
     public Coin getLockingCap() {
-        return lockingCapSupport.getLockingCap();
+        return lockingCapSupport.getLockingCap().orElse(null);
     }
 
     /**
@@ -2745,11 +2745,11 @@ public class BridgeSupport {
         }
 
         Coin fedCurrentFunds = getBtcLockedInFederation();
-        Coin lockingCap = this.getLockingCap();
+        Optional<Coin> lockingCap = lockingCapSupport.getLockingCap();
         logger.trace("Evaluating locking cap for: TxId {}. Value to lock {}. Current funds {}. Current locking cap {}", btcTx.getHash(true), totalAmount, fedCurrentFunds, lockingCap);
         Coin fedUTXOsAfterThisLock = fedCurrentFunds.add(totalAmount);
         // If the federation funds (including this new UTXO) are smaller than or equals to the current locking cap, we are fine.
-        if (fedUTXOsAfterThisLock.compareTo(lockingCap) <= 0) {
+        if (lockingCap.isPresent() && fedUTXOsAfterThisLock.compareTo(lockingCap.get()) <= 0) {
             return true;
         }
 

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -138,7 +138,7 @@ class ReleaseTransactionBuilderTest {
         assertEquals(standardMultisigFederation.getAddress(), changeOutput.getAddressFromP2SH(networkParameters));
         // And if its value is the spent UTXOs summatory minus the requested pegout amount
         // we can ensure the Federation is not paying fees for pegouts
-        assertEquals(inputsValue.minus(pegoutAmount), changeOutput.getValue());
+        Assertions.assertEquals(inputsValue.minus(pegoutAmount), changeOutput.getValue());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -138,7 +138,7 @@ class ReleaseTransactionBuilderTest {
         assertEquals(standardMultisigFederation.getAddress(), changeOutput.getAddressFromP2SH(networkParameters));
         // And if its value is the spent UTXOs summatory minus the requested pegout amount
         // we can ensure the Federation is not paying fees for pegouts
-        Assertions.assertEquals(inputsValue.minus(pegoutAmount), changeOutput.getValue());
+        assertEquals(inputsValue.minus(pegoutAmount), changeOutput.getValue());
     }
 
     @Test


### PR DESCRIPTION
## Description
After the `LockingCapSupport` interface has been created, we will use it on the `BridgeSupport`. Adapt `LockingCap` methods in the `BridgeSupport`. Use the new interface created, `LockingCapSupport`, under `co.rsk.peg.lockingcap` package to create `LockingCap` behavior.

## Motivation and Context
This relates to the Bridge Refactor to decouple some objects tied closely to the Bridge.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
