### PR TITLE
Add LockingCapSupport To BridgeSupportBuilder

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -45,6 +45,7 @@ import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.feeperkb.FeePerKbSupport;
 import co.rsk.peg.flyover.FlyoverFederationInformation;
 import co.rsk.peg.flyover.FlyoverTxResponseCodes;
+import co.rsk.peg.lockingcap.LockingCapSupport;
 import co.rsk.peg.pegin.*;
 import co.rsk.peg.pegininstructions.PeginInstructionsException;
 import co.rsk.peg.pegininstructions.PeginInstructionsProvider;
@@ -116,6 +117,7 @@ public class BridgeSupport {
     private final FeePerKbSupport feePerKbSupport;
     private final WhitelistSupport whitelistSupport;
     private final FederationSupport federationSupport;
+    private final LockingCapSupport lockingCapSupport;
 
     private final Context btcContext;
     private final BtcBlockStoreWithCache.Factory btcBlockStoreFactory;
@@ -138,6 +140,7 @@ public class BridgeSupport {
         FeePerKbSupport feePerKbSupport,
         WhitelistSupport whitelistSupport,
         FederationSupport federationSupport,
+        LockingCapSupport lockingCapSupport,
         BtcBlockStoreWithCache.Factory btcBlockStoreFactory,
         ActivationConfig.ForBlock activations,
         SignatureCache signatureCache) {
@@ -152,6 +155,7 @@ public class BridgeSupport {
         this.feePerKbSupport = feePerKbSupport;
         this.whitelistSupport = whitelistSupport;
         this.federationSupport = federationSupport;
+        this.lockingCapSupport = lockingCapSupport;
         this.btcBlockStoreFactory = btcBlockStoreFactory;
         this.activations = activations;
         this.signatureCache = signatureCache;

--- a/rskj-core/src/test/java/co/rsk/test/builders/BridgeSupportBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/BridgeSupportBuilder.java
@@ -10,6 +10,7 @@ import co.rsk.peg.btcLockSender.BtcLockSenderProvider;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.federation.FederationSupport;
 import co.rsk.peg.feeperkb.FeePerKbSupport;
+import co.rsk.peg.lockingcap.LockingCapSupport;
 import co.rsk.peg.pegininstructions.PeginInstructionsProvider;
 import co.rsk.peg.utils.BridgeEventLogger;
 import co.rsk.peg.whitelist.WhitelistSupport;
@@ -27,6 +28,7 @@ public class BridgeSupportBuilder {
     private FeePerKbSupport feePerKbSupport;
     private WhitelistSupport whitelistSupport;
     private FederationSupport federationSupport;
+    private LockingCapSupport lockingCapSupport;
     private Factory btcBlockStoreFactory;
     private ActivationConfig.ForBlock activations;
     private SignatureCache signatureCache;
@@ -42,6 +44,7 @@ public class BridgeSupportBuilder {
         this.feePerKbSupport = mock(FeePerKbSupport.class);
         this.whitelistSupport = mock(WhitelistSupport.class);
         this.federationSupport = mock(FederationSupport.class);
+        this.lockingCapSupport = mock(LockingCapSupport.class);
         this.btcBlockStoreFactory = mock(Factory.class);
         this.activations = mock(ActivationConfig.ForBlock.class);
         this.signatureCache = mock(BlockTxSignatureCache.class);
@@ -97,6 +100,11 @@ public class BridgeSupportBuilder {
         return this;
     }
 
+    public BridgeSupportBuilder withLockingCapSupport(LockingCapSupport lockingCapSupport) {
+        this.lockingCapSupport = lockingCapSupport;
+        return this;
+    }
+
     public BridgeSupportBuilder withBtcBlockStoreFactory(Factory btcBlockStoreFactory) {
         this.btcBlockStoreFactory = btcBlockStoreFactory;
         return this;
@@ -127,6 +135,7 @@ public class BridgeSupportBuilder {
             feePerKbSupport,
             whitelistSupport,
             federationSupport,
+            lockingCapSupport,
             btcBlockStoreFactory,
             activations,
             signatureCache


### PR DESCRIPTION
## Description
Following with the Bridge refactors, it is now time to refactor and remove locking cap logic from Bridge objects to LockingCap objects. This time we need to add Locking Cap logic to BridgeSupportBuilder class. Add WhitelistSupport to BridgeSupportBuilder business logic.

## Motivation and Context
This relates to the Bridge Refactor to decouple some objects tied closely to the Bridge.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
