### PR TITLE
Add methods to save proposedFederation entries

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProvider.java
@@ -25,6 +25,8 @@ public interface FederationStorageProvider {
     PendingFederation getPendingFederation();
     void setPendingFederation(PendingFederation federation);
 
+    void setProposedFederation(Federation proposedFederation);
+
     ABICallElection getFederationElection(AddressBasedAuthorizer authorizer);
 
     Optional<Long> getActiveFederationCreationBlockHeight(ActivationConfig.ForBlock activations);

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
@@ -373,8 +373,7 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
     }
 
     private void saveProposedFederation(Federation proposedFederation) {
-        // we only need to save the standard part of the fed since the emergency part is constant
-        saveFederationFormatVersion(PROPOSED_FEDERATION_FORMAT_VERSION.getKey(), STANDARD_MULTISIG_FEDERATION.getFormatVersion());
+        saveFederationFormatVersion(PROPOSED_FEDERATION_FORMAT_VERSION.getKey(), proposedFederation.getFormatVersion());
         bridgeStorageAccessor.saveToRepository(PROPOSED_FEDERATION.getKey(), proposedFederation, BridgeSerializationUtils::serializeFederation);
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
@@ -29,9 +29,11 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
     private Federation oldFederation;
     private boolean shouldSaveOldFederation = false;
 
-    private Federation proposedFederation;
     private PendingFederation pendingFederation;
     private boolean shouldSavePendingFederation = false;
+
+    private Federation proposedFederation;
+    private boolean proposedFederationIsSet = false;
 
     private ABICallElection federationElection;
 
@@ -209,6 +211,7 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
     @Override
     public void setProposedFederation(Federation proposedFederation) {
         this.proposedFederation = proposedFederation;
+        proposedFederationIsSet = true;
     }
 
     @Override
@@ -373,6 +376,10 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
     }
 
     private void saveProposedFederation(Federation proposedFederation) {
+        if (!proposedFederationIsSet) {
+            return;
+        }
+
         saveFederationFormatVersion(PROPOSED_FEDERATION_FORMAT_VERSION.getKey(), proposedFederation.getFormatVersion());
         bridgeStorageAccessor.saveToRepository(PROPOSED_FEDERATION.getKey(), proposedFederation, BridgeSerializationUtils::serializeFederation);
     }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
@@ -376,11 +376,7 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
     }
 
     private void saveProposedFederation(ActivationConfig.ForBlock activations) {
-        if (!activations.isActive(RSKIP419)) {
-            return;
-        }
-
-        if (!isProposedFederationSet) {
+        if (!activations.isActive(RSKIP419) || !isProposedFederationSet) {
             return;
         }
 

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
@@ -33,6 +33,7 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
     private boolean shouldSavePendingFederation = false;
 
     private Federation proposedFederation;
+    private boolean isProposedFederationSet = false;
 
     private ABICallElection federationElection;
 
@@ -210,6 +211,7 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
     @Override
     public void setProposedFederation(Federation proposedFederation) {
         this.proposedFederation = proposedFederation;
+        isProposedFederationSet = true;
     }
 
     @Override
@@ -374,6 +376,10 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
     }
 
     private void saveProposedFederation(Federation proposedFederation) {
+        if (!isProposedFederationSet) {
+            return;
+        }
+
         saveFederationFormatVersion(PROPOSED_FEDERATION_FORMAT_VERSION.getKey(), proposedFederation.getFormatVersion());
         bridgeStorageAccessor.saveToRepository(PROPOSED_FEDERATION.getKey(), proposedFederation, BridgeSerializationUtils::serializeFederation);
     }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
@@ -207,6 +207,11 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
     }
 
     @Override
+    public void setProposedFederation(Federation proposedFederation) {
+        this.proposedFederation = proposedFederation;
+    }
+
+    @Override
     public ABICallElection getFederationElection(AddressBasedAuthorizer authorizer) {
         if (federationElection != null) {
             return federationElection;
@@ -365,6 +370,11 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
         }
 
         bridgeStorageAccessor.saveToRepository(PENDING_FEDERATION_KEY.getKey(), serializedPendingFederation);
+    }
+
+    private void saveProposedFederation(Federation proposedFederation) {
+        saveFederationFormatVersion(PROPOSED_FEDERATION_FORMAT_VERSION.getKey(), proposedFederation.getFormatVersion());
+        bridgeStorageAccessor.saveToRepository(PROPOSED_FEDERATION_KEY.getKey(), proposedFederation, BridgeSerializationUtils::serializeFederation);
     }
 
     @Nullable

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
@@ -384,8 +384,17 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
             return;
         }
 
-        saveFederationFormatVersion(PROPOSED_FEDERATION_FORMAT_VERSION.getKey(), proposedFederation.getFormatVersion());
+        Integer formatVersion = getProposedFederationFormatVersion();
+        saveFederationFormatVersion(PROPOSED_FEDERATION_FORMAT_VERSION.getKey(), formatVersion);
         bridgeStorageAccessor.saveToRepository(PROPOSED_FEDERATION.getKey(), proposedFederation, BridgeSerializationUtils::serializeFederation);
+    }
+
+    private Integer getProposedFederationFormatVersion() {
+        if (proposedFederation == null) {
+            return null;
+        }
+
+        return proposedFederation.getFormatVersion();
     }
 
     @Nullable

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
@@ -384,17 +384,9 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
             return;
         }
 
-        Integer formatVersion = getProposedFederationFormatVersion();
+        Integer formatVersion = Optional.of(proposedFederation.getFormatVersion()).orElse(null);
         saveFederationFormatVersion(PROPOSED_FEDERATION_FORMAT_VERSION.getKey(), formatVersion);
         bridgeStorageAccessor.saveToRepository(PROPOSED_FEDERATION.getKey(), proposedFederation, BridgeSerializationUtils::serializeFederation);
-    }
-
-    private Integer getProposedFederationFormatVersion() {
-        if (proposedFederation == null) {
-            return null;
-        }
-
-        return proposedFederation.getFormatVersion();
     }
 
     @Nullable

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
@@ -375,7 +375,11 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
         bridgeStorageAccessor.saveToRepository(PENDING_FEDERATION_KEY.getKey(), serializedPendingFederation);
     }
 
-    private void saveProposedFederation(Federation proposedFederation) {
+    private void saveProposedFederation(ActivationConfig.ForBlock activations) {
+        if (!activations.isActive(RSKIP419)) {
+            return;
+        }
+
         if (!isProposedFederationSet) {
             return;
         }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
@@ -33,7 +33,6 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
     private boolean shouldSavePendingFederation = false;
 
     private Federation proposedFederation;
-    private boolean proposedFederationIsSet = false;
 
     private ABICallElection federationElection;
 
@@ -211,7 +210,6 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
     @Override
     public void setProposedFederation(Federation proposedFederation) {
         this.proposedFederation = proposedFederation;
-        proposedFederationIsSet = true;
     }
 
     @Override
@@ -376,10 +374,6 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
     }
 
     private void saveProposedFederation(Federation proposedFederation) {
-        if (!proposedFederationIsSet) {
-            return;
-        }
-
         saveFederationFormatVersion(PROPOSED_FEDERATION_FORMAT_VERSION.getKey(), proposedFederation.getFormatVersion());
         bridgeStorageAccessor.saveToRepository(PROPOSED_FEDERATION.getKey(), proposedFederation, BridgeSerializationUtils::serializeFederation);
     }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
@@ -373,8 +373,9 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
     }
 
     private void saveProposedFederation(Federation proposedFederation) {
-        saveFederationFormatVersion(PROPOSED_FEDERATION_FORMAT_VERSION.getKey(), proposedFederation.getFormatVersion());
-        bridgeStorageAccessor.saveToRepository(PROPOSED_FEDERATION_KEY.getKey(), proposedFederation, BridgeSerializationUtils::serializeFederation);
+        // we only need to save the standard part of the fed since the emergency part is constant
+        saveFederationFormatVersion(PROPOSED_FEDERATION_FORMAT_VERSION.getKey(), STANDARD_MULTISIG_FEDERATION.getFormatVersion());
+        bridgeStorageAccessor.saveToRepository(PROPOSED_FEDERATION.getKey(), proposedFederation, BridgeSerializationUtils::serializeFederation);
     }
 
     @Nullable


### PR DESCRIPTION
- Create `setProposedFederation` public method in `FederationStorageProviderImpl` to set the proposed federation

- Create `saveProposedFederation` private method in `FederationStorageProviderImpl` to save the serialized proposed federation in the repository