### PR TITLE
Create LockingCapConstants in BridgeConstants

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeConstants.java
@@ -22,6 +22,7 @@ import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.feeperkb.constants.FeePerKbConstants;
+import co.rsk.peg.lockingcap.constants.LockingCapConstants;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
 import co.rsk.peg.whitelist.constants.WhitelistConstants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
@@ -33,6 +34,7 @@ public abstract class BridgeConstants {
     protected FeePerKbConstants feePerKbConstants;
     protected WhitelistConstants whitelistConstants;
     protected FederationConstants federationConstants;
+    protected LockingCapConstants lockingCapConstants;
 
     protected int btc2RskMinimumAcceptableConfirmations;
     protected int btc2RskMinimumAcceptableConfirmationsOnRsk;
@@ -74,6 +76,8 @@ public abstract class BridgeConstants {
     public WhitelistConstants getWhitelistConstants() { return whitelistConstants; }
 
     public FederationConstants getFederationConstants() { return federationConstants; }
+
+    public LockingCapConstants getLockingCapConstants() { return lockingCapConstants; }
 
     public String getBtcParamsString() {
         return btcParamsString;


### PR DESCRIPTION
## Description
Following with the Bridge refactors, it is now time to refactor and remove locking cap logic from BridgeSupport class. Create LockingCapConstants in BridgeConstants.

## Motivation and Context
This relates to the Bridge Refactor to decouple some objects tied closely to the Bridge.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
