### PR TITLE
Make gradle fail fast when running tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -250,7 +250,7 @@ jobs:
 
       - name: Run tests
         run: |
-          ./gradlew --no-daemon --stacktrace test
+          ./gradlew --no-daemon --stacktrace test --fail-fast
 
       - name: Persist test results for sonar
         uses: actions/upload-artifact@v4
@@ -289,7 +289,7 @@ jobs:
 
       - name: Run tests
         run: |
-          ./gradlew --no-daemon --stacktrace test
+          ./gradlew --no-daemon --stacktrace test --fail-fast
 
   integration-tests:
     needs: build
@@ -314,4 +314,4 @@ jobs:
 
       - name: Run tests
         run: |
-          ./gradlew --no-daemon --stacktrace integrationTest
+          ./gradlew --no-daemon --stacktrace integrationTest --fail-fast


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
To make Gradle fail fast when running tests, you can add the `--fail-fast` option to the test execution commands. This will ensure that the Gradle test tasks will stop as soon as any test fails. 

## Motivation and Context
This is beneficial so that if there is a test that fails it does not keep executing all the rest of the tests. This will save time and resources since it will reach to a failed result faster. It takes around 12 minutes to run the tests, this way we do not need to wait for the job to finish if it encounters one failed test.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
