### PR TITLE
Change method signature on extractStandardRedeemScript

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/PegUtilsLegacy.java
+++ b/rskj-core/src/main/java/co/rsk/peg/PegUtilsLegacy.java
@@ -230,8 +230,7 @@ public class PegUtilsLegacy {
                         return false;
                     }
 
-                    Script inputRedeeemScript = new ScriptBuilder().addChunks(inputStandardRedeemScriptChunks).build();
-                    Script outputScript = ScriptBuilder.createP2SHOutputScript(inputRedeeemScript);
+                    Script outputScript = ScriptBuilder.createP2SHOutputScript(inputStandardRedeemScript);
                     if (outputScript.equals(retiredFederationP2SHScript)) {
                         return false;
                     }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/ErpFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/ErpFederation.java
@@ -55,7 +55,8 @@ public class ErpFederation extends Federation {
     public Script getDefaultRedeemScript() {
         if (defaultRedeemScript == null) {
             RedeemScriptParser redeemScriptParser = getRedeemScriptParser();
-            defaultRedeemScript = redeemScriptParser.extractStandardRedeemScript();
+            List<ScriptChunk> defaultRedeemScriptChunks = redeemScriptParser.extractStandardRedeemScriptChunks();
+            defaultRedeemScript = new ScriptBuilder().addChunks(defaultRedeemScriptChunks).build();
         }
         return defaultRedeemScript;
     }

--- a/rskj-core/src/test/java/co/rsk/peg/federation/PowpegMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/PowpegMigrationTest.java
@@ -732,7 +732,10 @@ class PowpegMigrationTest {
                 // Get the standard redeem script to compare against, since it could be a flyover redeem script
                 ScriptParserResult result = ScriptParser.parseScriptProgram(inputRedeemScript.getProgram());
                 assertFalse(result.getException().isPresent());
-                Script inputStandardRedeemScript = RedeemScriptParserFactory.get(result.getChunks()).extractStandardRedeemScript();
+
+                RedeemScriptParser redeemScriptParser = RedeemScriptParserFactory.get(result.getChunks());
+                List<ScriptChunk> inputStandardRedeemScriptChunks = redeemScriptParser.extractStandardRedeemScriptChunks();
+                Script inputStandardRedeemScript = new ScriptBuilder().addChunks(inputStandardRedeemScriptChunks).build();
 
                 Optional<Federation> spendingFederationOptional = Optional.empty();
                 if (inputStandardRedeemScript.equals(getFederationDefaultRedeemScript(activeFederation))) {


### PR DESCRIPTION
## Description
Once the method signature on RedeemScriptParser#extractStandardRedeemScript is changed, we need to apply this to RSKj to modify how the method is used from it.

Old method signature: Script extractStandardRedeemScript();

New method signature: List<ScriptChunk> extractStandardRedeemScriptChunks();

## Motivation and Context
This relates to the Reactors to add SegwitRedeemScriptParser.


## How Has This Been Tested?
Unit Tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
