### PR TITLE
Create new svpSpendTxWaitingForSignatures storage entry with Serialization/Deseralization Logic 

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -61,18 +61,18 @@ public class BridgeSerializationUtils {
         throw new IllegalAccessError("Utility class, do not instantiate it");
     }
 
-    public static byte[] serializeSingleEntry(Map.Entry<Keccak256, BtcTransaction> entry) {
-        byte[][] entryBytes = serializeMapEntry(entry);
+    public static byte[] serializeRskTxWaitingForSignatures(Map.Entry<Keccak256, BtcTransaction> entry) {
+        byte[][] entryBytes = serializeRskTxWaitingForSignaturesSingleEntry(entry);
         return RLP.encodeList(entryBytes);
     }
 
-    public static byte[] serializeMap(SortedMap<Keccak256, BtcTransaction> map) {
+    public static byte[] serializeRskTxsWaitingForSignatures(SortedMap<Keccak256, BtcTransaction> map) {
         int ntxs = map.size();
         byte[][] bytes = new byte[ntxs * 2][];
         int n = 0;
 
         for (Map.Entry<Keccak256, BtcTransaction> entry : map.entrySet()) {
-            byte[][] entryBytes = serializeMapEntry(entry);
+            byte[][] entryBytes = serializeRskTxWaitingForSignaturesSingleEntry(entry);
             bytes[n++] = entryBytes[0];
             bytes[n++] = entryBytes[1];
         }
@@ -80,13 +80,13 @@ public class BridgeSerializationUtils {
         return RLP.encodeList(bytes);
     }
 
-    private static byte[][] serializeMapEntry(Map.Entry<Keccak256, BtcTransaction> entry) {
+    private static byte[][] serializeRskTxWaitingForSignaturesSingleEntry(Map.Entry<Keccak256, BtcTransaction> entry) {
         byte[] keyBytes = RLP.encodeElement(entry.getKey().getBytes());
         byte[] valueBytes = RLP.encodeElement(entry.getValue().bitcoinSerialize());
         return new byte[][] { keyBytes, valueBytes };
     }
 
-    public static Map.Entry<Keccak256, BtcTransaction> deserializeSingleEntry(
+    public static Map.Entry<Keccak256, BtcTransaction> deserializeRskTxWaitingForSignatures(
             byte[] data, NetworkParameters networkParameters, boolean noInputsTxs) {
         if (data == null || data.length == 0) {
             return new AbstractMap.SimpleEntry<>(null, null);
@@ -94,10 +94,10 @@ public class BridgeSerializationUtils {
 
         RLPList rlpList = (RLPList) RLP.decode2(data).get(0);
 
-        return deserializeMapEntry(rlpList, 0, networkParameters, noInputsTxs);
+        return deserializeRskTxWaitingForSignaturesSingleEntry(rlpList, 0, networkParameters, noInputsTxs);
     }
 
-    public static SortedMap<Keccak256, BtcTransaction> deserializeMap(
+    public static SortedMap<Keccak256, BtcTransaction> deserializeRskTxsWaitingForSignatures(
             byte[] data, NetworkParameters networkParameters, boolean noInputsTxs) {
         SortedMap<Keccak256, BtcTransaction> map = new TreeMap<>();
 
@@ -110,14 +110,14 @@ public class BridgeSerializationUtils {
 
         for (int k = 0; k < ntxs; k++) {
             Map.Entry<Keccak256, BtcTransaction> entry =
-                deserializeMapEntry(rlpList, k, networkParameters, noInputsTxs);
+                deserializeRskTxWaitingForSignaturesSingleEntry(rlpList, k, networkParameters, noInputsTxs);
             map.put(entry.getKey(), entry.getValue());
         }
 
         return map;
     }
   
-    private static Map.Entry<Keccak256, BtcTransaction> deserializeMapEntry(
+    private static Map.Entry<Keccak256, BtcTransaction> deserializeRskTxWaitingForSignaturesSingleEntry(
             RLPList rlpList, int index, NetworkParameters networkParameters, boolean noInputsTxs) {
         Keccak256 hash = new Keccak256(rlpList.get(index * 2).getRLPData());
         byte[] payload = rlpList.get(index * 2 + 1).getRLPData();

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -62,7 +62,7 @@ public class BridgeSerializationUtils {
     }
 
     public static byte[] serializeRskTxWaitingForSignatures(Map.Entry<Keccak256, BtcTransaction> entry) {
-        byte[][] entryBytes = serializeRskTxWaitingForSignaturesSingleEntry(entry);
+        byte[][] entryBytes = serializeRskTxWaitingForSignaturesEntry(entry);
         return RLP.encodeList(entryBytes);
     }
 
@@ -72,7 +72,7 @@ public class BridgeSerializationUtils {
         int n = 0;
 
         for (Map.Entry<Keccak256, BtcTransaction> entry : map.entrySet()) {
-            byte[][] entryBytes = serializeRskTxWaitingForSignaturesSingleEntry(entry);
+            byte[][] entryBytes = serializeRskTxWaitingForSignaturesEntry(entry);
             bytes[n++] = entryBytes[0];
             bytes[n++] = entryBytes[1];
         }
@@ -80,7 +80,7 @@ public class BridgeSerializationUtils {
         return RLP.encodeList(bytes);
     }
 
-    private static byte[][] serializeRskTxWaitingForSignaturesSingleEntry(Map.Entry<Keccak256, BtcTransaction> entry) {
+    private static byte[][] serializeRskTxWaitingForSignaturesEntry(Map.Entry<Keccak256, BtcTransaction> entry) {
         byte[] keyBytes = RLP.encodeElement(entry.getKey().getBytes());
         byte[] valueBytes = RLP.encodeElement(entry.getValue().bitcoinSerialize());
         return new byte[][] { keyBytes, valueBytes };
@@ -94,7 +94,7 @@ public class BridgeSerializationUtils {
 
         RLPList rlpList = (RLPList) RLP.decode2(data).get(0);
 
-        return deserializeRskTxWaitingForSignaturesSingleEntry(rlpList, 0, networkParameters, noInputsTxs);
+        return deserializeRskTxWaitingForSignaturesEntry(rlpList, 0, networkParameters, noInputsTxs);
     }
 
     public static SortedMap<Keccak256, BtcTransaction> deserializeRskTxsWaitingForSignatures(
@@ -110,16 +110,16 @@ public class BridgeSerializationUtils {
 
         for (int k = 0; k < ntxs; k++) {
             Map.Entry<Keccak256, BtcTransaction> entry =
-                deserializeRskTxWaitingForSignaturesSingleEntry(rlpList, k, networkParameters, noInputsTxs);
+                deserializeRskTxWaitingForSignaturesEntry(rlpList, k, networkParameters, noInputsTxs);
             map.put(entry.getKey(), entry.getValue());
         }
 
         return map;
     }
   
-    private static Map.Entry<Keccak256, BtcTransaction> deserializeRskTxWaitingForSignaturesSingleEntry(
+    private static Map.Entry<Keccak256, BtcTransaction> deserializeRskTxWaitingForSignaturesEntry(
             RLPList rlpList, int index, NetworkParameters networkParameters, boolean noInputsTxs) {
-        Keccak256 hash = new Keccak256(rlpList.get(index * 2).getRLPData());
+        Keccak256 rskTxHash = new Keccak256(rlpList.get(index * 2).getRLPData());
         byte[] payload = rlpList.get(index * 2 + 1).getRLPData();
         BtcTransaction tx;
 
@@ -130,7 +130,7 @@ public class BridgeSerializationUtils {
             tx.parseNoInputs(payload);
         }
 
-        return new AbstractMap.SimpleEntry<>(hash, tx);
+        return new AbstractMap.SimpleEntry<>(rskTxHash, tx);
     }
 
     public static byte[] serializeUTXOList(List<UTXO> list) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeState.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeState.java
@@ -111,7 +111,7 @@ public class BridgeState {
     public byte[] getEncoded() throws IOException {
         byte[] rlpBtcBlockchainBestChainHeight = RLP.encodeBigInteger(BigInteger.valueOf(this.btcBlockchainBestChainHeight));
         byte[] rlpActiveFederationBtcUTXOs = RLP.encodeElement(BridgeSerializationUtils.serializeUTXOList(activeFederationBtcUTXOs));
-        byte[] rlpRskTxsWaitingForSignatures = RLP.encodeElement(BridgeSerializationUtils.serializeMap(rskTxsWaitingForSignatures));
+        byte[] rlpRskTxsWaitingForSignatures = RLP.encodeElement(BridgeSerializationUtils.serializeRskTxsWaitingForSignatures(rskTxsWaitingForSignatures));
         byte[] serializedReleaseRequestQueue = shouldUsePapyrusEncoding(this.activations) ?
                 BridgeSerializationUtils.serializeReleaseRequestQueueWithTxHash(releaseRequestQueue):
                 BridgeSerializationUtils.serializeReleaseRequestQueue(releaseRequestQueue);
@@ -133,7 +133,7 @@ public class BridgeState {
         byte[] btcUTXOsBytes = rlpList.get(1).getRLPData();
         List<UTXO> btcUTXOs = BridgeSerializationUtils.deserializeUTXOList(btcUTXOsBytes);
         byte[] rskTxsWaitingForSignaturesBytes = rlpList.get(2).getRLPData();
-        SortedMap<Keccak256, BtcTransaction> rskTxsWaitingForSignatures = BridgeSerializationUtils.deserializeMap(rskTxsWaitingForSignaturesBytes, bridgeConstants.getBtcParams(), false);
+        SortedMap<Keccak256, BtcTransaction> rskTxsWaitingForSignatures = BridgeSerializationUtils.deserializeRskTxsWaitingForSignatures(rskTxsWaitingForSignaturesBytes, bridgeConstants.getBtcParams(), false);
         byte[] releaseRequestQueueBytes = rlpList.get(3).getRLPData();
         ReleaseRequestQueue releaseRequestQueue = new ReleaseRequestQueue(BridgeSerializationUtils.deserializeReleaseRequestQueue(releaseRequestQueueBytes, bridgeConstants.getBtcParams(), shouldUsePapyrusEncoding(activations)));
         byte[] pegoutsWaitingForConfirmationsBytes = rlpList.get(4).getRLPData();

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -82,6 +82,7 @@ public class BridgeStorageProvider {
     private boolean isSvpFundTxHashSignedSet = false;
     private Sha256Hash svpSpendTxHashUnsigned;
     private boolean isSvpSpendTxHashUnsignedSet = false;
+    private Map.Entry<Keccak256, BtcTransaction> svpSpendTxWaitingForSignatures;
 
     public BridgeStorageProvider(
         Repository repository,

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -242,7 +242,7 @@ public class BridgeStorageProvider {
 
         pegoutsWaitingForSignatures = getFromRepository(
             PEGOUTS_WAITING_FOR_SIGNATURES,
-                data -> BridgeSerializationUtils.deserializeMap(data, networkParameters, false)
+                data -> BridgeSerializationUtils.deserializeRskTxsWaitingForSignatures(data, networkParameters, false)
         );
         return pegoutsWaitingForSignatures;
     }
@@ -252,7 +252,7 @@ public class BridgeStorageProvider {
             return;
         }
 
-        safeSaveToRepository(PEGOUTS_WAITING_FOR_SIGNATURES, pegoutsWaitingForSignatures, BridgeSerializationUtils::serializeMap);
+        safeSaveToRepository(PEGOUTS_WAITING_FOR_SIGNATURES, pegoutsWaitingForSignatures, BridgeSerializationUtils::serializeRskTxsWaitingForSignatures);
     }
 
     public CoinbaseInformation getCoinbaseInformation(Sha256Hash blockHash) {

--- a/rskj-core/src/main/java/co/rsk/peg/StateForFederator.java
+++ b/rskj-core/src/main/java/co/rsk/peg/StateForFederator.java
@@ -40,7 +40,7 @@ public class StateForFederator {
         RLPList rlpList = (RLPList) RLP.decode2(rlpData).get(0);
         byte[] encodedWaitingForSign = rlpList.get(0).getRLPData();
 
-        this.rskTxsWaitingForSignatures = BridgeSerializationUtils.deserializeMap(encodedWaitingForSign, parameters, false);
+        this.rskTxsWaitingForSignatures = BridgeSerializationUtils.deserializeRskTxsWaitingForSignatures(encodedWaitingForSign, parameters, false);
     }
 
     public SortedMap<Keccak256, BtcTransaction> getRskTxsWaitingForSignatures() {
@@ -48,7 +48,7 @@ public class StateForFederator {
     }
 
     public byte[] getEncoded() {
-        byte[] encodedWaitingForSign = BridgeSerializationUtils.serializeMap(this.rskTxsWaitingForSignatures);
+        byte[] encodedWaitingForSign = BridgeSerializationUtils.serializeRskTxsWaitingForSignatures(this.rskTxsWaitingForSignatures);
         return RLP.encodeList(encodedWaitingForSign);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -19,7 +19,6 @@
 package co.rsk.peg;
 
 import static co.rsk.peg.PegTestUtils.createHash3;
-import static co.rsk.peg.PegTestUtils.createRandomBtcECKeys;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.*;
@@ -80,24 +79,26 @@ import java.util.stream.Collectors;
 
 class BridgeSerializationUtilsTest {
 
-    private static final NetworkParameters NETWORK_PARAMETERS = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
-    private static final Address ADDRESS = Address.fromBase58(NETWORK_PARAMETERS, "mvc8mwDcdLEq2jGqrL43Ub3sxTR13tB8LL");
-    private static final Address OTHER_ADDRESS = Address.fromBase58(NETWORK_PARAMETERS, "n3CaAPu2PR7FDdGK8tFwe8thr7hV7zz599");
+    private static final NetworkParameters NETWORK_PARAMETERS = NetworkParameters.fromID(NetworkParameters.ID_MAINNET);
+    private static final Address ADDRESS = Address.fromBase58(NETWORK_PARAMETERS, "16zJJhTZWB1txoisGjEmhtHQam4sikpTd2");
+    private static final Address OTHER_ADDRESS = Address.fromBase58(NETWORK_PARAMETERS, "3NWYFKUegmqAjoW8aMhSLNVW2jy4MiA2eS");
 
     @Test
     void serializeAndDeserializeSingleEntry_whenValidData_shouldReturnEqualResults() {
         // Arrange
-        BtcTransaction input = new BtcTransaction(NETWORK_PARAMETERS);
-        input.addOutput(Coin.FIFTY_COINS, ADDRESS);
+        BtcTransaction prevTx = new BtcTransaction(NETWORK_PARAMETERS);
+        prevTx.addOutput(Coin.FIFTY_COINS, ADDRESS);
 
         Keccak256 key = createHash3(1);
         BtcTransaction tx = new BtcTransaction(NETWORK_PARAMETERS);
-        tx.addInput(input.getOutput(0));
+        tx.addInput(prevTx.getOutput(0));
         tx.addOutput(Coin.COIN, OTHER_ADDRESS);
 
         // Act
-        byte[] serializedEntry = BridgeSerializationUtils.serializeSingleEntry(new AbstractMap.SimpleEntry<>(key, tx));
-        Map.Entry<Keccak256, BtcTransaction> deserializedEntry = BridgeSerializationUtils.deserializeSingleEntry(serializedEntry, NETWORK_PARAMETERS, false);
+        byte[] serializedEntry = 
+            BridgeSerializationUtils.serializeRskTxWaitingForSignatures(new AbstractMap.SimpleEntry<>(key, tx));
+        Map.Entry<Keccak256, BtcTransaction> deserializedEntry =
+            BridgeSerializationUtils.deserializeRskTxWaitingForSignatures(serializedEntry, NETWORK_PARAMETERS, false);
 
         // Assert
         assertNotNull(serializedEntry);
@@ -115,7 +116,7 @@ class BridgeSerializationUtilsTest {
         
         // Act
         Map.Entry<Keccak256, BtcTransaction> result =
-            BridgeSerializationUtils.deserializeSingleEntry(data, NETWORK_PARAMETERS, false);
+            BridgeSerializationUtils.deserializeRskTxWaitingForSignatures(data, NETWORK_PARAMETERS, false);
         
         // Assert
         assertNotNull(result);
@@ -130,7 +131,7 @@ class BridgeSerializationUtilsTest {
         
         // Act
         Map.Entry<Keccak256, BtcTransaction> result =
-            BridgeSerializationUtils.deserializeSingleEntry(data, NETWORK_PARAMETERS, false);
+            BridgeSerializationUtils.deserializeRskTxWaitingForSignatures(data, NETWORK_PARAMETERS, false);
         
         // Assert
         assertNotNull(result);
@@ -143,25 +144,25 @@ class BridgeSerializationUtilsTest {
         // Arrange
         SortedMap<Keccak256, BtcTransaction> map = new TreeMap<>();
 
-        BtcTransaction input = new BtcTransaction(NETWORK_PARAMETERS);
-        input.addOutput(Coin.FIFTY_COINS, ADDRESS);
+        BtcTransaction prevTx = new BtcTransaction(NETWORK_PARAMETERS);
+        prevTx.addOutput(Coin.COIN.multiply(5), ADDRESS);
 
         Keccak256 key1 = createHash3(1);
         BtcTransaction tx1 = new BtcTransaction(NETWORK_PARAMETERS);
-        tx1.addInput(input.getOutput(0));
+        tx1.addInput(prevTx.getOutput(0));
         tx1.addOutput(Coin.COIN, OTHER_ADDRESS);
         Keccak256 key2 = createHash3(2);
         BtcTransaction tx2 = new BtcTransaction(NETWORK_PARAMETERS);
-        tx2.addInput(input.getOutput(0));
+        tx2.addInput(prevTx.getOutput(0));
         tx2.addOutput(Coin.COIN.multiply(10), OTHER_ADDRESS);
         
         map.put(key1, tx1);
         map.put(key2, tx2);
 
         // Act
-        byte[] serializedMap = BridgeSerializationUtils.serializeMap(map);
+        byte[] serializedMap = BridgeSerializationUtils.serializeRskTxsWaitingForSignatures(map);
         SortedMap<Keccak256, BtcTransaction> deserializedMap = 
-            BridgeSerializationUtils.deserializeMap(serializedMap, NETWORK_PARAMETERS, false);
+            BridgeSerializationUtils.deserializeRskTxsWaitingForSignatures(serializedMap, NETWORK_PARAMETERS, false);
 
         // Assert
         assertNotNull(serializedMap);
@@ -177,7 +178,7 @@ class BridgeSerializationUtilsTest {
         
         // Act
         SortedMap<Keccak256, BtcTransaction> result =
-            BridgeSerializationUtils.deserializeMap(data, NETWORK_PARAMETERS, false);
+            BridgeSerializationUtils.deserializeRskTxsWaitingForSignatures(data, NETWORK_PARAMETERS, false);
         
         // Assert
         assertNotNull(result);
@@ -191,7 +192,7 @@ class BridgeSerializationUtilsTest {
         
         // Act
         SortedMap<Keccak256, BtcTransaction> result =
-            BridgeSerializationUtils.deserializeMap(data, NETWORK_PARAMETERS, false);
+            BridgeSerializationUtils.deserializeRskTxsWaitingForSignatures(data, NETWORK_PARAMETERS, false);
         
         // Assert
         assertNotNull(result);


### PR DESCRIPTION
## Description
To proceed with its signing, the spend transaction object has to be accessed from the storage. In order to do so, we need to include serialization and deserialization for map entries using the RLP format. This also includes a minor refactor to the existing logic. 

## Motivation and Context
https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP419.md