### PR TITLE
Stop using FastBridge enum and FastBridgeErpRedeemScriptBuilder

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWalletWithStorageTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWalletWithStorageTest.java
@@ -8,8 +8,7 @@ import co.rsk.RskTestUtils;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Context;
 import co.rsk.bitcoinj.core.NetworkParameters;
-import co.rsk.bitcoinj.core.Sha256Hash;
-import co.rsk.bitcoinj.script.FastBridgeErpRedeemScriptParser;
+
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.wallet.RedeemData;
@@ -108,10 +107,9 @@ class FlyoverCompatibleBtcWalletWithStorageTest {
         BridgeStorageProvider provider = mock(BridgeStorageProvider.class);
         Keccak256 derivationArgumentsHash = PegTestUtils.createHash3(1);
 
-        Script flyoverRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-                nonStandardErpFederation.getRedeemScript(),
-                Sha256Hash.wrap(derivationArgumentsHash.getBytes()
-            )
+        Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
+            derivationArgumentsHash,
+            nonStandardErpFederation.getRedeemScript()
         );
 
         Script p2SHOutputScript = ScriptBuilder.createP2SHOutputScript(flyoverRedeemScript);

--- a/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWallextWithSingleScriptTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/FlyoverCompatibleBtcWallextWithSingleScriptTest.java
@@ -6,8 +6,7 @@ import static org.mockito.Mockito.when;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Context;
 import co.rsk.bitcoinj.core.NetworkParameters;
-import co.rsk.bitcoinj.core.Sha256Hash;
-import co.rsk.bitcoinj.script.FastBridgeErpRedeemScriptParser;
+
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.wallet.RedeemData;
 import co.rsk.crypto.Keccak256;
@@ -120,9 +119,9 @@ class FlyoverCompatibleBtcWallextWithSingleScriptTest {
         RedeemData redeemData = flyoverCompatibleBtcWalletWithSingleScript.findRedeemDataFromScriptHash(
             nonStandardErpFederation.getP2SHScript().getPubKeyHash());
 
-        Script flyoverRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-            nonStandardErpFederation.getRedeemScript(),
-            Sha256Hash.wrap(flyoverFederationInformation.getDerivationHash().getBytes())
+        Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
+            flyoverFederationInformation.getDerivationHash(),
+            nonStandardErpFederation.getRedeemScript()
         );
 
         Assertions.assertNotNull(redeemData);

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
@@ -562,7 +562,7 @@ class PegUtilsLegacyTest {
 
         Script redeemScript = nonStandardErpFederation.getRedeemScript();
 
-        Script flyoverErpRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
+        Script flyoverNonStandardRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
             RskTestUtils.createHash(1),
             redeemScript
         );
@@ -570,7 +570,7 @@ class PegUtilsLegacyTest {
         // Create a tx from the fast bridge erp fed to the active fed
         BtcTransaction tx = new BtcTransaction(networkParameters);
         tx.addOutput(Coin.COIN, activeFederation.getAddress());
-        tx.addInput(Sha256Hash.ZERO_HASH, 0, flyoverErpRedeemScript);
+        tx.addInput(Sha256Hash.ZERO_HASH, 0, flyoverNonStandardRedeemScript);
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
 
@@ -604,7 +604,7 @@ class PegUtilsLegacyTest {
             networkParameters
         );
 
-        Script erpRedeemScript = nonStandardErpRedeemScriptBuilder.of(
+        Script nonStandardRedeemScript = nonStandardErpRedeemScriptBuilder.of(
             activeFederation.getBtcPublicKeys(),
             activeFederation.getNumberOfSignaturesRequired(),
             standardMultisigFederation.getBtcPublicKeys(),
@@ -612,16 +612,16 @@ class PegUtilsLegacyTest {
             500L
         );
 
-        Script flyoverErpRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
+        Script flyoverNonStandardRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
             RskTestUtils.createHash(1),
-            erpRedeemScript
+            nonStandardRedeemScript
         );
 
         // Create a tx from the fast bridge erp fed to the active fed
         BtcTransaction tx = new BtcTransaction(networkParameters);
         tx.addOutput(Coin.COIN, activeFederation.getAddress());
 
-        Script flyoverInputScriptSig = ScriptBuilder.createP2SHMultiSigInputScript(null, flyoverErpRedeemScript);
+        Script flyoverInputScriptSig = ScriptBuilder.createP2SHMultiSigInputScript(null, flyoverNonStandardRedeemScript);
         tx.addInput(Sha256Hash.ZERO_HASH, 0, flyoverInputScriptSig);
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
@@ -867,12 +867,12 @@ class PegUtilsLegacyTest {
         );
         tx.addInput(txInput);
 
-        Script flyoverErpRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
+        Script flyoverNonStandardRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
             RskTestUtils.createHash(1),
             nonStandardErpFederation.getRedeemScript()
         );
 
-        signWithNecessaryKeys(nonStandardErpFederation, flyoverErpRedeemScript, retiredFederationKeys, txInput, tx);
+        signWithNecessaryKeys(nonStandardErpFederation, flyoverNonStandardRedeemScript, retiredFederationKeys, txInput, tx);
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
 
@@ -922,12 +922,12 @@ class PegUtilsLegacyTest {
         );
         tx.addInput(txInput);
 
-        Script flyoverErpRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
+        Script flyoverNonStandardRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
             RskTestUtils.createHash(2),
             nonStandardErpFederation.getRedeemScript()
         );
 
-        signWithNecessaryKeys(nonStandardErpFederation, flyoverErpRedeemScript, retiredFederationKeys, txInput, tx);
+        signWithNecessaryKeys(nonStandardErpFederation, flyoverNonStandardRedeemScript, retiredFederationKeys, txInput, tx);
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
 
@@ -2051,12 +2051,12 @@ class PegUtilsLegacyTest {
         );
         pegOutTx1.addInput(pegOutInput1);
 
-        Script flyoverErpRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
+        Script flyoverNonStandardRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
             RskTestUtils.createHash(2),
             nonStandardErpFederation.getRedeemScript()
         );
 
-        signWithNecessaryKeys(nonStandardErpFederation, flyoverErpRedeemScript, defaultFederationKeys, pegOutInput1, pegOutTx1);
+        signWithNecessaryKeys(nonStandardErpFederation, flyoverNonStandardRedeemScript, defaultFederationKeys, pegOutInput1, pegOutTx1);
 
         // Before RSKIP 201 activation
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(false);

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
@@ -561,9 +561,10 @@ class PegUtilsLegacyTest {
         ErpFederation nonStandardErpFederation = FederationFactory.buildNonStandardErpFederation(federationArgs, erpPubKeys, activationDelay, activations);
 
         Script redeemScript = nonStandardErpFederation.getRedeemScript();
-        Script flyoverErpRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-            redeemScript,
-            Sha256Hash.of(PegTestUtils.createHash(1).getBytes())
+
+        Script flyoverErpRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
+            RskTestUtils.createHash(1),
+            redeemScript
         );
 
         // Create a tx from the fast bridge erp fed to the active fed
@@ -611,9 +612,9 @@ class PegUtilsLegacyTest {
             500L
         );
 
-        Script flyoverErpRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-            erpRedeemScript,
-            Sha256Hash.of(PegTestUtils.createHash(1).getBytes())
+        Script flyoverErpRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
+            RskTestUtils.createHash(1),
+            erpRedeemScript
         );
 
         // Create a tx from the fast bridge erp fed to the active fed
@@ -866,10 +867,11 @@ class PegUtilsLegacyTest {
         );
         tx.addInput(txInput);
 
-        Script flyoverErpRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-            nonStandardErpFederation.getRedeemScript(),
-            PegTestUtils.createHash(2)
+        Script flyoverErpRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
+            RskTestUtils.createHash(1),
+            nonStandardErpFederation.getRedeemScript()
         );
+
         signWithNecessaryKeys(nonStandardErpFederation, flyoverErpRedeemScript, retiredFederationKeys, txInput, tx);
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
@@ -920,10 +922,11 @@ class PegUtilsLegacyTest {
         );
         tx.addInput(txInput);
 
-        Script flyoverErpRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-            nonStandardErpFederation.getRedeemScript(),
-            PegTestUtils.createHash(2)
+        Script flyoverErpRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
+            RskTestUtils.createHash(2),
+            nonStandardErpFederation.getRedeemScript()
         );
+
         signWithNecessaryKeys(nonStandardErpFederation, flyoverErpRedeemScript, retiredFederationKeys, txInput, tx);
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
@@ -2048,10 +2051,11 @@ class PegUtilsLegacyTest {
         );
         pegOutTx1.addInput(pegOutInput1);
 
-        Script flyoverErpRedeemScript = FastBridgeErpRedeemScriptParser.createFastBridgeErpRedeemScript(
-            nonStandardErpFederation.getRedeemScript(),
-            PegTestUtils.createHash(2)
+        Script flyoverErpRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
+            RskTestUtils.createHash(2),
+            nonStandardErpFederation.getRedeemScript()
         );
+
         signWithNecessaryKeys(nonStandardErpFederation, flyoverErpRedeemScript, defaultFederationKeys, pegOutInput1, pegOutTx1);
 
         // Before RSKIP 201 activation


### PR DESCRIPTION
- Stop using FastBridgeErpRedeemScriptParser. Now, it uses FlyoverRedeemScriptBuilderImpl to create flyover redeem scripts.
- Replace Fast Bridge MultiSigTypes for MultiSigType.FLYOVER
- Move logic to check if the redeem script is Erp to its own method

## Motivation and Context

This is related to refactors done in bitcoinj-thin, where the FastBridgeErpParser static method to create FastBridgeRedeemScripts was removed. Now, rskj should use `FlyoverRedeemScriptBuilderImpl` to create FlyoverRedeemScripts.

## How Has This Been Tested?

Unit Tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)
