### PR TITLE
Zero - Negative LockingCap Value Business Logic

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -1165,9 +1165,6 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         logger.trace("increaseLockingCap");
 
         Coin newLockingCap = BridgeUtils.getCoinFromBigInteger((BigInteger) args[0]);
-        if (newLockingCap.getValue() <= 0) {
-            throw new BridgeIllegalArgumentException("Locking cap must be bigger than zero");
-        }
 
         return bridgeSupport.increaseLockingCap(rskTx, newLockingCap);
     }

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -29,6 +29,7 @@ import co.rsk.crypto.Keccak256;
 import co.rsk.panic.PanicProcessor;
 import co.rsk.peg.BridgeMethods.BridgeMethodExecutor;
 import co.rsk.peg.feeperkb.FeePerKbResponseCode;
+import co.rsk.peg.lockingcap.LockingCapIllegalArgumentException;
 import co.rsk.peg.vote.ABICallSpec;
 import co.rsk.peg.bitcoin.MerkleBranch;
 import co.rsk.peg.federation.Federation;
@@ -1161,12 +1162,14 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         }
     }
 
-    public boolean increaseLockingCap(Object[] args) throws VMException {
+    public boolean increaseLockingCap(Object[] args) throws BridgeIllegalArgumentException {
         logger.trace("increaseLockingCap");
-
         Coin newLockingCap = BridgeUtils.getCoinFromBigInteger((BigInteger) args[0]);
-
-        return bridgeSupport.increaseLockingCap(rskTx, newLockingCap);
+        try {
+            return bridgeSupport.increaseLockingCap(rskTx, newLockingCap);
+        } catch (LockingCapIllegalArgumentException e) {
+            throw new BridgeIllegalArgumentException(e.getMessage());
+        }
     }
 
     public void registerBtcCoinbaseTransaction(Object[] args) throws VMException {

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -1161,7 +1161,7 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         }
     }
 
-    public boolean increaseLockingCap(Object[] args) throws BridgeIllegalArgumentException {
+    public boolean increaseLockingCap(Object[] args) throws VMException {
         logger.trace("increaseLockingCap");
 
         Coin newLockingCap = BridgeUtils.getCoinFromBigInteger((BigInteger) args[0]);

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -2125,7 +2125,7 @@ public class BridgeSupport {
         return federationSupport.getActiveFederationRedeemScript();
     }
 
-    public boolean increaseLockingCap(Transaction tx, Coin newLockingCap) throws BridgeIllegalArgumentException {
+    public boolean increaseLockingCap(Transaction tx, Coin newLockingCap) throws VMException {
         return lockingCapSupport.increaseLockingCap(tx, newLockingCap);
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -45,6 +45,7 @@ import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.feeperkb.FeePerKbSupport;
 import co.rsk.peg.flyover.FlyoverFederationInformation;
 import co.rsk.peg.flyover.FlyoverTxResponseCodes;
+import co.rsk.peg.lockingcap.LockingCapIllegalArgumentException;
 import co.rsk.peg.lockingcap.LockingCapSupport;
 import co.rsk.peg.pegin.*;
 import co.rsk.peg.pegininstructions.PeginInstructionsException;
@@ -2125,7 +2126,7 @@ public class BridgeSupport {
         return federationSupport.getActiveFederationRedeemScript();
     }
 
-    public boolean increaseLockingCap(Transaction tx, Coin newLockingCap) throws VMException {
+    public boolean increaseLockingCap(Transaction tx, Coin newLockingCap) throws LockingCapIllegalArgumentException {
         return lockingCapSupport.increaseLockingCap(tx, newLockingCap);
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -2125,7 +2125,7 @@ public class BridgeSupport {
         return federationSupport.getActiveFederationRedeemScript();
     }
 
-    public boolean increaseLockingCap(Transaction tx, Coin newLockingCap) {
+    public boolean increaseLockingCap(Transaction tx, Coin newLockingCap) throws BridgeIllegalArgumentException {
         return lockingCapSupport.increaseLockingCap(tx, newLockingCap);
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapIllegalArgumentException.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapIllegalArgumentException.java
@@ -1,0 +1,18 @@
+package co.rsk.peg.lockingcap;
+
+import org.ethereum.vm.exception.VMException;
+
+public class LockingCapIllegalArgumentException extends VMException {
+
+    public LockingCapIllegalArgumentException() {
+        super();
+    }
+
+    public LockingCapIllegalArgumentException(String message) {
+        super(message);
+    }
+
+    public LockingCapIllegalArgumentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupport.java
@@ -9,7 +9,7 @@ public interface LockingCapSupport {
 
     Optional<Coin> getLockingCap();
 
-    boolean increaseLockingCap(Transaction tx, Coin newCap) throws BridgeIllegalArgumentException;
+    boolean increaseLockingCap(Transaction tx, Coin newCap) throws LockingCapIllegalArgumentException;
 
     void save();
 }

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupport.java
@@ -1,6 +1,7 @@
 package co.rsk.peg.lockingcap;
 
 import co.rsk.bitcoinj.core.Coin;
+import co.rsk.peg.BridgeIllegalArgumentException;
 import java.util.Optional;
 import org.ethereum.core.Transaction;
 
@@ -8,7 +9,7 @@ public interface LockingCapSupport {
 
     Optional<Coin> getLockingCap();
 
-    boolean increaseLockingCap(Transaction tx, Coin newCap);
+    boolean increaseLockingCap(Transaction tx, Coin newCap) throws BridgeIllegalArgumentException;
 
     void save();
 }

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupport.java
@@ -1,7 +1,6 @@
 package co.rsk.peg.lockingcap;
 
 import co.rsk.bitcoinj.core.Coin;
-import co.rsk.peg.BridgeIllegalArgumentException;
 import java.util.Optional;
 import org.ethereum.core.Transaction;
 

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupportImpl.java
@@ -48,6 +48,7 @@ public class LockingCapSupportImpl implements LockingCapSupport {
     @Override
     public boolean increaseLockingCap(Transaction tx, Coin newLockingCap) throws BridgeIllegalArgumentException {
         if (newLockingCap.getValue() <= 0) {
+            logger.warn("[increaseLockingCap] {} {}", "Locking Cap must be greater than zero. Value attempted: ", newLockingCap.value);
             throw new BridgeIllegalArgumentException("Locking Cap must be greater than zero");
         }
 

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupportImpl.java
@@ -48,6 +48,7 @@ public class LockingCapSupportImpl implements LockingCapSupport {
     public boolean increaseLockingCap(Transaction tx, Coin newLockingCap) throws LockingCapIllegalArgumentException {
         final String INCREASE_LOCKING_CAP_TAG = "[increaseLockingCap] %s";
         String baseMessage = String.format(INCREASE_LOCKING_CAP_TAG, " {} {}");
+
         if (newLockingCap.getValue() <= 0) {
             String message = "Locking Cap must be greater than zero. Value attempted: ";
             logger.warn(baseMessage, message, newLockingCap.value);
@@ -57,7 +58,7 @@ public class LockingCapSupportImpl implements LockingCapSupport {
         // Only pre-configured addresses can modify Locking Cap
         AddressBasedAuthorizer authorizer = constants.getIncreaseAuthorizer();
         if (!authorizer.isAuthorized(tx, signatureCache)) {
-            logger.warn(baseMessage, "Not authorized address tried to increase Locking Cap. Address: ", tx.getSender(signatureCache));
+            logger.warn(baseMessage, "An unauthorized address tried to increase Locking Cap. Address: ", tx.getSender(signatureCache));
             return false;
         }
 

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupportImpl.java
@@ -47,6 +47,7 @@ public class LockingCapSupportImpl implements LockingCapSupport {
     @Override
     public boolean increaseLockingCap(Transaction tx, Coin newLockingCap) throws LockingCapIllegalArgumentException {
         final String INCREASE_LOCKING_CAP_LOG_TAG = "[increaseLockingCap] {} {}";
+
         if (newLockingCap.getValue() <= 0) {
             logger.warn(INCREASE_LOCKING_CAP_LOG_TAG, "Locking Cap must be greater than zero. Value attempted: ", newLockingCap.value);
             throw new LockingCapIllegalArgumentException("Locking Cap must be greater than zero");

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupportImpl.java
@@ -46,19 +46,19 @@ public class LockingCapSupportImpl implements LockingCapSupport {
 
     @Override
     public boolean increaseLockingCap(Transaction tx, Coin newLockingCap) throws LockingCapIllegalArgumentException {
-        final String INCREASE_LOCKING_CAP_TAG = "[increaseLockingCap] %s";
-        String baseMessage = String.format(INCREASE_LOCKING_CAP_TAG, " {} {}");
+        final String INCREASE_LOCKING_CAP_TAG = "increaseLockingCap";
 
         if (newLockingCap.getValue() <= 0) {
-            String message = "Locking Cap must be greater than zero. Value attempted: ";
-            logger.warn(baseMessage, message, newLockingCap.value);
-            throw new LockingCapIllegalArgumentException(message + newLockingCap.value);
+            String message = "Locking Cap must be greater than zero. Value attempted: %d";
+            String baseMessage = String.format(message, newLockingCap.value);
+            logger.warn("[{}] {}}", INCREASE_LOCKING_CAP_TAG, baseMessage);
+            throw new LockingCapIllegalArgumentException(baseMessage);
         }
 
         // Only pre-configured addresses can modify Locking Cap
         AddressBasedAuthorizer authorizer = constants.getIncreaseAuthorizer();
         if (!authorizer.isAuthorized(tx, signatureCache)) {
-            logger.warn(baseMessage, "An unauthorized address tried to increase Locking Cap. Address: ", tx.getSender(signatureCache));
+            logger.warn("[{}] An unauthorized address tried to increase Locking Cap. Address: {}", INCREASE_LOCKING_CAP_TAG, tx.getSender(signatureCache));
             return false;
         }
 
@@ -66,26 +66,25 @@ public class LockingCapSupportImpl implements LockingCapSupport {
         Optional<Coin> currentLockingCap = getLockingCap();
 
         if (!currentLockingCap.isPresent()) {
-            logger.warn(baseMessage, "Current Locking Cap is not set since RSKIP134 is not active. Value attempted: ", newLockingCap.value);
+            logger.warn("[{}] Current Locking Cap is not set since RSKIP134 is not active. Value attempted: {}", INCREASE_LOCKING_CAP_TAG, newLockingCap.value);
             return false;
         }
 
         Coin lockingCap = currentLockingCap.get();
 
         if (newLockingCap.compareTo(lockingCap) < 0) {
-            logger.warn(baseMessage, "Attempted value doesn't increase Locking Cap. Value attempted: ", newLockingCap.value);
+            logger.warn("[{}] Attempted value doesn't increase Locking Cap. Value attempted: {}", INCREASE_LOCKING_CAP_TAG, newLockingCap.value);
             return false;
         }
 
         Coin maxLockingCapVoteValueAllowed = lockingCap.multiply(constants.getIncrementsMultiplier());
         if (newLockingCap.compareTo(maxLockingCapVoteValueAllowed) > 0) {
-            baseMessage = String.format(INCREASE_LOCKING_CAP_TAG, "Attempted value tries to increase Locking Cap above its limit. Value attempted: {} . maxLockingCapVoteValueAllowed: {}");
-            logger.warn(baseMessage, newLockingCap.value, maxLockingCapVoteValueAllowed.value);
+            logger.warn("[{}] Attempted value tries to increase Locking Cap above its limit. Value attempted: {} . maxLockingCapVoteValueAllowed: {}", INCREASE_LOCKING_CAP_TAG, newLockingCap.value, maxLockingCapVoteValueAllowed.value);
             return false;
         }
 
         storageProvider.setLockingCap(newLockingCap);
-        logger.info(baseMessage, "Increased locking cap: ", newLockingCap.value);
+        logger.info("[{}] Increased locking cap: {}", INCREASE_LOCKING_CAP_TAG, newLockingCap.value);
 
         return true;
     }

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupportImpl.java
@@ -46,18 +46,18 @@ public class LockingCapSupportImpl implements LockingCapSupport {
 
     @Override
     public boolean increaseLockingCap(Transaction tx, Coin newLockingCap) throws LockingCapIllegalArgumentException {
-        final String INCREASE_LOCKING_CAP_LOG_TAG = "[increaseLockingCap] {} {}";
-
+        final String INCREASE_LOCKING_CAP_TAG = "[increaseLockingCap] %s";
+        String baseMessage = String.format(INCREASE_LOCKING_CAP_TAG, " {} {}");
         if (newLockingCap.getValue() <= 0) {
             String message = "Locking Cap must be greater than zero. Value attempted: ";
-            logger.warn(INCREASE_LOCKING_CAP_LOG_TAG, message, newLockingCap.value);
+            logger.warn(baseMessage, message, newLockingCap.value);
             throw new LockingCapIllegalArgumentException(message + newLockingCap.value);
         }
 
         // Only pre-configured addresses can modify Locking Cap
         AddressBasedAuthorizer authorizer = constants.getIncreaseAuthorizer();
         if (!authorizer.isAuthorized(tx, signatureCache)) {
-            logger.warn(INCREASE_LOCKING_CAP_LOG_TAG, "Not authorized address tried to increase Locking Cap. Address: ", tx.getSender(signatureCache));
+            logger.warn(baseMessage, "Not authorized address tried to increase Locking Cap. Address: ", tx.getSender(signatureCache));
             return false;
         }
 
@@ -65,25 +65,25 @@ public class LockingCapSupportImpl implements LockingCapSupport {
         Optional<Coin> currentLockingCap = getLockingCap();
 
         if (!currentLockingCap.isPresent()) {
-            logger.warn(INCREASE_LOCKING_CAP_LOG_TAG, "Current Locking Cap is not set since RSKIP134 is not active. Value attempted: ", newLockingCap.value);
+            logger.warn(baseMessage, "Current Locking Cap is not set since RSKIP134 is not active. Value attempted: ", newLockingCap.value);
             return false;
         }
 
         Coin lockingCap = currentLockingCap.get();
 
         if (newLockingCap.compareTo(lockingCap) < 0) {
-            logger.warn(INCREASE_LOCKING_CAP_LOG_TAG, "Attempted value doesn't increase Locking Cap. Value attempted: ", newLockingCap.value);
+            logger.warn(baseMessage, "Attempted value doesn't increase Locking Cap. Value attempted: ", newLockingCap.value);
             return false;
         }
 
         Coin maxLockingCapVoteValueAllowed = lockingCap.multiply(constants.getIncrementsMultiplier());
         if (newLockingCap.compareTo(maxLockingCapVoteValueAllowed) > 0) {
-            logger.warn(INCREASE_LOCKING_CAP_LOG_TAG, "Attempted value increases Locking Cap above its limit. Value attempted: ", newLockingCap.value);
+            logger.warn(baseMessage, "Attempted value increases Locking Cap above its limit. Value attempted: ", newLockingCap.value);
             return false;
         }
 
         storageProvider.setLockingCap(newLockingCap);
-        logger.info(INCREASE_LOCKING_CAP_LOG_TAG, "Increased locking cap: ", newLockingCap.value);
+        logger.info(baseMessage, "Increased locking cap: ", newLockingCap.value);
 
         return true;
     }

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupportImpl.java
@@ -1,6 +1,7 @@
 package co.rsk.peg.lockingcap;
 
 import co.rsk.bitcoinj.core.Coin;
+import co.rsk.peg.BridgeIllegalArgumentException;
 import co.rsk.peg.lockingcap.constants.LockingCapConstants;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
 import java.util.Optional;
@@ -45,7 +46,11 @@ public class LockingCapSupportImpl implements LockingCapSupport {
     }
 
     @Override
-    public boolean increaseLockingCap(Transaction tx, Coin newLockingCap) {
+    public boolean increaseLockingCap(Transaction tx, Coin newLockingCap) throws BridgeIllegalArgumentException {
+        if (newLockingCap.getValue() <= 0) {
+            throw new BridgeIllegalArgumentException("Locking Cap must be greater than zero");
+        }
+
         // Only pre-configured addresses can modify Locking Cap
         AddressBasedAuthorizer authorizer = constants.getIncreaseAuthorizer();
         if (!authorizer.isAuthorized(tx, signatureCache)) {

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupportImpl.java
@@ -79,7 +79,8 @@ public class LockingCapSupportImpl implements LockingCapSupport {
 
         Coin maxLockingCapVoteValueAllowed = lockingCap.multiply(constants.getIncrementsMultiplier());
         if (newLockingCap.compareTo(maxLockingCapVoteValueAllowed) > 0) {
-            logger.warn(baseMessage, "Attempted value increases Locking Cap above its limit. Value attempted: ", newLockingCap.value);
+            baseMessage = String.format(INCREASE_LOCKING_CAP_TAG, "Attempted value tries to increase Locking Cap above its limit. Value attempted: {} . maxLockingCapVoteValueAllowed: {}");
+            logger.warn(baseMessage, newLockingCap.value, maxLockingCapVoteValueAllowed.value);
             return false;
         }
 

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupportImpl.java
@@ -49,8 +49,7 @@ public class LockingCapSupportImpl implements LockingCapSupport {
         final String INCREASE_LOCKING_CAP_TAG = "increaseLockingCap";
 
         if (newLockingCap.getValue() <= 0) {
-            String message = "Locking Cap must be greater than zero. Value attempted: %d";
-            String baseMessage = String.format(message, newLockingCap.value);
+            String baseMessage = String.format("Locking Cap must be greater than zero. Value attempted: %d", newLockingCap.value);
             logger.warn("[{}] {}}", INCREASE_LOCKING_CAP_TAG, baseMessage);
             throw new LockingCapIllegalArgumentException(baseMessage);
         }

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupportImpl.java
@@ -49,8 +49,9 @@ public class LockingCapSupportImpl implements LockingCapSupport {
         final String INCREASE_LOCKING_CAP_LOG_TAG = "[increaseLockingCap] {} {}";
 
         if (newLockingCap.getValue() <= 0) {
-            logger.warn(INCREASE_LOCKING_CAP_LOG_TAG, "Locking Cap must be greater than zero. Value attempted: ", newLockingCap.value);
-            throw new LockingCapIllegalArgumentException("Locking Cap must be greater than zero");
+            String message = "Locking Cap must be greater than zero. Value attempted: ";
+            logger.warn(INCREASE_LOCKING_CAP_LOG_TAG, message, newLockingCap.value);
+            throw new LockingCapIllegalArgumentException(message + newLockingCap.value);
         }
 
         // Only pre-configured addresses can modify Locking Cap

--- a/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/lockingcap/LockingCapSupportImpl.java
@@ -46,10 +46,10 @@ public class LockingCapSupportImpl implements LockingCapSupport {
     }
 
     @Override
-    public boolean increaseLockingCap(Transaction tx, Coin newLockingCap) throws BridgeIllegalArgumentException {
+    public boolean increaseLockingCap(Transaction tx, Coin newLockingCap) throws LockingCapIllegalArgumentException {
         if (newLockingCap.getValue() <= 0) {
             logger.warn("[increaseLockingCap] {} {}", "Locking Cap must be greater than zero. Value attempted: ", newLockingCap.value);
-            throw new BridgeIllegalArgumentException("Locking Cap must be greater than zero");
+            throw new LockingCapIllegalArgumentException("Locking Cap must be greater than zero");
         }
 
         // Only pre-configured addresses can modify Locking Cap

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -581,7 +581,7 @@ class BridgeSupportTest {
         }
 
         @Test
-        void increaseLockingCap() throws BridgeIllegalArgumentException {
+        void increaseLockingCap() throws VMException {
             // Arrange
             Coin newLockingCap = constants.getInitialValue().add(Coin.SATOSHI);
             Transaction tx = TransactionUtils.getTransactionFromCaller(signatureCache, LockingCapCaller.AUTHORIZED.getRskAddress());

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -581,7 +581,7 @@ class BridgeSupportTest {
         }
 
         @Test
-        void increaseLockingCap() {
+        void increaseLockingCap() throws BridgeIllegalArgumentException {
             // Arrange
             Coin newLockingCap = constants.getInitialValue().add(Coin.SATOSHI);
             Transaction tx = TransactionUtils.getTransactionFromCaller(signatureCache, LockingCapCaller.AUTHORIZED.getRskAddress());

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -204,7 +204,7 @@ class BridgeTest {
     }
 
     @Test
-    void increaseLockingCap_whenNoArgumentsInTheMethodSignature_shouldReturnFalse() throws VMException {
+    void increaseLockingCap_whenNoArgumentsInTheMethodSignature_shouldThrowVMException() {
         // Arrange
         ActivationConfig activationConfig = ActivationConfigsForTest.papyrus200();
         CallTransaction.Function increaseLockingCapFunction = Bridge.INCREASE_LOCKING_CAP;
@@ -213,14 +213,10 @@ class BridgeTest {
             .build();
 
         // No arguments signature
-        final byte[] noArgumentData = increaseLockingCapFunction.encodeSignature();
+        final byte[] noArgumentData = increaseLockingCapFunction.encodeArguments();
 
-        // Act
-        byte[] result = bridge.execute(noArgumentData);
-
-        // Assert
-        boolean decodedResult = (boolean) increaseLockingCapFunction.decodeResult(result)[0];
-        assertFalse(decodedResult);
+        // Act / Assert
+        assertThrows(VMException.class, () -> bridge.execute(noArgumentData));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -153,7 +153,7 @@ class BridgeTest {
     @ParameterizedTest()
     @MethodSource("lockingCapValues")
     void increaseLockingCap_after_RSKIP134_activation(long newLockingCapValue) throws VMException {
-        ActivationConfig activationConfig = ActivationConfigsForTest.papyrus200();
+        ActivationConfig activationConfig = ActivationConfigsForTest.all();
         CallTransaction.Function increaseLockingCapFunction = Bridge.INCREASE_LOCKING_CAP;
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
@@ -184,7 +184,7 @@ class BridgeTest {
 
     @Test
     void increaseLockingCap_whenNewLockingCapIsInvalidParameter_shouldThrowVMException() {
-        ActivationConfig activationConfig = ActivationConfigsForTest.papyrus200();
+        ActivationConfig activationConfig = ActivationConfigsForTest.all();
         CallTransaction.Function increaseLockingCapFunction = Bridge.INCREASE_LOCKING_CAP;
         Bridge bridge = bridgeBuilder
             .activationConfig(activationConfig)
@@ -206,7 +206,7 @@ class BridgeTest {
     @Test
     void increaseLockingCap_whenNoArgumentsInTheMethodSignature_shouldThrowVMException() {
         // Arrange
-        ActivationConfig activationConfig = ActivationConfigsForTest.papyrus200();
+        ActivationConfig activationConfig = ActivationConfigsForTest.all();
         CallTransaction.Function increaseLockingCapFunction = Bridge.INCREASE_LOCKING_CAP;
         Bridge bridge = bridgeBuilder
             .activationConfig(activationConfig)
@@ -222,7 +222,7 @@ class BridgeTest {
     @Test
     void increaseLockingCap_whenNewLockingCapIsNegativeValue_shouldThrowVMException() {
         // Arrange
-        ActivationConfig activationConfig = ActivationConfigsForTest.papyrus200();
+        ActivationConfig activationConfig = ActivationConfigsForTest.all();
         CallTransaction.Function increaseLockingCapFunction = Bridge.INCREASE_LOCKING_CAP;
         Bridge bridge = bridgeBuilder
             .activationConfig(activationConfig)
@@ -238,7 +238,7 @@ class BridgeTest {
     @Test
     void increaseLockingCap_whenNewLockingCapIsZeroValue_shouldThrowVMException() {
         // Arrange
-        ActivationConfig activationConfig = ActivationConfigsForTest.papyrus200();
+        ActivationConfig activationConfig = ActivationConfigsForTest.all();
         CallTransaction.Function increaseLockingCapFunction = Bridge.INCREASE_LOCKING_CAP;
         Bridge bridge = bridgeBuilder
             .activationConfig(activationConfig)

--- a/rskj-core/src/test/java/co/rsk/peg/lockingcap/LockingCapSupportImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/lockingcap/LockingCapSupportImplTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.net.utils.TransactionUtils;
-import co.rsk.peg.BridgeIllegalArgumentException;
 import co.rsk.peg.InMemoryStorage;
 import co.rsk.peg.lockingcap.constants.LockingCapConstants;
 import co.rsk.peg.lockingcap.constants.LockingCapMainNetConstants;
@@ -82,7 +81,7 @@ class LockingCapSupportImplTest {
 
     @Test
     void increaseLockingCap_whenNewValueIsGreaterThanCurrentLockingCap_shouldReturnTrue()
-        throws BridgeIllegalArgumentException {
+        throws LockingCapIllegalArgumentException {
         // Arrange
         Coin newLockingCap = constants.getInitialValue().add(Coin.SATOSHI);
         Transaction tx = TransactionUtils.getTransactionFromCaller(signatureCache, LockingCapCaller.AUTHORIZED.getRskAddress());
@@ -97,7 +96,7 @@ class LockingCapSupportImplTest {
 
     @Test
     void increaseLockingCap_whenNewValueIsLessThanInitialValue_shouldReturnFalse()
-        throws BridgeIllegalArgumentException {
+        throws LockingCapIllegalArgumentException {
         // Arrange
         Coin newLockingCap = constants.getInitialValue().subtract(Coin.SATOSHI);
         Transaction tx = TransactionUtils.getTransactionFromCaller(signatureCache, LockingCapCaller.AUTHORIZED.getRskAddress());
@@ -112,7 +111,7 @@ class LockingCapSupportImplTest {
 
     @Test
     void increaseLockingCap_whenPreviousValueExistsInStorageAndNewLockingCapIsGreaterThanPreviousValue_shouldReturnTrue()
-        throws BridgeIllegalArgumentException {
+        throws LockingCapIllegalArgumentException {
         // Arrange
         Coin previousLockingCap = constants.getInitialValue().add(Coin.SATOSHI);
         lockingCapStorageProvider.setLockingCap(previousLockingCap);
@@ -134,7 +133,7 @@ class LockingCapSupportImplTest {
 
     @Test
     void increaseLockingCap_whenPreviousValueExistsInStorageAndNewLockingCapIsLessThanPreviousValue_shouldReturnFalse()
-        throws BridgeIllegalArgumentException {
+        throws LockingCapIllegalArgumentException {
         // Arrange
         Coin expectedLockingCap = constants.getInitialValue().add(Coin.SATOSHI);
         lockingCapStorageProvider.setLockingCap(expectedLockingCap);
@@ -156,7 +155,7 @@ class LockingCapSupportImplTest {
 
     @Test
     void increaseLockingCap_whenAnUnauthorizedCallerRequestToIncreaseLockingCapValue_shouldReturnFalse()
-        throws BridgeIllegalArgumentException {
+        throws LockingCapIllegalArgumentException {
         // Arrange
         Coin newLockingCap = constants.getInitialValue().add(Coin.SATOSHI);
         Transaction tx = TransactionUtils.getTransactionFromCaller(signatureCache, LockingCapCaller.UNAUTHORIZED.getRskAddress());
@@ -171,7 +170,7 @@ class LockingCapSupportImplTest {
 
     @Test
     void increaseLockingCap_whenNewLockingCapIsGreaterThanMaxLockingCap_shouldReturnFalse()
-        throws BridgeIllegalArgumentException {
+        throws LockingCapIllegalArgumentException {
         // Arrange
         Coin expectedLockingCap = constants.getInitialValue().add(Coin.SATOSHI);
         lockingCapStorageProvider.setLockingCap(expectedLockingCap);
@@ -194,7 +193,7 @@ class LockingCapSupportImplTest {
 
     @Test
     void increaseLockingCap_whenNewLockingCapIsEqualToMaxLockingCap_shouldReturnTrue()
-        throws BridgeIllegalArgumentException {
+        throws LockingCapIllegalArgumentException {
         // Arrange
         Coin previousLockingCap = constants.getInitialValue().add(Coin.SATOSHI);
         lockingCapStorageProvider.setLockingCap(previousLockingCap);
@@ -217,7 +216,7 @@ class LockingCapSupportImplTest {
 
     @Test
     void increaseLockingCap_whenNewValueIsEqualToCurrentValue_shouldReturnTrue()
-        throws BridgeIllegalArgumentException {
+        throws LockingCapIllegalArgumentException {
         // Arrange
         Coin newLockingCap = constants.getInitialValue();
         Transaction tx = TransactionUtils.getTransactionFromCaller(signatureCache, LockingCapCaller.AUTHORIZED.getRskAddress());
@@ -237,7 +236,7 @@ class LockingCapSupportImplTest {
         Transaction tx = TransactionUtils.getTransactionFromCaller(signatureCache, LockingCapCaller.AUTHORIZED.getRskAddress());
 
         // Act / Assert
-        assertThrows(BridgeIllegalArgumentException.class, () -> lockingCapSupport.increaseLockingCap(tx, newLockingCap));
+        assertThrows(LockingCapIllegalArgumentException.class, () -> lockingCapSupport.increaseLockingCap(tx, newLockingCap));
         assertEquals(Optional.of(constants.getInitialValue()), lockingCapSupport.getLockingCap());
     }
 
@@ -248,13 +247,13 @@ class LockingCapSupportImplTest {
         Transaction tx = TransactionUtils.getTransactionFromCaller(signatureCache, LockingCapCaller.AUTHORIZED.getRskAddress());
 
         // Act / Assert
-        assertThrows(BridgeIllegalArgumentException.class, () -> lockingCapSupport.increaseLockingCap(tx, newLockingCap));
+        assertThrows(LockingCapIllegalArgumentException.class, () -> lockingCapSupport.increaseLockingCap(tx, newLockingCap));
         assertEquals(Optional.of(constants.getInitialValue()), lockingCapSupport.getLockingCap());
     }
 
     @Test
     void increaseLockingCap_prePapyrus200_whenLockingCapIsNotSet_shouldReturnFalse()
-        throws BridgeIllegalArgumentException {
+        throws LockingCapIllegalArgumentException {
         // Arrange
         activations = ActivationConfigsForTest.wasabi100().forBlock(0);
         lockingCapSupport = new LockingCapSupportImpl(lockingCapStorageProvider, activations, constants, signatureCache);
@@ -271,7 +270,7 @@ class LockingCapSupportImplTest {
 
     @Test
     void save_whenIsIncreasedLockingCapValue_shouldSaveLockingCap()
-        throws BridgeIllegalArgumentException {
+        throws LockingCapIllegalArgumentException {
         // Arrange
         Coin newLockingCap = constants.getInitialValue().add(Coin.SATOSHI);
         Transaction tx = TransactionUtils.getTransactionFromCaller(signatureCache, LockingCapCaller.AUTHORIZED.getRskAddress());
@@ -289,7 +288,7 @@ class LockingCapSupportImplTest {
 
     @Test
     void save_prePapyrus200_whenIsAttemptedIncreaseLockingCapValue_shouldNotSaveLockingCap()
-        throws BridgeIllegalArgumentException {
+        throws LockingCapIllegalArgumentException {
         // Arrange
         activations = ActivationConfigsForTest.wasabi100().forBlock(0);
         lockingCapSupport = new LockingCapSupportImpl(lockingCapStorageProvider, activations, constants, signatureCache);

--- a/rskj-core/src/test/java/co/rsk/peg/lockingcap/LockingCapSupportImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/lockingcap/LockingCapSupportImplTest.java
@@ -2,10 +2,12 @@ package co.rsk.peg.lockingcap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.net.utils.TransactionUtils;
+import co.rsk.peg.BridgeIllegalArgumentException;
 import co.rsk.peg.InMemoryStorage;
 import co.rsk.peg.lockingcap.constants.LockingCapConstants;
 import co.rsk.peg.lockingcap.constants.LockingCapMainNetConstants;
@@ -79,7 +81,8 @@ class LockingCapSupportImplTest {
     }
 
     @Test
-    void increaseLockingCap_whenNewValueIsGreaterThanCurrentLockingCap_shouldReturnTrue() {
+    void increaseLockingCap_whenNewValueIsGreaterThanCurrentLockingCap_shouldReturnTrue()
+        throws BridgeIllegalArgumentException {
         // Arrange
         Coin newLockingCap = constants.getInitialValue().add(Coin.SATOSHI);
         Transaction tx = TransactionUtils.getTransactionFromCaller(signatureCache, LockingCapCaller.AUTHORIZED.getRskAddress());
@@ -93,7 +96,8 @@ class LockingCapSupportImplTest {
     }
 
     @Test
-    void increaseLockingCap_whenNewValueIsLessThanInitialValue_shouldReturnFalse() {
+    void increaseLockingCap_whenNewValueIsLessThanInitialValue_shouldReturnFalse()
+        throws BridgeIllegalArgumentException {
         // Arrange
         Coin newLockingCap = constants.getInitialValue().subtract(Coin.SATOSHI);
         Transaction tx = TransactionUtils.getTransactionFromCaller(signatureCache, LockingCapCaller.AUTHORIZED.getRskAddress());
@@ -107,7 +111,8 @@ class LockingCapSupportImplTest {
     }
 
     @Test
-    void increaseLockingCap_whenPreviousValueExistsInStorageAndNewLockingCapIsGreaterThanPreviousValue_shouldReturnTrue() {
+    void increaseLockingCap_whenPreviousValueExistsInStorageAndNewLockingCapIsGreaterThanPreviousValue_shouldReturnTrue()
+        throws BridgeIllegalArgumentException {
         // Arrange
         Coin previousLockingCap = constants.getInitialValue().add(Coin.SATOSHI);
         lockingCapStorageProvider.setLockingCap(previousLockingCap);
@@ -128,7 +133,8 @@ class LockingCapSupportImplTest {
     }
 
     @Test
-    void increaseLockingCap_whenPreviousValueExistsInStorageAndNewLockingCapIsLessThanPreviousValue_shouldReturnFalse() {
+    void increaseLockingCap_whenPreviousValueExistsInStorageAndNewLockingCapIsLessThanPreviousValue_shouldReturnFalse()
+        throws BridgeIllegalArgumentException {
         // Arrange
         Coin expectedLockingCap = constants.getInitialValue().add(Coin.SATOSHI);
         lockingCapStorageProvider.setLockingCap(expectedLockingCap);
@@ -149,7 +155,8 @@ class LockingCapSupportImplTest {
     }
 
     @Test
-    void increaseLockingCap_whenAnUnauthorizedCallerRequestToIncreaseLockingCapValue_shouldReturnFalse() {
+    void increaseLockingCap_whenAnUnauthorizedCallerRequestToIncreaseLockingCapValue_shouldReturnFalse()
+        throws BridgeIllegalArgumentException {
         // Arrange
         Coin newLockingCap = constants.getInitialValue().add(Coin.SATOSHI);
         Transaction tx = TransactionUtils.getTransactionFromCaller(signatureCache, LockingCapCaller.UNAUTHORIZED.getRskAddress());
@@ -163,7 +170,8 @@ class LockingCapSupportImplTest {
     }
 
     @Test
-    void increaseLockingCap_whenNewLockingCapIsGreaterThanMaxLockingCap_shouldReturnFalse() {
+    void increaseLockingCap_whenNewLockingCapIsGreaterThanMaxLockingCap_shouldReturnFalse()
+        throws BridgeIllegalArgumentException {
         // Arrange
         Coin expectedLockingCap = constants.getInitialValue().add(Coin.SATOSHI);
         lockingCapStorageProvider.setLockingCap(expectedLockingCap);
@@ -185,7 +193,8 @@ class LockingCapSupportImplTest {
     }
 
     @Test
-    void increaseLockingCap_whenNewLockingCapIsEqualToMaxLockingCap_shouldReturnTrue() {
+    void increaseLockingCap_whenNewLockingCapIsEqualToMaxLockingCap_shouldReturnTrue()
+        throws BridgeIllegalArgumentException {
         // Arrange
         Coin previousLockingCap = constants.getInitialValue().add(Coin.SATOSHI);
         lockingCapStorageProvider.setLockingCap(previousLockingCap);
@@ -207,7 +216,8 @@ class LockingCapSupportImplTest {
     }
 
     @Test
-    void increaseLockingCap_whenNewValueIsEqualToCurrentValue_shouldReturnTrue() {
+    void increaseLockingCap_whenNewValueIsEqualToCurrentValue_shouldReturnTrue()
+        throws BridgeIllegalArgumentException {
         // Arrange
         Coin newLockingCap = constants.getInitialValue();
         Transaction tx = TransactionUtils.getTransactionFromCaller(signatureCache, LockingCapCaller.AUTHORIZED.getRskAddress());
@@ -226,11 +236,8 @@ class LockingCapSupportImplTest {
         Coin newLockingCap = Coin.ZERO;
         Transaction tx = TransactionUtils.getTransactionFromCaller(signatureCache, LockingCapCaller.AUTHORIZED.getRskAddress());
 
-        // Act
-        boolean actualResult = lockingCapSupport.increaseLockingCap(tx, newLockingCap);
-
-        // Assert
-        assertFalse(actualResult);
+        // Act / Assert
+        assertThrows(BridgeIllegalArgumentException.class, () -> lockingCapSupport.increaseLockingCap(tx, newLockingCap));
         assertEquals(Optional.of(constants.getInitialValue()), lockingCapSupport.getLockingCap());
     }
 
@@ -240,16 +247,14 @@ class LockingCapSupportImplTest {
         Coin newLockingCap = Coin.NEGATIVE_SATOSHI;
         Transaction tx = TransactionUtils.getTransactionFromCaller(signatureCache, LockingCapCaller.AUTHORIZED.getRskAddress());
 
-        // Act
-        boolean actualResult = lockingCapSupport.increaseLockingCap(tx, newLockingCap);
-
-        // Assert
-        assertFalse(actualResult);
+        // Act / Assert
+        assertThrows(BridgeIllegalArgumentException.class, () -> lockingCapSupport.increaseLockingCap(tx, newLockingCap));
         assertEquals(Optional.of(constants.getInitialValue()), lockingCapSupport.getLockingCap());
     }
 
     @Test
-    void increaseLockingCap_prePapyrus200_whenLockingCapIsNotSet_shouldReturnFalse() {
+    void increaseLockingCap_prePapyrus200_whenLockingCapIsNotSet_shouldReturnFalse()
+        throws BridgeIllegalArgumentException {
         // Arrange
         activations = ActivationConfigsForTest.wasabi100().forBlock(0);
         lockingCapSupport = new LockingCapSupportImpl(lockingCapStorageProvider, activations, constants, signatureCache);
@@ -265,7 +270,8 @@ class LockingCapSupportImplTest {
     }
 
     @Test
-    void save_whenIsIncreasedLockingCapValue_shouldSaveLockingCap() {
+    void save_whenIsIncreasedLockingCapValue_shouldSaveLockingCap()
+        throws BridgeIllegalArgumentException {
         // Arrange
         Coin newLockingCap = constants.getInitialValue().add(Coin.SATOSHI);
         Transaction tx = TransactionUtils.getTransactionFromCaller(signatureCache, LockingCapCaller.AUTHORIZED.getRskAddress());
@@ -282,7 +288,8 @@ class LockingCapSupportImplTest {
     }
 
     @Test
-    void save_prePapyrus200_whenIsAttemptedIncreaseLockingCapValue_shouldNotSaveLockingCap() {
+    void save_prePapyrus200_whenIsAttemptedIncreaseLockingCapValue_shouldNotSaveLockingCap()
+        throws BridgeIllegalArgumentException {
         // Arrange
         activations = ActivationConfigsForTest.wasabi100().forBlock(0);
         lockingCapSupport = new LockingCapSupportImpl(lockingCapStorageProvider, activations, constants, signatureCache);


### PR DESCRIPTION
## Description
Following the `Bridge` refactors, we migrated the `LockingCap` processes to their classes to break the high coupling LockingCap had with the Bridge objects. Please move the business logic related to the zero-negative LockingCap value from `Bridge.java` to `LockingCapSupportImpl.java`. This way, decouple the process and get all `LockingCap` business logic, in the `LockingCapSupport` object.

- Move business logic related to the zero-negative LockingCap value from Bridge.java to LockingCapSupportImpl.java.
- Put this validation at the beginning of the `increaseLockingCap` Method.
- Fix issues related to `BridgeIllegalArgumentException` in the `LockingCapSupportImpl#increaseLockingCap` Method because of adding the new validation.
- Fix issues related to `BridgeIllegalArgumentException` in the tests.
- Modify tests related to the zero-negative value that validate the behavior with these inputs.

## Motivation and Context
This relates to the Bridge Refactor to decouple some objects tied closely to the Bridge.


## How Has This Been Tested?
Unit Tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
