### PR TITLE
Create StateForProposedFederator and Refactor StateForFederator

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1657,7 +1657,7 @@ public class BridgeSupport {
      */
     public byte[] getStateForBtcReleaseClient() throws IOException {
         StateForFederator stateForFederator = new StateForFederator(provider.getPegoutsWaitingForSignatures());
-        return stateForFederator.getEncoded();
+        return stateForFederator.encodeToRlp();
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/peg/StateForFederator.java
+++ b/rskj-core/src/main/java/co/rsk/peg/StateForFederator.java
@@ -19,10 +19,12 @@
 package co.rsk.peg;
 
 import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.crypto.Keccak256;
 import java.util.Collections;
 import java.util.SortedMap;
 import org.ethereum.util.RLP;
+import org.ethereum.util.RLPList;
 
 public class StateForFederator {
 
@@ -30,6 +32,12 @@ public class StateForFederator {
 
     public StateForFederator(SortedMap<Keccak256, BtcTransaction> rskTxsWaitingForSignatures) {
         this.rskTxsWaitingForSignatures = Collections.unmodifiableSortedMap(rskTxsWaitingForSignatures);
+    }
+
+    public StateForFederator(byte[] rlpData, NetworkParameters networkParameters) {
+        this(
+            BridgeSerializationUtils.deserializeRskTxsWaitingForSignatures(
+                decodeRlpToMap(rlpData), networkParameters));
     }
 
     public SortedMap<Keccak256, BtcTransaction> getRskTxsWaitingForSignatures() {
@@ -45,5 +53,10 @@ public class StateForFederator {
         byte[] serializedRskTxsWaitingForSignatures = 
             BridgeSerializationUtils.serializeRskTxsWaitingForSignatures(rskTxsWaitingForSignatures);
         return RLP.encodeList(serializedRskTxsWaitingForSignatures);
+    }
+
+    private static byte[] decodeRlpToMap(byte[] rlpData) {
+        RLPList rlpList = (RLPList) RLP.decode2(rlpData).get(0);
+        return rlpList.get(0).getRLPData();
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/StateForFederator.java
+++ b/rskj-core/src/main/java/co/rsk/peg/StateForFederator.java
@@ -18,37 +18,32 @@
 
 package co.rsk.peg;
 
-import co.rsk.crypto.Keccak256;
-import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.core.BtcTransaction;
-import org.ethereum.util.RLP;
-import org.ethereum.util.RLPList;
-
+import co.rsk.crypto.Keccak256;
+import java.util.Collections;
 import java.util.SortedMap;
+import org.ethereum.util.RLP;
 
-/**
- * Created by mario on 20/04/17.
- */
 public class StateForFederator {
-    private SortedMap<Keccak256, BtcTransaction> rskTxsWaitingForSignatures;
+
+    private final SortedMap<Keccak256, BtcTransaction> rskTxsWaitingForSignatures;
 
     public StateForFederator(SortedMap<Keccak256, BtcTransaction> rskTxsWaitingForSignatures) {
-        this.rskTxsWaitingForSignatures = rskTxsWaitingForSignatures;
-    }
-
-    public StateForFederator(byte[] rlpData, NetworkParameters parameters) {
-        RLPList rlpList = (RLPList) RLP.decode2(rlpData).get(0);
-        byte[] encodedWaitingForSign = rlpList.get(0).getRLPData();
-
-        this.rskTxsWaitingForSignatures = BridgeSerializationUtils.deserializeRskTxsWaitingForSignatures(encodedWaitingForSign, parameters);
+        this.rskTxsWaitingForSignatures = Collections.unmodifiableSortedMap(rskTxsWaitingForSignatures);
     }
 
     public SortedMap<Keccak256, BtcTransaction> getRskTxsWaitingForSignatures() {
         return rskTxsWaitingForSignatures;
     }
 
-    public byte[] getEncoded() {
-        byte[] encodedWaitingForSign = BridgeSerializationUtils.serializeRskTxsWaitingForSignatures(this.rskTxsWaitingForSignatures);
-        return RLP.encodeList(encodedWaitingForSign);
+    /**
+     * Encodes the current state into RLP format.
+     * 
+     * @return The RLP-encoded byte array representing the current state.
+     */
+    public byte[] encodeToRlp() {
+        byte[] serializedRskTxsWaitingForSignatures = 
+            BridgeSerializationUtils.serializeRskTxsWaitingForSignatures(rskTxsWaitingForSignatures);
+        return RLP.encodeList(serializedRskTxsWaitingForSignatures);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/StateForFederator.java
+++ b/rskj-core/src/main/java/co/rsk/peg/StateForFederator.java
@@ -22,6 +22,7 @@ import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.crypto.Keccak256;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.SortedMap;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
@@ -31,6 +32,8 @@ public class StateForFederator {
     private final SortedMap<Keccak256, BtcTransaction> rskTxsWaitingForSignatures;
 
     public StateForFederator(SortedMap<Keccak256, BtcTransaction> rskTxsWaitingForSignatures) {
+        Objects.requireNonNull(rskTxsWaitingForSignatures);
+
         this.rskTxsWaitingForSignatures = Collections.unmodifiableSortedMap(rskTxsWaitingForSignatures);
     }
 
@@ -56,6 +59,8 @@ public class StateForFederator {
     }
 
     private static byte[] decodeRlpToMap(byte[] rlpData) {
+        Objects.requireNonNull(rlpData);
+
         RLPList rlpList = (RLPList) RLP.decode2(rlpData).get(0);
         return rlpList.get(0).getRLPData();
     }

--- a/rskj-core/src/main/java/co/rsk/peg/StateForProposedFederator.java
+++ b/rskj-core/src/main/java/co/rsk/peg/StateForProposedFederator.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2024 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.crypto.Keccak256;
+import java.util.Map;
+import org.ethereum.util.RLP;
+
+public class StateForProposedFederator {
+
+    private final Map.Entry<Keccak256, BtcTransaction> rskTxWaitingForSignatures;
+
+    public StateForProposedFederator(Map.Entry<Keccak256, BtcTransaction> rskTxsWaitingForSignatures) {
+        this.rskTxWaitingForSignatures = rskTxsWaitingForSignatures;
+    }
+
+    public Map.Entry<Keccak256, BtcTransaction> getRskTxWaitingForSignatures() {
+        return rskTxWaitingForSignatures;
+    }
+
+    /**
+     * Encodes the current state into RLP format.
+     * 
+     * @return The RLP-encoded byte array representing the current state.
+     */
+    public byte[] encodeToRlp() {
+        byte[] serializedRskTxWaitingForSignatures = 
+            BridgeSerializationUtils.serializeRskTxWaitingForSignatures(rskTxWaitingForSignatures);
+        return RLP.encodeList(serializedRskTxWaitingForSignatures);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/StateForProposedFederator.java
+++ b/rskj-core/src/main/java/co/rsk/peg/StateForProposedFederator.java
@@ -23,6 +23,8 @@ import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.crypto.Keccak256;
 import java.util.AbstractMap;
 import java.util.Map;
+import java.util.Objects;
+
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 
@@ -31,9 +33,10 @@ public class StateForProposedFederator {
     private final Map.Entry<Keccak256, BtcTransaction> svpSpendTxWaitingForSignatures;
 
     public StateForProposedFederator(Map.Entry<Keccak256, BtcTransaction> svpSpendTxWaitingForSignatures) {
-        this.svpSpendTxWaitingForSignatures = new AbstractMap.SimpleImmutableEntry<>(
-            svpSpendTxWaitingForSignatures.getKey(),
-            svpSpendTxWaitingForSignatures.getValue());
+        Objects.requireNonNull(svpSpendTxWaitingForSignatures);
+
+        this.svpSpendTxWaitingForSignatures = 
+            new AbstractMap.SimpleImmutableEntry<>(svpSpendTxWaitingForSignatures);
     }
 
     public StateForProposedFederator(byte[] rlpData, NetworkParameters networkParameters) {
@@ -58,6 +61,8 @@ public class StateForProposedFederator {
     }
 
     private static byte[] decodeRlpToEntry(byte[] rlpData) {
+        Objects.requireNonNull(rlpData);
+
         RLPList rlpList = (RLPList) RLP.decode2(rlpData).get(0);
         return rlpList.get(0).getRLPData();
     }

--- a/rskj-core/src/main/java/co/rsk/peg/StateForProposedFederator.java
+++ b/rskj-core/src/main/java/co/rsk/peg/StateForProposedFederator.java
@@ -19,20 +19,31 @@
 package co.rsk.peg;
 
 import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.crypto.Keccak256;
+import java.util.AbstractMap;
 import java.util.Map;
 import org.ethereum.util.RLP;
+import org.ethereum.util.RLPList;
 
 public class StateForProposedFederator {
 
-    private final Map.Entry<Keccak256, BtcTransaction> rskTxWaitingForSignatures;
+    private final Map.Entry<Keccak256, BtcTransaction> svpSpendTxWaitingForSignatures;
 
-    public StateForProposedFederator(Map.Entry<Keccak256, BtcTransaction> rskTxsWaitingForSignatures) {
-        this.rskTxWaitingForSignatures = rskTxsWaitingForSignatures;
+    public StateForProposedFederator(Map.Entry<Keccak256, BtcTransaction> svpSpendTxWaitingForSignatures) {
+        this.svpSpendTxWaitingForSignatures = new AbstractMap.SimpleImmutableEntry<>(
+            svpSpendTxWaitingForSignatures.getKey(),
+            svpSpendTxWaitingForSignatures.getValue());
     }
 
-    public Map.Entry<Keccak256, BtcTransaction> getRskTxWaitingForSignatures() {
-        return rskTxWaitingForSignatures;
+    public StateForProposedFederator(byte[] rlpData, NetworkParameters networkParameters) {
+        this(
+            BridgeSerializationUtils.deserializeRskTxWaitingForSignatures(
+                decodeRlpToEntry(rlpData), networkParameters));
+    }
+
+    public Map.Entry<Keccak256, BtcTransaction> getSvpSpendTxWaitingForSignatures() {
+        return svpSpendTxWaitingForSignatures;
     }
 
     /**
@@ -41,8 +52,13 @@ public class StateForProposedFederator {
      * @return The RLP-encoded byte array representing the current state.
      */
     public byte[] encodeToRlp() {
-        byte[] serializedRskTxWaitingForSignatures = 
-            BridgeSerializationUtils.serializeRskTxWaitingForSignatures(rskTxWaitingForSignatures);
-        return RLP.encodeList(serializedRskTxWaitingForSignatures);
+        byte[] serializedSvpSpendTxWaitingForSignatures = 
+            BridgeSerializationUtils.serializeRskTxWaitingForSignatures(svpSpendTxWaitingForSignatures);
+        return RLP.encodeList(serializedSvpSpendTxWaitingForSignatures);
+    }
+
+    private static byte[] decodeRlpToEntry(byte[] rlpData) {
+        RLPList rlpList = (RLPList) RLP.decode2(rlpData).get(0);
+        return rlpList.get(0).getRLPData();
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/StateForFederatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/StateForFederatorTest.java
@@ -19,15 +19,13 @@
 package co.rsk.peg;
 
 import static co.rsk.RskTestUtils.createHash;
+import static org.ethereum.TestUtils.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.crypto.Keccak256;
-import java.util.Arrays;
-import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import org.junit.jupiter.api.Test;
@@ -57,15 +55,31 @@ class StateForFederatorTest {
 
         // Assert
         assertNotNull(deserializedStateForFederator);
-        assertEquals(2, deserializedStateForFederator.getRskTxsWaitingForSignatures().size());
-        assertEquals(tx1, deserializedStateForFederator.getRskTxsWaitingForSignatures().get(rskTxHash1));
-        assertEquals(tx2, deserializedStateForFederator.getRskTxsWaitingForSignatures().get(rskTxHash2));
-        assertTrue(containsRskTxHashes(
-            deserializedStateForFederator.getRskTxsWaitingForSignatures().keySet(),
-            rskTxHash1, rskTxHash2));
+        assertEquals(rskTxsWaitingForSignatures,
+            deserializedStateForFederator.getRskTxsWaitingForSignatures());
     }
 
-    private static boolean containsRskTxHashes(Set<Keccak256> txHashes, Keccak256... requiredHashes) {
-        return Arrays.stream(requiredHashes).allMatch(txHashes::contains);
+    @Test
+    void stateForFederator_whenEmptyMapAndSerializeAndDeserialize_shouldHaveEqualState() {
+        // Arrange
+        SortedMap<Keccak256, BtcTransaction> rskTxsWaitingForSignatures = new TreeMap<>();
+
+        // Act
+        StateForFederator stateForFederator = 
+            new StateForFederator(rskTxsWaitingForSignatures);
+        StateForFederator deserializedStateForFederator = 
+            new StateForFederator(stateForFederator.encodeToRlp(), NETWORK_PARAMETERS);
+
+        // Assert
+        assertNotNull(deserializedStateForFederator);
+        assertEquals(rskTxsWaitingForSignatures,
+            deserializedStateForFederator.getRskTxsWaitingForSignatures());
+    }
+    
+    @Test
+    void stateForFederator_whenNullValueAndSerializeAndDeserialize_shouldThrowNullPointerException() {
+        // Assert
+        assertThrows(NullPointerException.class, () -> new StateForFederator(null));
+        assertThrows(NullPointerException.class, () -> new StateForFederator(null, NETWORK_PARAMETERS));
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/StateForFederatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/StateForFederatorTest.java
@@ -18,70 +18,65 @@
 
 package co.rsk.peg;
 
+import static co.rsk.peg.PegTestUtils.createHash3;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.crypto.Keccak256;
-import org.apache.commons.lang3.tuple.Pair;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
+import java.util.Arrays;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import org.ethereum.util.RLP;
+import org.ethereum.util.RLPList;
+import org.junit.jupiter.api.Test;
 
-/**
- * Created by mario on 20/04/17.
- */
 class StateForFederatorTest {
 
-    private static final String SHA3_1 = "1111111111111111111111111111111111111111111111111111111111111111";
-    private static final String SHA3_2 = "2222222222222222222222222222222222222222222222222222222222222222";
-    private static final String SHA3_3 = "3333333333333333333333333333333333333333333333333333333333333333";
-    private static final String SHA3_4 = "4444444444444444444444444444444444444444444444444444444444444444";
-
-    private static final NetworkParameters NETWORK_PARAMETERS = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
+    private static final NetworkParameters NETWORK_PARAMETERS = NetworkParameters.fromID(NetworkParameters.ID_MAINNET);
 
     @Test
-    void serialize() {
-        Keccak256 hash1 = new Keccak256(SHA3_1);
-        Keccak256 hash2 = new Keccak256(SHA3_2);
-        Keccak256 hash3 = new Keccak256(SHA3_3);
-        Keccak256 hash4 = new Keccak256(SHA3_4);
+    void stateForFederator_whenSerializeAndDeserialize_shouldHaveEqualState() {
+        // Arrange
+        Keccak256 rskTxHash1 = createHash3(1);
+        Keccak256 rskTxHash2 = createHash3(2);
 
         BtcTransaction tx1 = new BtcTransaction(NETWORK_PARAMETERS);
         BtcTransaction tx2 = new BtcTransaction(NETWORK_PARAMETERS);
-        BtcTransaction tx3 = new BtcTransaction(NETWORK_PARAMETERS);
-        BtcTransaction tx4 = new BtcTransaction(NETWORK_PARAMETERS);
 
         SortedMap<Keccak256, BtcTransaction> rskTxsWaitingForSignatures = new TreeMap<>();
-        rskTxsWaitingForSignatures.put(hash1, tx1);
-        rskTxsWaitingForSignatures.put(hash2, tx2);
-
-        SortedMap<Keccak256, Pair<BtcTransaction, Long>> rskTxsWaitingForBroadcasting = new TreeMap<>();
-        rskTxsWaitingForBroadcasting.put(hash3, Pair.of(tx3, 3L));
-        rskTxsWaitingForBroadcasting.put(hash4, Pair.of(tx4, 4L));
+        rskTxsWaitingForSignatures.put(rskTxHash1, tx1);
+        rskTxsWaitingForSignatures.put(rskTxHash2, tx2);
 
         StateForFederator stateForFederator = new StateForFederator(rskTxsWaitingForSignatures);
 
-        byte[] encoded = stateForFederator.getEncoded();
+        // Act
+        byte[] rlpData = stateForFederator.encodeToRlp();
+        StateForFederator deserializedStateForFederator = fromRlpData(rlpData, NETWORK_PARAMETERS);
 
-        Assertions.assertTrue(encoded.length > 0);
-
-        StateForFederator reverseResult = new StateForFederator(encoded, NETWORK_PARAMETERS);
-
-        Assertions.assertNotNull(reverseResult);
-        Assertions.assertEquals(2, reverseResult.getRskTxsWaitingForSignatures().size());
-
-        Assertions.assertEquals(tx1, reverseResult.getRskTxsWaitingForSignatures().get(hash1));
-        Assertions.assertEquals(tx2, reverseResult.getRskTxsWaitingForSignatures().get(hash2));
-
-        Assertions.assertTrue(checkKeys(reverseResult.getRskTxsWaitingForSignatures().keySet(), hash1, hash2));
+        // Assert
+        assertNotNull(deserializedStateForFederator);
+        assertEquals(2, deserializedStateForFederator.getRskTxsWaitingForSignatures().size());
+        assertEquals(tx1, deserializedStateForFederator.getRskTxsWaitingForSignatures().get(rskTxHash1));
+        assertEquals(tx2, deserializedStateForFederator.getRskTxsWaitingForSignatures().get(rskTxHash2));
+        assertTrue(containsRskTxHashes(
+            deserializedStateForFederator.getRskTxsWaitingForSignatures().keySet(),
+            rskTxHash1, rskTxHash2));
     }
 
-    private boolean checkKeys(Set<Keccak256> keccak256s, Keccak256... keys) {
-        for(Keccak256 sha3 : keys)
-            if(!keccak256s.contains(sha3))
-                return false;
-        return true;
+    private static StateForFederator fromRlpData(byte[] rlpData, NetworkParameters parameters) {
+        RLPList rlpList = (RLPList) RLP.decode2(rlpData).get(0);
+        byte[] encodedWaitingForSign = rlpList.get(0).getRLPData();
+        SortedMap<Keccak256, BtcTransaction> rskTxsWaitingForSignatures = 
+            BridgeSerializationUtils.deserializeRskTxsWaitingForSignatures(encodedWaitingForSign, parameters, false);
+
+        return new StateForFederator(rskTxsWaitingForSignatures);
+    }
+
+    private static boolean containsRskTxHashes(Set<Keccak256> txHashes, Keccak256... requiredHashes) {
+        return Arrays.stream(requiredHashes).allMatch(txHashes::contains);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/StateForFederatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/StateForFederatorTest.java
@@ -69,9 +69,9 @@ class StateForFederatorTest {
 
     private static StateForFederator fromRlpData(byte[] rlpData, NetworkParameters parameters) {
         RLPList rlpList = (RLPList) RLP.decode2(rlpData).get(0);
-        byte[] encodedWaitingForSign = rlpList.get(0).getRLPData();
+        byte[] encodedRskTxsWaitingForSignatures = rlpList.get(0).getRLPData();
         SortedMap<Keccak256, BtcTransaction> rskTxsWaitingForSignatures = 
-            BridgeSerializationUtils.deserializeRskTxsWaitingForSignatures(encodedWaitingForSign, parameters, false);
+            BridgeSerializationUtils.deserializeRskTxsWaitingForSignatures(encodedRskTxsWaitingForSignatures, parameters);
 
         return new StateForFederator(rskTxsWaitingForSignatures);
     }

--- a/rskj-core/src/test/java/co/rsk/peg/StateForProposedFederatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/StateForProposedFederatorTest.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2024 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.peg;
+
+import static co.rsk.peg.PegTestUtils.createHash3;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.crypto.Keccak256;
+import java.util.AbstractMap;
+import java.util.Map;
+import org.ethereum.util.RLP;
+import org.ethereum.util.RLPList;
+import org.junit.jupiter.api.Test;
+
+class StateForProposedFederatorTest {
+
+    private static final NetworkParameters NETWORK_PARAMETERS = NetworkParameters.fromID(NetworkParameters.ID_MAINNET);
+
+    @Test
+    void stateForProposedFederator_whenSerializeAndDeserialize_shouldHaveEqualState() {
+        // Arrange
+        Keccak256 rskTxHash = createHash3(1);
+        BtcTransaction tx = new BtcTransaction(NETWORK_PARAMETERS);
+
+        Map.Entry<Keccak256, BtcTransaction> rskTxWaitingForSignatures = new AbstractMap.SimpleEntry<>(rskTxHash, tx);
+
+        StateForProposedFederator stateForProposedFederator = new StateForProposedFederator(rskTxWaitingForSignatures);
+
+        // Act
+        byte[] rlpData = stateForProposedFederator.encodeToRlp();
+        StateForProposedFederator deserializedStateForProposedFederator = fromRlpData(rlpData, NETWORK_PARAMETERS);
+
+        // Assert
+        assertNotNull(deserializedStateForProposedFederator);
+        assertEquals(rskTxWaitingForSignatures, deserializedStateForProposedFederator.getRskTxWaitingForSignatures());
+    }
+
+    private static StateForProposedFederator fromRlpData(byte[] rlpData, NetworkParameters parameters) {
+        RLPList rlpList = (RLPList) RLP.decode2(rlpData).get(0);
+        byte[] encodedRskTxsWaitingForSignatures = rlpList.get(0).getRLPData();
+        Map.Entry<Keccak256, BtcTransaction> rskTxsWaitingForSignatures = 
+            BridgeSerializationUtils.deserializeRskTxWaitingForSignatures(encodedRskTxsWaitingForSignatures, parameters);
+
+        return new StateForProposedFederator(rskTxsWaitingForSignatures);
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/StateForProposedFederatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/StateForProposedFederatorTest.java
@@ -19,6 +19,7 @@
 package co.rsk.peg;
 
 import static co.rsk.RskTestUtils.createHash;
+import static org.ethereum.TestUtils.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -27,44 +28,34 @@ import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.crypto.Keccak256;
 import java.util.AbstractMap;
 import java.util.Map;
-import java.util.stream.Stream;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.Test;
 
 class StateForProposedFederatorTest {
 
     private static final NetworkParameters NETWORK_PARAMETERS = NetworkParameters.fromID(NetworkParameters.ID_MAINNET);
 
-    @ParameterizedTest
-    @MethodSource("provideSvpSpendTxWaitingForSignatures")
-    void stateForProposedFederator_whenSerializeAndDeserialize_shouldHaveEqualState(
-          Map.Entry<Keccak256, BtcTransaction> svpSpendTxWaitingForSignatures) {
+    @Test
+    void stateForProposedFederator_whenTxWaitingForSignaturesAndSerializeAndDeserialize_shouldHaveEqualState() {
+        // Arrange
+        Keccak256 rskTxHash = createHash(1);
+        BtcTransaction tx = new BtcTransaction(NETWORK_PARAMETERS);
+        Map.Entry<Keccak256, BtcTransaction> rskTxWaitingForSignatures = new AbstractMap.SimpleEntry<>(rskTxHash, tx);
+
         // Act
         StateForProposedFederator stateForProposedFederator =
-            new StateForProposedFederator(svpSpendTxWaitingForSignatures);
+            new StateForProposedFederator(rskTxWaitingForSignatures);
         StateForProposedFederator deserializedStateForProposedFederator =
             new StateForProposedFederator(stateForProposedFederator.encodeToRlp(), NETWORK_PARAMETERS);
 
         // Assert
         assertNotNull(deserializedStateForProposedFederator);
-        assertEquals(svpSpendTxWaitingForSignatures,
-            deserializedStateForProposedFederator.getSvpSpendTxWaitingForSignatures());
+        assertEquals(rskTxWaitingForSignatures, deserializedStateForProposedFederator.getSvpSpendTxWaitingForSignatures());
     }
 
-    private static Stream<Arguments> provideSvpSpendTxWaitingForSignatures() {
-        Keccak256 rskTxHash = createHash(1);
-        BtcTransaction tx = new BtcTransaction(NETWORK_PARAMETERS);
-        
-        // Non-null entry
-        Map.Entry<Keccak256, BtcTransaction> nonNullEntry =
-            new AbstractMap.SimpleEntry<>(rskTxHash, tx);
-        
-        // Null entry
-        Map.Entry<Keccak256, BtcTransaction> nullEntry = null;
-
-        return Stream.of(
-            Arguments.of(nonNullEntry),
-            Arguments.of(nullEntry));
+    @Test
+    void stateForProposedFederator_whenNullValueAndSerializeAndDeserialize_shouldThrowNullPointerException() {
+        // Assert
+        assertThrows(NullPointerException.class, () -> new StateForProposedFederator(null));
+        assertThrows(NullPointerException.class, () -> new StateForProposedFederator(null, NETWORK_PARAMETERS));
     }
 }


### PR DESCRIPTION
## Description
New DTO class called `StateForProposedFederator`, which would act similar to existing`StateForFederator`. It will receive the `svpSpendTxWaitingForSignatures` to notify the pegnatories.

Also includes a refactor of `StateForFederator`. 

## Motivation and Context
https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP419.md