### PR TITLE
Add getProposedFederation method

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProvider.java
@@ -27,6 +27,8 @@ public interface FederationStorageProvider {
 
     void setProposedFederation(Federation proposedFederation);
 
+    Optional<Federation> getProposedFederation(FederationConstants federationConstants, ActivationConfig.ForBlock activations);
+
     ABICallElection getFederationElection(AddressBasedAuthorizer authorizer);
 
     Optional<Long> getActiveFederationCreationBlockHeight(ActivationConfig.ForBlock activations);

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
@@ -236,8 +236,10 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
                     return null;
                 }
 
-                // storage version is always present for non-null proposed federation
                 Optional<Integer> storageVersion = getStorageVersion(PROPOSED_FEDERATION_FORMAT_VERSION.getKey());
+                if (!storageVersion.isPresent()) {
+                    throw new IllegalStateException("Storage version should be present for non-null proposed federation");
+                }
                 return BridgeSerializationUtils.deserializeFederationAccordingToVersion(data, storageVersion.get(), federationConstants, activations);
             }
         );

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
@@ -4,12 +4,15 @@ import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.core.UTXO;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.peg.BridgeSerializationUtils;
+import co.rsk.peg.bitcoin.ErpRedeemScriptBuilderUtils;
 import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.storage.StorageAccessor;
 import co.rsk.peg.vote.ABICallElection;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.vm.DataWord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
@@ -21,6 +24,7 @@ import static co.rsk.peg.federation.FederationFormatVersion.*;
 import static org.ethereum.config.blockchain.upgrades.ConsensusRule.*;
 
 public class FederationStorageProviderImpl implements FederationStorageProvider {
+    private static final Logger logger = LoggerFactory.getLogger(FederationStorageProviderImpl.class);
     private final StorageAccessor bridgeStorageAccessor;
     private List<UTXO> newFederationBtcUTXOs;
     private List<UTXO> oldFederationBtcUTXOs;
@@ -238,7 +242,9 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
 
                 Optional<Integer> storageVersion = getStorageVersion(PROPOSED_FEDERATION_FORMAT_VERSION.getKey());
                 if (!storageVersion.isPresent()) {
-                    throw new IllegalStateException("Storage version should be present for non-null proposed federation");
+                    String message = "Storage version should be present for non-null proposed federation";
+                    logger.warn("[getProposedFederation] {}", message);
+                    throw new IllegalStateException(message);
                 }
                 return BridgeSerializationUtils.deserializeFederationAccordingToVersion(data, storageVersion.get(), federationConstants, activations);
             }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
@@ -215,6 +215,31 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
     }
 
     @Override
+    public Optional<Federation> getProposedFederation(FederationConstants federationConstants, ActivationConfig.ForBlock activations) {
+        if (!activations.isActive(RSKIP419)) {
+            return Optional.empty();
+        }
+
+        if (proposedFederation != null || isProposedFederationSet) {
+            return Optional.ofNullable(proposedFederation);
+        }
+
+        proposedFederation = bridgeStorageAccessor.getFromRepository(
+            PROPOSED_FEDERATION.getKey(),
+            data -> {
+                if (data == null) {
+                    return null;
+                }
+                // storage version should be always present for non-null proposed federation
+                Optional<Integer> storageVersion = getStorageVersion(PROPOSED_FEDERATION_FORMAT_VERSION.getKey());
+                return BridgeSerializationUtils.deserializeFederationAccordingToVersion(data, storageVersion.get(), federationConstants, activations);
+            }
+        );
+
+        return Optional.ofNullable(proposedFederation);
+    }
+
+    @Override
     public ABICallElection getFederationElection(AddressBasedAuthorizer authorizer) {
         if (federationElection != null) {
             return federationElection;

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
@@ -4,7 +4,6 @@ import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.core.UTXO;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.peg.BridgeSerializationUtils;
-import co.rsk.peg.bitcoin.ErpRedeemScriptBuilderUtils;
 import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.storage.StorageAccessor;
 import co.rsk.peg.vote.ABICallElection;

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
@@ -220,8 +220,13 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
             return Optional.empty();
         }
 
-        if (proposedFederation != null || isProposedFederationSet) {
-            return Optional.ofNullable(proposedFederation);
+        if (proposedFederation != null) {
+            return Optional.of(proposedFederation);
+        }
+
+        // reaching this point means the proposed federation was set to null
+        if (isProposedFederationSet) {
+            return Optional.empty();
         }
 
         proposedFederation = bridgeStorageAccessor.getFromRepository(
@@ -230,6 +235,7 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
                 if (data == null) {
                     return null;
                 }
+
                 // storage version is always present for non-null proposed federation
                 Optional<Integer> storageVersion = getStorageVersion(PROPOSED_FEDERATION_FORMAT_VERSION.getKey());
                 return BridgeSerializationUtils.deserializeFederationAccordingToVersion(data, storageVersion.get(), federationConstants, activations);

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
@@ -230,7 +230,7 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
                 if (data == null) {
                     return null;
                 }
-                // storage version should be always present for non-null proposed federation
+                // storage version is always present for non-null proposed federation
                 Optional<Integer> storageVersion = getStorageVersion(PROPOSED_FEDERATION_FORMAT_VERSION.getKey());
                 return BridgeSerializationUtils.deserializeFederationAccordingToVersion(data, storageVersion.get(), federationConstants, activations);
             }

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
@@ -1036,6 +1036,18 @@ class FederationStorageProviderImplTests {
         }
 
         @Test
+        void getProposedFederation_whenNullProposedFederationIsSaved_shouldReturnEmpty() {
+            // first save a non-null value to make sure saving a null one is actually happening
+            bridgeStorageAccessor.saveToRepository(PROPOSED_FEDERATION_FORMAT_VERSION.getKey(), proposedFederation.getFormatVersion(), BridgeSerializationUtils::serializeInteger);
+            bridgeStorageAccessor.saveToRepository(PROPOSED_FEDERATION.getKey(), proposedFederation, BridgeSerializationUtils::serializeFederation);
+
+            bridgeStorageAccessor.saveToRepository(PROPOSED_FEDERATION_FORMAT_VERSION.getKey(), null, BridgeSerializationUtils::serializeInteger);
+            bridgeStorageAccessor.saveToRepository(PROPOSED_FEDERATION.getKey(), null, BridgeSerializationUtils::serializeFederation);
+
+            assertFalse(federationStorageProvider.getProposedFederation(federationConstants, allActivations).isPresent());
+        }
+
+        @Test
         void getProposedFederation_whenProposedFederationIsCached_shouldReturnCachedFederation() {
             // first we have to save the proposed fed so the repo is not empty
             bridgeStorageAccessor.saveToRepository(PROPOSED_FEDERATION_FORMAT_VERSION.getKey(), proposedFederation.getFormatVersion(), BridgeSerializationUtils::serializeInteger);

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
@@ -1001,15 +1001,15 @@ class FederationStorageProviderImplTests {
         }
 
         @Test
-        void getProposedFederation_preRSKIP419_shouldReturnEmpty() {
-            federationStorageProvider.setProposedFederation(proposedFederation);
-
-            assertFalse(federationStorageProvider.getProposedFederation(federationConstants, preLovellActivations).isPresent());
+        void getProposedFederation_whenThereIsNoProposedFederationSaved_shouldReturnEmpty() {
+            assertFalse(federationStorageProvider.getProposedFederation(federationConstants, allActivations).isPresent());
         }
 
         @Test
-        void getProposedFederation_whenStorageEntryIsNull_shouldReturnEmpty() {
-            assertFalse(federationStorageProvider.getProposedFederation(federationConstants, allActivations).isPresent());
+        void getProposedFederation_preRSKIP419_whenProposedFederationIsSet_shouldReturnEmpty() {
+            federationStorageProvider.setProposedFederation(proposedFederation);
+
+            assertFalse(federationStorageProvider.getProposedFederation(federationConstants, preLovellActivations).isPresent());
         }
 
         @Test
@@ -1037,8 +1037,6 @@ class FederationStorageProviderImplTests {
 
         @Test
         void getProposedFederation_whenProposedFederationIsCached_shouldReturnCachedFederation() {
-            Federation proposedFederationToBeSavedAfterCache = new StandardMultiSigFederationBuilder().build();
-
             // first we have to save the proposed fed so the repo is not empty
             bridgeStorageAccessor.saveToRepository(PROPOSED_FEDERATION_FORMAT_VERSION.getKey(), proposedFederation.getFormatVersion(), BridgeSerializationUtils::serializeInteger);
             bridgeStorageAccessor.saveToRepository(PROPOSED_FEDERATION.getKey(), proposedFederation, BridgeSerializationUtils::serializeFederation);
@@ -1046,8 +1044,9 @@ class FederationStorageProviderImplTests {
             federationStorageProvider.getProposedFederation(federationConstants, allActivations);
 
             // saving in the repo another fed to make sure the cached value is the one being returned
-            bridgeStorageAccessor.saveToRepository(PROPOSED_FEDERATION_FORMAT_VERSION.getKey(), proposedFederationToBeSavedAfterCache.getFormatVersion(), BridgeSerializationUtils::serializeInteger);
-            bridgeStorageAccessor.saveToRepository(PROPOSED_FEDERATION.getKey(), proposedFederationToBeSavedAfterCache, BridgeSerializationUtils::serializeFederation);
+            Federation anotherFederation = new StandardMultiSigFederationBuilder().build();
+            bridgeStorageAccessor.saveToRepository(PROPOSED_FEDERATION_FORMAT_VERSION.getKey(), anotherFederation.getFormatVersion(), BridgeSerializationUtils::serializeInteger);
+            bridgeStorageAccessor.saveToRepository(PROPOSED_FEDERATION.getKey(), anotherFederation, BridgeSerializationUtils::serializeFederation);
 
             assertEquals(Optional.of(proposedFederation), federationStorageProvider.getProposedFederation(federationConstants, allActivations));
         }

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
@@ -1001,7 +1001,7 @@ class FederationStorageProviderImplTests {
         }
 
         @Test
-        void getProposedFederation_whenThereIsNoProposedFederationSaved_shouldReturnEmpty() {
+        void getProposedFederation_whenThereIsNoProposedFederationSavedNorSet_shouldReturnEmpty() {
             assertFalse(federationStorageProvider.getProposedFederation(federationConstants, allActivations).isPresent());
         }
 

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
@@ -929,7 +929,7 @@ class FederationStorageProviderImplTests {
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ProposedFederationTests {
         private final ActivationConfig.ForBlock preLovellActivations = ActivationConfigsForTest.arrowhead631().forBlock(0L);
-        private final ActivationConfig.ForBlock allActivations = ActivationConfigsForTest.lovell700().forBlock(0L);
+        private final ActivationConfig.ForBlock allActivations = ActivationConfigsForTest.all().forBlock(0L);
         private final Federation proposedFederation = new P2shErpFederationBuilder().build();
         private StorageAccessor bridgeStorageAccessor;
         private FederationStorageProvider federationStorageProvider;


### PR DESCRIPTION
- Create `getProposedFederation` method to get the proposed federation saved in the repository.
- Create tests for different scenarios