### PR TITLE
Add Coverage in BridgeConstants

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/constants/BridgeConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/constants/BridgeConstantsTest.java
@@ -6,10 +6,22 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import co.rsk.bitcoinj.core.Coin;
+import co.rsk.peg.federation.constants.FederationConstants;
+import co.rsk.peg.federation.constants.FederationMainNetConstants;
+import co.rsk.peg.federation.constants.FederationRegTestConstants;
+import co.rsk.peg.federation.constants.FederationTestNetConstants;
+import co.rsk.peg.feeperkb.constants.FeePerKbConstants;
+import co.rsk.peg.feeperkb.constants.FeePerKbMainNetConstants;
+import co.rsk.peg.feeperkb.constants.FeePerKbRegTestConstants;
+import co.rsk.peg.feeperkb.constants.FeePerKbTestNetConstants;
 import co.rsk.peg.lockingcap.constants.LockingCapConstants;
 import co.rsk.peg.lockingcap.constants.LockingCapMainNetConstants;
 import co.rsk.peg.lockingcap.constants.LockingCapRegTestConstants;
 import co.rsk.peg.lockingcap.constants.LockingCapTestNetConstants;
+import co.rsk.peg.whitelist.constants.WhitelistConstants;
+import co.rsk.peg.whitelist.constants.WhitelistMainNetConstants;
+import co.rsk.peg.whitelist.constants.WhitelistRegTestConstants;
+import co.rsk.peg.whitelist.constants.WhitelistTestNetConstants;
 import java.util.stream.Stream;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
@@ -80,6 +92,64 @@ class BridgeConstantsTest {
 
         // assert
         assertEquals(expectedValue, pegoutTxIndexGracePeriodInBtcBlocks);
+    }
+
+    @ParameterizedTest()
+    @MethodSource("getFeePerKbConstantsProvider")
+    void getFeePerKbConstants(BridgeConstants bridgeConstants, FeePerKbConstants expectedValue) {
+        // Act
+        FeePerKbConstants actualFeePerKbConstants = bridgeConstants.getFeePerKbConstants();
+
+        // Assert
+        assertEquals(expectedValue, actualFeePerKbConstants);
+        assertInstanceOf(expectedValue.getClass(), actualFeePerKbConstants);
+    }
+
+    private static Stream<Arguments> getFeePerKbConstantsProvider() {
+        return Stream.of(
+            Arguments.of(BridgeMainNetConstants.getInstance(), FeePerKbMainNetConstants.getInstance()),
+            Arguments.of(BridgeTestNetConstants.getInstance(), FeePerKbTestNetConstants.getInstance()),
+            Arguments.of(new BridgeRegTestConstants(), FeePerKbRegTestConstants.getInstance())
+        );
+    }
+
+    @ParameterizedTest()
+    @MethodSource("getWhitelistConstantsProvider")
+    void getWhitelistConstants(BridgeConstants bridgeConstants, WhitelistConstants expectedValue) {
+        // Act
+        WhitelistConstants actualWhitelistConstants = bridgeConstants.getWhitelistConstants();
+
+        // Assert
+        assertEquals(expectedValue, actualWhitelistConstants);
+        assertInstanceOf(expectedValue.getClass(), actualWhitelistConstants);
+    }
+
+    private static Stream<Arguments> getWhitelistConstantsProvider() {
+        return Stream.of(
+            Arguments.of(BridgeMainNetConstants.getInstance(), WhitelistMainNetConstants.getInstance()),
+            Arguments.of(BridgeTestNetConstants.getInstance(), WhitelistTestNetConstants.getInstance()),
+            Arguments.of(new BridgeRegTestConstants(), WhitelistRegTestConstants.getInstance())
+        );
+    }
+
+    @ParameterizedTest()
+    @MethodSource("getFederationConstantsProvider")
+    void getFederationConstants(BridgeConstants bridgeConstants, FederationConstants expectedValue) {
+        // Act
+        FederationConstants actualFederationConstants = bridgeConstants.getFederationConstants();
+
+        // Assert
+        assertInstanceOf(expectedValue.getClass(), actualFederationConstants);
+    }
+
+    private static Stream<Arguments> getFederationConstantsProvider() {
+        BridgeConstants bridgeRegTestConstants = new BridgeRegTestConstants();
+        FederationConstants federationRegTestConstants = bridgeRegTestConstants.getFederationConstants();
+        return Stream.of(
+            Arguments.of(BridgeMainNetConstants.getInstance(), FederationMainNetConstants.getInstance()),
+            Arguments.of(BridgeTestNetConstants.getInstance(), FederationTestNetConstants.getInstance()),
+            Arguments.of(bridgeRegTestConstants, new FederationRegTestConstants(federationRegTestConstants.getGenesisFederationPublicKeys()))
+        );
     }
 
     @ParameterizedTest()

--- a/rskj-core/src/test/java/co/rsk/peg/constants/BridgeConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/constants/BridgeConstantsTest.java
@@ -6,22 +6,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import co.rsk.bitcoinj.core.Coin;
-import co.rsk.peg.federation.constants.FederationConstants;
-import co.rsk.peg.federation.constants.FederationMainNetConstants;
-import co.rsk.peg.federation.constants.FederationRegTestConstants;
-import co.rsk.peg.federation.constants.FederationTestNetConstants;
-import co.rsk.peg.feeperkb.constants.FeePerKbConstants;
-import co.rsk.peg.feeperkb.constants.FeePerKbMainNetConstants;
-import co.rsk.peg.feeperkb.constants.FeePerKbRegTestConstants;
-import co.rsk.peg.feeperkb.constants.FeePerKbTestNetConstants;
-import co.rsk.peg.lockingcap.constants.LockingCapConstants;
-import co.rsk.peg.lockingcap.constants.LockingCapMainNetConstants;
-import co.rsk.peg.lockingcap.constants.LockingCapRegTestConstants;
-import co.rsk.peg.lockingcap.constants.LockingCapTestNetConstants;
-import co.rsk.peg.whitelist.constants.WhitelistConstants;
-import co.rsk.peg.whitelist.constants.WhitelistMainNetConstants;
-import co.rsk.peg.whitelist.constants.WhitelistRegTestConstants;
-import co.rsk.peg.whitelist.constants.WhitelistTestNetConstants;
+import co.rsk.peg.federation.constants.*;
+import co.rsk.peg.feeperkb.constants.*;
+import co.rsk.peg.lockingcap.constants.*;
+import co.rsk.peg.whitelist.constants.*;
 import java.util.stream.Stream;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
@@ -43,10 +31,11 @@ class BridgeConstantsTest {
 
     @ParameterizedTest()
     @MethodSource("minimumPeginTxValueArgProvider")
-    void test_getMinimumPeginTxValue(BridgeConstants bridgeConstants, boolean isRSKIP219Active){
+    void getMinimumPeginTxValue(BridgeConstants bridgeConstants, boolean isRSKIP219Active){
         // Arrange
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
         when(activations.isActive(ConsensusRule.RSKIP219)).thenReturn(isRSKIP219Active);
+
         // Act
         Coin minimumPeginTxValue = bridgeConstants.getMinimumPeginTxValue(activations);
 
@@ -68,7 +57,7 @@ class BridgeConstantsTest {
 
     @ParameterizedTest()
     @MethodSource("getBtcHeightWhenPegoutTxIndexActivatesArgProvider")
-    void test_getBtcHeightWhenPegoutTxIndexActivates(BridgeConstants bridgeConstants, int expectedValue){
+    void getBtcHeightWhenPegoutTxIndexActivates(BridgeConstants bridgeConstants, int expectedValue){
         // Act
         int btcHeightWhenPegoutTxIndexActivates = bridgeConstants.getBtcHeightWhenPegoutTxIndexActivates();
 

--- a/rskj-core/src/test/java/co/rsk/peg/constants/BridgeConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/constants/BridgeConstantsTest.java
@@ -90,7 +90,6 @@ class BridgeConstantsTest {
         FeePerKbConstants actualFeePerKbConstants = bridgeConstants.getFeePerKbConstants();
 
         // Assert
-        assertEquals(expectedValue, actualFeePerKbConstants);
         assertInstanceOf(expectedValue.getClass(), actualFeePerKbConstants);
     }
 
@@ -109,7 +108,6 @@ class BridgeConstantsTest {
         WhitelistConstants actualWhitelistConstants = bridgeConstants.getWhitelistConstants();
 
         // Assert
-        assertEquals(expectedValue, actualWhitelistConstants);
         assertInstanceOf(expectedValue.getClass(), actualWhitelistConstants);
     }
 
@@ -148,7 +146,6 @@ class BridgeConstantsTest {
         LockingCapConstants actualLockingCapConstants = bridgeConstants.getLockingCapConstants();
 
         // Assert
-        assertEquals(expectedValue, actualLockingCapConstants);
         assertInstanceOf(expectedValue.getClass(), actualLockingCapConstants);
     }
 


### PR DESCRIPTION
## Description
Add coverage for `getFeePerKbConstants`, `getWhitelistConstants`, and `getFederationConstants` methods, placed in `BridgeConstants`.


## Motivation and Context
This relates to the Bridge Refactor to decouple some objects tied closely to the Bridge.


## How Has This Been Tested?
Unit Tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
