### PR TITLE
Create SVP spend tx hash unsigned storage entry

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageIndexKey.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageIndexKey.java
@@ -25,6 +25,7 @@ public enum BridgeStorageIndexKey {
 
     SVP_FUND_TX_HASH_UNSIGNED("svpFundTxHashUnsigned"),
     SVP_FUND_TX_HASH_SIGNED("svpFundTxHashSigned"),
+    SVP_SPEND_TX_HASH_UNSIGNED("svpSpendTxHashUnsigned"),
     ;
 
     private final String key;


### PR DESCRIPTION
## Description
Just as we did with the [fund transaction unsigned hash](https://github.com/rsksmart/rskj/blob/feature/powpeg_validation_protocol/rskj-core/src/main/java/co/rsk/peg/BridgeStorageIndexKey.java#L26), we need to save the spend transaction hash to be able to identify it when trying to register it later.

## Motivation and Context
https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP419.md
