### PR TITLE
Stop using FastBridgeRedeemScriptParser and legacy builder

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -272,7 +272,7 @@ public class BridgeSupport {
      * Get the wallet for the currently active federation
      * @return A BTC wallet for the currently active federation
      *
-     * @param shouldConsiderFlyoverUTXOs
+     * @param shouldConsiderFlyoverUTXOs Whether to consider flyover UTXOs
      */
     public Wallet getActiveFederationWallet(boolean shouldConsiderFlyoverUTXOs) {
         Federation federation = getActiveFederation();
@@ -292,7 +292,7 @@ public class BridgeSupport {
      * or null if there's currently no retiring federation
      * @return A BTC wallet for the currently active federation
      *
-     * @param shouldConsiderFlyoverUTXOs
+     * @param shouldConsiderFlyoverUTXOs Whether to consider flyover UTXOs
      */
     protected Wallet getRetiringFederationWallet(boolean shouldConsiderFlyoverUTXOs) {
         List<UTXO> retiringFederationBtcUTXOs = federationSupport.getRetiringFederationBtcUTXOs();
@@ -349,8 +349,8 @@ public class BridgeSupport {
      * @param btcTxSerialized The raw BTC tx
      * @param height The height of the BTC block that contains the tx
      * @param pmtSerialized The raw partial Merkle tree
-     * @throws BlockStoreException
-     * @throws IOException
+     * @throws BlockStoreException If there's an error while executing validations
+     * @throws IOException If there's an error while processing the tx
      */
     public void registerBtcTransaction(
         Transaction rskTx,
@@ -802,7 +802,7 @@ public class BridgeSupport {
      * The funds will be sent to the bitcoin address controlled by the private key that signed the rsk tx.
      * The amount sent to the bridge in this tx will be the amount sent in the btc network minus fees.
      * @param rskTx The rsk tx being executed.
-     * @throws IOException
+     * @throws IOException If there's an error while processing the release request.
      */
     public void releaseBtc(Transaction rskTx) throws IOException {
         final co.rsk.core.Coin pegoutValueInWeis = rskTx.getValue();
@@ -865,7 +865,7 @@ public class BridgeSupport {
      *
      * @param destinationAddress the destination BTC address.
      * @param value the amount of BTC to release.
-     * @throws IOException
+     * @throws IOException if there's an error while processing the request.
      */
     private void requestRelease(Address destinationAddress, Coin value, Transaction rskTx) throws IOException {
         Optional<RejectedPegoutReason> optionalRejectedPegoutReason = Optional.empty();
@@ -2430,17 +2430,20 @@ public class BridgeSupport {
     }
 
     protected FlyoverFederationInformation createFlyoverFederationInformation(Keccak256 flyoverDerivationHash, Federation federation) {
-        Script flyoverScript = FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
-            federation.getRedeemScript(),
-            Sha256Hash.wrap(flyoverDerivationHash.getBytes())
+        FlyoverRedeemScriptBuilderImpl flyoverRedeemScriptBuilder = FlyoverRedeemScriptBuilderImpl.builder();
+
+        Script federationRedeemScript = federation.getRedeemScript();
+        Script flyoverRedeemScript = flyoverRedeemScriptBuilder.of(
+            flyoverDerivationHash,
+            federationRedeemScript
         );
 
-        Script flyoverScriptHash = ScriptBuilder.createP2SHOutputScript(flyoverScript);
+        Script flyoverP2shOutputScript = ScriptBuilder.createP2SHOutputScript(flyoverRedeemScript);
 
         return new FlyoverFederationInformation(
             flyoverDerivationHash,
             federation.getP2SHScript().getPubKeyHash(),
-            flyoverScriptHash.getPubKeyHash()
+            flyoverP2shOutputScript.getPubKeyHash()
         );
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -2430,10 +2430,8 @@ public class BridgeSupport {
     }
 
     protected FlyoverFederationInformation createFlyoverFederationInformation(Keccak256 flyoverDerivationHash, Federation federation) {
-        FlyoverRedeemScriptBuilderImpl flyoverRedeemScriptBuilder = FlyoverRedeemScriptBuilderImpl.builder();
-
         Script federationRedeemScript = federation.getRedeemScript();
-        Script flyoverRedeemScript = flyoverRedeemScriptBuilder.of(
+        Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
             flyoverDerivationHash,
             federationRedeemScript
         );

--- a/rskj-core/src/main/java/co/rsk/peg/FlyoverCompatibleBtcWallet.java
+++ b/rskj-core/src/main/java/co/rsk/peg/FlyoverCompatibleBtcWallet.java
@@ -1,14 +1,9 @@
 package co.rsk.peg;
 
 import co.rsk.bitcoinj.core.Context;
-import co.rsk.bitcoinj.core.Sha256Hash;
-import co.rsk.bitcoinj.script.FastBridgeErpRedeemScriptParser;
-import co.rsk.bitcoinj.script.FastBridgeRedeemScriptParser;
-import co.rsk.bitcoinj.script.RedeemScriptParser;
-import co.rsk.bitcoinj.script.RedeemScriptParser.MultiSigType;
-import co.rsk.bitcoinj.script.RedeemScriptParserFactory;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.wallet.RedeemData;
+import co.rsk.peg.bitcoin.FlyoverRedeemScriptBuilderImpl;
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.flyover.FlyoverFederationInformation;
 import java.util.List;
@@ -44,26 +39,10 @@ public abstract class FlyoverCompatibleBtcWallet extends BridgeBtcWallet {
             Federation destinationFederationInstance = destinationFederation.get();
             Script fedRedeemScript = destinationFederationInstance.getRedeemScript();
 
-            RedeemScriptParser parser = RedeemScriptParserFactory.get(fedRedeemScript.getChunks());
-            Script flyoverRedeemScript;
-
-            if (parser.getMultiSigType() == MultiSigType.NON_STANDARD_ERP_FED) {
-                flyoverRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-                    fedRedeemScript,
-                    Sha256Hash.wrap(flyoverFederationInformationInstance
-                        .getDerivationHash()
-                        .getBytes()
-                    )
-                );
-            } else {
-                flyoverRedeemScript = FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
-                    fedRedeemScript,
-                    Sha256Hash.wrap(flyoverFederationInformationInstance
-                        .getDerivationHash()
-                        .getBytes()
-                    )
-                );
-            }
+            Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
+                flyoverFederationInformationInstance.getDerivationHash(),
+                fedRedeemScript
+            );
 
             return RedeemData.of(destinationFederationInstance.getBtcPublicKeys(), flyoverRedeemScript);
         }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportFlyoverTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportFlyoverTest.java
@@ -17,6 +17,7 @@
  */
 package co.rsk.peg;
 
+import co.rsk.RskTestUtils;
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
@@ -3481,7 +3482,7 @@ class BridgeSupportFlyoverTest {
         Federation genesisFederation = FederationTestUtils.getGenesisFederation(federationConstantsRegtest);
         Script federationRedeemScript = genesisFederation.getRedeemScript();
 
-        Keccak256 flyoverDerivationHash = PegTestUtils.createHash3(1);
+        Keccak256 flyoverDerivationHash = RskTestUtils.createHash(1);
 
         Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
             flyoverDerivationHash,
@@ -3662,7 +3663,7 @@ class BridgeSupportFlyoverTest {
         Federation genesisFederation = FederationTestUtils.getGenesisFederation(federationConstantsRegtest);
         Script federationRedeemScript = genesisFederation.getRedeemScript();
 
-        Keccak256 flyoverDerivationHash = PegTestUtils.createHash3(1);
+        Keccak256 flyoverDerivationHash = RskTestUtils.createHash(1);
         Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
             flyoverDerivationHash,
             federationRedeemScript

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -17,6 +17,7 @@
  */
 package co.rsk.peg;
 
+import co.rsk.RskTestUtils;
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.crypto.TransactionSignature;
 import co.rsk.bitcoinj.params.RegTestParams;
@@ -1494,7 +1495,7 @@ class BridgeUtilsTest {
         }
 
         if (isFlyover) {
-            Keccak256 flyoverDerivationHash = PegTestUtils.createHash3(1);
+            Keccak256 flyoverDerivationHash = RskTestUtils.createHash(1);
 
             Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
                 flyoverDerivationHash,

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -25,6 +25,7 @@ import co.rsk.bitcoinj.wallet.CoinSelector;
 import co.rsk.bitcoinj.wallet.RedeemData;
 import co.rsk.bitcoinj.wallet.Wallet;
 import co.rsk.blockchain.utils.BlockGenerator;
+import co.rsk.peg.bitcoin.FlyoverRedeemScriptBuilderImpl;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.constants.BridgeMainNetConstants;
 import co.rsk.peg.constants.BridgeRegTestConstants;
@@ -1493,23 +1494,12 @@ class BridgeUtilsTest {
         }
 
         if (isFlyover) {
-            // Create fast bridge redeem script
-            Sha256Hash derivationArgumentsHash = Sha256Hash.of(new byte[]{1});
-            Script flyoverRedeemScript;
+            Keccak256 flyoverDerivationHash = PegTestUtils.createHash3(1);
 
-            if (federation instanceof ErpFederation) {
-                flyoverRedeemScript =
-                    FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-                        federation.getRedeemScript(),
-                        derivationArgumentsHash
-                    );
-            } else {
-                flyoverRedeemScript =
-                    FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
-                        federation.getRedeemScript(),
-                        derivationArgumentsHash
-                    );
-            }
+            Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
+                flyoverDerivationHash,
+                federation.getRedeemScript()
+            );
 
             Script flyoverP2SH = ScriptBuilder
                 .createP2SHOutputScript(flyoverRedeemScript);

--- a/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWalletWithStorageTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWalletWithStorageTest.java
@@ -9,11 +9,11 @@ import co.rsk.bitcoinj.core.Context;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.bitcoinj.script.FastBridgeErpRedeemScriptParser;
-import co.rsk.bitcoinj.script.FastBridgeRedeemScriptParser;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.wallet.RedeemData;
 import co.rsk.crypto.Keccak256;
+import co.rsk.peg.bitcoin.FlyoverRedeemScriptBuilderImpl;
 import co.rsk.peg.federation.*;
 import co.rsk.peg.flyover.FlyoverFederationInformation;
 import java.time.Instant;
@@ -73,17 +73,19 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
     @Test
     void findRedeemDataFromScriptHash_with_flyoverInformation_in_storage() {
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
-        Keccak256 derivationArgumentsHash = PegTestUtils.createHash3(1);
+        Keccak256 flyoverDerivationHash = PegTestUtils.createHash3(1);
 
-        Script flyoverRedeemScript = FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
-            federation.getRedeemScript(), Sha256Hash.wrap(derivationArgumentsHash.getBytes()));
+        Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
+            flyoverDerivationHash,
+            federation.getRedeemScript()
+        );
 
         Script p2SHOutputScript = ScriptBuilder.createP2SHOutputScript(flyoverRedeemScript);
         byte[] flyoverFederationP2SH = p2SHOutputScript.getPubKeyHash();
 
         FlyoverFederationInformation flyoverFederationInformation =
             new FlyoverFederationInformation(
-                derivationArgumentsHash,
+                flyoverDerivationHash,
                 federation.getP2SHScript().getPubKeyHash(),
                 flyoverFederationP2SH);
 

--- a/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWalletWithStorageTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWalletWithStorageTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import co.rsk.RskTestUtils;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Context;
 import co.rsk.bitcoinj.core.NetworkParameters;
@@ -73,7 +74,7 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
     @Test
     void findRedeemDataFromScriptHash_with_flyoverInformation_in_storage() {
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
-        Keccak256 flyoverDerivationHash = PegTestUtils.createHash3(1);
+        Keccak256 flyoverDerivationHash = RskTestUtils.createHash(1);
 
         Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
             flyoverDerivationHash,

--- a/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWallextWithSingleScriptTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWallextWithSingleScriptTest.java
@@ -8,9 +8,10 @@ import co.rsk.bitcoinj.core.Context;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.bitcoinj.script.FastBridgeErpRedeemScriptParser;
-import co.rsk.bitcoinj.script.FastBridgeRedeemScriptParser;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.wallet.RedeemData;
+import co.rsk.crypto.Keccak256;
+import co.rsk.peg.bitcoin.FlyoverRedeemScriptBuilderImpl;
 import co.rsk.peg.federation.*;
 import co.rsk.peg.flyover.FlyoverFederationInformation;
 import java.time.Instant;
@@ -91,8 +92,10 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
         RedeemData redeemData = flyoverCompatibleBtcWalletWithSingleScript.findRedeemDataFromScriptHash(
             federation.getP2SHScript().getPubKeyHash());
 
-        Script flyoverRedeemScript = FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
-            federation.getRedeemScript(), Sha256Hash.wrap(flyoverFederationInformation.getDerivationHash().getBytes())
+        Keccak256 flyoverDerivationHash = flyoverFederationInformation.getDerivationHash();
+        Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
+            flyoverDerivationHash,
+            federation.getRedeemScript()
         );
 
         Assertions.assertNotNull(redeemData);

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -20,9 +20,9 @@ package co.rsk.peg;
 
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.params.RegTestParams;
-import co.rsk.bitcoinj.script.FastBridgeRedeemScriptParser;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
+import co.rsk.peg.bitcoin.FlyoverRedeemScriptBuilderImpl;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
@@ -312,10 +312,13 @@ public final class PegTestUtils {
     }
 
     public static Address getFlyoverAddressFromRedeemScript(BridgeConstants bridgeConstants, Script redeemScript, Sha256Hash derivationArgumentHash) {
-        Script flyoverRedeemScript = FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
-            redeemScript,
-            derivationArgumentHash
+
+        Keccak256 flyoverDerivationHash = new Keccak256(derivationArgumentHash.getBytes());
+        Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
+            flyoverDerivationHash,
+            redeemScript
         );
+
         Script flyoverP2SH = ScriptBuilder.createP2SHOutputScript(flyoverRedeemScript);
         return Address.fromP2SHScript(bridgeConstants.getBtcParams(), flyoverP2SH);
     }

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
@@ -1,5 +1,6 @@
 package co.rsk.peg;
 
+import co.rsk.RskTestUtils;
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.crypto.TransactionSignature;
 import co.rsk.bitcoinj.script.*;
@@ -499,7 +500,7 @@ class PegUtilsLegacyTest {
 
         Federation activeFederation = FederationTestUtils.getGenesisFederation(federationConstantsMainnet);
 
-        Keccak256 flyoverDerivationHash = PegTestUtils.createHash3(1);
+        Keccak256 flyoverDerivationHash = RskTestUtils.createHash(1);
         Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
             flyoverDerivationHash,
             activeFederation.getRedeemScript()
@@ -523,7 +524,7 @@ class PegUtilsLegacyTest {
 
         Federation activeFederation = FederationTestUtils.getGenesisFederation(federationConstantsMainnet);
 
-        Keccak256 flyoverDerivationHash = PegTestUtils.createHash3(1);
+        Keccak256 flyoverDerivationHash = RskTestUtils.createHash(1);
         Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
             flyoverDerivationHash,
             activeFederation.getRedeemScript()
@@ -757,7 +758,7 @@ class PegUtilsLegacyTest {
         );
         tx.addInput(txInput);
 
-        Keccak256 flyoverDerivationHash = PegTestUtils.createHash3(2);
+        Keccak256 flyoverDerivationHash = RskTestUtils.createHash(2);
         Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
             flyoverDerivationHash,
             retiredFederation.getRedeemScript()
@@ -809,7 +810,7 @@ class PegUtilsLegacyTest {
         );
         tx.addInput(txInput);
 
-        Keccak256 flyoverDerivationHash = PegTestUtils.createHash3(2);
+        Keccak256 flyoverDerivationHash = RskTestUtils.createHash(2);
         Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
             flyoverDerivationHash,
             retiredFederation.getRedeemScript()
@@ -1256,7 +1257,7 @@ class PegUtilsLegacyTest {
 
         ErpFederation p2shErpFederation = FederationFactory.buildP2shErpFederation(activeFederationArgs, emergencyKeys, activationDelay);
 
-        Keccak256 flyoverDerivationHash = PegTestUtils.createHash3(2);
+        Keccak256 flyoverDerivationHash = RskTestUtils.createHash(2);
         Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
             flyoverDerivationHash,
             p2shErpFederation.getRedeemScript()
@@ -1915,7 +1916,7 @@ class PegUtilsLegacyTest {
         );
         pegOutTx1.addInput(pegOutInput1);
 
-        Keccak256 flyoverDerivationHash = PegTestUtils.createHash3(2);
+        Keccak256 flyoverDerivationHash = RskTestUtils.createHash(2);
         Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
             flyoverDerivationHash,
             standardMultisigFederation.getRedeemScript()

--- a/rskj-core/src/test/java/co/rsk/peg/federation/PowpegMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/PowpegMigrationTest.java
@@ -5,6 +5,7 @@ import co.rsk.bitcoinj.script.*;
 import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.bitcoinj.store.BtcBlockStore;
 import co.rsk.peg.*;
+import co.rsk.peg.bitcoin.FlyoverRedeemScriptBuilderImpl;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.constants.BridgeMainNetConstants;
 import co.rsk.core.RskAddress;
@@ -1197,12 +1198,11 @@ class PowpegMigrationTest {
             pos,
             liquidityProviderBtcAddressHash160.length
         );
-        Keccak256 derivationHash = new Keccak256(HashUtil.keccak256(infoToHash));
 
-        Script flyoverRedeemScript = FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
-            recipientFederation.getRedeemScript(),
-            Sha256Hash.wrap(derivationHash.toHexString())
-            // Parsing to Sha256Hash in order to use helper. Does not change functionality
+        Keccak256 flyoverDerivationHash = new Keccak256(HashUtil.keccak256(infoToHash));
+        Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
+            flyoverDerivationHash,
+            recipientFederation.getRedeemScript()
         );
 
         Address recipient = getAddressFromRedeemScript(bridgeConstants, flyoverRedeemScript);
@@ -1260,7 +1260,7 @@ class PowpegMigrationTest {
 
         bridgeSupport.save();
 
-        return Pair.of(peginBtcTx, derivationHash);
+        return Pair.of(peginBtcTx, flyoverDerivationHash);
     }
 
     private BtcTransaction createPegin(

--- a/rskj-core/src/test/java/co/rsk/peg/performance/RegisterFlyoverBtcTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/RegisterFlyoverBtcTransactionTest.java
@@ -1,5 +1,6 @@
 package co.rsk.peg.performance;
 
+import co.rsk.RskTestUtils;
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
@@ -159,7 +160,7 @@ class RegisterFlyoverBtcTransactionTest extends BridgePerformanceTestCase {
             Script federationRedeemScript = genesisFederation.getRedeemScript();
 
             Keccak256 flyoverDerivationHash = getFlyoverDerivationHash(
-                PegTestUtils.createHash3(1),
+                RskTestUtils.createHash(1),
                 AddressesBuilder.userRefundAddress,
                 AddressesBuilder.lpBtcAddress,
                 AddressesBuilder.lbcAddress

--- a/rskj-core/src/test/java/co/rsk/peg/performance/RegisterFlyoverBtcTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/performance/RegisterFlyoverBtcTransactionTest.java
@@ -1,7 +1,6 @@
 package co.rsk.peg.performance;
 
 import co.rsk.bitcoinj.core.*;
-import co.rsk.bitcoinj.script.FastBridgeRedeemScriptParser;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.store.BlockStoreException;
@@ -10,6 +9,7 @@ import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
 import co.rsk.peg.*;
 import co.rsk.peg.PegTestUtils;
+import co.rsk.peg.bitcoin.FlyoverRedeemScriptBuilderImpl;
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.FederationTestUtils;
 import org.ethereum.config.Constants;
@@ -136,52 +136,57 @@ class RegisterFlyoverBtcTransactionTest extends BridgePerformanceTestCase {
             int minBtcBlocks,
             int maxBtcBlocks
             ) {
+
         return (BridgeStorageProvider provider, Repository repository, int executionIndex, BtcBlockStore blockStore) -> {
-                BtcBlockStoreWithCache.Factory btcBlockStoreFactory = new RepositoryBtcBlockStoreWithCache.Factory(bridgeConstants.getBtcParams());
-                Repository thisRepository = repository.startTracking();
-                BtcBlockStore btcBlockStore = btcBlockStoreFactory
-                    .newInstance(thisRepository, bridgeConstants, provider, activationConfig.forBlock(0));
-                Context btcContext = new Context(networkParameters);
-                BtcBlockChain btcBlockChain;
-                try {
-                    btcBlockChain = new BtcBlockChain(btcContext, btcBlockStore);
-                } catch (BlockStoreException e) {
-                    throw new RuntimeException("Error initializing btc blockchain for tests");
-                }
+            BtcBlockStoreWithCache.Factory btcBlockStoreFactory = new RepositoryBtcBlockStoreWithCache.Factory(
+                bridgeConstants.getBtcParams());
+            Repository thisRepository = repository.startTracking();
+            BtcBlockStore btcBlockStore = btcBlockStoreFactory
+                .newInstance(thisRepository, bridgeConstants, provider,
+                    activationConfig.forBlock(0));
+            Context btcContext = new Context(networkParameters);
+            BtcBlockChain btcBlockChain;
+            try {
+                btcBlockChain = new BtcBlockChain(btcContext, btcBlockStore);
+            } catch (BlockStoreException e) {
+                throw new RuntimeException("Error initializing btc blockchain for tests");
+            }
 
-                int blocksToGenerate = Helper.randomInRange(minBtcBlocks, maxBtcBlocks);
-                BtcBlock lastBlock = Helper.generateAndAddBlocks(btcBlockChain, blocksToGenerate);
-                Federation genesisFederation = FederationTestUtils.getGenesisFederation(bridgeConstants.getFederationConstants());
-                Script federationRedeemScript= genesisFederation.getRedeemScript();
+            int blocksToGenerate = Helper.randomInRange(minBtcBlocks, maxBtcBlocks);
+            BtcBlock lastBlock = Helper.generateAndAddBlocks(btcBlockChain, blocksToGenerate);
+            Federation genesisFederation = FederationTestUtils.getGenesisFederation(
+                bridgeConstants.getFederationConstants());
+            Script federationRedeemScript = genesisFederation.getRedeemScript();
 
+            Keccak256 flyoverDerivationHash = getFlyoverDerivationHash(
+                PegTestUtils.createHash3(1),
+                AddressesBuilder.userRefundAddress,
+                AddressesBuilder.lpBtcAddress,
+                AddressesBuilder.lbcAddress
+            );
 
-            Script flyoverRedeemScript = FastBridgeRedeemScriptParser.createMultiSigFastBridgeRedeemScript(
-                        federationRedeemScript,
-                        Sha256Hash.wrap(
-                                getFLyoverDerivationHash(
-                                        PegTestUtils.createHash3(1),
-                                        AddressesBuilder.userRefundAddress,
-                                        AddressesBuilder.lpBtcAddress,
-                                        AddressesBuilder.lbcAddress
-                                ).getBytes()
-                        )
-                );
+            Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
+                flyoverDerivationHash,
+                federationRedeemScript
+            );
 
-                Script flyoverP2SH = ScriptBuilder.createP2SHOutputScript(flyoverRedeemScript);
-                Address flyoverFederationAddress = Address.fromP2SHScript(bridgeConstants.getBtcParams(), flyoverP2SH);
+            Script flyoverP2SH = ScriptBuilder.createP2SHOutputScript(flyoverRedeemScript);
+            Address flyoverFederationAddress = Address.fromP2SHScript(
+                bridgeConstants.getBtcParams(), flyoverP2SH);
 
-                btcTx = createBtcTransactionWithOutputToAddress(totalAmount, flyoverFederationAddress);
+            btcTx = createBtcTransactionWithOutputToAddress(totalAmount, flyoverFederationAddress);
 
-                pmt = PartialMerkleTree.buildFromLeaves(networkParameters, new byte[]{(byte) 0xff}, Arrays.asList(btcTx.getHash()));
-                List<Sha256Hash> hashes = new ArrayList<>();
-                Sha256Hash merkleRoot = pmt.getTxnHashAndMerkleRoot(hashes);
+            pmt = PartialMerkleTree.buildFromLeaves(networkParameters, new byte[]{(byte) 0xff},
+                Arrays.asList(btcTx.getHash()));
+            List<Sha256Hash> hashes = new ArrayList<>();
+            Sha256Hash merkleRoot = pmt.getTxnHashAndMerkleRoot(hashes);
 
-                blockWithTx = Helper.generateBtcBlock(lastBlock, Arrays.asList(btcTx), merkleRoot);
-                btcBlockChain.add(blockWithTx);
-                blockWithTxHeight = btcBlockChain.getBestChainHeight();
+            blockWithTx = Helper.generateBtcBlock(lastBlock, Arrays.asList(btcTx), merkleRoot);
+            btcBlockChain.add(blockWithTx);
+            blockWithTxHeight = btcBlockChain.getBestChainHeight();
 
-                Helper.generateAndAddBlocks(btcBlockChain, 10);
-                thisRepository.commit();
+            Helper.generateAndAddBlocks(btcBlockChain, 10);
+            thisRepository.commit();
         };
     }
 
@@ -194,7 +199,7 @@ class RegisterFlyoverBtcTransactionTest extends BridgePerformanceTestCase {
         return tx;
     }
 
-    private Keccak256 getFLyoverDerivationHash(
+    private Keccak256 getFlyoverDerivationHash(
             Keccak256 derivationArgumentsHash,
             Address userRefundAddress,
             Address lpBtcAddress,


### PR DESCRIPTION
Stop using FastBridgeRedeemScriptParser and legacy builder; instead, use FlyoverRedeemScriptParser and FlyoverRedeemScriptBuilderImpl to create flyover redeem scripts.

## Motivation and Context

This is related to refactors done in bitcoinj-thin where the FastBridge parser was replaced by a new simpler parser called FlyoverRedeemScript parser.

## How Has This Been Tested?

Unit Tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)
