### PR TITLE
Create set and save SvpFundTransactionHashUnsigned methods

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -80,6 +80,8 @@ public class BridgeStorageProvider {
     private boolean isSvpFundTxHashUnsignedSet = false;
     private Sha256Hash svpFundTxHashSigned;
     private boolean isSvpFundTxHashSignedSet = false;
+    private Sha256Hash svpSpendTxHashUnsigned;
+    private boolean isSvpSpendTxHashUnsignedSet = false;
 
     public BridgeStorageProvider(
         Repository repository,
@@ -594,6 +596,23 @@ public class BridgeStorageProvider {
         repository.addStorageBytes(contractAddress, SVP_FUND_TX_HASH_SIGNED.getKey(), data);
     }
 
+    public void setSvpSpendTxHashUnsigned(Sha256Hash hash) {
+        this.svpSpendTxHashUnsigned = hash;
+        this.isSvpSpendTxHashUnsignedSet = true;
+    }
+
+    private void saveSvpSpendTxHashUnsigned() {
+        if (!activations.isActive(RSKIP419) || !isSvpSpendTxHashUnsignedSet) {
+            return;
+        }
+
+        byte[] data = Optional.ofNullable(svpSpendTxHashUnsigned)
+            .map(BridgeSerializationUtils::serializeSha256Hash)
+            .orElse(null);
+
+        repository.addStorageBytes(contractAddress, SVP_SPEND_TX_HASH_UNSIGNED.getKey(), data);
+    }
+
     public void save() {
         saveBtcTxHashesAlreadyProcessed();
 
@@ -619,6 +638,7 @@ public class BridgeStorageProvider {
 
         saveSvpFundTxHashUnsigned();
         saveSvpFundTxHashSigned();
+        saveSvpSpendTxHashUnsigned();
     }
 
     private DataWord getStorageKeyForBtcTxHashAlreadyProcessed(Sha256Hash btcTxHash) {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -633,6 +633,63 @@ class BridgeStorageProviderTest {
         }
     }
 
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @Tag("save, set and get svp spend transaction hash unsigned tests")
+    class SvpSpendTxHashUnsignedTests {
+        private final Sha256Hash svpSpendTxHash = BitcoinTestUtils.createHash(123_456_789);
+        private Repository repository;
+        private BridgeStorageProvider bridgeStorageProvider;
+
+        @BeforeEach
+        void setup() {
+            repository = createRepository();
+            bridgeStorageProvider = createBridgeStorageProvider(repository, mainnetBtcParams, activationsAllForks);
+        }
+
+        @Test
+        void saveSvpSpendTxHashUnsigned_preLovell700_shouldNotSaveInStorage() throws IOException {
+            // Arrange
+            ActivationConfig.ForBlock arrowheadActivations = ActivationConfigsForTest.arrowhead631().forBlock(0L);
+            bridgeStorageProvider = createBridgeStorageProvider(repository, mainnetBtcParams, arrowheadActivations);
+
+            // Act
+            bridgeStorageProvider.setSvpSpendTxHashUnsigned(svpSpendTxHash);
+            bridgeStorageProvider.save();
+
+            // Assert
+            byte[] actualSvpSpendTxHashSerialized = repository.getStorageBytes(bridgeAddress, SVP_SPEND_TX_HASH_UNSIGNED.getKey());
+            assertNull(actualSvpSpendTxHashSerialized);
+        }
+
+        @Test
+        void saveSvpSpendTxHashUnsigned_postLovell700_shouldSaveInStorage() throws IOException {
+            // Act
+            bridgeStorageProvider.setSvpSpendTxHashUnsigned(svpSpendTxHash);
+            bridgeStorageProvider.save();
+
+            // Assert
+            byte[] svpSpendTxHashSerialized = BridgeSerializationUtils.serializeSha256Hash(svpSpendTxHash);
+            byte[] actualSvpSpendTxHashSerialized = repository.getStorageBytes(bridgeAddress, SVP_SPEND_TX_HASH_UNSIGNED.getKey());
+            assertArrayEquals(svpSpendTxHashSerialized, actualSvpSpendTxHashSerialized);
+        }
+
+        @Test
+        void saveSvpSpendTxHashUnsigned_postLovell700AndResettingToNull_shouldSaveNullInStorage() throws IOException {
+            // Initially setting a valid hash in storage
+            bridgeStorageProvider.setSvpSpendTxHashUnsigned(svpSpendTxHash);
+            bridgeStorageProvider.save();
+
+            // Act
+            bridgeStorageProvider.setSvpSpendTxHashUnsigned(null);
+            bridgeStorageProvider.save();
+
+            // Assert
+            byte[] actualSvpSpendTxHashSerialized = repository.getStorageBytes(bridgeAddress, SVP_SPEND_TX_HASH_UNSIGNED.getKey());
+            assertNull(actualSvpSpendTxHashSerialized);
+        }
+    }
+
     @Test
     void getReleaseRequestQueue_before_rskip_146_activation() throws IOException {
         Repository repositoryMock = mock(Repository.class);


### PR DESCRIPTION
## Description
To save the spend transaction (unsigned) hash in the repository, we need to create new methods in BridgeStorageProvider: one for setting the variable and another one for saving it in the repository.

## Motivation and Context
https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP419.md
