### PR TITLE
Add on error handler for snap blocks

### DIFF
--- a/rskj-core/src/integrationTest/java/co/rsk/snapshotsync/SnapshotSyncIntegrationTest.java
+++ b/rskj-core/src/integrationTest/java/co/rsk/snapshotsync/SnapshotSyncIntegrationTest.java
@@ -104,7 +104,7 @@ public class SnapshotSyncIntegrationTest {
         boolean isClientSynced = false;
 
         while (System.currentTimeMillis() < endTime) {
-            if (clientNode.getOutput().contains("CLIENT - Starting Snapshot sync.") && clientNode.getOutput().contains("CLIENT - Snapshot sync finished!")) {
+            if (clientNode.getOutput().contains("CLIENT - Starting Snapshot sync.") && clientNode.getOutput().contains("CLIENT - Snapshot sync finished successfully!")) {
                 try {
                     JsonNode jsonResponse = OkHttpClientTestFixture.getJsonResponseForGetBestBlockMessage(portClientRpc, serverBestBlockNumber);
                     JsonNode jsonResult = jsonResponse.get(0).get("result");

--- a/rskj-core/src/main/java/co/rsk/net/SnapshotProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/SnapshotProcessor.java
@@ -62,6 +62,7 @@ public class SnapshotProcessor implements InternalService {
     public static final int BLOCK_NUMBER_CHECKPOINT = 5000;
     public static final int BLOCK_CHUNK_SIZE = 400;
     public static final int BLOCKS_REQUIRED = 6000;
+    public static final long CHUNK_ITEM_SIZE = 1024L;
     private final Blockchain blockchain;
     private final TrieStore trieStore;
     private final BlockStore blockStore;
@@ -77,7 +78,6 @@ public class SnapshotProcessor implements InternalService {
 
     private volatile Boolean isRunning;
     private final Thread thread;
-
     public SnapshotProcessor(Blockchain blockchain,
                              TrieStore trieStore,
                              SnapshotPeersInformation peersInformation,
@@ -157,6 +157,7 @@ public class SnapshotProcessor implements InternalService {
         logger.debug("SERVER - Processing snapshot status request.");
         long bestBlockNumber = blockchain.getBestBlock().getNumber();
         long checkpointBlockNumber = bestBlockNumber - (bestBlockNumber % BLOCK_NUMBER_CHECKPOINT);
+        logger.debug("SERVER - checkpointBlockNumber: {}, bestBlockNumber: {}", checkpointBlockNumber, bestBlockNumber);
         List<Block> blocks = Lists.newArrayList();
         List<BlockDifficulty> difficulties = Lists.newArrayList();
         for (long i = checkpointBlockNumber - BLOCK_CHUNK_SIZE; i < checkpointBlockNumber; i++) {
@@ -165,8 +166,10 @@ public class SnapshotProcessor implements InternalService {
             difficulties.add(blockStore.getTotalDifficultyForHash(block.getHash().getBytes()));
         }
 
+        logger.trace("SERVER - Sending snapshot status response. From block {} to block {} - chunksize {}", blocks.get(0).getNumber(), blocks.get(blocks.size() - 1).getNumber(), BLOCK_CHUNK_SIZE);
         Block checkpointBlock = blockchain.getBlockByNumber(checkpointBlockNumber);
         blocks.add(checkpointBlock);
+        logger.trace("SERVER - adding checkpoint block: {}", checkpointBlock.getNumber());
         difficulties.add(blockStore.getTotalDifficultyForHash(checkpointBlock.getHash().getBytes()));
         byte[] rootHash = checkpointBlock.getStateRoot();
         Optional<TrieDTO> opt = trieStore.retrieveDTO(rootHash);
@@ -196,7 +199,7 @@ public class SnapshotProcessor implements InternalService {
             state.addBlock(new ImmutablePair<>(blocksFromResponse.get(i), difficultiesFromResponse.get(i)));
         }
         logger.debug("CLIENT - Processing snapshot status response - last blockNumber: {} triesize: {}", lastBlock.getNumber(), state.getRemoteTrieSize());
-        logger.debug("Blocks included in the response: {} from {} to {}", blocksFromResponse.size(), blocksFromResponse.get(0).getNumber(),blocksFromResponse.get(blocksFromResponse.size()-1).getNumber());
+        logger.debug("Blocks included in the response: {} from {} to {}", blocksFromResponse.size(), blocksFromResponse.get(0).getNumber(), blocksFromResponse.get(blocksFromResponse.size() - 1).getNumber());
         requestBlocksChunk(sender, blocksFromResponse.get(0).getNumber());
         generateChunkRequestTasks(state);
         startRequestingChunks(state);
@@ -255,7 +258,7 @@ public class SnapshotProcessor implements InternalService {
             state.addBlock(new ImmutablePair<>(blocksFromResponse.get(i), difficultiesFromResponse.get(i)));
         }
         long nextChunk = blocksFromResponse.get(0).getNumber();
-        logger.debug("CLIENT - SnapBlock - nexChunk : {} - lastRequired {}, missing {}", nextChunk, lastRequiredBlock, nextChunk-lastRequiredBlock);
+        logger.debug("CLIENT - SnapBlock - nexChunk : {} - lastRequired {}, missing {}", nextChunk, lastRequiredBlock, nextChunk - lastRequiredBlock);
         if (nextChunk > lastRequiredBlock) {
             requestBlocksChunk(sender, nextChunk);
         } else {
@@ -267,10 +270,9 @@ public class SnapshotProcessor implements InternalService {
      * STATE CHUNK
      */
     private void requestStateChunk(Peer peer, long from, long blockNumber, int chunkSize) {
-        logger.debug("CLIENT - Requesting state chunk to node {} - block {} - from {}", peer.getPeerNodeID(), blockNumber, from);
+        logger.debug("CLIENT - Requesting state chunk to node {} - block {} - chunkNumber {}", peer.getPeerNodeID(), blockNumber, from / chunkSize);
         SnapStateChunkRequestMessage message = new SnapStateChunkRequestMessage(messageId++, blockNumber, from, chunkSize);
         peer.sendMessage(message);
-        logger.debug("CLIENT - Request sent state chunk to node {} - block {} - from {}", peer.getPeerNodeID(), blockNumber, from);
     }
 
     public void processStateChunkRequest(Peer sender, SnapStateChunkRequestMessage requestMessage) {
@@ -297,7 +299,7 @@ public class SnapshotProcessor implements InternalService {
 
         List<byte[]> trieEncoded = new ArrayList<>();
         Block block = blockchain.getBlockByNumber(request.getBlockNumber());
-        final long to = request.getFrom() + (request.getChunkSize() * 1024);
+        final long to = request.getFrom() + (request.getChunkSize() * CHUNK_ITEM_SIZE);
         logger.debug("SERVER - Processing state chunk request from node {}. From {} to calculated {} being chunksize {}", sender.getPeerNodeID(), request.getFrom(), to, request.getChunkSize());
         logger.debug("SERVER - Sending state chunk from {} to {}", request.getFrom(), to);
         TrieDTOInOrderIterator it = new TrieDTOInOrderIterator(trieStore, block.getStateRoot(), request.getFrom(), to);
@@ -319,7 +321,6 @@ public class SnapshotProcessor implements InternalService {
         byte[] firstNodeLeftHash = RLP.encodeElement(first.getLeftHash());
         byte[] nodesBytes = RLP.encodeList(trieEncoded.toArray(new byte[0][0]));
         byte[] lastNodeHashes = last != null ? RLP.encodeList(RLP.encodeElement(getBytes(last.getLeftHash())), RLP.encodeElement(getBytes(last.getRightHash()))) : RLP.encodedEmptyList();
-
         // Last we add the root nodes on the right of the last visited node. They are used to validate the chunk.
         List<byte[]> postRootNodes = it.getNodesLeftVisiting().stream().map((t) -> RLP.encodeList(RLP.encodeElement(t.getEncoded()), RLP.encodeElement(getBytes(t.getRightHash())))).collect(Collectors.toList());
         byte[] postRootNodesBytes = !postRootNodes.isEmpty() ? RLP.encodeList(postRootNodes.toArray(new byte[0][0])) : RLP.encodedEmptyList();
@@ -334,7 +335,7 @@ public class SnapshotProcessor implements InternalService {
     }
 
     public void processStateChunkResponse(SnapSyncState state, Peer peer, SnapStateChunkResponseMessage responseMessage) {
-        logger.debug("CLIENT - State chunk received from {} to {} of {}", responseMessage.getFrom(), responseMessage.getTo(), state.getLastBlock());
+        logger.debug("CLIENT - State chunk received chunkNumber {}. From {} to {} of total size {}", responseMessage.getFrom() / CHUNK_ITEM_SIZE, responseMessage.getFrom(), responseMessage.getTo(), state.getRemoteTrieSize());
 
         PriorityQueue<SnapStateChunkResponseMessage> queue = state.getSnapStateChunkQueue();
         queue.add(responseMessage);
@@ -346,120 +347,122 @@ public class SnapshotProcessor implements InternalService {
             if (nextMessage.getFrom() == nextExpectedFrom) {
                 try {
                     processOrderedStateChunkResponse(state, peer, queue.poll());
+                    state.setNextExpectedFrom(nextExpectedFrom + chunkSize * CHUNK_ITEM_SIZE);
                 } catch (Exception e) {
                     logger.error("Error while processing chunk response. {}", e.getMessage(), e);
+                    onStateChunkResponseError(peer, nextMessage);
                 }
-                state.setNextExpectedFrom(nextExpectedFrom + chunkSize * 1024L);
             } else {
                 break;
             }
         }
 
         if (!responseMessage.isComplete()) {
-            logger.debug("CLIENT - State chunk response not complete. Requesting next chunk."   );
+            logger.debug("CLIENT - State chunk response not complete. Requesting next chunk.");
             executeNextChunkRequestTask(state, peer);
         }
     }
 
-
-    private void processOrderedStateChunkResponse(SnapSyncState state, Peer peer, SnapStateChunkResponseMessage message) {
-        try {
-            logger.debug("CLIENT - Processing State chunk received from {} to {}", message.getFrom(), message.getTo());
-            peersInformation.getOrRegisterPeer(peer);
-            state.onNewChunk();
-
-            RLPList nodeLists = RLP.decodeList(message.getChunkOfTrieKeyValue());
-            final RLPList preRootElements = RLP.decodeList(nodeLists.get(0).getRLPData());
-            final RLPList trieElements = RLP.decodeList(nodeLists.get(1).getRLPData());
-            byte[] firstNodeLeftHash = nodeLists.get(2).getRLPData();
-            final RLPList lastNodeHashes = RLP.decodeList(nodeLists.get(3).getRLPData());
-            final RLPList postRootElements = RLP.decodeList(nodeLists.get(4).getRLPData());
-            logger.debug(
-                    "CLIENT - Received state chunk of {} elements ({} bytes).",
-                    trieElements.size(),
-                    message.getChunkOfTrieKeyValue().length
-            );
-            List<TrieDTO> preRootNodes = new ArrayList<>();
-            List<TrieDTO> nodes = new ArrayList<>();
-            List<TrieDTO> postRootNodes = new ArrayList<>();
+    private void onStateChunkResponseError(Peer peer, SnapStateChunkResponseMessage responseMessage) {
+        logger.error("Error while processing chunk response from {} of peer {}. Asking for chunk again.", responseMessage.getFrom(), peer.getPeerNodeID());
+        Peer alternativePeer = peersInformation.getBestSnapPeerCandidates().stream()
+                .filter(listedPeer -> !listedPeer.getPeerNodeID().equals(peer.getPeerNodeID()))
+                .findFirst()
+                .orElse(peer);
+        logger.debug("Requesting state chunk \"from\" {} to peer {}", responseMessage.getFrom(), peer.getPeerNodeID());
+        requestStateChunk(alternativePeer, responseMessage.getFrom(), responseMessage.getBlockNumber(), chunkSize);
+    }
 
 
-            for (int i = 0; i < preRootElements.size(); i++) {
-                final RLPList trieElement = (RLPList) preRootElements.get(i);
-                final byte[] value = trieElement.get(0).getRLPData();
-                final byte[] leftHash = trieElement.get(1).getRLPData();
-                TrieDTO node = TrieDTO.decodeFromSync(value);
-                node.setLeftHash(leftHash);
-                preRootNodes.add(node);
+    private void processOrderedStateChunkResponse(SnapSyncState state, Peer peer, SnapStateChunkResponseMessage message) throws Exception {
+        logger.debug("CLIENT - Processing State chunk received from {} to {}", message.getFrom(), message.getTo());
+        peersInformation.getOrRegisterPeer(peer);
+        state.onNewChunk();
+
+        RLPList nodeLists = RLP.decodeList(message.getChunkOfTrieKeyValue());
+        final RLPList preRootElements = RLP.decodeList(nodeLists.get(0).getRLPData());
+        final RLPList trieElements = RLP.decodeList(nodeLists.get(1).getRLPData());
+        byte[] firstNodeLeftHash = nodeLists.get(2).getRLPData();
+        final RLPList lastNodeHashes = RLP.decodeList(nodeLists.get(3).getRLPData());
+        final RLPList postRootElements = RLP.decodeList(nodeLists.get(4).getRLPData());
+        List<TrieDTO> preRootNodes = new ArrayList<>();
+        List<TrieDTO> nodes = new ArrayList<>();
+        List<TrieDTO> postRootNodes = new ArrayList<>();
+
+
+        for (int i = 0; i < preRootElements.size(); i++) {
+            final RLPList trieElement = (RLPList) preRootElements.get(i);
+            final byte[] value = trieElement.get(0).getRLPData();
+            final byte[] leftHash = trieElement.get(1).getRLPData();
+            TrieDTO node = TrieDTO.decodeFromSync(value);
+            node.setLeftHash(leftHash);
+            preRootNodes.add(node);
+        }
+
+        if (trieElements.size() > 0) {
+            for (int i = 0; i < trieElements.size(); i++) {
+                final RLPElement trieElement = trieElements.get(i);
+                byte[] value = trieElement.getRLPData();
+                nodes.add(TrieDTO.decodeFromSync(value));
             }
+            nodes.get(0).setLeftHash(firstNodeLeftHash);
+        }
 
-            if (trieElements.size() > 0) {
-                for (int i = 0; i < trieElements.size(); i++) {
-                    final RLPElement trieElement = trieElements.get(i);
-                    byte[] value = trieElement.getRLPData();
-                    nodes.add(TrieDTO.decodeFromSync(value));
-                }
-                nodes.get(0).setLeftHash(firstNodeLeftHash);
-            }
+        if (lastNodeHashes.size() > 0) {
+            TrieDTO lastNode = nodes.get(nodes.size() - 1);
+            lastNode.setLeftHash(lastNodeHashes.get(0).getRLPData());
+            lastNode.setRightHash(lastNodeHashes.get(1).getRLPData());
+        }
 
-            if (lastNodeHashes.size() > 0) {
-                TrieDTO lastNode = nodes.get(nodes.size() - 1);
-                lastNode.setLeftHash(lastNodeHashes.get(0).getRLPData());
-                lastNode.setRightHash(lastNodeHashes.get(1).getRLPData());
-            }
+        for (int i = 0; i < postRootElements.size(); i++) {
+            final RLPList trieElement = (RLPList) postRootElements.get(i);
+            final byte[] value = trieElement.get(0).getRLPData();
+            final byte[] rightHash = trieElement.get(1).getRLPData();
+            TrieDTO node = TrieDTO.decodeFromSync(value);
+            node.setRightHash(rightHash);
+            postRootNodes.add(node);
+        }
 
-            for (int i = 0; i < postRootElements.size(); i++) {
-                final RLPList trieElement = (RLPList) postRootElements.get(i);
-                final byte[] value = trieElement.get(0).getRLPData();
-                final byte[] rightHash = trieElement.get(1).getRLPData();
-                TrieDTO node = TrieDTO.decodeFromSync(value);
-                node.setRightHash(rightHash);
-                postRootNodes.add(node);
-            }
-
-            if (TrieDTOInOrderRecoverer.verifyChunk(state.getRemoteRootHash(), preRootNodes, nodes, postRootNodes)) {
-                state.getAllNodes().addAll(nodes);
-                state.setStateSize(state.getStateSize().add(BigInteger.valueOf(trieElements.size())));
-                state.setStateChunkSize(state.getStateChunkSize().add(BigInteger.valueOf(message.getChunkOfTrieKeyValue().length)));
-                logger.debug("CLIENT - State progress: {} chunks ({} bytes)", state.getStateSize(), state.getStateChunkSize());
-                if (!message.isComplete()) {
-                    executeNextChunkRequestTask(state, peer);
-                } else {
-                    rebuildStateAndSave(state);
-                    logger.info("CLIENT - Snapshot sync finished!");
-                    stopSyncing(state);
-                }
+        if (TrieDTOInOrderRecoverer.verifyChunk(state.getRemoteRootHash(), preRootNodes, nodes, postRootNodes)) {
+            state.getAllNodes().addAll(nodes);
+            state.setStateSize(state.getStateSize().add(BigInteger.valueOf(trieElements.size())));
+            state.setStateChunkSize(state.getStateChunkSize().add(BigInteger.valueOf(message.getChunkOfTrieKeyValue().length)));
+            if (!message.isComplete()) {
+                executeNextChunkRequestTask(state, peer);
             } else {
-                logger.error("Error while verifying chunk response: {}", message);
-                throw new Exception("Error verifying chunk.");
+                boolean result = rebuildStateAndSave(state);
+                logger.info("CLIENT - Snapshot sync finished {}! ", result ? "successfully" : "with errors");
+                stopSyncing(state);
             }
-        } catch (Exception e) {
-            logger.error("Error while processing chunk response.", e);
+        } else {
+            logger.error("Error while verifying chunk response: {}", message);
+            throw new Exception("Error verifying chunk.");
         }
     }
 
     /**
      * Once state share is received, rebuild the trie, save it in db and save all the blocks.
      */
-    private void rebuildStateAndSave(SnapSyncState state) {
-        logger.info("CLIENT - State Completed! {} chunks ({} bytes) - chunk size = {}",
-                state.getStateSize(), state.getStateChunkSize(), this.chunkSize);
-        final TrieDTO[] nodeArray = state.getAllNodes().toArray(new TrieDTO[0]);
+    private boolean rebuildStateAndSave(SnapSyncState state) {
         logger.info("CLIENT - Recovering trie...");
+        final TrieDTO[] nodeArray = state.getAllNodes().toArray(new TrieDTO[0]);
         Optional<TrieDTO> result = TrieDTOInOrderRecoverer.recoverTrie(nodeArray, this.trieStore::saveDTO);
-        if (!result.isPresent() || !Arrays.equals(state.getRemoteRootHash(), result.get().calculateHash())) {
-            logger.error("CLIENT - State final validation FAILED");
-        } else {
-            logger.info("CLIENT - State final validation OK!");
-        }
 
-        logger.info("CLIENT - Saving previous blocks...");
-        this.blockchain.removeBlocksByNumber(0);
-        BlockConnectorHelper blockConnector = new BlockConnectorHelper(this.blockStore);
-        state.connectBlocks(blockConnector);
-        logger.info("CLIENT - Setting last block as best block...");
-        this.blockchain.setStatus(state.getLastBlock(), state.getLastBlockDifficulty());
-        this.transactionPool.setBestBlock(state.getLastBlock());
+        if (result.isPresent() && Arrays.equals(state.getRemoteRootHash(), result.get().calculateHash())) {
+            logger.info("CLIENT - State final validation OK!");
+
+            this.blockchain.removeBlocksByNumber(0);
+            //genesis is removed so backwards sync will always start.
+
+            BlockConnectorHelper blockConnector = new BlockConnectorHelper(this.blockStore);
+            state.connectBlocks(blockConnector);
+            logger.info("CLIENT - Setting last block as best block...");
+            this.blockchain.setStatus(state.getLastBlock(), state.getLastBlockDifficulty());
+            this.transactionPool.setBestBlock(state.getLastBlock());
+            return true;
+        }
+        logger.error("CLIENT - State final validation FAILED");
+        return false;
     }
 
     private void generateChunkRequestTasks(SnapSyncState state) {
@@ -468,7 +471,7 @@ public class SnapshotProcessor implements InternalService {
         while (from < state.getRemoteTrieSize()) {
             ChunkTask task = new ChunkTask(state.getLastBlock().getNumber(), from);
             state.getChunkTaskQueue().add(task);
-            from += chunkSize * 1024L;
+            from += chunkSize * CHUNK_ITEM_SIZE;
         }
     }
 

--- a/rskj-core/src/main/java/co/rsk/net/SnapshotProcessor.java
+++ b/rskj-core/src/main/java/co/rsk/net/SnapshotProcessor.java
@@ -247,7 +247,6 @@ public class SnapshotProcessor implements InternalService {
         sender.sendMessage(responseMessage);
     }
 
-    //TODO no multipeer here.
     public void processSnapBlocksResponse(SnapSyncState state, Peer sender, SnapBlocksResponseMessage responseMessage) {
         long lastRequiredBlock = state.getLastBlock().getNumber() - BLOCKS_REQUIRED;
         List<Block> blocksFromResponse = responseMessage.getBlocks();
@@ -363,7 +362,8 @@ public class SnapshotProcessor implements InternalService {
         }
     }
 
-    private void onStateChunkResponseError(Peer peer, SnapStateChunkResponseMessage responseMessage) {
+    @VisibleForTesting
+    void onStateChunkResponseError(Peer peer, SnapStateChunkResponseMessage responseMessage) {
         logger.error("Error while processing chunk response from {} of peer {}. Asking for chunk again.", responseMessage.getFrom(), peer.getPeerNodeID());
         Peer alternativePeer = peersInformation.getBestSnapPeerCandidates().stream()
                 .filter(listedPeer -> !listedPeer.getPeerNodeID().equals(peer.getPeerNodeID()))

--- a/rskj-core/src/main/java/co/rsk/net/sync/BlockConnectorHelper.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/BlockConnectorHelper.java
@@ -43,7 +43,7 @@ public class BlockConnectorHelper {
 
         blockAndDifficultiesList.sort(new BlockAndDiffComparator());
         Block child = null;
-        logger.info("Start connecting Blocks. To connect from {} to {} - Total: {}",
+        logger.info("Start connecting blocks ranging from {} to {} - Total: {}",
                 blockAndDifficultiesList.get(0).getKey().getNumber(),
                 blockAndDifficultiesList.get(blockAndDifficultiesList.size() - 1).getKey().getNumber(),
                 blockAndDifficultiesList.size());

--- a/rskj-core/src/main/java/co/rsk/net/sync/BlockConnectorHelper.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/BlockConnectorHelper.java
@@ -30,24 +30,26 @@ import java.util.List;
 public class BlockConnectorHelper {
     private static final Logger logger = LoggerFactory.getLogger("SnapBlockConnector");
     private final BlockStore blockStore;
-    private final List<Pair<Block,BlockDifficulty>> blockAndDifficultiesList;
 
-    public BlockConnectorHelper(BlockStore blockStore, List<Pair<Block,BlockDifficulty>> blockAndDifficultiesList) {
+    public BlockConnectorHelper(BlockStore blockStore) {
         this.blockStore = blockStore;
-        this.blockAndDifficultiesList = blockAndDifficultiesList;
-        blockAndDifficultiesList.sort(new BlockAndDiffComparator());
     }
 
-    public void startConnecting() {
+    public void startConnecting(List<Pair<Block, BlockDifficulty>> blockAndDifficultiesList) {
+        blockAndDifficultiesList.sort(new BlockAndDiffComparator());
         Block child = null;
-        logger.info("Start connecting Blocks");
+        logger.info("Start connecting Blocks. To connect from {} to {} - Total: {}",
+                blockAndDifficultiesList.get(0).getKey().getNumber(),
+                blockAndDifficultiesList.get(blockAndDifficultiesList.size() - 1).getKey().getNumber(),
+                blockAndDifficultiesList.size());
+
         if (blockAndDifficultiesList.isEmpty()) {
             logger.debug("Block list is empty, nothing to connect");
             return;
         }
         int blockIndex = blockAndDifficultiesList.size() - 1;
         if (blockStore.isEmpty()) {
-            Pair<Block,BlockDifficulty> blockAndDifficulty = blockAndDifficultiesList.get(blockIndex);
+            Pair<Block, BlockDifficulty> blockAndDifficulty = blockAndDifficultiesList.get(blockIndex);
             child = blockAndDifficulty.getLeft();
             logger.debug("BlockStore is empty, setting child block number the last block from the list: {}", child.getNumber());
             blockStore.saveBlock(child, blockAndDifficulty.getRight(), true);
@@ -58,7 +60,7 @@ public class BlockConnectorHelper {
             logger.debug("Best block number: {}", child.getNumber());
         }
         while (blockIndex >= 0) {
-            Pair<Block,BlockDifficulty> currentBlockAndDifficulty = blockAndDifficultiesList.get(blockIndex);
+            Pair<Block, BlockDifficulty> currentBlockAndDifficulty = blockAndDifficultiesList.get(blockIndex);
             Block currentBlock = currentBlockAndDifficulty.getLeft();
             logger.info("Connecting block number: {}", currentBlock.getNumber());
 
@@ -72,10 +74,10 @@ public class BlockConnectorHelper {
         logger.info("Finished connecting blocks");
     }
 
-    static class BlockAndDiffComparator implements java.util.Comparator<Pair<Block,BlockDifficulty>> {
+    static class BlockAndDiffComparator implements java.util.Comparator<Pair<Block, BlockDifficulty>> {
         @Override
-        public int compare(Pair<Block,BlockDifficulty> o1, Pair<Block,BlockDifficulty> o2) {
-            return Long.compare(o1.getLeft().getNumber(),o2.getLeft().getNumber());
+        public int compare(Pair<Block, BlockDifficulty> o1, Pair<Block, BlockDifficulty> o2) {
+            return Long.compare(o1.getLeft().getNumber(), o2.getLeft().getNumber());
         }
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/sync/BlockConnectorHelper.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/BlockConnectorHelper.java
@@ -36,6 +36,11 @@ public class BlockConnectorHelper {
     }
 
     public void startConnecting(List<Pair<Block, BlockDifficulty>> blockAndDifficultiesList) {
+        if (blockAndDifficultiesList.isEmpty()) {
+            logger.debug("Block list is empty, nothing to connect");
+            return;
+        }
+
         blockAndDifficultiesList.sort(new BlockAndDiffComparator());
         Block child = null;
         logger.info("Start connecting Blocks. To connect from {} to {} - Total: {}",
@@ -43,16 +48,13 @@ public class BlockConnectorHelper {
                 blockAndDifficultiesList.get(blockAndDifficultiesList.size() - 1).getKey().getNumber(),
                 blockAndDifficultiesList.size());
 
-        if (blockAndDifficultiesList.isEmpty()) {
-            logger.debug("Block list is empty, nothing to connect");
-            return;
-        }
         int blockIndex = blockAndDifficultiesList.size() - 1;
         if (blockStore.isEmpty()) {
             Pair<Block, BlockDifficulty> blockAndDifficulty = blockAndDifficultiesList.get(blockIndex);
             child = blockAndDifficulty.getLeft();
             logger.debug("BlockStore is empty, setting child block number the last block from the list: {}", child.getNumber());
             blockStore.saveBlock(child, blockAndDifficulty.getRight(), true);
+            logger.debug("Block number: {} saved", child.getNumber());
             blockIndex--;
         } else {
             logger.debug("BlockStore is not empty, getting best block");
@@ -62,7 +64,7 @@ public class BlockConnectorHelper {
         while (blockIndex >= 0) {
             Pair<Block, BlockDifficulty> currentBlockAndDifficulty = blockAndDifficultiesList.get(blockIndex);
             Block currentBlock = currentBlockAndDifficulty.getLeft();
-            logger.info("Connecting block number: {}", currentBlock.getNumber());
+            logger.trace("Connecting block number: {}", currentBlock.getNumber());
 
             if (!currentBlock.isParentOf(child)) {
                 throw new BlockConnectorException(currentBlock.getNumber(), child.getNumber());
@@ -71,7 +73,7 @@ public class BlockConnectorHelper {
             child = currentBlock;
             blockIndex--;
         }
-        logger.info("Finished connecting blocks");
+        logger.info("Finished connecting blocks. Last saved block: {}",child.getNumber());
     }
 
     static class BlockAndDiffComparator implements java.util.Comparator<Pair<Block, BlockDifficulty>> {

--- a/rskj-core/src/main/java/co/rsk/net/sync/PeerAndModeDecidingSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/PeerAndModeDecidingSyncState.java
@@ -107,7 +107,7 @@ public class PeerAndModeDecidingSyncState extends BaseSyncState {
         }
 
         // we consider Snap as part of the Long Sync
-        if (!shouldSnapSync(peerBestBlockNumOpt.get())) {
+        if (!isValidSnapDistance(peerBestBlockNumOpt.get())) {
             logger.debug("Snap syncing not required (long sync not required)");
             return false;
         }
@@ -163,9 +163,9 @@ public class PeerAndModeDecidingSyncState extends BaseSyncState {
         return distanceToTip > syncConfiguration.getLongSyncLimit() || checkGenesisConnected();
     }
 
-    private boolean shouldSnapSync(long peerBestBlockNumber) {
+    private boolean isValidSnapDistance(long peerBestBlockNumber) {
         long distanceToTip = peerBestBlockNumber - blockStore.getBestBlock().getNumber();
-        return distanceToTip > syncConfiguration.getSnapshotSyncLimit() && syncConfiguration.isClientSnapSyncEnabled();
+        return distanceToTip > syncConfiguration.getSnapshotSyncLimit();
     }
 
     private Optional<Long> getPeerBestBlockNumber(Peer peer) {

--- a/rskj-core/src/main/java/co/rsk/net/sync/SnapSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SnapSyncState.java
@@ -41,7 +41,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 public class SnapSyncState extends BaseSyncState {
 
-    private static final Logger logger = LoggerFactory.getLogger("snapSyncState");
+    private static final Logger logger = LoggerFactory.getLogger("SnapSyncState");
 
     private final SnapshotProcessor snapshotProcessor;
 

--- a/rskj-core/src/main/java/co/rsk/net/sync/SnapSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/SnapSyncState.java
@@ -41,7 +41,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 public class SnapSyncState extends BaseSyncState {
 
-    private static final Logger logger = LoggerFactory.getLogger("syncprocessor");
+    private static final Logger logger = LoggerFactory.getLogger("snapSyncState");
 
     private final SnapshotProcessor snapshotProcessor;
 
@@ -76,7 +76,7 @@ public class SnapSyncState extends BaseSyncState {
 
     @VisibleForTesting
     SnapSyncState(SyncEventsHandler syncEventsHandler, SnapshotProcessor snapshotProcessor,
-                         SyncConfiguration syncConfiguration, @Nullable SyncMessageHandler.Listener listener) {
+                  SyncConfiguration syncConfiguration, @Nullable SyncMessageHandler.Listener listener) {
         super(syncEventsHandler, syncConfiguration);
         this.snapshotProcessor = snapshotProcessor; // TODO(snap-poc) code in SnapshotProcessor should be moved here probably
         this.allNodes = Lists.newArrayList();
@@ -207,8 +207,16 @@ public class SnapSyncState extends BaseSyncState {
         this.remoteTrieSize = remoteTrieSize;
     }
 
-    public List<Pair<Block, BlockDifficulty>> getBlocks() {
-        return blocks;
+    public void addBlock(Pair<Block, BlockDifficulty> blockPair) {
+        blocks.add(blockPair);
+    }
+
+    public void addAllBlocks(List<Pair<Block, BlockDifficulty>> blocks) {
+        this.blocks.addAll(blocks);
+    }
+
+    public void connectBlocks(BlockConnectorHelper blockConnectorHelper) {
+        blockConnectorHelper.startConnecting(blocks);
     }
 
     public List<TrieDTO> getAllNodes() {

--- a/rskj-core/src/test/java/co/rsk/net/sync/BlockConnectorHelperTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/sync/BlockConnectorHelperTest.java
@@ -44,8 +44,8 @@ class BlockConnectorHelperTest {
 
     @Test
     void testStartConnectingWhenBlockListIsEmpty() {
-        blockConnectorHelper = new BlockConnectorHelper(blockStore, Collections.emptyList());
-        blockConnectorHelper.startConnecting();
+        blockConnectorHelper = new BlockConnectorHelper(blockStore);
+        blockConnectorHelper.startConnecting(Collections.emptyList());
         verify(blockStore, never()).saveBlock(any(), any(), anyBoolean());
     }
 
@@ -69,9 +69,9 @@ class BlockConnectorHelperTest {
         blockAndDifficultiesList = buildBlockDifficulties(Arrays.asList(block1, block2,block3),
                 Arrays.asList(diff1, diff2,diff3));
 
-        blockConnectorHelper = new BlockConnectorHelper(blockStore, blockAndDifficultiesList);
+        blockConnectorHelper = new BlockConnectorHelper(blockStore);
 
-        blockConnectorHelper.startConnecting();
+        blockConnectorHelper.startConnecting(blockAndDifficultiesList);
 
         verify(blockStore, times(3)).saveBlock(blockCaptor.capture(), difficultyCaptor.capture(), anyBoolean());
         verify(blockStore, times(0)).getBestBlock();
@@ -101,9 +101,9 @@ class BlockConnectorHelperTest {
         blockAndDifficultiesList = buildBlockDifficulties(Arrays.asList(block2, block1),
                 Arrays.asList(diff2, diff1));
 
-        blockConnectorHelper = new BlockConnectorHelper(blockStore, blockAndDifficultiesList);
+        blockConnectorHelper = new BlockConnectorHelper(blockStore);
 
-        blockConnectorHelper.startConnecting();
+        blockConnectorHelper.startConnecting(blockAndDifficultiesList);
 
         verify(blockStore, times(2)).saveBlock(blockCaptor.capture(), difficultyCaptor.capture(), anyBoolean());
         verify(blockStore, times(0)).getBestBlock();
@@ -131,9 +131,9 @@ class BlockConnectorHelperTest {
         when(blockStore.getBestBlock()).thenReturn(block3);
 
         blockAndDifficultiesList = buildBlockDifficulties(Arrays.asList(block1, block2), Arrays.asList(mock(BlockDifficulty.class), mock(BlockDifficulty.class)));
-        blockConnectorHelper = new BlockConnectorHelper(blockStore, blockAndDifficultiesList);
+        blockConnectorHelper = new BlockConnectorHelper(blockStore);
 
-        blockConnectorHelper.startConnecting();
+        blockConnectorHelper.startConnecting(blockAndDifficultiesList);
         verify(blockStore, times(1)).getBestBlock();
         verify(blockStore, times(2)).saveBlock(any(), any(), anyBoolean());
     }
@@ -148,12 +148,12 @@ class BlockConnectorHelperTest {
         blockAndDifficultiesList = buildBlockDifficulties(Collections.singletonList(block2),
                 Collections.singletonList(mock(BlockDifficulty.class)));
 
-        blockConnectorHelper = new BlockConnectorHelper(blockStore, blockAndDifficultiesList);
+        blockConnectorHelper = new BlockConnectorHelper(blockStore);
 
         when(blockStore.isEmpty()).thenReturn(false);
         when(blockStore.getBestBlock()).thenReturn(block3);
 
-        assertThrows(BlockConnectorException.class, () -> blockConnectorHelper.startConnecting());
+        assertThrows(BlockConnectorException.class, () -> blockConnectorHelper.startConnecting(blockAndDifficultiesList));
     }
 
     @Test
@@ -166,9 +166,9 @@ class BlockConnectorHelperTest {
         when(blockStore.isEmpty()).thenReturn(true);
         blockAndDifficultiesList = buildBlockDifficulties(Arrays.asList(block1, block2),
                 Arrays.asList(mock(BlockDifficulty.class), mock(BlockDifficulty.class)));
-        blockConnectorHelper = new BlockConnectorHelper(blockStore, blockAndDifficultiesList);
+        blockConnectorHelper = new BlockConnectorHelper(blockStore);
 
-        assertThrows(BlockConnectorException.class, () -> blockConnectorHelper.startConnecting());
+        assertThrows(BlockConnectorException.class, () -> blockConnectorHelper.startConnecting(blockAndDifficultiesList));
     }
 
     List<Pair<Block,BlockDifficulty>> buildBlockDifficulties(List<Block> blocks, List<BlockDifficulty> difficulties) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The main purpose of this PR is to add the onStateChunkResponseError method, so if during the process of a stateChunkResponse, an error happens we ask for the same stateChunk again and to another peer if possible.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
