### PR TITLE
Fix PowpegMigrationTest after LockingCap refactor

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/federation/PowpegMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/PowpegMigrationTest.java
@@ -95,7 +95,6 @@ class PowpegMigrationTest {
         );
 
         repository.addBalance(PrecompiledContracts.BRIDGE_ADDR, co.rsk.core.Coin.fromBitcoin(bridgeConstants.getMaxRbtc()));
-        bridgeStorageProvider.setLockingCap(bridgeConstants.getMaxRbtc());
 
         BtcBlockStoreWithCache.Factory btcBlockStoreFactory = new RepositoryBtcBlockStoreWithCache.Factory(
             btcParams,


### PR DESCRIPTION
## Description
Following the Bridge refactors, we already migrated the LockingCap processes to their classes to break the high coupling LockingCap had with the Bridge objects. After refactoring, showed up different issues in the tests and it is time to fix them.

- Fix the PowpegMigrationTest class.
- Get rid of setting the LockingCap since it is not mandatory in the test. From now on, the test will use the LockingCap default value, i.e., the LockingCapConstants.initialValue().

## Motivation and Context
This relates to the Bridge Refactor to decouple some objects tied closely to the Bridge.

## How Has This Been Tested?
Unit Tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
