### PR TITLE
Create commit federation failed event

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeEvents.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeEvents.java
@@ -113,8 +113,8 @@ public enum BridgeEvents {
         }
     );
 
-    private String eventName;
-    private CallTransaction.Param[] params;
+    private final String eventName;
+    private final CallTransaction.Param[] params;
 
     BridgeEvents(String eventName, CallTransaction.Param[] params) {
         this.eventName = eventName;

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeEvents.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeEvents.java
@@ -60,6 +60,12 @@ public enum BridgeEvents {
                     new CallTransaction.Param(false, "activationHeight", SolidityType.getType(SolidityType.INT256))
             }
     ),
+    COMMIT_FEDERATION_FAILED("commit_federation_failed",
+        new CallTransaction.Param[]{
+            new CallTransaction.Param(false, "proposedFederationRedeemScriptSerialized", SolidityType.getType(SolidityType.BYTES)),
+            new CallTransaction.Param(false, "blockNumber", SolidityType.getType(SolidityType.INT256))
+        }
+    ),
     RELEASE_REQUESTED("release_requested",
             new CallTransaction.Param[]{
                     new CallTransaction.Param(true, "rskTxHash", SolidityType.getType(SolidityType.BYTES32)),

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
@@ -43,6 +43,8 @@ public interface BridgeEventLogger {
 
     void logCommitFederation(Block executionBlock, Federation oldFederation, Federation newFederation);
 
+    void logCommitFederationFailure(Block executionBlock, Federation proposedFederation);
+
     default void logLockBtc(RskAddress rskReceiver, BtcTransaction btcTx, Address senderBtcAddress, Coin amount) {
         throw new UnsupportedOperationException();
     }

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -150,6 +150,24 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
     }
 
     @Override
+    public void logCommitFederationFailure(Block executionBlock, Federation proposedFederation) {
+        CallTransaction.Function event = BridgeEvents.COMMIT_FEDERATION_FAILED.getEvent();
+
+        byte[][] encodedTopicsSerialized = event.encodeEventTopics();
+        List<DataWord> encodedTopics = getEncodedTopics(encodedTopicsSerialized);
+
+        byte[] proposedFederationRedeemScriptSerialized = proposedFederation.getRedeemScript().getProgram();
+        long executionBlockNumber = executionBlock.getNumber();
+
+        byte[] encodedData = event.encodeEventData(
+            proposedFederationRedeemScriptSerialized,
+            executionBlockNumber
+        );
+
+        addLog(encodedTopics, encodedData);
+    }
+
+    @Override
     public void logLockBtc(RskAddress receiver, BtcTransaction btcTx, Address senderBtcAddress, Coin amount) {
         CallTransaction.Function event = BridgeEvents.LOCK_BTC.getEvent();
 

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BrigeEventLoggerLegacyImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BrigeEventLoggerLegacyImpl.java
@@ -38,7 +38,6 @@ import org.ethereum.vm.PrecompiledContracts;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Responsible for logging events triggered by BridgeContract in RLP format.
@@ -67,7 +66,7 @@ public class BrigeEventLoggerLegacyImpl implements BridgeEventLogger {
     public void logUpdateCollections(Transaction rskTx) {
         if (activations.isActive(ConsensusRule.RSKIP146)) {
             throw new DeprecatedMethodCallException(
-                "Calling BrigeEventLoggerLegacyImpl.logUpdateCollections method after RSKIP146 activation"
+                "Calling BridgeEventLoggerLegacyImpl.logUpdateCollections method after RSKIP146 activation"
             );
         }
         this.logs.add(
@@ -82,7 +81,7 @@ public class BrigeEventLoggerLegacyImpl implements BridgeEventLogger {
     public void logAddSignature(FederationMember federationMember, BtcTransaction btcTx, byte[] rskTxHash) {
         if (activations.isActive(ConsensusRule.RSKIP146)) {
             throw new DeprecatedMethodCallException(
-                "Calling BrigeEventLoggerLegacyImpl.logAddSignature method after RSKIP146 activation"
+                "Calling BridgeEventLoggerLegacyImpl.logAddSignature method after RSKIP146 activation"
             );
         }
         List<DataWord> topics = Collections.singletonList(Bridge.ADD_SIGNATURE_TOPIC);
@@ -97,7 +96,7 @@ public class BrigeEventLoggerLegacyImpl implements BridgeEventLogger {
     public void logReleaseBtc(BtcTransaction btcTx, byte[] rskTxHash) {
         if (activations.isActive(ConsensusRule.RSKIP146)) {
             throw new DeprecatedMethodCallException(
-                "Calling BrigeEventLoggerLegacyImpl.logReleaseBtc method after RSKIP146 activation"
+                "Calling BridgeEventLoggerLegacyImpl.logReleaseBtc method after RSKIP146 activation"
             );
         }
         List<DataWord> topics = Collections.singletonList(Bridge.RELEASE_BTC_TOPIC);
@@ -110,7 +109,7 @@ public class BrigeEventLoggerLegacyImpl implements BridgeEventLogger {
     public void logCommitFederation(Block executionBlock, Federation oldFederation, Federation newFederation) {
         if (activations.isActive(ConsensusRule.RSKIP146)) {
             throw new DeprecatedMethodCallException(
-                "Calling BrigeEventLoggerLegacyImpl.logCommitFederation method after RSKIP146 activation"
+                "Calling BridgeEventLoggerLegacyImpl.logCommitFederation method after RSKIP146 activation"
             );
         }
         List<DataWord> topics = Collections.singletonList(Bridge.COMMIT_FEDERATION_TOPIC);
@@ -129,6 +128,13 @@ public class BrigeEventLoggerLegacyImpl implements BridgeEventLogger {
         this.logs.add(new LogInfo(BRIDGE_CONTRACT_ADDRESS, topics, data));
     }
 
+    @Override
+    public void logCommitFederationFailure(Block executionBlock, Federation proposedFederation) {
+        throw new UnsupportedOperationException(
+            "Calling BridgeEventLoggerLegacyImpl.logCommitFederationFailure is not allowed, since this event was created after deprecating the class."
+        );
+    }
+
     private byte[] flatKeysAsRlpCollection(List<BtcECKey> keys) {
         return flatKeys(keys, (k -> RLP.encodeElement(k.getPubKey())));
     }
@@ -136,7 +142,7 @@ public class BrigeEventLoggerLegacyImpl implements BridgeEventLogger {
     private byte[] flatKeys(List<BtcECKey> keys, Function<BtcECKey, byte[]> parser) {
         List<byte[]> pubKeys = keys.stream()
             .map(parser)
-            .collect(Collectors.toList());
+            .toList();
         int pubKeysLength = pubKeys.stream().mapToInt(key -> key.length).sum();
 
         byte[] flatPubKeys = new byte[pubKeysLength];

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
@@ -333,6 +333,31 @@ class BridgeEventLoggerImplTest {
         return FederationFactory.buildStandardMultiSigFederation(federationArgs);
     }
 
+    @Test
+    void logCommitFederationFailed() {
+        // arrange
+        Block rskExecutionBlock = arrangeRskExecutionBlock();
+        long executionBlockNumber = rskExecutionBlock.getNumber();
+
+        Federation proposedFederation = P2shErpFederationBuilder.builder().build();
+        byte[] proposedFederationRedeemScriptSerialized = proposedFederation.getRedeemScript().getProgram();
+
+        CallTransaction.Function event = BridgeEvents.COMMIT_FEDERATION_FAILED.getEvent();
+        Object[] topics = {};
+        Object[] data = new Object[]{
+            proposedFederationRedeemScriptSerialized,
+            executionBlockNumber
+        };
+
+        // act
+        eventLogger.logCommitFederationFailure(rskExecutionBlock, proposedFederation);
+
+        // assert
+        commonAssertLogs();
+        assertTopics(1);
+        assertEvent(event, topics, data);
+    }
+
     private Block arrangeRskExecutionBlock() {
         long rskExecutionBlockNumber = 15005L;
         long rskExecutionBlockTimestamp = 15L;

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
@@ -39,13 +39,13 @@ import co.rsk.peg.pegin.RejectedPeginReason;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.*;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.*;
 import org.ethereum.core.*;
 import org.ethereum.core.CallTransaction.Function;
 import org.ethereum.crypto.ECKey;
+import org.ethereum.vm.DataWord;
 import org.ethereum.vm.LogInfo;
 import org.ethereum.vm.PrecompiledContracts;
 import org.junit.jupiter.api.*;
@@ -58,6 +58,8 @@ import org.junit.jupiter.params.provider.*;
  * @author martin.medina
  */
 class BridgeEventLoggerImplTest {
+    private static final RskAddress BRIDGE_ADDRESS = PrecompiledContracts.BRIDGE_ADDR;
+    private static final byte[] BRIDGE_ADDRESS_SERIALIZED = BRIDGE_ADDRESS.getBytes();
     private static final BridgeConstants BRIDGE_CONSTANTS = BridgeMainNetConstants.getInstance();
     private static final FederationConstants FEDERATION_CONSTANTS = BRIDGE_CONSTANTS.getFederationConstants();
     private static final NetworkParameters NETWORK_PARAMETERS = BRIDGE_CONSTANTS.getBtcParams();
@@ -86,11 +88,9 @@ class BridgeEventLoggerImplTest {
         // Act
         eventLogger.logLockBtc(RSK_ADDRESS, BTC_TRANSACTION, senderAddress, amount);
 
-        commonAssertLogs(eventLogs);
-        assertTopics(2, eventLogs);
+        commonAssertLogs();
+        assertTopics(2);
         assertEvent(
-            eventLogs,
-            0,
             BridgeEvents.LOCK_BTC.getEvent(),
             new Object[]{RSK_ADDRESS.toString()},
             new Object[]{BTC_TRANSACTION.getHash().getBytes(), senderAddress.toString(), amount.getValue()}
@@ -109,11 +109,9 @@ class BridgeEventLoggerImplTest {
         // Act
         eventLogger.logLockBtc(RSK_ADDRESS, BTC_TRANSACTION, senderAddress, amount);
 
-        commonAssertLogs(eventLogs);
-        assertTopics(2, eventLogs);
+        commonAssertLogs();
+        assertTopics(2);
         assertEvent(
-            eventLogs,
-            0,
             BridgeEvents.LOCK_BTC.getEvent(),
             new Object[]{RSK_ADDRESS.toString()},
             new Object[]{BTC_TRANSACTION.getHash().getBytes(), "3L4zu4GWVVSfAWCPbP3RqkJUvxpiiQebPX", amount.getValue()}
@@ -135,7 +133,7 @@ class BridgeEventLoggerImplTest {
         CallTransaction.Function event = BridgeEvents.PEGIN_BTC.getEvent();
 
         // Assert address that made the log
-        assertEquals(PrecompiledContracts.BRIDGE_ADDR, new RskAddress(logResult.getAddress()));
+        assertEquals(BRIDGE_ADDRESS, new RskAddress(logResult.getAddress()));
 
         // Assert log topics
         assertEquals(3, logResult.getTopics().size());
@@ -158,11 +156,9 @@ class BridgeEventLoggerImplTest {
         // Act
         eventLogger.logUpdateCollections(tx);
 
-        commonAssertLogs(eventLogs);
-        assertTopics(1, eventLogs);
+        commonAssertLogs();
+        assertTopics(1);
         assertEvent(
-            eventLogs,
-            0,
             BridgeEvents.UPDATE_COLLECTIONS.getEvent(),
             new Object[]{},
             new Object[]{tx.getSender(signatureCache).toString()}
@@ -216,14 +212,14 @@ class BridgeEventLoggerImplTest {
         bridgeEventLogger.logAddSignature(federationMember, BTC_TRANSACTION, RSK_TX_HASH.getBytes());
 
         // Assert
-        commonAssertLogs(eventLogs);
-        assertTopics(3, eventLogs);
+        commonAssertLogs();
+        assertTopics(3);
 
         CallTransaction.Function bridgeEvent = BridgeEvents.ADD_SIGNATURE.getEvent();
         Object[] eventTopics = new Object[]{RSK_TX_HASH.getBytes(), expectedRskAddress.toString()};
         Object[] eventParams = new Object[]{federatorBtcPubKey.getPubKey()};
 
-        assertEvent(eventLogs, 0, bridgeEvent, eventTopics, eventParams);
+        assertEvent(bridgeEvent, eventTopics, eventParams);
     }
 
     @Test
@@ -231,11 +227,9 @@ class BridgeEventLoggerImplTest {
         // Act
         eventLogger.logReleaseBtc(BTC_TRANSACTION, RSK_TX_HASH.getBytes());
 
-        commonAssertLogs(eventLogs);
-        assertTopics(2, eventLogs);
+        commonAssertLogs();
+        assertTopics(2);
         assertEvent(
-            eventLogs,
-            0,
             BridgeEvents.RELEASE_BTC.getEvent(),
             new Object[]{RSK_TX_HASH.getBytes()},
             new Object[]{BTC_TRANSACTION.bitcoinSerialize()}
@@ -255,48 +249,17 @@ class BridgeEventLoggerImplTest {
         long federationActivationAgePostRskip383 = FEDERATION_CONSTANTS.getFederationActivationAge(allActivations);
 
         // Setup parameters for test method call
-        Instant creationTime = Instant.ofEpochMilli(15005L);
-        Block executionBlock = mock(Block.class);
-        when(executionBlock.getTimestamp()).thenReturn(15005L);
-        when(executionBlock.getNumber()).thenReturn(15L);
+        Block rskExecutionBlock = arrangeRskExecutionBlock();
+        long rskExecutionBlockNumber = rskExecutionBlock.getNumber();
 
-        List<BtcECKey> oldFederationKeys = Arrays.asList(
-            BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
-            BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")),
-            BtcECKey.fromPublicOnly(Hex.decode("025eefeeeed5cdc40822880c7db1d0a88b7b986945ed3fc05a0b45fe166fe85e12")),
-            BtcECKey.fromPublicOnly(Hex.decode("03c67ad63527012fd4776ae892b5dc8c56f80f1be002dc65cd520a2efb64e37b49"))
-        );
-
-        List<FederationMember> oldFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(oldFederationKeys);
-        NetworkParameters btcParams = BRIDGE_CONSTANTS.getBtcParams();
-        FederationArgs oldFedArgs = new FederationArgs(
-            oldFederationMembers,
-            creationTime,
-            15L,
-            btcParams
-        );
-
-        Federation oldFederation = FederationFactory.buildStandardMultiSigFederation(oldFedArgs);
-
-        List<BtcECKey> newFederationKeys = Arrays.asList(
-            BtcECKey.fromPublicOnly(Hex.decode("0346cb6b905e4dee49a862eeb2288217d06afcd4ace4b5ca77ebedfbc6afc1c19d")),
-            BtcECKey.fromPublicOnly(Hex.decode("0269a0dbe7b8f84d1b399103c466fb20531a56b1ad3a7b44fe419e74aad8c46db7")),
-            BtcECKey.fromPublicOnly(Hex.decode("026192d8ab41bd402eb0431457f6756a3f3ce15c955c534d2b87f1e0372d8ba338"))
-        );
-        List<FederationMember> newFederationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(newFederationKeys);
-        FederationArgs newFedArgs = new FederationArgs(
-            newFederationMembers,
-            creationTime,
-            15L,
-            btcParams
-        );
-
-        Federation newFederation = FederationFactory.buildStandardMultiSigFederation(newFedArgs);
+        Instant creationTime = Instant.ofEpochMilli(rskExecutionBlockNumber);
+        Federation oldFederation = getOldFederation(creationTime);
+        Federation newFederation = getNewFederation(creationTime);
 
         // Act
-        eventLogger.logCommitFederation(executionBlock, oldFederation, newFederation);
-        commonAssertLogs(eventLogs);
-        assertTopics(1, eventLogs);
+        eventLogger.logCommitFederation(rskExecutionBlock, oldFederation, newFederation);
+        commonAssertLogs();
+        assertTopics(1);
 
         // Assert log data
         byte[] oldFederationFlatPubKeys = flatKeysAsByteArray(oldFederation.getBtcPublicKeys());
@@ -304,8 +267,8 @@ class BridgeEventLoggerImplTest {
         byte[] newFederationFlatPubKeys = flatKeysAsByteArray(newFederation.getBtcPublicKeys());
         String newFederationBtcAddress = newFederation.getAddress().toBase58();
         long newFedActivationBlockNumber = isRSKIP383Active ?
-            executionBlock.getNumber() + federationActivationAgePostRskip383 :
-            executionBlock.getNumber() + federationActivationAgePreRskip383;
+            rskExecutionBlock.getNumber() + federationActivationAgePostRskip383 :
+            rskExecutionBlock.getNumber() + federationActivationAgePreRskip383;
 
         Object[] data = new Object[]{
             oldFederationFlatPubKeys,
@@ -317,7 +280,7 @@ class BridgeEventLoggerImplTest {
 
         CallTransaction.Function event = BridgeEvents.COMMIT_FEDERATION.getEvent();
         Object[] topics = {};
-        assertEvent(eventLogs, 0, event, topics, data);
+        assertEvent(event, topics, data);
 
         final LogInfo log = eventLogs.get(0);
         Object[] decodeEventData = event.decodeEventData(log.getData());
@@ -327,12 +290,58 @@ class BridgeEventLoggerImplTest {
 
         // assert fed activation has different values before and after RSKIP383 respectively
         if (isRSKIP383Active){
-            long legacyFedActivationBlockNumber = executionBlock.getNumber() + federationActivationAgePreRskip383;
+            long legacyFedActivationBlockNumber = rskExecutionBlockNumber + federationActivationAgePreRskip383;
             assertNotEquals(loggedFedActivationBlockNumber, legacyFedActivationBlockNumber);
         } else {
-            long defaultFedActivationBlockNumber = executionBlock.getNumber() + federationActivationAgePostRskip383;
+            long defaultFedActivationBlockNumber = rskExecutionBlockNumber + federationActivationAgePostRskip383;
             assertNotEquals(loggedFedActivationBlockNumber, defaultFedActivationBlockNumber);
         }
+    }
+
+    private Federation getOldFederation(Instant creationTime) {
+        List<BtcECKey> oldFederationKeys = Arrays.asList(
+            BtcECKey.fromPublicOnly(Hex.decode("036bb9eab797eadc8b697f0e82a01d01cabbfaaca37e5bafc06fdc6fdd38af894a")),
+            BtcECKey.fromPublicOnly(Hex.decode("031da807c71c2f303b7f409dd2605b297ac494a563be3b9ca5f52d95a43d183cc5")),
+            BtcECKey.fromPublicOnly(Hex.decode("025eefeeeed5cdc40822880c7db1d0a88b7b986945ed3fc05a0b45fe166fe85e12")),
+            BtcECKey.fromPublicOnly(Hex.decode("03c67ad63527012fd4776ae892b5dc8c56f80f1be002dc65cd520a2efb64e37b49"))
+        );
+
+        return getFederationFromBtcKeys(oldFederationKeys, creationTime);
+    }
+
+    private Federation getNewFederation(Instant creationTime) {
+        List<BtcECKey> newFederationKeys = Arrays.asList(
+            BtcECKey.fromPublicOnly(Hex.decode("0346cb6b905e4dee49a862eeb2288217d06afcd4ace4b5ca77ebedfbc6afc1c19d")),
+            BtcECKey.fromPublicOnly(Hex.decode("0269a0dbe7b8f84d1b399103c466fb20531a56b1ad3a7b44fe419e74aad8c46db7")),
+            BtcECKey.fromPublicOnly(Hex.decode("026192d8ab41bd402eb0431457f6756a3f3ce15c955c534d2b87f1e0372d8ba338"))
+        );
+
+        return getFederationFromBtcKeys(newFederationKeys, creationTime);
+    }
+
+    private Federation getFederationFromBtcKeys(List<BtcECKey> federationKeys, Instant creationTime) {
+        NetworkParameters btcParams = BRIDGE_CONSTANTS.getBtcParams();
+
+        List<FederationMember> federationMembers = FederationTestUtils.getFederationMembersWithBtcKeys(federationKeys);
+        FederationArgs federationArgs = new FederationArgs(
+            federationMembers,
+            creationTime,
+            15L,
+            btcParams
+        );
+
+        return FederationFactory.buildStandardMultiSigFederation(federationArgs);
+    }
+
+    private Block arrangeRskExecutionBlock() {
+        long rskExecutionBlockNumber = 15005L;
+        long rskExecutionBlockTimestamp = 15L;
+        BlockHeader blockHeader = new BlockHeaderBuilder(mock(ActivationConfig.class))
+            .setNumber(rskExecutionBlockNumber)
+            .setTimestamp(rskExecutionBlockTimestamp)
+            .build();
+
+        return Block.createBlockFromHeader(blockHeader, true);
     }
 
     @Test
@@ -341,11 +350,9 @@ class BridgeEventLoggerImplTest {
 
         eventLogger.logReleaseBtcRequested(RSK_TX_HASH.getBytes(), BTC_TRANSACTION, amount);
 
-        commonAssertLogs(eventLogs);
-        assertTopics(3, eventLogs);
+        commonAssertLogs();
+        assertTopics(3);
         assertEvent(
-            eventLogs,
-            0,
             BridgeEvents.RELEASE_REQUESTED.getEvent(),
             new Object[]{RSK_TX_HASH.getBytes(), BTC_TRANSACTION.getHash().getBytes()},
             new Object[]{amount.getValue()}
@@ -359,11 +366,11 @@ class BridgeEventLoggerImplTest {
         assertEquals(1, eventLogs.size());
         LogInfo entry = eventLogs.get(0);
 
-        assertEquals(PrecompiledContracts.BRIDGE_ADDR, new RskAddress(entry.getAddress()));
+        assertEquals(BRIDGE_ADDRESS, new RskAddress(entry.getAddress()));
 
         // Assert address that made the log
         LogInfo result = eventLogs.get(0);
-        assertArrayEquals(PrecompiledContracts.BRIDGE_ADDR.getBytes(), result.getAddress());
+        assertArrayEquals(BRIDGE_ADDRESS_SERIALIZED, result.getAddress());
 
         // Assert log topics
         assertEquals(2, result.getTopics().size());
@@ -387,11 +394,11 @@ class BridgeEventLoggerImplTest {
         assertEquals(1, eventLogs.size());
         LogInfo entry = eventLogs.get(0);
 
-        assertEquals(PrecompiledContracts.BRIDGE_ADDR, new RskAddress(entry.getAddress()));
+        assertEquals(BRIDGE_ADDRESS, new RskAddress(entry.getAddress()));
 
         // Assert address that made the log
         LogInfo result = eventLogs.get(0);
-        assertArrayEquals(PrecompiledContracts.BRIDGE_ADDR.getBytes(), result.getAddress());
+        assertArrayEquals(BRIDGE_ADDRESS_SERIALIZED, result.getAddress());
 
         // Assert log topics
         assertEquals(2, result.getTopics().size());
@@ -424,11 +431,9 @@ class BridgeEventLoggerImplTest {
 
         eventLogger.logReleaseBtcRequestReceived(RSK_ADDRESS.toString(), btcRecipientAddress, amount);
 
-        commonAssertLogs(eventLogs);
-        assertTopics(2, eventLogs);
+        commonAssertLogs();
+        assertTopics(2);
         assertEvent(
-            eventLogs,
-            0,
             BridgeEvents.RELEASE_REQUEST_RECEIVED_LEGACY.getEvent(),
             new Object[]{RSK_ADDRESS.toString()},
             new Object[]{btcRecipientAddress.getHash160(), amount.value}
@@ -446,11 +451,9 @@ class BridgeEventLoggerImplTest {
 
         eventLogger.logReleaseBtcRequestReceived(RSK_ADDRESS.toString(), btcRecipientAddress, amount);
 
-        commonAssertLogs(eventLogs);
-        assertTopics(2, eventLogs);
+        commonAssertLogs();
+        assertTopics(2);
         assertEvent(
-            eventLogs,
-            0,
             BridgeEvents.RELEASE_REQUEST_RECEIVED.getEvent(),
             new Object[]{RSK_ADDRESS.toString()},
             new Object[]{btcRecipientAddress.toString(), amount.value}
@@ -464,11 +467,9 @@ class BridgeEventLoggerImplTest {
 
         eventLogger.logReleaseBtcRequestRejected(RSK_ADDRESS.toString(), amount, reason);
 
-        commonAssertLogs(eventLogs);
-        assertTopics(2, eventLogs);
+        commonAssertLogs();
+        assertTopics(2);
         assertEvent(
-            eventLogs,
-            0,
             BridgeEvents.RELEASE_REQUEST_REJECTED.getEvent(),
             new Object[]{RSK_ADDRESS.toString()},
             new Object[]{amount.value, reason.getValue()}
@@ -485,11 +486,9 @@ class BridgeEventLoggerImplTest {
 
         eventLogger.logBatchPegoutCreated(BTC_TRANSACTION.getHash(), rskTxHashes);
 
-        commonAssertLogs(eventLogs);
-        assertTopics(2, eventLogs);
+        commonAssertLogs();
+        assertTopics(2);
         assertEvent(
-            eventLogs,
-            0,
             BridgeEvents.BATCH_PEGOUT_CREATED.getEvent(),
             new Object[]{BTC_TRANSACTION.getHash().getBytes()},
             new Object[]{serializeRskTxHashes(rskTxHashes)}
@@ -516,11 +515,9 @@ class BridgeEventLoggerImplTest {
         BTC_TRANSACTION.setWitness(0, txWitness);
         eventLogger.logBatchPegoutCreated(BTC_TRANSACTION.getHash(true), rskTxHashes);
 
-        commonAssertLogs(eventLogs);
-        assertTopics(2, eventLogs);
+        commonAssertLogs();
+        assertTopics(2);
         assertEvent(
-            eventLogs,
-            0,
             BridgeEvents.BATCH_PEGOUT_CREATED.getEvent(),
             new Object[]{BTC_TRANSACTION.getHash(true).getBytes()},
             new Object[]{serializeRskTxHashes(rskTxHashes)}
@@ -532,11 +529,9 @@ class BridgeEventLoggerImplTest {
         long pegoutCreationRskBlockNumber = 50;
         eventLogger.logPegoutConfirmed(BTC_TRANSACTION.getHash(), pegoutCreationRskBlockNumber);
 
-        commonAssertLogs(eventLogs);
-        assertTopics(2, eventLogs);
+        commonAssertLogs();
+        assertTopics(2);
         assertEvent(
-            eventLogs,
-            0,
             BridgeEvents.PEGOUT_CONFIRMED.getEvent(),
             new Object[]{BTC_TRANSACTION.getHash().getBytes()},
             new Object[]{pegoutCreationRskBlockNumber}
@@ -559,15 +554,14 @@ class BridgeEventLoggerImplTest {
     @MethodSource("logPegoutTransactionCreatedValidArgProvider")
     void logPegoutTransactionCreated_ok(Sha256Hash btcTxHash, List<Coin> outpointValues) {
         eventLogger.logPegoutTransactionCreated(btcTxHash, outpointValues);
-        commonAssertLogs(eventLogs);
+        commonAssertLogs();
 
-        assertTopics(2, eventLogs);
+        assertTopics(2);
 
-        int index = 0;
         Function expectedEvent = BridgeEvents.PEGOUT_TRANSACTION_CREATED.getEvent();
         Object[] topics = {btcTxHash.getBytes()};
         Object[] params = {UtxoUtils.encodeOutpointValues(outpointValues)};
-        assertEvent(eventLogs, index, expectedEvent, topics, params);
+        assertEvent(expectedEvent, topics, params);
     }
 
     private static Stream<Arguments> logPegoutTransactionCreatedInvalidArgProvider() {
@@ -591,29 +585,37 @@ class BridgeEventLoggerImplTest {
     /**********************************
      *  -------     UTILS     ------- *
      *********************************/
-    private static void assertEvent(List<LogInfo> logs, int index, CallTransaction.Function event, Object[] topics, Object[] params) {
-        final LogInfo log = logs.get(index);
-        assertEquals(LogInfo.byteArrayToList(event.encodeEventTopics(topics)), log.getTopics());
-        assertArrayEquals(event.encodeEventData(params), log.getData());
+    private void assertEvent(CallTransaction.Function event, Object[] topics, Object[] data) {
+        LogInfo log = eventLogs.get(0);
+
+        byte[][] expectedEventTopicsSerialized = event.encodeEventTopics(topics);
+        List<DataWord> expectedEventTopics = LogInfo.byteArrayToList(expectedEventTopicsSerialized);
+        assertEquals(expectedEventTopics, log.getTopics());
+        
+        byte[] expectedEventData = event.encodeEventData(data);
+        assertArrayEquals(expectedEventData, log.getData());
     }
 
-    private void assertTopics(int topics, List<LogInfo> logs) {
-        assertEquals(topics, logs.get(0).getTopics().size());
+    private void assertTopics(int expectedTopicsSize) {
+        int topicsSize = eventLogs.get(0).getTopics().size();
+
+        assertEquals(expectedTopicsSize, topicsSize);
     }
 
-    private void commonAssertLogs(List<LogInfo> logs) {
-        assertEquals(1, logs.size());
-        LogInfo entry = logs.get(0);
+    private void commonAssertLogs() {
+        assertEquals(1, eventLogs.size());
 
         // Assert address that made the log
-        assertEquals(PrecompiledContracts.BRIDGE_ADDR, new RskAddress(entry.getAddress()));
-        assertArrayEquals(PrecompiledContracts.BRIDGE_ADDR.getBytes(), entry.getAddress());
+        LogInfo entry = eventLogs.get(0);
+        byte[] entryAddressSerialized = entry.getAddress();
+        assertArrayEquals(BRIDGE_ADDRESS_SERIALIZED, entryAddressSerialized);
+        assertEquals(BRIDGE_ADDRESS, new RskAddress(entryAddressSerialized));
     }
 
     private byte[] serializeRskTxHashes(List<Keccak256> rskTxHashes) {
         List<byte[]> rskTxHashesList = rskTxHashes.stream()
             .map(Keccak256::getBytes)
-            .collect(Collectors.toList());
+            .toList();
         int rskTxHashesLength = rskTxHashesList.stream().mapToInt(key -> key.length).sum();
 
         byte[] serializedRskTxHashes = new byte[rskTxHashesLength];


### PR DESCRIPTION
**Background**

Since the `commitFederation` event was emitted at the beginning of the validation process, its failure means that we have to emit a new event to inform it with transparency.
A new `commitFederationFailed` event has to be created to be emitted if the validation is a failure.

In this PR:
- Create a new `commitFederationFailed`(bytes proposedFederationRedeemScript, uint blockNumber) to be emitted when concluding the validation was a failure, logging the redeem script of the proposed federation and the block number where this took place