### PR TITLE
- Add tests and internal redeem script validations to flyover

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/bitcoin/FlyoverRedeemScriptBuilderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/bitcoin/FlyoverRedeemScriptBuilderImpl.java
@@ -1,8 +1,11 @@
 package co.rsk.peg.bitcoin;
 
 import static co.rsk.peg.bitcoin.RedeemScriptCreationException.Reason.INVALID_FLYOVER_DERIVATION_HASH;
+import static co.rsk.peg.bitcoin.RedeemScriptCreationException.Reason.INVALID_INTERNAL_REDEEM_SCRIPTS;
 import static java.util.Objects.isNull;
 
+import co.rsk.bitcoinj.script.RedeemScriptParser;
+import co.rsk.bitcoinj.script.RedeemScriptParserFactory;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.script.ScriptOpCodes;
@@ -22,6 +25,7 @@ public class FlyoverRedeemScriptBuilderImpl implements FlyoverRedeemScriptBuilde
     @Override
     public Script of(Keccak256 flyoverDerivationHash, Script redeemScript) {
         validateFlyoverDerivationHash(flyoverDerivationHash);
+        validateInternalRedeemScript(redeemScript);
 
         ScriptBuilder scriptBuilder = new ScriptBuilder();
         byte[] flyoverDerivationHashSerialized = flyoverDerivationHash.getBytes();
@@ -38,6 +42,29 @@ public class FlyoverRedeemScriptBuilderImpl implements FlyoverRedeemScriptBuilde
             String message = String.format("Provided flyover derivation hash %s is invalid.", flyoverDerivationHash);
             logger.warn("[validateFlyoverDerivationHash] {}", message);
             throw new RedeemScriptCreationException(message, INVALID_FLYOVER_DERIVATION_HASH);
+        }
+    }
+
+    private void validateInternalRedeemScript(Script internalRedeemScript) {
+        if (isNull(internalRedeemScript)) {
+            String message = "Provided redeem script is null.";
+            logger.warn("[validateRedeemScript] {}", message);
+            throw new RedeemScriptCreationException(message, INVALID_INTERNAL_REDEEM_SCRIPTS);
+        }
+
+        RedeemScriptParser redeemScriptParser;
+        try {
+            redeemScriptParser = RedeemScriptParserFactory.get(internalRedeemScript.getChunks());
+        } catch (Exception e) {
+            String message = "Provided redeem script has an invalid structure.";
+            logger.warn("[validateRedeemScript] {}", message);
+            throw new RedeemScriptCreationException(message, INVALID_INTERNAL_REDEEM_SCRIPTS);
+        }
+
+        if (redeemScriptParser.getMultiSigType() == RedeemScriptParser.MultiSigType.FLYOVER) {
+            String message = "Provided redeem script cannot be a flyover redeem script.";
+            logger.warn("[validateRedeemScript] {}", message);
+            throw new RedeemScriptCreationException(message, INVALID_INTERNAL_REDEEM_SCRIPTS);
         }
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/FlyoverRedeemScriptBuilderImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/FlyoverRedeemScriptBuilderImplTest.java
@@ -1,36 +1,51 @@
 package co.rsk.peg.bitcoin;
 
 import static co.rsk.peg.bitcoin.RedeemScriptCreationException.Reason.INVALID_FLYOVER_DERIVATION_HASH;
+import static co.rsk.peg.bitcoin.RedeemScriptCreationException.Reason.INVALID_INTERNAL_REDEEM_SCRIPTS;
 import static org.junit.jupiter.api.Assertions.*;
 
+import co.rsk.RskTestUtils;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.script.RedeemScriptParser.MultiSigType;
+import co.rsk.bitcoinj.script.RedeemScriptParserFactory;
 import co.rsk.bitcoinj.script.Script;
+import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.script.ScriptChunk;
 import co.rsk.bitcoinj.script.ScriptOpCodes;
 import co.rsk.crypto.Keccak256;
-import co.rsk.peg.federation.Federation;
+import co.rsk.peg.constants.BridgeMainNetConstants;
+import co.rsk.peg.constants.BridgeTestNetConstants;
+import co.rsk.peg.federation.ErpFederation;
+import co.rsk.peg.federation.FederationTestUtils;
 import co.rsk.peg.federation.P2shErpFederationBuilder;
+import co.rsk.peg.federation.StandardMultiSigFederationBuilder;
 import java.util.List;
 import java.util.stream.Stream;
-import org.ethereum.TestUtils;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig.ForBlock;
+import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class FlyoverRedeemScriptBuilderImplTest {
-    private Script redeemScript;
+
+    private static NetworkParameters mainNetParams = BridgeMainNetConstants.getInstance().getBtcParams();
+    private static NetworkParameters testNetParams = BridgeTestNetConstants.getInstance().getBtcParams();
+    private static ErpFederation erpFederation = FederationTestUtils.getErpFederation(testNetParams);
+
     private FlyoverRedeemScriptBuilder flyoverRedeemScriptBuilder;
 
     @BeforeEach
     void setUp() {
-        Federation federation = P2shErpFederationBuilder.builder().build();
-        redeemScript = federation.getRedeemScript();
         flyoverRedeemScriptBuilder = FlyoverRedeemScriptBuilderImpl.builder();
     }
 
     @ParameterizedTest
     @MethodSource("invalidDerivationHashArgsProvider")
-    void addFlyoverDerivationHashToRedeemScript_withInvalidPrefix_shouldThrowFlyoverRedeemScriptCreationException(Keccak256 flyoverDerivationHash) {
+    void of_invalidPrefix_shouldThrowRedeemScriptCreationException(Keccak256 flyoverDerivationHash) {
+        Script redeemScript = P2shErpFederationBuilder.builder().build().getRedeemScript();
+
         RedeemScriptCreationException exception = assertThrows(
             RedeemScriptCreationException.class,
             () -> flyoverRedeemScriptBuilder.of(flyoverDerivationHash, redeemScript)
@@ -46,23 +61,76 @@ class FlyoverRedeemScriptBuilderImplTest {
         return Stream.of(null, Keccak256.ZERO_HASH);
     }
 
-    @Test
-    void addFlyoverDerivationHashToRedeemScript_shouldReturnRedeemScriptWithFlyoverDerivationHash() {
+    @ParameterizedTest
+    @MethodSource("validRedeemScriptsArgsProvider")
+    void of_whenValidInternalRedeemScript_shouldReturnFlyoverRedeemScript(Script internalRedeemScript) {
         // arrange
-        Keccak256 flyoverDerivationHash = TestUtils.generateHash("hash");
+        Keccak256 flyoverDerivationHash = RskTestUtils.createHash(1);
 
         // act
-        Script redeemScriptWithFlyoverDerivationHash = flyoverRedeemScriptBuilder.of(flyoverDerivationHash, redeemScript);
+        Script flyoverRedeemScript = flyoverRedeemScriptBuilder.of(flyoverDerivationHash, internalRedeemScript);
 
         // assert
-        List<ScriptChunk> originalRedeemScriptChunks = getOriginalRedeemScriptChunks(redeemScriptWithFlyoverDerivationHash);
-        assertEquals(redeemScript.getChunks(), originalRedeemScriptChunks);
+        List<ScriptChunk> originalRedeemScriptChunks = getOriginalRedeemScriptChunks(flyoverRedeemScript);
+        List<ScriptChunk> flyoverRedeemScriptChunks = flyoverRedeemScript.getChunks();
 
-        List<ScriptChunk> redeemScriptWithFlyoverDerivationHashChunks = redeemScriptWithFlyoverDerivationHash.getChunks();
-        ScriptChunk flyoverDerivationHashChunk = redeemScriptWithFlyoverDerivationHashChunks.get(0);
-        ScriptChunk opDropChunk = redeemScriptWithFlyoverDerivationHashChunks.get(1);
+        ScriptChunk flyoverDerivationHashChunk = flyoverRedeemScriptChunks.get(0);
+        ScriptChunk opDropChunk = flyoverRedeemScriptChunks.get(1);
+        MultiSigType multiSigType = RedeemScriptParserFactory.get(flyoverRedeemScriptChunks)
+            .getMultiSigType();
+
+        assertEquals(MultiSigType.FLYOVER, multiSigType);
+        assertEquals(internalRedeemScript.getChunks(), originalRedeemScriptChunks);
         assertArrayEquals(flyoverDerivationHash.getBytes(), flyoverDerivationHashChunk.data);
         assertEquals(ScriptOpCodes.OP_DROP, opDropChunk.opcode);
+
+    }
+
+    private static Stream<Arguments> validRedeemScriptsArgsProvider() {
+        ForBlock hopActivations = ActivationConfigsForTest.hop400().forBlock(0);
+        ForBlock allActivations = ActivationConfigsForTest.all().forBlock(0);
+        Script nonStandardErpRedeemScriptForHop = NonStandardErpRedeemScriptBuilderFactory.getNonStandardErpRedeemScriptBuilder(
+            hopActivations,
+            testNetParams
+        ).of(
+            erpFederation.getBtcPublicKeys(),
+            erpFederation.getNumberOfEmergencySignaturesRequired(),
+            erpFederation.getErpPubKeys(),
+            erpFederation.getNumberOfEmergencySignaturesRequired(),
+            erpFederation.getActivationDelay()
+        );
+        Script nonStandardErpRedeemScriptForTestnetHop = NonStandardErpRedeemScriptBuilderFactory.getNonStandardErpRedeemScriptBuilder(
+            hopActivations,
+            testNetParams
+        ).of(
+            erpFederation.getBtcPublicKeys(),
+            erpFederation.getNumberOfEmergencySignaturesRequired(),
+            erpFederation.getErpPubKeys(),
+            erpFederation.getNumberOfEmergencySignaturesRequired(),
+            erpFederation.getActivationDelay()
+        );
+        Script nonStandardErpRedeemScriptAllActivations = NonStandardErpRedeemScriptBuilderFactory.getNonStandardErpRedeemScriptBuilder(
+            allActivations,
+            mainNetParams
+        ).of(
+            erpFederation.getBtcPublicKeys(),
+            erpFederation.getNumberOfEmergencySignaturesRequired(),
+            erpFederation.getErpPubKeys(),
+            erpFederation.getNumberOfEmergencySignaturesRequired(),
+            erpFederation.getActivationDelay()
+        );
+
+        Script standardRedeemScript = StandardMultiSigFederationBuilder.builder().build()
+            .getRedeemScript();
+        Script p2shRedemptionScript = P2shErpFederationBuilder.builder().build().getRedeemScript();
+
+        return Stream.of(
+            Arguments.of(nonStandardErpRedeemScriptForHop),
+            Arguments.of(nonStandardErpRedeemScriptForTestnetHop),
+            Arguments.of(nonStandardErpRedeemScriptAllActivations),
+            Arguments.of(standardRedeemScript),
+            Arguments.of(p2shRedemptionScript)
+        );
     }
 
     private List<ScriptChunk> getOriginalRedeemScriptChunks(Script redeemScript) {
@@ -71,5 +139,44 @@ class FlyoverRedeemScriptBuilderImplTest {
         int lastOriginalChunkIndex = redeemScriptChunks.size();
 
         return redeemScriptChunks.subList(firstOriginalChunkIndex, lastOriginalChunkIndex);
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidRedeemScriptsArgsProvider")
+    void of_whenInvalidRedeemScript_shouldThrowRedeemScriptCreationException(
+        Script internalRedeemScript, String expectedMessage) {
+        // arrange
+        Keccak256 flyoverDerivationHash = RskTestUtils.createHash(1);
+
+        RedeemScriptCreationException exception = assertThrows(
+            RedeemScriptCreationException.class,
+            () -> flyoverRedeemScriptBuilder.of(flyoverDerivationHash, internalRedeemScript)
+        );
+
+        assertEquals(INVALID_INTERNAL_REDEEM_SCRIPTS, exception.getReason());
+
+        assertEquals(expectedMessage, exception.getMessage());
+
+    }
+
+    private static Stream<Arguments> invalidRedeemScriptsArgsProvider() {
+        Script p2shRedemptionScript = P2shErpFederationBuilder.builder().build().getRedeemScript();
+
+        Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
+            RskTestUtils.createHash(1),
+            p2shRedemptionScript
+        );
+
+        Script p2SHOutputScript = ScriptBuilder.createP2SHOutputScript(p2shRedemptionScript);
+        Script scriptSig = p2SHOutputScript.createEmptyInputScript(null, p2shRedemptionScript);
+        Script emptyScript = new Script(new byte[]{});
+
+        return Stream.of(
+            Arguments.of(flyoverRedeemScript, "Provided redeem script cannot be a flyover redeem script."),
+            Arguments.of(p2SHOutputScript, "Provided redeem script has an invalid structure."),
+            Arguments.of(scriptSig, "Provided redeem script has an invalid structure."),
+            Arguments.of(emptyScript, "Provided redeem script has an invalid structure."),
+            Arguments.of(null, "Provided redeem script is null.")
+        );
     }
 }


### PR DESCRIPTION
- Add internal redeem script validations to flyover redeem script builder
- Add missing and corner tests to FlyoverRedeemScriptBuilderImplTest

## Motivation and Context

This is related to refactors done in bitcoinj-thin, where the FastBridgeErpParser static method to create FastBridgeRedeemScripts was removed. Now, rskj should use FlyoverRedeemScriptBuilderImpl to create FlyoverRedeemScripts.

## How Has This Been Tested?

Unit Tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)
