### PR TITLE
Fix BridgeSupportIT after LockingCap refactor

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportIT.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportIT.java
@@ -39,6 +39,11 @@ import co.rsk.peg.federation.*;
 import co.rsk.peg.federation.FederationMember.KeyType;
 import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.feeperkb.FeePerKbSupport;
+import co.rsk.peg.lockingcap.LockingCapStorageProvider;
+import co.rsk.peg.lockingcap.LockingCapStorageProviderImpl;
+import co.rsk.peg.lockingcap.LockingCapSupport;
+import co.rsk.peg.lockingcap.LockingCapSupportImpl;
+import co.rsk.peg.lockingcap.constants.LockingCapMainNetConstants;
 import co.rsk.peg.pegininstructions.PeginInstructionsProvider;
 import co.rsk.peg.simples.SimpleBlockChain;
 import co.rsk.peg.storage.BridgeStorageAccessorImpl;
@@ -143,6 +148,7 @@ public class BridgeSupportIT {
     private FeePerKbSupport feePerKbSupport;
     private WhitelistSupport whitelistSupport;
     private WhitelistStorageProvider whitelistStorageProvider;
+    private LockingCapSupport lockingCapSupport;
 
     @BeforeEach
     void setUpOnEachTest() {
@@ -162,6 +168,13 @@ public class BridgeSupportIT {
             WhitelistMainNetConstants.getInstance(),
             whitelistStorageProvider,
             activations,
+            signatureCache
+        );
+        LockingCapStorageProvider lockingCapStorageProvider = new LockingCapStorageProviderImpl(inMemoryStorage);
+        lockingCapSupport = new LockingCapSupportImpl(
+            lockingCapStorageProvider,
+            activations,
+            LockingCapMainNetConstants.getInstance(),
             signatureCache
         );
     }
@@ -328,6 +341,7 @@ public class BridgeSupportIT {
             feePerKbSupport,
             whitelistSupport,
             federationSupport,
+            lockingCapSupport,
             btcBlockStoreFactory,
             mock(ActivationConfig.ForBlock.class),
             signatureCache


### PR DESCRIPTION
## Description
Following the Bridge refactors, we already migrated the LockingCap processes to their classes to break the high coupling LockingCap had with the Bridge objects. After refactoring, showed up different issues in the tests and it is time to fix them.

Fix BridgeSupportIT class.

## Motivation and Context
This relates to the Bridge Refactor to decouple some objects tied closely to the Bridge.

## How Has This Been Tested?
Unit Tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
