### PR TITLE
Add methods to create a real valid chain with stored blocks to avoid using mocks

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestUtil.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestUtil.java
@@ -1,17 +1,19 @@
 package co.rsk.peg;
 
-import co.rsk.bitcoinj.core.BtcBlock;
-import co.rsk.bitcoinj.core.Sha256Hash;
-import co.rsk.bitcoinj.core.StoredBlock;
+import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.db.MutableTrieCache;
 import co.rsk.db.MutableTrieImpl;
+import co.rsk.peg.bitcoin.BitcoinTestUtils;
 import co.rsk.trie.Trie;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.Repository;
 import org.ethereum.db.MutableRepository;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -20,6 +22,44 @@ import static org.mockito.Mockito.when;
 public final class BridgeSupportTestUtil {
     public static Repository createRepository() {
         return new MutableRepository(new MutableTrieCache(new MutableTrieImpl(null, new Trie())));
+    }
+
+    public static PartialMerkleTree createValidPmtWithTransactions(List<Sha256Hash> hashesToAdd, NetworkParameters networkParameters) {
+        byte[] bits = new byte[1];
+        bits[0] = 0x3f;
+
+        return new PartialMerkleTree(networkParameters, bits, hashesToAdd, 1);
+    }
+
+    public static BtcBlock createBtcBlockWithPmt(PartialMerkleTree pmt, NetworkParameters networkParameters) {
+        Sha256Hash prevBlockHash = BitcoinTestUtils.createHash(1);
+        Sha256Hash merkleRoot = pmt.getTxnHashAndMerkleRoot(new ArrayList<>());
+
+        return new co.rsk.bitcoinj.core.BtcBlock(
+            networkParameters,
+            1,
+            prevBlockHash,
+            merkleRoot,
+            1,
+            1,
+            1,
+            new ArrayList<>()
+        );
+    }
+
+    public static void createChainWithBlockStoredAtHeight(BtcBlock btcBlock, BtcBlockStoreWithCache btcBlockStoreWithCache, int btcBlockHeight, int chainHeight, NetworkParameters networkParameters) throws BlockStoreException {
+        // first store our block on the chain at its height
+        StoredBlock storedBtcBlock = new StoredBlock(btcBlock, BigInteger.ONE, btcBlockHeight);
+        btcBlockStoreWithCache.put(storedBtcBlock);
+        btcBlockStoreWithCache.setMainChainBlock(btcBlockHeight, btcBlock.getHash());
+
+        // create the new chain head at final height
+        Sha256Hash randomTransactionHash = Sha256Hash.of(Hex.decode("aa"));
+        PartialMerkleTree pmt = createValidPmtWithTransactions(Collections.singletonList(randomTransactionHash), networkParameters);
+        BtcBlock currentBlock = createBtcBlockWithPmt(pmt, networkParameters);
+        StoredBlock currentStoredBlock = new StoredBlock(currentBlock, BigInteger.TEN, chainHeight);
+        btcBlockStoreWithCache.put(currentStoredBlock);
+        btcBlockStoreWithCache.setChainHead(currentStoredBlock);
     }
 
     public static void mockChainOfStoredBlocks(BtcBlockStoreWithCache btcBlockStore, BtcBlock targetHeader, int headHeight, int targetHeight) throws BlockStoreException {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestUtil.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestUtil.java
@@ -39,9 +39,9 @@ public final class BridgeSupportTestUtil {
         NetworkParameters networkParameters
     ) throws BlockStoreException {
 
-        // first create the block to have the wanted partial merkle tree
+        // first create a block that has the wanted partial merkle tree
         BtcBlock btcBlockWithPmt = createBtcBlockWithPmt(partialMerkleTree, networkParameters);
-        // stored it on the chain at wanted height
+        // store it on the chain at wanted height
         StoredBlock storedBtcBlockThatHasTransactions = new StoredBlock(btcBlockWithPmt, BigInteger.ONE, btcBlockWithPmtHeight);
         btcBlockStoreWithCache.put(storedBtcBlockThatHasTransactions);
         btcBlockStoreWithCache.setMainChainBlock(btcBlockWithPmtHeight, btcBlockWithPmt.getHash());

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestUtil.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestUtil.java
@@ -24,14 +24,14 @@ public final class BridgeSupportTestUtil {
         return new MutableRepository(new MutableTrieCache(new MutableTrieImpl(null, new Trie())));
     }
 
-    public static PartialMerkleTree createValidPmtWithTransactions(List<Sha256Hash> hashesToAdd, NetworkParameters networkParameters) {
+    public static PartialMerkleTree createValidPmtWithTransactions(List<Sha256Hash> hashesToAdd, int transactionsInBlock, NetworkParameters networkParameters) {
         byte[] bits = new byte[1];
         bits[0] = 0x3f;
 
-        return new PartialMerkleTree(networkParameters, bits, hashesToAdd, 1);
+        return new PartialMerkleTree(networkParameters, bits, hashesToAdd, transactionsInBlock);
     }
 
-    public static void recreateChainAtHeightWithStoredBlockWithPmtAtHeight(
+    public static void recreateChainFromPmt(
         BtcBlockStoreWithCache btcBlockStoreWithCache,
         int chainHeight,
         PartialMerkleTree partialMerkleTree,
@@ -48,7 +48,7 @@ public final class BridgeSupportTestUtil {
 
         // create and store a new chainHead at wanted chain height
         Sha256Hash randomTransactionHash = Sha256Hash.of(Hex.decode("aa"));
-        PartialMerkleTree pmt = createValidPmtWithTransactions(Collections.singletonList(randomTransactionHash), networkParameters);
+        PartialMerkleTree pmt = createValidPmtWithTransactions(Collections.singletonList(randomTransactionHash), 1, networkParameters);
         BtcBlock chainHeadBlock = createBtcBlockWithPmt(pmt, networkParameters);
         StoredBlock storedChainHeadBlock = new StoredBlock(chainHeadBlock, BigInteger.TEN, chainHeight);
         btcBlockStoreWithCache.put(storedChainHeadBlock);


### PR DESCRIPTION
To avoid keep using the `mockChainOfStoredBlocks` method, two new ones were created to recreate a valid chain that has:
- a valid partial merkle tree with the wanted transactions
- the block with that merkle root stored at wanted height
- a new chainhead stored block at wanted height