### PR TITLE
Refactor Java version output in web3_clientVersion

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -63,6 +63,7 @@ import org.ethereum.rpc.dto.TransactionResultDTO;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.ethereum.rpc.parameters.*;
 import org.ethereum.util.BuildInfo;
+import org.ethereum.util.Utils;
 import org.ethereum.vm.DataWord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -195,12 +196,10 @@ public class Web3Impl implements Web3 {
 
     @Override
     public String web3_clientVersion() {
-        String javaVersion = System.getProperty("java.version");
-        String javaMajorVersion = javaVersion.startsWith("1.") ? javaVersion.split("\\.")[1] : javaVersion.split("\\.")[0];
-        String formattedJavaVersion = "Java" + javaMajorVersion;
+        String javaVersion = Utils.getFormattedJavaVersion();
 
         String clientVersion = CLIENT_VERSION_PREFIX + "/" + config.projectVersion() + "/" +
-                System.getProperty("os.name") + "/" + formattedJavaVersion + "/" +
+                System.getProperty("os.name") + "/" + javaVersion + "/" +
                 config.projectVersionModifier() + "-" + buildInfo.getBuildHash();
 
         if (logger.isDebugEnabled()) {

--- a/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/Web3Impl.java
@@ -195,8 +195,12 @@ public class Web3Impl implements Web3 {
 
     @Override
     public String web3_clientVersion() {
+        String javaVersion = System.getProperty("java.version");
+        String javaMajorVersion = javaVersion.startsWith("1.") ? javaVersion.split("\\.")[1] : javaVersion.split("\\.")[0];
+        String formattedJavaVersion = "Java" + javaMajorVersion;
+
         String clientVersion = CLIENT_VERSION_PREFIX + "/" + config.projectVersion() + "/" +
-                System.getProperty("os.name") + "/Java1.8/" +
+                System.getProperty("os.name") + "/" + formattedJavaVersion + "/" +
                 config.projectVersionModifier() + "-" + buildInfo.getBuildHash();
 
         if (logger.isDebugEnabled()) {

--- a/rskj-core/src/main/java/org/ethereum/util/Utils.java
+++ b/rskj-core/src/main/java/org/ethereum/util/Utils.java
@@ -254,4 +254,10 @@ public class Utils {
         }
         return result;
     }
+
+    public static String getFormattedJavaVersion(){
+        String javaVersion = System.getProperty("java.specification.version");
+        String javaMajorVersion = javaVersion.replace("1.", "");
+        return String.format("Java%s", javaMajorVersion);
+    }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -141,6 +141,28 @@ class Web3ImplTest {
     }
 
     @Test
+    void web3_clientVersion_ShouldIncludeJava8() {
+        System.setProperty("java.specification.version", "1.8");
+
+        Web3 web3 = createWeb3();
+
+        String clientVersion = web3.web3_clientVersion();
+
+        assertTrue(clientVersion.contains("Java8"), "Java version is not Java8");
+    }
+
+    @Test
+    void web3_clientVersion_ShouldIncludeJava17() {
+        System.setProperty("java.specification.version", "17");
+
+        Web3 web3 = createWeb3();
+
+        String clientVersion = web3.web3_clientVersion();
+
+        assertTrue(clientVersion.contains("Java17"), "Java version is not Java17");
+    }
+
+    @Test
     void net_version() {
         Web3Impl web3 = createWeb3();
 

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -3119,14 +3119,12 @@ class Web3ImplTest {
 
     //Chain Param Object creations
     private class ChainParams {
-        private final World world;
         private final Web3Impl web3;
         private final String accountAddress;
         private final Block block;
         private CallArguments argsForCall; // for call tests could be null
 
         private ChainParams(World world, String accountAddress, Block block) {
-            this.world = world;
             this.web3 = createWeb3(world);
             this.accountAddress = accountAddress;
             this.block = block;


### PR DESCRIPTION
# Update Java Version Reporting in `web3_clientVersion` RPC Call

## Description
Currently, the `web3_clientVersion()` RPC call always returns a hardcoded Java version string, such as `Java1.8`, in the client version string (`e.g., RskJ/6.3.1/Linux/Java1.8/ARROWHEAD-27cba5598`). We need to update this functionality to return the actual Java major version in the format `Java<MAJOR_VERSION>` (e.g., `Java8`, `Java17`, etc.)

## Motivation and Context
Providing the real Java major version in the `web3_clientVersion` RPC call will enhance accuracy and help users and developers better understand the Java environment in use. This improvement is crucial for debugging and ensuring compatibility with various Java versions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
