### PR TITLE
Add LockingCapSupport Creation To BridgeSupportFactory

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupportFactory.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupportFactory.java
@@ -27,6 +27,11 @@ import co.rsk.peg.federation.*;
 import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.feeperkb.*;
 import co.rsk.peg.feeperkb.constants.FeePerKbConstants;
+import co.rsk.peg.lockingcap.LockingCapStorageProvider;
+import co.rsk.peg.lockingcap.LockingCapStorageProviderImpl;
+import co.rsk.peg.lockingcap.LockingCapSupport;
+import co.rsk.peg.lockingcap.LockingCapSupportImpl;
+import co.rsk.peg.lockingcap.constants.LockingCapConstants;
 import co.rsk.peg.pegininstructions.PeginInstructionsProvider;
 import co.rsk.peg.storage.BridgeStorageAccessorImpl;
 import co.rsk.peg.storage.StorageAccessor;
@@ -92,6 +97,7 @@ public class BridgeSupportFactory {
             executionBlock,
             activations
         );
+        LockingCapSupport lockingCapSupport = getLockingCapSupportInstance(bridgeStorageAccessor, activations);
 
         BridgeEventLogger eventLogger = null;
         if (logs != null) {
@@ -117,6 +123,7 @@ public class BridgeSupportFactory {
             feePerKbSupport,
             whitelistSupport,
             federationSupport,
+            lockingCapSupport,
             btcBlockStoreFactory,
             activations,
             signatureCache
@@ -151,5 +158,12 @@ public class BridgeSupportFactory {
         FederationConstants federationConstants = bridgeConstants.getFederationConstants();
         FederationStorageProvider federationStorageProvider = new FederationStorageProviderImpl(bridgeStorageAccessor);
         return new FederationSupportImpl(federationConstants, federationStorageProvider, rskExecutionBlock, activations);
+    }
+
+    private LockingCapSupport getLockingCapSupportInstance(StorageAccessor bridgeStorageAccessor, ActivationConfig.ForBlock activations) {
+        LockingCapConstants lockingCapConstants = bridgeConstants.getLockingCapConstants();
+        LockingCapStorageProvider lockingCapStorageProvider = new LockingCapStorageProviderImpl(bridgeStorageAccessor);
+
+        return new LockingCapSupportImpl(lockingCapStorageProvider, activations, lockingCapConstants, signatureCache);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupportImpl.java
@@ -22,7 +22,8 @@ public class LockingCapSupportImpl implements LockingCapSupport {
 
     public LockingCapSupportImpl(
         LockingCapStorageProvider storageProvider,
-        ForBlock activations, LockingCapConstants constants,
+        ActivationConfig.ForBlock activations,
+        LockingCapConstants constants,
         SignatureCache signatureCache
     ) {
         this.storageProvider = storageProvider;


### PR DESCRIPTION
## Description
Update BridgeSupportFactory to create an instance of LockingCapSupport and pass it to BridgeSupport constructor.

## Motivation and Context
This relates to the Bridge Refactor to decouple some objects tied closely to the Bridge.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
