### PR TITLE
BugFix For LockingCapConstants in all the Networks

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeMainNetConstants.java
@@ -4,6 +4,7 @@ import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.federation.constants.FederationMainNetConstants;
 import co.rsk.peg.feeperkb.constants.FeePerKbMainNetConstants;
+import co.rsk.peg.lockingcap.constants.LockingCapMainNetConstants;
 import co.rsk.peg.whitelist.constants.WhitelistMainNetConstants;
 
 public class BridgeMainNetConstants extends BridgeConstants {
@@ -14,6 +15,7 @@ public class BridgeMainNetConstants extends BridgeConstants {
         feePerKbConstants = FeePerKbMainNetConstants.getInstance();
         whitelistConstants = WhitelistMainNetConstants.getInstance();
         federationConstants = FederationMainNetConstants.getInstance();
+        lockingCapConstants = LockingCapMainNetConstants.getInstance();
 
         btc2RskMinimumAcceptableConfirmations = 100;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 1000;

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
@@ -32,7 +32,6 @@ import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
 
 public class BridgeRegTestConstants extends BridgeConstants {
-    private static final BridgeRegTestConstants instance = new BridgeRegTestConstants();
     private static final List<BtcECKey> defaultFederationPublicKeys = Collections.unmodifiableList(Stream.of(
         "0362634ab57dae9cb373a5d536e66a8c4f67468bbcfb063809bab643072d78a124",
         "03c5946b3fbae03a654237da863c9ed534e0878657175b132b8ca630f245df04db",
@@ -80,9 +79,5 @@ public class BridgeRegTestConstants extends BridgeConstants {
         pegoutTxIndexGracePeriodInBtcBlocks = 100;
 
         blockWithTooMuchChainWorkHeight = Integer.MAX_VALUE;
-    }
-
-    public static BridgeRegTestConstants getInstance() {
-        return instance;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
@@ -23,6 +23,7 @@ import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.federation.constants.FederationRegTestConstants;
 import co.rsk.peg.feeperkb.constants.FeePerKbRegTestConstants;
+import co.rsk.peg.lockingcap.constants.LockingCapRegTestConstants;
 import co.rsk.peg.whitelist.constants.WhitelistRegTestConstants;
 import java.util.Collections;
 import java.util.List;
@@ -47,6 +48,7 @@ public class BridgeRegTestConstants extends BridgeConstants {
         feePerKbConstants = FeePerKbRegTestConstants.getInstance();
         whitelistConstants = WhitelistRegTestConstants.getInstance();
         federationConstants = new FederationRegTestConstants(federationPublicKeys);
+        lockingCapConstants = LockingCapRegTestConstants.getInstance();
 
         btc2RskMinimumAcceptableConfirmations = 3;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 5;

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
@@ -32,7 +32,7 @@ import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
 
 public class BridgeRegTestConstants extends BridgeConstants {
-
+    private static final BridgeRegTestConstants instance = new BridgeRegTestConstants();
     private static final List<BtcECKey> defaultFederationPublicKeys = Collections.unmodifiableList(Stream.of(
         "0362634ab57dae9cb373a5d536e66a8c4f67468bbcfb063809bab643072d78a124",
         "03c5946b3fbae03a654237da863c9ed534e0878657175b132b8ca630f245df04db",
@@ -80,5 +80,9 @@ public class BridgeRegTestConstants extends BridgeConstants {
         pegoutTxIndexGracePeriodInBtcBlocks = 100;
 
         blockWithTooMuchChainWorkHeight = Integer.MAX_VALUE;
+    }
+
+    public static BridgeRegTestConstants getInstance() {
+        return instance;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeTestNetConstants.java
@@ -22,6 +22,7 @@ import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.federation.constants.FederationTestNetConstants;
 import co.rsk.peg.feeperkb.constants.FeePerKbTestNetConstants;
+import co.rsk.peg.lockingcap.constants.LockingCapTestNetConstants;
 import co.rsk.peg.whitelist.constants.WhitelistTestNetConstants;
 
 public class BridgeTestNetConstants extends BridgeConstants {
@@ -32,6 +33,7 @@ public class BridgeTestNetConstants extends BridgeConstants {
         feePerKbConstants = FeePerKbTestNetConstants.getInstance();
         whitelistConstants = WhitelistTestNetConstants.getInstance();
         federationConstants = FederationTestNetConstants.getInstance();
+        lockingCapConstants = LockingCapTestNetConstants.getInstance();
 
         btc2RskMinimumAcceptableConfirmations = 10;
         btc2RskMinimumAcceptableConfirmationsOnRsk = 10;

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -536,8 +536,7 @@ class BridgeSupportTest {
 
         private LockingCapSupport lockingCapSupport;
         private BridgeSupport bridgeSupport;
-        private final BridgeConstants bridgeMainNetConstants = BridgeMainNetConstants.getInstance();
-        private final LockingCapConstants constants = bridgeMainNetConstants.getLockingCapConstants();
+        private final LockingCapConstants constants = LockingCapMainNetConstants.getInstance();
 
         @BeforeEach
         void setUp() {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -536,7 +536,8 @@ class BridgeSupportTest {
 
         private LockingCapSupport lockingCapSupport;
         private BridgeSupport bridgeSupport;
-        private final LockingCapConstants constants = LockingCapMainNetConstants.getInstance();
+        private final BridgeConstants bridgeMainNetConstants = BridgeMainNetConstants.getInstance();
+        private final LockingCapConstants constants = bridgeMainNetConstants.getLockingCapConstants();
 
         @BeforeEach
         void setUp() {

--- a/rskj-core/src/test/java/co/rsk/peg/constants/BridgeConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/constants/BridgeConstantsTest.java
@@ -97,7 +97,7 @@ class BridgeConstantsTest {
         return Stream.of(
             Arguments.of(BridgeMainNetConstants.getInstance(), LockingCapMainNetConstants.getInstance()),
             Arguments.of(BridgeTestNetConstants.getInstance(), LockingCapTestNetConstants.getInstance()),
-            Arguments.of(BridgeRegTestConstants.getInstance(), LockingCapRegTestConstants.getInstance())
+            Arguments.of(new BridgeRegTestConstants(), LockingCapRegTestConstants.getInstance())
         );
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/constants/BridgeConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/constants/BridgeConstantsTest.java
@@ -1,10 +1,15 @@
 package co.rsk.peg.constants;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import co.rsk.bitcoinj.core.Coin;
+import co.rsk.peg.lockingcap.constants.LockingCapConstants;
+import co.rsk.peg.lockingcap.constants.LockingCapMainNetConstants;
+import co.rsk.peg.lockingcap.constants.LockingCapRegTestConstants;
+import co.rsk.peg.lockingcap.constants.LockingCapTestNetConstants;
 import java.util.stream.Stream;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
@@ -75,5 +80,24 @@ class BridgeConstantsTest {
 
         // assert
         assertEquals(expectedValue, pegoutTxIndexGracePeriodInBtcBlocks);
+    }
+
+    @ParameterizedTest()
+    @MethodSource("getLockingCapConstantsProvider")
+    void getLockingCapConstants(BridgeConstants bridgeConstants, LockingCapConstants expectedValue){
+        // Act
+        LockingCapConstants actualLockingCapConstants = bridgeConstants.getLockingCapConstants();
+
+        // Assert
+        assertEquals(expectedValue, actualLockingCapConstants);
+        assertInstanceOf(expectedValue.getClass(), actualLockingCapConstants);
+    }
+
+    private static Stream<Arguments> getLockingCapConstantsProvider() {
+        return Stream.of(
+            Arguments.of(BridgeMainNetConstants.getInstance(), LockingCapMainNetConstants.getInstance()),
+            Arguments.of(BridgeTestNetConstants.getInstance(), LockingCapTestNetConstants.getInstance()),
+            Arguments.of(BridgeRegTestConstants.getInstance(), LockingCapRegTestConstants.getInstance())
+        );
     }
 }


### PR DESCRIPTION
## Description
Bug fix For LockingCapConstants in all the networks placed in BridgeConstants.

## Motivation and Context
This relates to the Bridge Refactor to decouple some objects tied closely to the Bridge.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
