### PR TITLE
Fix BridgeSupportAddSignatureTest after LockingCap refactor

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
@@ -2,6 +2,7 @@ package co.rsk.peg;
 
 import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.feeperkb.FeePerKbSupport;
+import co.rsk.peg.lockingcap.LockingCapSupport;
 import co.rsk.peg.whitelist.WhitelistSupport;
 import java.time.Instant;
 import java.math.BigInteger;
@@ -81,6 +82,7 @@ class BridgeSupportAddSignatureTest {
     private ActivationConfig.ForBlock activationsAfterForks;
     private BridgeSupportBuilder bridgeSupportBuilder;
     private WhitelistSupport whitelistSupport;
+    private LockingCapSupport lockingCapSupport;
 
     @BeforeEach
     void setUpOnEachTest() {
@@ -88,6 +90,7 @@ class BridgeSupportAddSignatureTest {
         activationsAfterForks = ActivationConfigsForTest.all().forBlock(0);
         bridgeSupportBuilder = new BridgeSupportBuilder();
         whitelistSupport = mock(WhitelistSupport.class);
+        lockingCapSupport = mock(LockingCapSupport.class);
     }
 
     @Test
@@ -125,6 +128,7 @@ class BridgeSupportAddSignatureTest {
             feePerKbSupport,
             whitelistSupport,
             mockFederationSupport,
+            lockingCapSupport,
             null,
             null,
             null
@@ -160,6 +164,7 @@ class BridgeSupportAddSignatureTest {
             feePerKbSupport,
             whitelistSupport,
             mockFederationSupport,
+            lockingCapSupport,
             null,
             null,
             null
@@ -226,6 +231,7 @@ class BridgeSupportAddSignatureTest {
             feePerKbSupport,
             whitelistSupport,
             mockFederationSupport,
+            lockingCapSupport,
             null,
             null,
             null


### PR DESCRIPTION
## Description
Following the Bridge refactors, we already migrated the LockingCap processes to their classes to break the high coupling LockingCap had with the Bridge objects. After refactoring, showed up different issues in the tests and it is time to fix them.

Fix BridgeSupportAddSignatureTest class.


## Motivation and Context
This relates to the Bridge Refactor to decouple some objects tied closely to the Bridge.

## How Has This Been Tested?
Unit Tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
