### PR TITLE
Add Coverage To LockingCap-Related Methods In BridgeSupport

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -32,6 +32,7 @@ import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.feeperkb.FeePerKbResponseCode;
 import co.rsk.peg.feeperkb.FeePerKbStorageProvider;
 import co.rsk.peg.feeperkb.FeePerKbSupport;
+import co.rsk.peg.lockingcap.LockingCapCaller;
 import co.rsk.peg.lockingcap.LockingCapStorageProvider;
 import co.rsk.peg.lockingcap.LockingCapStorageProviderImpl;
 import co.rsk.peg.lockingcap.LockingCapSupport;
@@ -54,7 +55,6 @@ import co.rsk.peg.utils.MerkleTreeUtils;
 import co.rsk.peg.pegin.RejectedPeginReason;
 import co.rsk.peg.utils.UnrefundablePeginReason;
 import co.rsk.peg.vote.ABICallSpec;
-import co.rsk.peg.vote.AddressBasedAuthorizer;
 import co.rsk.peg.whitelist.*;
 import co.rsk.peg.whitelist.constants.WhitelistMainNetConstants;
 import co.rsk.test.builders.BridgeSupportBuilder;
@@ -536,6 +536,52 @@ class BridgeSupportTest {
             int result = bridgeSupport.setLockWhitelistDisableBlockDelay(tx, disableBlockDelayBI);
 
             assertEquals(WhitelistResponseCode.SUCCESS.getCode(), result);
+        }
+    }
+
+    @Nested
+    @Tag("LockingCap")
+    class LockingCapTest {
+
+        private LockingCapSupport lockingCapSupport;
+        private BridgeSupport bridgeSupport;
+        LockingCapConstants constants = LockingCapMainNetConstants.getInstance();
+
+        @BeforeEach
+        void setUp() {
+            lockingCapSupport = mock(LockingCapSupportImpl.class);
+            bridgeSupport = bridgeSupportBuilder
+                .withLockingCapSupport(lockingCapSupport)
+                .build();
+        }
+
+        @Test
+        void getLockingCap() {
+            // Arrange
+            Optional<Coin> expectedLockingCap = Optional.of(constants.getInitialValue());
+            when(lockingCapSupport.getLockingCap()).thenReturn(expectedLockingCap);
+
+            // Act
+            Optional<Coin> actualLockingCap = Optional.of(bridgeSupport.getLockingCap());
+
+            // Assert
+            assertEquals(expectedLockingCap, actualLockingCap);
+        }
+
+        @Test
+        void increaseLockingCap() {
+            // Arrange
+            Coin newLockingCap = constants.getInitialValue().add(Coin.SATOSHI);
+            Transaction tx = TransactionUtils.getTransactionFromCaller(signatureCache, LockingCapCaller.AUTHORIZED.getRskAddress());
+            when(lockingCapSupport.increaseLockingCap(tx, newLockingCap)).thenReturn(true);
+            when(lockingCapSupport.getLockingCap()).thenReturn(Optional.of(newLockingCap));
+
+            // Act
+            boolean actualResult = bridgeSupport.increaseLockingCap(tx, newLockingCap);
+
+            // Assert
+            assertTrue(actualResult);
+            assertEquals(newLockingCap, bridgeSupport.getLockingCap());
         }
     }
 


### PR DESCRIPTION
## Description
Following the Bridge refactors, we already migrated the LockingCapConstants to their classes to break the high coupling LockingCap had with the Bridge objects, however, it’s missing add coverage, so we need to create Unit Tests to get reliability that your new code doesn't break existing functionality when a change is made to the application.

- Create Unit Tests for all methods LockingCap-related in BridgeSupport.

## Motivation and Context
This relates to the Bridge Refactor to decouple some objects tied closely to the Bridge, so it's crucial to add coverage to the code that has been migrated.

## How Has This Been Tested?
Unit Tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
