### PR TITLE
Fix bridge support flyover tests after locking cap refactor

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -7916,6 +7916,9 @@ class BridgeSupportTest {
 
         Repository repository = createRepository();
 
+        LockingCapStorageProvider lockingCapStorageProvider = new LockingCapStorageProviderImpl(new BridgeStorageAccessorImpl(repository));
+        lockingCapSupport = new LockingCapSupportImpl(lockingCapStorageProvider, activations, lockingCapConstants, signatureCache);
+
         Federation oldFederation = PegTestUtils.createSimpleActiveFederation(bridgeConstants);
 
         BridgeStorageProvider provider = new BridgeStorageProvider(


### PR DESCRIPTION
- Fix registerBtcTransaction_after_RSKIP134_activation_sends_above_lockingcap test
- Fix BridgeSupportFlyoverTest after LockingCap refactor

## Motivation and Context

Since the locking cap refactor `BridgeSupportFlyoverTest` has been failing, those tests needed to be fixed once the refactor was done.

## How Has This Been Tested?

Unit testes

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)
