### PR TITLE
Create new getStateForSvpClient Bridge Method

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -95,6 +95,8 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
     public static final CallTransaction.Function ADD_SIGNATURE = BridgeMethods.ADD_SIGNATURE.getFunction();
     // Returns a StateForFederator encoded in RLP
     public static final CallTransaction.Function GET_STATE_FOR_BTC_RELEASE_CLIENT = BridgeMethods.GET_STATE_FOR_BTC_RELEASE_CLIENT.getFunction();
+    // Returns a StateForProposedFederator encoded in RLP
+    public static final CallTransaction.Function GET_STATE_FOR_SVP_CLIENT = BridgeMethods.GET_STATE_FOR_SVP_CLIENT.getFunction();
     // Returns a BridgeState encoded in RLP
     public static final CallTransaction.Function GET_STATE_FOR_DEBUGGING = BridgeMethods.GET_STATE_FOR_DEBUGGING.getFunction();
     // Return the bitcoin blockchain best chain height know by the bridge contract
@@ -636,6 +638,17 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         } catch (Exception e) {
             logger.warn("Exception in getStateForBtcReleaseClient", e);
             throw new VMException("Exception in getStateForBtcReleaseClient", e);
+        }
+    }
+
+    public byte[] getStateForSvpClient(Object[] args) throws VMException {
+        logger.trace("getStateForSvpClient");
+
+        try {
+            return bridgeSupport.getStateForSvpClient();
+        } catch (Exception e) {
+            logger.warn("Exception in getStateForSvpClient", e);
+            throw new VMException("Exception in getStateForSvpClient", e);
         }
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
@@ -460,6 +460,18 @@ public enum BridgeMethods {
         fixedPermission(true),
         CallTypeHelper.ALLOW_STATIC_CALL
     ),
+    GET_STATE_FOR_SVP_CLIENT(
+        CallTransaction.Function.fromSignature(
+                "getStateForSvpClient",
+                new String[]{},
+                new String[]{"bytes"}
+        ),
+        fixedCost(4000L),
+        (BridgeMethodExecutorTyped) Bridge::getStateForSvpClient,
+        activations -> activations.isActive(RSKIP419),
+        fixedPermission(true),
+        CallTypeHelper.ALLOW_STATIC_CALL
+    ),
     GET_STATE_FOR_DEBUGGING(
         CallTransaction.Function.fromSignature(
                 "getStateForDebugging",

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
@@ -467,7 +467,7 @@ public enum BridgeMethods {
                 new String[]{"bytes"}
         ),
         fixedCost(4000L), // TODO: check fixed cost value
-        (BridgeMethodExecutorTyped) Bridge::getStateForSvpClient,
+        (BridgeMethodExecutorTyped<byte[]>) Bridge::getStateForSvpClient,
         activations -> activations.isActive(RSKIP419),
         fixedPermission(true),
         CallTypeHelper.ALLOW_STATIC_CALL

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
@@ -466,7 +466,7 @@ public enum BridgeMethods {
                 new String[]{},
                 new String[]{"bytes"}
         ),
-        fixedCost(4000L),
+        fixedCost(4000L), // TODO: check fixed cost value
         (BridgeMethodExecutorTyped) Bridge::getStateForSvpClient,
         activations -> activations.isActive(RSKIP419),
         fixedPermission(true),

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -68,6 +68,7 @@ import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.*;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.util.ByteUtil;
+import org.ethereum.util.RLP;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.exception.VMException;
@@ -1658,6 +1659,23 @@ public class BridgeSupport {
     public byte[] getStateForBtcReleaseClient() throws IOException {
         StateForFederator stateForFederator = new StateForFederator(provider.getPegoutsWaitingForSignatures());
         return stateForFederator.encodeToRlp();
+    }
+
+   /**
+     * Retrieves the current SVP spend transaction state for the SVP client.
+     * <p>
+     * This method checks if there is an SVP spend transaction waiting for signatures, and if so, it serializes 
+     * the state into RLP format. If no transaction is waiting, it returns an encoded empty RLP list.
+     * </p>
+     *
+     * @return A byte array representing the RLP-encoded state of the SVP spend transaction. If no transaction 
+     *         is waiting, returns an RLP-encoded empty list.
+     */
+    public byte[] getStateForSvpClient() {
+        return provider.getSvpSpendTxWaitingForSignatures()
+            .map(StateForProposedFederator::new)
+            .map(StateForProposedFederator::encodeToRlp)
+            .orElse(RLP.encodedEmptyList());
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/peg/StateForFederator.java
+++ b/rskj-core/src/main/java/co/rsk/peg/StateForFederator.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.Objects;
 import java.util.SortedMap;
 import org.ethereum.util.RLP;
-import org.ethereum.util.RLPList;
 
 public class StateForFederator {
 
@@ -53,15 +52,13 @@ public class StateForFederator {
      * @return The RLP-encoded byte array representing the current state.
      */
     public byte[] encodeToRlp() {
-        byte[] serializedRskTxsWaitingForSignatures = 
-            BridgeSerializationUtils.serializeRskTxsWaitingForSignatures(rskTxsWaitingForSignatures);
-        return RLP.encodeList(serializedRskTxsWaitingForSignatures);
+        return BridgeSerializationUtils.serializeRskTxsWaitingForSignatures(
+            rskTxsWaitingForSignatures);
     }
 
     private static byte[] decodeRlpToMap(byte[] rlpData) {
         Objects.requireNonNull(rlpData);
 
-        RLPList rlpList = (RLPList) RLP.decode2(rlpData).get(0);
-        return rlpList.get(0).getRLPData();
+        return RLP.decode2(rlpData).get(0).getRLPData();
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/StateForFederator.java
+++ b/rskj-core/src/main/java/co/rsk/peg/StateForFederator.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Objects;
 import java.util.SortedMap;
 import org.ethereum.util.RLP;
+import org.ethereum.util.RLPList;
 
 public class StateForFederator {
 
@@ -52,13 +53,15 @@ public class StateForFederator {
      * @return The RLP-encoded byte array representing the current state.
      */
     public byte[] encodeToRlp() {
-        return BridgeSerializationUtils.serializeRskTxsWaitingForSignatures(
-            rskTxsWaitingForSignatures);
+        byte[] serializedRskTxsWaitingForSignatures = 
+            BridgeSerializationUtils.serializeRskTxsWaitingForSignatures(rskTxsWaitingForSignatures);
+        return RLP.encodeList(serializedRskTxsWaitingForSignatures);
     }
 
     private static byte[] decodeRlpToMap(byte[] rlpData) {
         Objects.requireNonNull(rlpData);
 
-        return RLP.decode2(rlpData).get(0).getRLPData();
+        RLPList rlpList = (RLPList) RLP.decode2(rlpData).get(0);
+        return rlpList.get(0).getRLPData();
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/StateForProposedFederator.java
+++ b/rskj-core/src/main/java/co/rsk/peg/StateForProposedFederator.java
@@ -54,13 +54,15 @@ public class StateForProposedFederator {
      * @return The RLP-encoded byte array representing the current state.
      */
     public byte[] encodeToRlp() {
-        return BridgeSerializationUtils.serializeRskTxWaitingForSignatures(
-            svpSpendTxWaitingForSignatures);
+        byte[] serializedSvpSpendTxWaitingForSignatures = 
+            BridgeSerializationUtils.serializeRskTxWaitingForSignatures(svpSpendTxWaitingForSignatures);
+        return RLP.encodeList(serializedSvpSpendTxWaitingForSignatures);
     }
 
     private static byte[] decodeRlpToEntry(byte[] rlpData) {
         Objects.requireNonNull(rlpData);
 
-        return RLP.decode2(rlpData).get(0).getRLPData();
+        RLPList rlpList = (RLPList) RLP.decode2(rlpData).get(0);
+        return rlpList.get(0).getRLPData();
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/StateForProposedFederator.java
+++ b/rskj-core/src/main/java/co/rsk/peg/StateForProposedFederator.java
@@ -24,7 +24,6 @@ import co.rsk.crypto.Keccak256;
 import java.util.AbstractMap;
 import java.util.Map;
 import java.util.Objects;
-
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 
@@ -55,15 +54,13 @@ public class StateForProposedFederator {
      * @return The RLP-encoded byte array representing the current state.
      */
     public byte[] encodeToRlp() {
-        byte[] serializedSvpSpendTxWaitingForSignatures = 
-            BridgeSerializationUtils.serializeRskTxWaitingForSignatures(svpSpendTxWaitingForSignatures);
-        return RLP.encodeList(serializedSvpSpendTxWaitingForSignatures);
+        return BridgeSerializationUtils.serializeRskTxWaitingForSignatures(
+            svpSpendTxWaitingForSignatures);
     }
 
     private static byte[] decodeRlpToEntry(byte[] rlpData) {
         Objects.requireNonNull(rlpData);
 
-        RLPList rlpList = (RLPList) RLP.decode2(rlpData).get(0);
-        return rlpList.get(0).getRLPData();
+        return RLP.decode2(rlpData).get(0).getRLPData();
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTestIntegration.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTestIntegration.java
@@ -1247,6 +1247,18 @@ public class BridgeTestIntegration {
     }
 
     @Test
+    void exceptionInGetStateForSvpClient() {
+        Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, null, signatureCache);
+
+        try {
+            bridge.getStateForSvpClient(null);
+            fail();
+        } catch (VMException ex) {
+            assertEquals("Exception in getStateForSvpClient", ex.getMessage());
+        }
+    }
+
+    @Test
     void exceptionInGetStateForDebugging() {
         Bridge bridge = new Bridge(PrecompiledContracts.BRIDGE_ADDR, constants, activationConfig, null, signatureCache);
 


### PR DESCRIPTION
## Description

The spend transaction should be signed as any other peg-out, but by the proposed powpeg. For this to happen, we need the proposed pegnatories to know when the spend transaction is waiting for signatures.

This also includes a small fix where the `StateForFederators*` where serializing their corresponding RLP raw data twice.

## Motivation and Context
https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP419.md