### PR TITLE
Add missing empty p2sh input script to svp spend transaction

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1083,13 +1083,15 @@ public class BridgeSupport {
         Script proposedFederationRedeemScript = proposedFederation.getRedeemScript();
         Script proposedFederationOutputScript = proposedFederation.getP2SHScript();
         addInputFromMatchingOutputScript(svpSpendTransaction, svpFundTxSigned, proposedFederationOutputScript);
-        addEmptyP2SHInputScript(svpSpendTransaction.getInput(0), proposedFederationRedeemScript);
+        svpSpendTransaction.getInput(0)
+            .setScriptSig(createBaseP2SHInputScriptThatSpendsFromRedeemScript(proposedFederationRedeemScript));
 
         Script flyoverRedeemScript =
             getFlyoverRedeemScript(bridgeConstants.getProposedFederationFlyoverPrefix(), proposedFederationRedeemScript);
         Script flyoverOutputScript = ScriptBuilder.createP2SHOutputScript(flyoverRedeemScript);
         addInputFromMatchingOutputScript(svpSpendTransaction, svpFundTxSigned, flyoverOutputScript);
-        addEmptyP2SHInputScript(svpSpendTransaction.getInput(1), flyoverRedeemScript);
+        svpSpendTransaction.getInput(1)
+                .setScriptSig(createBaseP2SHInputScriptThatSpendsFromRedeemScript(flyoverRedeemScript));
     }
 
     private Coin calculateSvpSpendTxAmount(Federation proposedFederation) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -18,11 +18,10 @@
 package co.rsk.peg;
 
 import static co.rsk.peg.BridgeUtils.calculatePegoutTxSize;
-import static co.rsk.peg.PegUtils.getFlyoverAddress;
 import static co.rsk.peg.BridgeUtils.getRegularPegoutTxSize;
-import static co.rsk.peg.PegUtils.getFlyoverScriptPubKey;
+import static co.rsk.peg.PegUtils.*;
 import static co.rsk.peg.ReleaseTransactionBuilder.BTC_TX_VERSION_2;
-import static co.rsk.peg.bitcoin.BitcoinUtils.addInputFromMatchingOutputScript;
+import static co.rsk.peg.bitcoin.BitcoinUtils.*;
 import static co.rsk.peg.bitcoin.UtxoUtils.extractOutpointValues;
 import static co.rsk.peg.pegin.RejectedPeginReason.INVALID_AMOUNT;
 import static java.util.Objects.isNull;
@@ -1081,11 +1080,16 @@ public class BridgeSupport {
     }
 
     private void addSvpSpendTransactionInputs(BtcTransaction svpSpendTransaction, BtcTransaction svpFundTxSigned, Federation proposedFederation) {
+        Script proposedFederationRedeemScript = proposedFederation.getRedeemScript();
         Script proposedFederationOutputScript = proposedFederation.getP2SHScript();
         addInputFromMatchingOutputScript(svpSpendTransaction, svpFundTxSigned, proposedFederationOutputScript);
+        addEmptyP2SHInputScript(svpSpendTransaction.getInput(0), proposedFederationRedeemScript);
 
-        Script flyoverProposedFederationOutputScript = getFlyoverScriptPubKey(bridgeConstants.getProposedFederationFlyoverPrefix(), proposedFederation.getRedeemScript());
-        addInputFromMatchingOutputScript(svpSpendTransaction, svpFundTxSigned, flyoverProposedFederationOutputScript);
+        Script flyoverRedeemScript =
+            getFlyoverRedeemScript(bridgeConstants.getProposedFederationFlyoverPrefix(), proposedFederationRedeemScript);
+        Script flyoverOutputScript = ScriptBuilder.createP2SHOutputScript(flyoverRedeemScript);
+        addInputFromMatchingOutputScript(svpSpendTransaction, svpFundTxSigned, flyoverOutputScript);
+        addEmptyP2SHInputScript(svpSpendTransaction.getInput(1), flyoverRedeemScript);
     }
 
     private Coin calculateSvpSpendTxAmount(Federation proposedFederation) {

--- a/rskj-core/src/main/java/co/rsk/peg/PegUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/PegUtils.java
@@ -199,16 +199,16 @@ public class PegUtils {
 
     public static Address getFlyoverAddress(NetworkParameters networkParameters, Keccak256 flyoverDerivationHash, Script redeemScript) {
         Script flyoverScriptPubKey = getFlyoverScriptPubKey(flyoverDerivationHash, redeemScript);
-
         return Address.fromP2SHScript(networkParameters, flyoverScriptPubKey);
     }
 
     public static Script getFlyoverScriptPubKey(Keccak256 flyoverDerivationHash, Script redeemScript) {
-        Script flyoverRedeemScript = FlyoverRedeemScriptBuilderImpl.builder().of(
-            flyoverDerivationHash,
-            redeemScript
-        );
-
+        Script flyoverRedeemScript = getFlyoverRedeemScript(flyoverDerivationHash, redeemScript);
         return ScriptBuilder.createP2SHOutputScript(flyoverRedeemScript);
+    }
+
+    public static Script getFlyoverRedeemScript(Keccak256 flyoverDerivationHash, Script redeemScript) {
+        return FlyoverRedeemScriptBuilderImpl.builder()
+            .of(flyoverDerivationHash, redeemScript);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
@@ -85,6 +85,13 @@ public class BitcoinUtils {
             .ifPresent(transaction::addInput);
     }
 
+    public static void addEmptyP2SHInputScript(TransactionInput input, Script redeemScript) {
+        Script outputScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
+        Script emptyInputScript = outputScript.createEmptyInputScript(null, redeemScript);
+
+        input.setScriptSig(emptyInputScript);
+    }
+
     public static Optional<TransactionOutput> searchForOutput(List<TransactionOutput> transactionOutputs, Script outputScriptPubKey) {
         return transactionOutputs.stream()
             .filter(output -> output.getScriptPubKey().equals(outputScriptPubKey))

--- a/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
@@ -85,11 +85,9 @@ public class BitcoinUtils {
             .ifPresent(transaction::addInput);
     }
 
-    public static void addEmptyP2SHInputScript(TransactionInput input, Script redeemScript) {
+    public static Script createBaseP2SHInputScriptThatSpendsFromRedeemScript(Script redeemScript) {
         Script outputScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
-        Script emptyInputScript = outputScript.createEmptyInputScript(null, redeemScript);
-
-        input.setScriptSig(emptyInputScript);
+        return outputScript.createEmptyInputScript(null, redeemScript);
     }
 
     public static Optional<TransactionOutput> searchForOutput(List<TransactionOutput> transactionOutputs, Script outputScriptPubKey) {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
@@ -32,6 +32,7 @@ import java.util.*;
 import java.util.stream.IntStream;
 
 import static co.rsk.peg.BridgeSupportTestUtil.*;
+import static co.rsk.peg.bitcoin.BitcoinUtils.createBaseP2SHInputScriptThatSpendsFromRedeemScript;
 import static co.rsk.peg.bitcoin.BitcoinUtils.searchForOutput;
 import static co.rsk.peg.bitcoin.UtxoUtils.extractOutpointValues;
 import static org.junit.jupiter.api.Assertions.*;
@@ -657,9 +658,11 @@ public class BridgeSupportSvpTest {
         // we need to add an input that we can actually sign,
         // and we know the private keys for the following scriptSig
         Federation federation = P2shErpFederationBuilder.builder().build();
-        Script scriptSig = federation.getP2SHScript().createEmptyInputScript(null, federation.getRedeemScript());
-
-        transaction.addInput(parentTxHash, 0, scriptSig);
+        transaction.addInput(
+            parentTxHash,
+            0,
+            createBaseP2SHInputScriptThatSpendsFromRedeemScript(federation.getRedeemScript())
+        );
     }
 
     private void signInputs(BtcTransaction transaction) {

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsTest.java
@@ -29,8 +29,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static co.rsk.peg.PegTestUtils.createFederation;
-import static co.rsk.peg.PegUtils.getFlyoverAddress;
-import static co.rsk.peg.PegUtils.getFlyoverScriptPubKey;
+import static co.rsk.peg.PegUtils.*;
 import static co.rsk.peg.federation.FederationTestUtils.createP2shErpFederation;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
@@ -64,6 +63,14 @@ class PegUtilsTest {
             new String[]{"fa01", "fa02", "fa03", "fa04", "fa05"}, true
         );
         activeFederation = createP2shErpFederation(federationMainNetConstants, activeFedSigners);
+    }
+
+    @ParameterizedTest
+    @MethodSource("derivationHashAndRedeemScriptArgs")
+    void getFlyoverRedeemScript_fromRealValues_shouldReturnSameRealRedeemScript(Keccak256 flyoverDerivationHash, Script redeemScript) {
+        Script flyoverRedeemScript = new Script(Hex.decode("20fc2bb93810d3d2332fed0b291c03822100a813eceaa0665896e0c82a8d50043975645521020ace50bab1230f8002a0bfe619482af74b338cc9e4c956add228df47e6adae1c21025093f439fb8006fd29ab56605ffec9cdc840d16d2361004e1337a2f86d8bd2db210275d473555de2733c47125f9702b0f870df1d817379f5587f09b6c40ed2c6c9492102a95f095d0ce8cb3b9bf70cc837e3ebe1d107959b1fa3f9b2d8f33446f9c8cbdb2103250c11be0561b1d7ae168b1f59e39cbc1fd1ba3cf4d2140c1a365b2723a2bf9321034851379ec6b8a701bd3eef8a0e2b119abb4bdde7532a3d6bcbff291b0daf3f25210350179f143a632ce4e6ac9a755b82f7f4266cfebb116a42cadb104c2c2a3350f92103b04fbd87ef5e2c0946a684c8c93950301a45943bbe56d979602038698facf9032103b58a5da144f5abab2e03e414ad044b732300de52fa25c672a7f7b3588877190659ae670350cd00b275532102370a9838e4d15708ad14a104ee5606b36caaaaf739d833e67770ce9fd9b3ec80210257c293086c4d4fe8943deda5f890a37d11bebd140e220faa76258a41d077b4d42103c2660a46aa73078ee6016dee953488566426cf55fc8011edd0085634d75395f92103cd3e383ec6e12719a6c69515e5559bcbe037d0aa24c187e1e26ce932e22ad7b354ae68"));
+
+        assertEquals(flyoverRedeemScript, getFlyoverRedeemScript(flyoverDerivationHash, redeemScript));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
The empty input script has to be added for every svp spend tx input.