### PR TITLE
Svp spend transaction creation

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1060,8 +1060,8 @@ public class BridgeSupport {
                 Keccak256 rskTxHash = rskTx.getHash();
                 updateSvpSpendTransactionValues(rskTxHash, svpSpendTransactionUnsigned);
 
-                Coin requestedAmount = svpSpendTransactionUnsigned.getOutput(0).getValue();
-                logReleaseRequested(rskTxHash, svpSpendTransactionUnsigned, requestedAmount);
+                Coin amountSentToActiveFed = svpSpendTransactionUnsigned.getOutput(0).getValue();
+                logReleaseRequested(rskTxHash, svpSpendTransactionUnsigned, amountSentToActiveFed);
                 logPegoutTransactionCreated(svpSpendTransactionUnsigned);
             }));
     }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -17,9 +17,11 @@
  */
 package co.rsk.peg;
 
+import static co.rsk.peg.BridgeUtils.calculatePegoutTxSize;
 import static co.rsk.peg.PegUtils.getFlyoverAddress;
 import static co.rsk.peg.BridgeUtils.getRegularPegoutTxSize;
 import static co.rsk.peg.ReleaseTransactionBuilder.BTC_TX_VERSION_2;
+import static co.rsk.peg.bitcoin.BitcoinUtils.searchForOutput;
 import static co.rsk.peg.bitcoin.UtxoUtils.extractOutpointValues;
 import static co.rsk.peg.pegin.RejectedPeginReason.INVALID_AMOUNT;
 import static java.util.Objects.isNull;
@@ -1046,6 +1048,92 @@ public class BridgeSupport {
         sendRequest.recipientsPayFees = false;
 
         return sendRequest;
+    }
+
+    protected void processSvpSpendTransactionUnsigned(Transaction rskTx) {
+        federationSupport.getProposedFederation()
+            .ifPresent(proposedFederation -> provider.getSvpFundTxSigned()
+            .ifPresent(svpFundTxSigned -> {
+                BtcTransaction svpSpendTransactionUnsigned = createSvpSpendTransaction(svpFundTxSigned, proposedFederation);
+                updateSvpSpendTransactionValues(rskTx.getHash(), svpSpendTransactionUnsigned);
+            }));
+    }
+
+    private BtcTransaction createSvpSpendTransaction(BtcTransaction svpFundTxSigned, Federation proposedFederation) {
+        BtcTransaction svpSpendTransaction = new BtcTransaction(networkParameters);
+        svpSpendTransaction.setVersion(BTC_TX_VERSION_2);
+
+        addSvpSpendTransactionInputs(svpSpendTransaction, svpFundTxSigned, proposedFederation);
+
+        svpSpendTransaction.addOutput(
+            calculateAmountToSendToActiveFederation(proposedFederation),
+            federationSupport.getActiveFederationAddress()
+        );
+
+        return svpSpendTransaction;
+    }
+
+    private Coin calculateAmountToSendToActiveFederation(Federation proposedFederation) {
+        int svpSpendTransactionSize = calculatePegoutTxSize(activations, proposedFederation, 2, 1);
+        long backupSizePercentage = (long) 1.2; // just to be sure the amount sent will be enough
+
+        return feePerKbSupport.getFeePerKb()
+            .multiply(svpSpendTransactionSize * backupSizePercentage)
+            .divide(1000);
+    }
+
+    private void addSvpSpendTransactionInputs(BtcTransaction svpSpendTransaction, BtcTransaction svpFundTxSigned, Federation proposedFederation) {
+        // TODO update when segwit since the scriptSig changes
+        addInputSentToProposedFederation(svpSpendTransaction, svpFundTxSigned, proposedFederation);
+        addInputSentToFlyoverProposedFederation(svpSpendTransaction, svpFundTxSigned, proposedFederation.getRedeemScript());
+    }
+
+    private void addInputSentToProposedFederation(BtcTransaction svpSpendTransaction, BtcTransaction svpFundTxSigned, Federation proposedFederation) {
+        List<TransactionOutput> svpFundTxSignedOutputs = svpFundTxSigned.getOutputs();
+        Script proposedFederationOutputScript = proposedFederation.getP2SHScript();
+        TransactionOutput outputToProposedFederation =
+            searchForOutput(svpFundTxSignedOutputs, proposedFederationOutputScript)
+            .orElseThrow(() ->
+                new IllegalStateException("Svp fund transaction must have an output to the proposed federation.")
+            );
+
+        Script proposedFederationRedeemScript = proposedFederation.getRedeemScript();
+        Script proposedFederationScriptSig = proposedFederationOutputScript.createEmptyInputScript(null, proposedFederationRedeemScript);
+        svpSpendTransaction.addInput(
+            svpFundTxSigned.getHash(),
+            svpFundTxSignedOutputs.indexOf(outputToProposedFederation),
+            proposedFederationScriptSig
+        );
+    }
+
+    private void addInputSentToFlyoverProposedFederation(BtcTransaction svpSpendTransaction, BtcTransaction svpFundTxSigned, Script proposedFederationRedeemScript) {
+        Keccak256 flyoverPrefix = bridgeConstants.getProposedFederationFlyoverPrefix();
+        Script flyoverProposedFederationRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(flyoverPrefix, proposedFederationRedeemScript);
+        Script flyoverProposedFederationScriptPubKey = ScriptBuilder.createP2SHOutputScript(flyoverProposedFederationRedeemScript);
+
+        List<TransactionOutput> svpFundTxSignedOutputs = svpFundTxSigned.getOutputs();
+        TransactionOutput outputToFlyoverProposedFederation =
+            searchForOutput(svpFundTxSignedOutputs, flyoverProposedFederationScriptPubKey)
+            .orElseThrow(() ->
+                new IllegalStateException("Svp fund transaction must have an output to the flyover proposed federation.")
+            );
+
+        Script flyoverProposedFederationEmptyScriptSig =
+            flyoverProposedFederationScriptPubKey.createEmptyInputScript(null, flyoverProposedFederationRedeemScript);
+        svpSpendTransaction.addInput(
+            svpFundTxSigned.getHash(),
+            svpFundTxSignedOutputs.indexOf(outputToFlyoverProposedFederation),
+            flyoverProposedFederationEmptyScriptSig
+        );
+    }
+
+    private void updateSvpSpendTransactionValues(Keccak256 rskTxHash, BtcTransaction svpSpendTransactionUnsigned) {
+        provider.setSvpSpendTxHashUnsigned(svpSpendTransactionUnsigned.getHash());
+        provider.setSvpSpendTxWaitingForSignatures(
+            new AbstractMap.SimpleEntry<>(rskTxHash, svpSpendTransactionUnsigned)
+        );
+
+        provider.setSvpFundTxSigned(null);
     }
 
     protected void updateFederationCreationBlockHeights() {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1073,7 +1073,7 @@ public class BridgeSupport {
         addSvpSpendTransactionInputs(svpSpendTransaction, svpFundTxSigned, proposedFederation);
 
         svpSpendTransaction.addOutput(
-            calculateAmountToSendToActiveFederation(proposedFederation),
+            calculateSvpSpendTxAmount(proposedFederation),
             federationSupport.getActiveFederationAddress()
         );
 
@@ -1088,7 +1088,7 @@ public class BridgeSupport {
         addInputFromMatchingOutputScript(svpSpendTransaction, svpFundTxSigned, flyoverProposedFederationOutputScript);
     }
 
-    private Coin calculateAmountToSendToActiveFederation(Federation proposedFederation) {
+    private Coin calculateSvpSpendTxAmount(Federation proposedFederation) {
         int svpSpendTransactionSize = calculatePegoutTxSize(activations, proposedFederation, 2, 1);
         long backupSizePercentage = (long) 1.2; // just to be sure the amount sent will be enough
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -20,8 +20,9 @@ package co.rsk.peg;
 import static co.rsk.peg.BridgeUtils.calculatePegoutTxSize;
 import static co.rsk.peg.PegUtils.getFlyoverAddress;
 import static co.rsk.peg.BridgeUtils.getRegularPegoutTxSize;
+import static co.rsk.peg.PegUtils.getFlyoverScriptPubKey;
 import static co.rsk.peg.ReleaseTransactionBuilder.BTC_TX_VERSION_2;
-import static co.rsk.peg.bitcoin.BitcoinUtils.searchForOutput;
+import static co.rsk.peg.bitcoin.BitcoinUtils.addInputFromOutputSentToScript;
 import static co.rsk.peg.bitcoin.UtxoUtils.extractOutpointValues;
 import static co.rsk.peg.pegin.RejectedPeginReason.INVALID_AMOUNT;
 import static java.util.Objects.isNull;
@@ -1055,7 +1056,13 @@ public class BridgeSupport {
             .ifPresent(proposedFederation -> provider.getSvpFundTxSigned()
             .ifPresent(svpFundTxSigned -> {
                 BtcTransaction svpSpendTransactionUnsigned = createSvpSpendTransaction(svpFundTxSigned, proposedFederation);
-                updateSvpSpendTransactionValues(rskTx.getHash(), svpSpendTransactionUnsigned);
+
+                Keccak256 rskTxHash = rskTx.getHash();
+                updateSvpSpendTransactionValues(rskTxHash, svpSpendTransactionUnsigned);
+
+                Coin requestedAmount = svpSpendTransactionUnsigned.getOutput(0).getValue();
+                logReleaseRequested(rskTxHash, svpSpendTransactionUnsigned, requestedAmount);
+                logPegoutTransactionCreated(svpSpendTransactionUnsigned);
             }));
     }
 
@@ -1083,48 +1090,11 @@ public class BridgeSupport {
     }
 
     private void addSvpSpendTransactionInputs(BtcTransaction svpSpendTransaction, BtcTransaction svpFundTxSigned, Federation proposedFederation) {
-        // TODO update when segwit since the scriptSig changes
-        addInputSentToProposedFederation(svpSpendTransaction, svpFundTxSigned, proposedFederation);
-        addInputSentToFlyoverProposedFederation(svpSpendTransaction, svpFundTxSigned, proposedFederation.getRedeemScript());
-    }
-
-    private void addInputSentToProposedFederation(BtcTransaction svpSpendTransaction, BtcTransaction svpFundTxSigned, Federation proposedFederation) {
-        List<TransactionOutput> svpFundTxSignedOutputs = svpFundTxSigned.getOutputs();
         Script proposedFederationOutputScript = proposedFederation.getP2SHScript();
-        TransactionOutput outputToProposedFederation =
-            searchForOutput(svpFundTxSignedOutputs, proposedFederationOutputScript)
-            .orElseThrow(() ->
-                new IllegalStateException("Svp fund transaction must have an output to the proposed federation.")
-            );
+        addInputFromOutputSentToScript(svpSpendTransaction, svpFundTxSigned, proposedFederationOutputScript);
 
-        Script proposedFederationRedeemScript = proposedFederation.getRedeemScript();
-        Script proposedFederationScriptSig = proposedFederationOutputScript.createEmptyInputScript(null, proposedFederationRedeemScript);
-        svpSpendTransaction.addInput(
-            svpFundTxSigned.getHash(),
-            svpFundTxSignedOutputs.indexOf(outputToProposedFederation),
-            proposedFederationScriptSig
-        );
-    }
-
-    private void addInputSentToFlyoverProposedFederation(BtcTransaction svpSpendTransaction, BtcTransaction svpFundTxSigned, Script proposedFederationRedeemScript) {
-        Keccak256 flyoverPrefix = bridgeConstants.getProposedFederationFlyoverPrefix();
-        Script flyoverProposedFederationRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(flyoverPrefix, proposedFederationRedeemScript);
-        Script flyoverProposedFederationScriptPubKey = ScriptBuilder.createP2SHOutputScript(flyoverProposedFederationRedeemScript);
-
-        List<TransactionOutput> svpFundTxSignedOutputs = svpFundTxSigned.getOutputs();
-        TransactionOutput outputToFlyoverProposedFederation =
-            searchForOutput(svpFundTxSignedOutputs, flyoverProposedFederationScriptPubKey)
-            .orElseThrow(() ->
-                new IllegalStateException("Svp fund transaction must have an output to the flyover proposed federation.")
-            );
-
-        Script flyoverProposedFederationEmptyScriptSig =
-            flyoverProposedFederationScriptPubKey.createEmptyInputScript(null, flyoverProposedFederationRedeemScript);
-        svpSpendTransaction.addInput(
-            svpFundTxSigned.getHash(),
-            svpFundTxSignedOutputs.indexOf(outputToFlyoverProposedFederation),
-            flyoverProposedFederationEmptyScriptSig
-        );
+        Script flyoverProposedFederationOutputScript = getFlyoverScriptPubKey(bridgeConstants.getProposedFederationFlyoverPrefix(), proposedFederation.getRedeemScript());
+        addInputFromOutputSentToScript(svpSpendTransaction, svpFundTxSigned, flyoverProposedFederationOutputScript);
     }
 
     private void updateSvpSpendTransactionValues(Keccak256 rskTxHash, BtcTransaction svpSpendTransactionUnsigned) {

--- a/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
@@ -79,6 +79,19 @@ public class BitcoinUtils {
         }
     }
 
+    public static void addInputFromOutputSentToScript(BtcTransaction transaction, BtcTransaction sourceTransaction, Script expectedOutputScript) {
+        List<TransactionOutput> outputs = sourceTransaction.getOutputs();
+        TransactionOutput matchingOutput = searchForOutput(outputs, expectedOutputScript)
+            .orElseThrow(
+                () -> {
+                    String message = String.format("Transaction must have an output to expected script %s", expectedOutputScript);
+                    logger.error("[addInputFromExpectedOutput] {}", message);
+                    return new IllegalStateException(message);
+                }
+            );
+        transaction.addInput(matchingOutput);
+    }
+
     public static Optional<TransactionOutput> searchForOutput(List<TransactionOutput> transactionOutputs, Script outputScriptPubKey) {
         return transactionOutputs.stream()
             .filter(output -> output.getScriptPubKey().equals(outputScriptPubKey))

--- a/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
@@ -79,17 +79,10 @@ public class BitcoinUtils {
         }
     }
 
-    public static void addInputFromOutputSentToScript(BtcTransaction transaction, BtcTransaction sourceTransaction, Script expectedOutputScript) {
+    public static void addInputFromMatchingOutputScript(BtcTransaction transaction, BtcTransaction sourceTransaction, Script expectedOutputScript) {
         List<TransactionOutput> outputs = sourceTransaction.getOutputs();
-        TransactionOutput matchingOutput = searchForOutput(outputs, expectedOutputScript)
-            .orElseThrow(
-                () -> {
-                    String message = String.format("Transaction must have an output to expected script %s", expectedOutputScript);
-                    logger.error("[addInputFromExpectedOutput] {}", message);
-                    return new IllegalStateException(message);
-                }
-            );
-        transaction.addInput(matchingOutput);
+        searchForOutput(outputs, expectedOutputScript)
+            .ifPresent(transaction::addInput);
     }
 
     public static Optional<TransactionOutput> searchForOutput(List<TransactionOutput> transactionOutputs, Script outputScriptPubKey) {

--- a/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
@@ -1,9 +1,6 @@
 package co.rsk.peg.bitcoin;
 
-import co.rsk.bitcoinj.core.BtcTransaction;
-import co.rsk.bitcoinj.core.ScriptException;
-import co.rsk.bitcoinj.core.Sha256Hash;
-import co.rsk.bitcoinj.core.TransactionInput;
+import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.script.ScriptChunk;
@@ -80,5 +77,11 @@ public class BitcoinUtils {
             Script emptyInputScript = p2shScript.createEmptyInputScript(null, inputRedeemScript);
             input.setScriptSig(emptyInputScript);
         }
+    }
+
+    public static Optional<TransactionOutput> searchForOutput(List<TransactionOutput> transactionOutputs, Script outputScriptPubKey) {
+        return transactionOutputs.stream()
+            .filter(output -> output.getScriptPubKey().equals(outputScriptPubKey))
+            .findFirst();
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
@@ -106,13 +106,14 @@ public class BridgeSupportSvpTest {
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     @Tag("svp fund transaction creation and processing tests")
     class SvpFundTxCreationAndProcessingTests {
-        private final List<LogInfo> logs = new ArrayList<>();
+        private List<LogInfo> logs;
 
         private BtcTransaction svpFundTransactionUnsigned;
         private Sha256Hash svpFundTransactionHashUnsigned;
 
         @BeforeEach
         void setUp() {
+            logs = new ArrayList<>();
             SignatureCache signatureCache = new BlockTxSignatureCache(new ReceivedTxSignatureCache());
             BridgeEventLogger bridgeEventLogger = new BridgeEventLoggerImpl(
                 bridgeMainNetConstants,
@@ -444,6 +445,12 @@ public class BridgeSupportSvpTest {
             return pegout;
         }
 
+        private void addOutputChange(BtcTransaction transaction) {
+            // add output to the active fed
+            Script activeFederationP2SHScript = activeFederation.getP2SHScript();
+            transaction.addOutput(Coin.COIN.multiply(10), activeFederationP2SHScript);
+        }
+
         private void savePegoutIndex(BtcTransaction pegout) {
             BitcoinUtils.getFirstInputSigHash(pegout)
                 .ifPresent(inputSigHash -> bridgeStorageProvider.setPegoutTxSigHash(inputSigHash));
@@ -498,13 +505,14 @@ public class BridgeSupportSvpTest {
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     @Tag("svp spend transaction creation and processing tests")
     class SvpSpendTxCreationAndProcessingTests {
-        private final List<LogInfo> logs = new ArrayList<>();
+        private List<LogInfo> logs;
         private BtcTransaction svpFundTransaction;
         private Sha256Hash svpSpendTransactionHashUnsigned;
         private BtcTransaction svpSpendTransactionUnsigned;
 
         @BeforeEach
         void setUp() {
+            logs = new ArrayList<>();
             SignatureCache signatureCache = new BlockTxSignatureCache(new ReceivedTxSignatureCache());
             BridgeEventLogger bridgeEventLogger = new BridgeEventLoggerImpl(
                 bridgeMainNetConstants,
@@ -533,6 +541,7 @@ public class BridgeSupportSvpTest {
 
             // assert
             assertSvpSpendTransactionValuesWereNotSaved();
+            assertSvpSpendTransactionReleaseWasNotLogged();
         }
 
         @Test
@@ -543,6 +552,7 @@ public class BridgeSupportSvpTest {
 
             // assert
             assertSvpSpendTransactionValuesWereNotSaved();
+            assertSvpSpendTransactionReleaseWasNotLogged();
         }
 
         private void assertSvpSpendTransactionValuesWereNotSaved() {
@@ -551,6 +561,10 @@ public class BridgeSupportSvpTest {
 
             Optional<Map.Entry<Keccak256, BtcTransaction>> svpSpendTxWaitingForSignatures = bridgeStorageProvider.getSvpSpendTxWaitingForSignatures();
             assertFalse(svpSpendTxWaitingForSignatures.isPresent());
+        }
+
+        private void assertSvpSpendTransactionReleaseWasNotLogged() {
+            assertEquals(0, logs.size());
         }
 
         @Test
@@ -655,12 +669,6 @@ public class BridgeSupportSvpTest {
         IntStream.range(0, inputs.size()).forEach(i ->
             BitcoinTestUtils.signTransactionInputFromP2shMultiSig(transaction, i, keysToSign)
         );
-    }
-
-    private void addOutputChange(BtcTransaction transaction) {
-        // add output to the active fed
-        Script activeFederationP2SHScript = activeFederation.getP2SHScript();
-        transaction.addOutput(Coin.COIN.multiply(10), activeFederationP2SHScript);
     }
 
     private void assertOutputWasSentToExpectedScriptWithExpectedAmount(List<TransactionOutput> transactionOutputs, Script expectedScriptPubKey, Coin expectedAmount) {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
@@ -581,11 +581,11 @@ public class BridgeSupportSvpTest {
             assertSvpSpendTxIsWaitingForSignatures();
             assertSvpSpendTxHasExpectedInputsAndOutputs();
 
-            assertSvpFundTxSignedWasRemoved();
+            assertSvpFundTxSignedWasRemovedFromStorage();
 
             assertLogPegoutTransactionCreated(logs, svpSpendTransactionUnsigned);
-            Coin requestedAmount = Coin.valueOf(1762);
-            assertLogReleaseRequested(logs, rskTx.getHash(), svpSpendTransactionHashUnsigned, requestedAmount);
+            Coin valueSentToActiveFed = Coin.valueOf(1762);
+            assertLogReleaseRequested(logs, rskTx.getHash(), svpSpendTransactionHashUnsigned, valueSentToActiveFed);
         }
 
         private void arrangeSvpFundTransactionSigned() {
@@ -616,7 +616,7 @@ public class BridgeSupportSvpTest {
             svpSpendTransactionUnsigned = svpSpendTxWaitingForSignaturesSpendTx;
         }
 
-        private void assertSvpFundTxSignedWasRemoved() {
+        private void assertSvpFundTxSignedWasRemovedFromStorage() {
             Optional<BtcTransaction> svpFundTxSigned = bridgeStorageProvider.getSvpFundTxSigned();
             assertFalse(svpFundTxSigned.isPresent());
         }

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.*;
 import java.util.stream.Stream;
 
+import static co.rsk.peg.bitcoin.BitcoinUtils.addInputFromOutputSentToScript;
+
 class BitcoinUtilsTest {
     private static final BridgeConstants bridgeMainnetConstants = BridgeMainNetConstants.getInstance();
     private static final NetworkParameters btcMainnetParams = bridgeMainnetConstants.getBtcParams();
@@ -395,5 +397,24 @@ class BitcoinUtilsTest {
 
         // assert
         assertEquals(transactionWithoutSignaturesHash, transaction.getHash());
+    }
+
+    @Test
+    void addInputFromOutputSentToScript_shouldAddInputWithOutpointFromOutput() {
+        // arrange
+        Script redeemScript = new Script(Hex.decode("645521020ace50bab1230f8002a0bfe619482af74b338cc9e4c956add228df47e6adae1c21025093f439fb8006fd29ab56605ffec9cdc840d16d2361004e1337a2f86d8bd2db21026b472f7d59d201ff1f540f111b6eb329e071c30a9d23e3d2bcd128fe73dc254c210275d473555de2733c47125f9702b0f870df1d817379f5587f09b6c40ed2c6c9492103250c11be0561b1d7ae168b1f59e39cbc1fd1ba3cf4d2140c1a365b2723a2bf93210357f7ed4c118e581f49cd3b4d9dd1edb4295f4def49d6dcf2faaaaac87a1a0a422103ae72827d25030818c4947a800187b1fbcc33ae751e248ae60094cc989fb880f62103b58a5da144f5abab2e03e414ad044b732300de52fa25c672a7f7b358887719062103e05bf6002b62651378b1954820539c36ca405cbb778c225395dd9ebff678029959ae670350cd00b275532102370a9838e4d15708ad14a104ee5606b36caaaaf739d833e67770ce9fd9b3ec80210257c293086c4d4fe8943deda5f890a37d11bebd140e220faa76258a41d077b4d42103c2660a46aa73078ee6016dee953488566426cf55fc8011edd0085634d75395f92103cd3e383ec6e12719a6c69515e5559bcbe037d0aa24c187e1e26ce932e22ad7b354ae68"));
+        Script outputScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
+
+        BtcTransaction sourceTransaction = new BtcTransaction(btcMainnetParams);
+        sourceTransaction.addOutput(Coin.valueOf(1000L), outputScript);
+
+        // act
+        BtcTransaction newTransaction = new BtcTransaction(btcMainnetParams);
+        addInputFromOutputSentToScript(newTransaction, sourceTransaction, outputScript);
+
+        // assert
+        TransactionInput newTransactionInput = newTransaction.getInput(0);
+        TransactionOutput sourceTransactionOutput = sourceTransaction.getOutput(0);
+        Assertions.assertEquals(newTransactionInput.getOutpoint().getHash(), sourceTransactionOutput.getParentTransactionHash());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
@@ -8,6 +8,7 @@ import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.constants.BridgeMainNetConstants;
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.P2shErpFederationBuilder;
+import co.rsk.peg.federation.StandardMultiSigFederationBuilder;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,6 +21,7 @@ import java.util.*;
 import java.util.stream.Stream;
 
 import static co.rsk.peg.bitcoin.BitcoinUtils.addInputFromMatchingOutputScript;
+import static co.rsk.peg.bitcoin.BitcoinUtils.searchForOutput;
 
 class BitcoinUtilsTest {
     private static final BridgeConstants bridgeMainnetConstants = BridgeMainNetConstants.getInstance();
@@ -377,16 +379,14 @@ class BitcoinUtilsTest {
         transaction.addOutput(Coin.COIN, destinationAddress);
         Sha256Hash transactionWithoutSignaturesHash = transaction.getHash();
 
-        List<BtcECKey> keysToSign = BitcoinTestUtils.getBtcEcKeysFromSeeds(new String[]{
-            "member01",
-            "member02",
-            "member03",
-            "member04",
-            "member05"
- }, true); // using private keys from federation declared above
+        List<BtcECKey> keysToSign = BitcoinTestUtils.getBtcEcKeysFromSeeds(
+            new String[]{ "member01", "member02", "member03", "member04", "member05"},
+            true
+        ); // using private keys from federation declared above
         List<TransactionInput> inputs = transaction.getInputs();
         for (TransactionInput input : inputs) {
-            BitcoinTestUtils.signTransactionInputFromP2shMultiSig                      ansaction,
+            BitcoinTestUtils.signTransactionInputFromP2shMultiSig(
+                transaction,
                 inputs.indexOf(input),
                 keysToSign
             );
@@ -402,7 +402,8 @@ class BitcoinUtilsTest {
     @Test
     void addInputFromOutputSentToScript_withNoMatchingOutputScript_shouldNotAddInput() {
         // arrange
-        Script redeemScript = new Script(Hex.decode("645521020ace50bab1230f8002a0bfe619482af74b338cc9e4c956add228df47e6adae1c21025093f439fb8006fd29ab56605ffec9cdc840d16d2361004e1337a2f86d8bd2db21026b472f7d59d201ff1f540f111b6eb329e071c30a9d23e3d2bcd128fe73dc254c210275d473555de2733c47125f9702b0f870df1d817379f5587f09b6c40ed2c6c9492103250c11be0561b1d7ae168b1f59e39cbc1fd1ba3cf4d2140c1a365b2723a2bf93210357f7ed4c118e581f49cd3b4d9dd1edb4295f4def49d6dcf2faaaaac87a1a0a422103ae72827d25030818c4947a800187b1fbcc33ae751e248ae60094cc989fb880f62103b58a5da144f5abab2e03e414ad044b732300de52fa25c672a7f7b358887719062103e05bf6002b62651378b1954820539c36ca405cbb778c225395dd9ebff678029959ae670350cd00b275532102370a9838e4d15708ad14a104ee5606b36caaaaf739d833e67770ce9fd9b3ec80210257c293086c4d4fe8943deda5f890a37d11bebd140e220faa76258a41d077b4d42103c2660a46aa73078ee6016dee953488566426cf55fc8011edd0085634d75395f92103cd3e383ec6e12719a6c69515e5559bcbe037d0aa24c187e1e26ce932e22ad7b354ae68"));
+        Federation federation = P2shErpFederationBuilder.builder().build();
+        Script redeemScript = federation.getRedeemScript();
         Script outputScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
         BtcTransaction sourceTransaction = new BtcTransaction(btcMainnetParams);
         sourceTransaction.addOutput(Coin.valueOf(1000L), outputScript);
@@ -410,7 +411,8 @@ class BitcoinUtilsTest {
         // act
         BtcTransaction newTransaction = new BtcTransaction(btcMainnetParams);
 
-        Script anotherRedeemScript = new Script(Hex.decode("556421020ace50bab1230f8002a0bfe619482af74b338cc9e4c956add228df47e6adae1c21025093f439fb8006fd29ab56605ffec9cdc840d16d2361004e1337a2f86d8bd2db21026b472f7d59d201ff1f540f111b6eb329e071c30a9d23e3d2bcd128fe73dc254c210275d473555de2733c47125f9702b0f870df1d817379f5587f09b6c40ed2c6c9492103250c11be0561b1d7ae168b1f59e39cbc1fd1ba3cf4d2140c1a365b2723a2bf93210357f7ed4c118e581f49cd3b4d9dd1edb4295f4def49d6dcf2faaaaac87a1a0a422103ae72827d25030818c4947a800187b1fbcc33ae751e248ae60094cc989fb880f62103b58a5da144f5abab2e03e414ad044b732300de52fa25c672a7f7b358887719062103e05bf6002b62651378b1954820539c36ca405cbb778c225395dd9ebff678029959ae670350cd00b275532102370a9838e4d15708ad14a104ee5606b36caaaaf739d833e67770ce9fd9b3ec80210257c293086c4d4fe8943deda5f890a37d11bebd140e220faa76258a41d077b4d42103c2660a46aa73078ee6016dee953488566426cf55fc8011edd0085634d75395f92103cd3e383ec6e12719a6c69515e5559bcbe037d0aa24c187e1e26ce932e22ad7b354ae68"));
+        Federation anotherFederation = StandardMultiSigFederationBuilder.builder().build();
+        Script anotherRedeemScript = anotherFederation.getRedeemScript();
         Script anotherOutputScript = ScriptBuilder.createP2SHOutputScript(anotherRedeemScript);
         addInputFromMatchingOutputScript(newTransaction, sourceTransaction, anotherOutputScript);
 
@@ -421,7 +423,8 @@ class BitcoinUtilsTest {
     @Test
     void addInputFromOutputSentToScript_withMatchingOutputScript_shouldAddInputWithOutpointFromOutput() {
         // arrange
-        Script redeemScript = new Script(Hex.decode("645521020ace50bab1230f8002a0bfe619482af74b338cc9e4c956add228df47e6adae1c21025093f439fb8006fd29ab56605ffec9cdc840d16d2361004e1337a2f86d8bd2db21026b472f7d59d201ff1f540f111b6eb329e071c30a9d23e3d2bcd128fe73dc254c210275d473555de2733c47125f9702b0f870df1d817379f5587f09b6c40ed2c6c9492103250c11be0561b1d7ae168b1f59e39cbc1fd1ba3cf4d2140c1a365b2723a2bf93210357f7ed4c118e581f49cd3b4d9dd1edb4295f4def49d6dcf2faaaaac87a1a0a422103ae72827d25030818c4947a800187b1fbcc33ae751e248ae60094cc989fb880f62103b58a5da144f5abab2e03e414ad044b732300de52fa25c672a7f7b358887719062103e05bf6002b62651378b1954820539c36ca405cbb778c225395dd9ebff678029959ae670350cd00b275532102370a9838e4d15708ad14a104ee5606b36caaaaf739d833e67770ce9fd9b3ec80210257c293086c4d4fe8943deda5f890a37d11bebd140e220faa76258a41d077b4d42103c2660a46aa73078ee6016dee953488566426cf55fc8011edd0085634d75395f92103cd3e383ec6e12719a6c69515e5559bcbe037d0aa24c187e1e26ce932e22ad7b354ae68"));
+        Federation federation = P2shErpFederationBuilder.builder().build();
+        Script redeemScript = federation.getRedeemScript();
         Script outputScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
 
         BtcTransaction sourceTransaction = new BtcTransaction(btcMainnetParams);
@@ -435,5 +438,44 @@ class BitcoinUtilsTest {
         TransactionInput newTransactionInput = newTransaction.getInput(0);
         TransactionOutput sourceTransactionOutput = sourceTransaction.getOutput(0);
         Assertions.assertEquals(newTransactionInput.getOutpoint().getHash(), sourceTransactionOutput.getParentTransactionHash());
+    }
+
+    @Test
+    void searchForOutput_whenTheOutputIsThere_shouldReturnOutputSentToExpectedScript() {
+        // arrange
+        Federation federation = P2shErpFederationBuilder.builder().build();
+        Script redeemScript = federation.getRedeemScript();
+        Script outputScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
+
+        BtcTransaction sourceTransaction = new BtcTransaction(btcMainnetParams);
+        sourceTransaction.addOutput(Coin.valueOf(1000L), outputScript);
+
+        // act
+        Optional<TransactionOutput> transactionOutput = searchForOutput(sourceTransaction.getOutputs(), outputScript);
+
+        // assert
+        Assertions.assertTrue(transactionOutput.isPresent());
+        Assertions.assertEquals(outputScript, transactionOutput.get().getScriptPubKey());
+    }
+
+    @Test
+    void searchForOutput_whenTheOutputIsNotThere_shouldReturnEmpty() {
+        // arrange
+        Federation federation = P2shErpFederationBuilder.builder().build();
+        Script redeemScript = federation.getRedeemScript();
+        Script outputScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
+
+        BtcTransaction sourceTransaction = new BtcTransaction(btcMainnetParams);
+        sourceTransaction.addOutput(Coin.valueOf(1000L), outputScript);
+
+        Federation anotherFederation = StandardMultiSigFederationBuilder.builder().build();
+        Script anotherRedeemScript = anotherFederation.getRedeemScript();
+        Script anotherOutputScript = ScriptBuilder.createP2SHOutputScript(anotherRedeemScript);
+
+        // act
+        Optional<TransactionOutput> transactionOutput = searchForOutput(sourceTransaction.getOutputs(), anotherOutputScript);
+
+        // assert
+        Assertions.assertFalse(transactionOutput.isPresent());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.*;
 import java.util.stream.Stream;
 
-import static co.rsk.peg.bitcoin.BitcoinUtils.addInputFromOutputSentToScript;
+import static co.rsk.peg.bitcoin.BitcoinUtils.addInputFromMatchingOutputScript;
 
 class BitcoinUtilsTest {
     private static final BridgeConstants bridgeMainnetConstants = BridgeMainNetConstants.getInstance();
@@ -400,7 +400,26 @@ class BitcoinUtilsTest {
     }
 
     @Test
-    void addInputFromOutputSentToScript_shouldAddInputWithOutpointFromOutput() {
+    void addInputFromOutputSentToScript_withNoMatchingOutputScript_shouldNotAddInput() {
+        // arrange
+        Script redeemScript = new Script(Hex.decode("645521020ace50bab1230f8002a0bfe619482af74b338cc9e4c956add228df47e6adae1c21025093f439fb8006fd29ab56605ffec9cdc840d16d2361004e1337a2f86d8bd2db21026b472f7d59d201ff1f540f111b6eb329e071c30a9d23e3d2bcd128fe73dc254c210275d473555de2733c47125f9702b0f870df1d817379f5587f09b6c40ed2c6c9492103250c11be0561b1d7ae168b1f59e39cbc1fd1ba3cf4d2140c1a365b2723a2bf93210357f7ed4c118e581f49cd3b4d9dd1edb4295f4def49d6dcf2faaaaac87a1a0a422103ae72827d25030818c4947a800187b1fbcc33ae751e248ae60094cc989fb880f62103b58a5da144f5abab2e03e414ad044b732300de52fa25c672a7f7b358887719062103e05bf6002b62651378b1954820539c36ca405cbb778c225395dd9ebff678029959ae670350cd00b275532102370a9838e4d15708ad14a104ee5606b36caaaaf739d833e67770ce9fd9b3ec80210257c293086c4d4fe8943deda5f890a37d11bebd140e220faa76258a41d077b4d42103c2660a46aa73078ee6016dee953488566426cf55fc8011edd0085634d75395f92103cd3e383ec6e12719a6c69515e5559bcbe037d0aa24c187e1e26ce932e22ad7b354ae68"));
+        Script outputScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
+        BtcTransaction sourceTransaction = new BtcTransaction(btcMainnetParams);
+        sourceTransaction.addOutput(Coin.valueOf(1000L), outputScript);
+
+        // act
+        BtcTransaction newTransaction = new BtcTransaction(btcMainnetParams);
+
+        Script anotherRedeemScript = new Script(Hex.decode("556421020ace50bab1230f8002a0bfe619482af74b338cc9e4c956add228df47e6adae1c21025093f439fb8006fd29ab56605ffec9cdc840d16d2361004e1337a2f86d8bd2db21026b472f7d59d201ff1f540f111b6eb329e071c30a9d23e3d2bcd128fe73dc254c210275d473555de2733c47125f9702b0f870df1d817379f5587f09b6c40ed2c6c9492103250c11be0561b1d7ae168b1f59e39cbc1fd1ba3cf4d2140c1a365b2723a2bf93210357f7ed4c118e581f49cd3b4d9dd1edb4295f4def49d6dcf2faaaaac87a1a0a422103ae72827d25030818c4947a800187b1fbcc33ae751e248ae60094cc989fb880f62103b58a5da144f5abab2e03e414ad044b732300de52fa25c672a7f7b358887719062103e05bf6002b62651378b1954820539c36ca405cbb778c225395dd9ebff678029959ae670350cd00b275532102370a9838e4d15708ad14a104ee5606b36caaaaf739d833e67770ce9fd9b3ec80210257c293086c4d4fe8943deda5f890a37d11bebd140e220faa76258a41d077b4d42103c2660a46aa73078ee6016dee953488566426cf55fc8011edd0085634d75395f92103cd3e383ec6e12719a6c69515e5559bcbe037d0aa24c187e1e26ce932e22ad7b354ae68"));
+        Script anotherOutputScript = ScriptBuilder.createP2SHOutputScript(anotherRedeemScript);
+        addInputFromMatchingOutputScript(newTransaction, sourceTransaction, anotherOutputScript);
+
+        // assert
+        Assertions.assertEquals(0, newTransaction.getInputs().size());
+    }
+
+    @Test
+    void addInputFromOutputSentToScript_withMatchingOutputScript_shouldAddInputWithOutpointFromOutput() {
         // arrange
         Script redeemScript = new Script(Hex.decode("645521020ace50bab1230f8002a0bfe619482af74b338cc9e4c956add228df47e6adae1c21025093f439fb8006fd29ab56605ffec9cdc840d16d2361004e1337a2f86d8bd2db21026b472f7d59d201ff1f540f111b6eb329e071c30a9d23e3d2bcd128fe73dc254c210275d473555de2733c47125f9702b0f870df1d817379f5587f09b6c40ed2c6c9492103250c11be0561b1d7ae168b1f59e39cbc1fd1ba3cf4d2140c1a365b2723a2bf93210357f7ed4c118e581f49cd3b4d9dd1edb4295f4def49d6dcf2faaaaac87a1a0a422103ae72827d25030818c4947a800187b1fbcc33ae751e248ae60094cc989fb880f62103b58a5da144f5abab2e03e414ad044b732300de52fa25c672a7f7b358887719062103e05bf6002b62651378b1954820539c36ca405cbb778c225395dd9ebff678029959ae670350cd00b275532102370a9838e4d15708ad14a104ee5606b36caaaaf739d833e67770ce9fd9b3ec80210257c293086c4d4fe8943deda5f890a37d11bebd140e220faa76258a41d077b4d42103c2660a46aa73078ee6016dee953488566426cf55fc8011edd0085634d75395f92103cd3e383ec6e12719a6c69515e5559bcbe037d0aa24c187e1e26ce932e22ad7b354ae68"));
         Script outputScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
@@ -410,7 +429,7 @@ class BitcoinUtilsTest {
 
         // act
         BtcTransaction newTransaction = new BtcTransaction(btcMainnetParams);
-        addInputFromOutputSentToScript(newTransaction, sourceTransaction, outputScript);
+        addInputFromMatchingOutputScript(newTransaction, sourceTransaction, outputScript);
 
         // assert
         TransactionInput newTransactionInput = newTransaction.getInput(0);


### PR DESCRIPTION
When the fund transaction is registered, we can proceed with the spend transaction (i.e., the transaction that will send back the funds from the proposed federation to the active one) process: its creation, its addition to the corresponding `svpSpendTxHashUnsigned` storage entry and `svpSpendTxWaitingForSignatures` map entry, and the broadcast of the `release_requested` and `pegout_transaction_created` events needed for the hsm signing.

 
In this pr:
-Create a new method `processSvpSpendTransactionUnsigned` that will:

 create the spend transaction as described [here](https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP419.md?plain=1#L151)

 add it to the `svpSpendTxHashUnsigned` storage entry

 add it and the rsk hash of the spend transaction creation to the `svpSpendTxWaitingForSignatures` map

 remove the fund transaction hash from the `svpFundTxHashSigned` entry

 log svp spend tx release