### PR TITLE
Fix reference to whitelist constants in BridgeTestNetConstants

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeTestNetConstants.java
@@ -22,7 +22,7 @@ import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.federation.constants.FederationTestNetConstants;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
-import co.rsk.peg.whitelist.constants.WhitelistRegTestConstants;
+import co.rsk.peg.whitelist.constants.WhitelistTestNetConstants;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -36,7 +36,7 @@ public class BridgeTestNetConstants extends BridgeConstants {
     BridgeTestNetConstants() {
         btcParamsString = NetworkParameters.ID_TESTNET;
         feePerKbConstants = FeePerKbTestNetConstants.getInstance();
-        whitelistConstants = WhitelistRegTestConstants.getInstance();
+        whitelistConstants = WhitelistTestNetConstants.getInstance();
         federationConstants = FederationTestNetConstants.getInstance();
 
         btc2RskMinimumAcceptableConfirmations = 10;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
