### PR TITLE
Update ErpRedeemScriptParser reference to new name and fix tests failing after RedeemScriptParserFactory refactor

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/FlyoverCompatibleBtcWallet.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FlyoverCompatibleBtcWallet.java
@@ -47,7 +47,7 @@ public abstract class FlyoverCompatibleBtcWallet extends BridgeBtcWallet {
             RedeemScriptParser parser = RedeemScriptParserFactory.get(fedRedeemScript.getChunks());
             Script flyoverRedeemScript;
 
-            if (parser.getMultiSigType() == MultiSigType.ERP_FED) {
+            if (parser.getMultiSigType() == MultiSigType.NON_STANDARD_ERP_FED) {
                 flyoverRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
                     fedRedeemScript,
                     Sha256Hash.wrap(flyoverFederationInformationInstance

--- a/rskj-core/src/main/java/co/rsk/peg/PegUtilsLegacy.java
+++ b/rskj-core/src/main/java/co/rsk/peg/PegUtilsLegacy.java
@@ -73,7 +73,7 @@ public class PegUtilsLegacy {
         int inputsSize = btcTx.getInputs().size();
         for (int i = 0; i < inputsSize; i++) {
             TransactionInput txInput = btcTx.getInput(i);
-            Optional<Script> redeemScriptOptional = BitcoinUtils.extractRedeemScriptFromInput(btcTx.getInput(i));
+            Optional<Script> redeemScriptOptional = BitcoinUtils.extractRedeemScriptFromInput(txInput);
             if (!redeemScriptOptional.isPresent()) {
                 continue;
             }
@@ -81,8 +81,8 @@ public class PegUtilsLegacy {
             List<ScriptChunk> redeemScriptChunks = redeemScriptOptional.get().getChunks();
             if (activations.isActive(ConsensusRule.RSKIP201)) {
                 // Extract standard redeem script chunks since the registered utxo could be from a fast bridge or erp federation
-                RedeemScriptParser redeemScriptParser = RedeemScriptParserFactory.get(txInput.getScriptSig().getChunks());
                 try {
+                    RedeemScriptParser redeemScriptParser = RedeemScriptParserFactory.get(redeemScriptChunks);
                     redeemScriptChunks = redeemScriptParser.extractStandardRedeemScriptChunks();
                 } catch (ScriptException e) {
                     logger.debug("[isPegOutTx] There is no redeem script", e);
@@ -205,11 +205,14 @@ public class PegUtilsLegacy {
                 return false;
             }
 
+            TransactionInput txInput = tx.getInput(i);
+            Optional<Script> redeemScriptOptional = BitcoinUtils.extractRedeemScriptFromInput(txInput);
             // Check if the registered utxo is not change from an utxo spent from either a fast bridge federation,
             // erp federation, or even a retired fast bridge or erp federation
-            if (activations.isActive(ConsensusRule.RSKIP201)) {
-                RedeemScriptParser redeemScriptParser = RedeemScriptParserFactory.get(tx.getInput(index).getScriptSig().getChunks());
+            if (activations.isActive(ConsensusRule.RSKIP201) && redeemScriptOptional.isPresent()) {
                 try {
+                    List<ScriptChunk> redeemScriptChunks = redeemScriptOptional.get().getChunks();
+                    RedeemScriptParser redeemScriptParser = RedeemScriptParserFactory.get(redeemScriptChunks);
                     // Consider transactions that have an input with a redeem script of type P2SH ERP FED
                     // to be "future transactions" that should not be pegins. These are gonna be considered pegouts.
                     // This is only for backwards compatibility reasons. As soon as RSKIP353 activates,

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
@@ -6,7 +6,6 @@ import co.rsk.bitcoinj.script.*;
 import co.rsk.bitcoinj.wallet.RedeemData;
 import co.rsk.bitcoinj.wallet.Wallet;
 import co.rsk.peg.bitcoin.ErpRedeemScriptBuilder;
-import co.rsk.peg.bitcoin.NonStandardErpRedeemScriptBuilder;
 import co.rsk.peg.bitcoin.NonStandardErpRedeemScriptBuilderFactory;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.constants.BridgeMainNetConstants;
@@ -527,7 +526,9 @@ class PegUtilsLegacyTest {
         // Create a tx from the fast bridge fed to the active fed
         BtcTransaction tx = new BtcTransaction(bridgeConstantsMainnet.getBtcParams());
         tx.addOutput(Coin.COIN, activeFederation.getAddress());
-        tx.addInput(Sha256Hash.ZERO_HASH, 0, ScriptBuilder.createP2SHMultiSigInputScript(null, flyoverRedeemScript));
+
+        Script flyoverInputScriptSig = ScriptBuilder.createP2SHMultiSigInputScript(null, flyoverRedeemScript);
+        tx.addInput(Sha256Hash.ZERO_HASH, 0, flyoverInputScriptSig);
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
         Assertions.assertFalse(isValidPegInTx(tx, activeFederation, federationWallet,
@@ -611,7 +612,9 @@ class PegUtilsLegacyTest {
         // Create a tx from the fast bridge erp fed to the active fed
         BtcTransaction tx = new BtcTransaction(networkParameters);
         tx.addOutput(Coin.COIN, activeFederation.getAddress());
-        tx.addInput(Sha256Hash.ZERO_HASH, 0, ScriptBuilder.createP2SHMultiSigInputScript(null, flyoverErpRedeemScript));
+
+        Script flyoverInputScriptSig = ScriptBuilder.createP2SHMultiSigInputScript(null, flyoverErpRedeemScript);
+        tx.addInput(Sha256Hash.ZERO_HASH, 0, flyoverInputScriptSig);
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
 
@@ -706,7 +709,9 @@ class PegUtilsLegacyTest {
         // Create a tx from the erp fed to the active fed
         BtcTransaction tx = new BtcTransaction(networkParameters);
         tx.addOutput(Coin.COIN, activeFederation.getAddress());
-        tx.addInput(Sha256Hash.ZERO_HASH, 0, ScriptBuilder.createP2SHMultiSigInputScript(null, erpRedeemScript));
+
+        Script flyoverInputScriptSig = ScriptBuilder.createP2SHMultiSigInputScript(null, erpRedeemScript);
+        tx.addInput(Sha256Hash.ZERO_HASH, 0, flyoverInputScriptSig);
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
 
@@ -1250,10 +1255,12 @@ class PegUtilsLegacyTest {
         BtcTransaction tx = new BtcTransaction(networkParameters);
         tx.addOutput(Coin.COIN, destinationAddress);
 
+        Script inputScriptSig = ScriptBuilder.createP2SHMultiSigInputScript(null,
+            flyoverFederation ? flyoverP2shErpRedeemScript : p2shErpFederation.getRedeemScript());
         tx.addInput(
             Sha256Hash.ZERO_HASH,
             0,
-            ScriptBuilder.createP2SHMultiSigInputScript(null, flyoverFederation ? flyoverP2shErpRedeemScript : p2shErpFederation.getRedeemScript())
+            inputScriptSig
         );
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
@@ -346,7 +346,7 @@ class BitcoinUtilsTest {
     @Test
     void removeSignaturesFromTransaction_whenNotAllTransactionInputsHaveP2shMultiSigInputScript_shouldThrowIllegalArgumentException() {
         // arrange
-        Federation federation = new P2shErpFederationBuilder().build();
+        Federation federation = P2shErpFederationBuilder.builder().build();
         Script p2shMultiSigScriptSig = federation.getP2SHScript().createEmptyInputScript(null, federation.getRedeemScript());
         BtcECKey pubKey = new BtcECKey();
         Script p2pkhScriptSig = ScriptBuilder.createInputScript(null, pubKey);
@@ -364,7 +364,8 @@ class BitcoinUtilsTest {
     @Test
     void removeSignaturesFromTransaction_whenTransactionIsLegacyAndInputsHaveP2shMultiSigInputScript_shouldRemoveSignatures() {
         // arrange
-        Federation federation = new P2shErpFederationBuilder().build();
+
+        Federation federation = P2shErpFederationBuilder.builder().build();
         Script scriptSig = federation.getP2SHScript().createEmptyInputScript(null, federation.getRedeemScript());
 
         BtcTransaction transaction = new BtcTransaction(btcMainnetParams);

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
@@ -364,7 +364,6 @@ class BitcoinUtilsTest {
     @Test
     void removeSignaturesFromTransaction_whenTransactionIsLegacyAndInputsHaveP2shMultiSigInputScript_shouldRemoveSignatures() {
         // arrange
-
         Federation federation = P2shErpFederationBuilder.builder().build();
         Script scriptSig = federation.getP2SHScript().createEmptyInputScript(null, federation.getRedeemScript());
 


### PR DESCRIPTION
## Description

- Update tests to use script builders instead of the deprecated static method inside the parsers 
- Fix MultiSigType.ERP_FED reference to MultiSigType.NON_STANDARD_ERP_FED after refactoring.
- Update isPegOutTx and isValidPegInTx instead of passing script sig, pass redeem script chunks to RedeemScriptParserFactory.get.

## Motivation and Context

To support new refactors in bitcoinj thin.

## How Has This Been Tested?

Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)
