### PR TITLE
Feat/create commit federation failed event 2

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeEvents.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeEvents.java
@@ -62,7 +62,7 @@ public enum BridgeEvents {
     ),
     COMMIT_FEDERATION_FAILED("commit_federation_failed",
         new CallTransaction.Param[]{
-            new CallTransaction.Param(false, "proposedFederationRedeemScriptSerialized", SolidityType.getType(SolidityType.BYTES)),
+            new CallTransaction.Param(false, "proposedFederationRedeemScript", SolidityType.getType(SolidityType.BYTES)),
             new CallTransaction.Param(false, "blockNumber", SolidityType.getType(SolidityType.INT256))
         }
     ),

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeEvents.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeEvents.java
@@ -113,8 +113,8 @@ public enum BridgeEvents {
         }
     );
 
-    private String eventName;
-    private CallTransaction.Param[] params;
+    private final String eventName;
+    private final CallTransaction.Param[] params;
 
     BridgeEvents(String eventName, CallTransaction.Param[] params) {
         this.eventName = eventName;

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeEvents.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeEvents.java
@@ -60,6 +60,12 @@ public enum BridgeEvents {
                     new CallTransaction.Param(false, "activationHeight", SolidityType.getType(SolidityType.INT256))
             }
     ),
+    COMMIT_FEDERATION_FAILED("commit_federation_failed",
+        new CallTransaction.Param[]{
+            new CallTransaction.Param(false, "proposedFederationRedeemScriptSerialized", SolidityType.getType(SolidityType.BYTES)),
+            new CallTransaction.Param(false, "blockNumber", SolidityType.getType(SolidityType.INT256))
+        }
+    ),
     RELEASE_REQUESTED("release_requested",
             new CallTransaction.Param[]{
                     new CallTransaction.Param(true, "rskTxHash", SolidityType.getType(SolidityType.BYTES32)),

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
@@ -42,6 +42,8 @@ public interface BridgeEventLogger {
 
     void logCommitFederation(Block executionBlock, Federation oldFederation, Federation newFederation);
 
+    void logCommitFederationFailure(Block executionBlock, Federation proposedFederation);
+
     default void logLockBtc(RskAddress rskReceiver, BtcTransaction btcTx, Address senderBtcAddress, Coin amount) {
         throw new UnsupportedOperationException();
     }

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -144,6 +144,24 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
     }
 
     @Override
+    public void logCommitFederationFailure(Block executionBlock, Federation proposedFederation) {
+        CallTransaction.Function event = BridgeEvents.COMMIT_FEDERATION_FAILED.getEvent();
+
+        byte[][] encodedTopicsSerialized = event.encodeEventTopics();
+        List<DataWord> encodedTopics = getEncodedTopics(encodedTopicsSerialized);
+
+        byte[] proposedFederationRedeemScriptSerialized = proposedFederation.getRedeemScript().getProgram();
+        long executionBlockNumber = executionBlock.getNumber();
+
+        byte[] encodedData = event.encodeEventData(
+            proposedFederationRedeemScriptSerialized,
+            executionBlockNumber
+        );
+
+        addLog(encodedTopics, encodedData);
+    }
+
+    @Override
     public void logLockBtc(RskAddress receiver, BtcTransaction btcTx, Address senderBtcAddress, Coin amount) {
         CallTransaction.Function event = BridgeEvents.LOCK_BTC.getEvent();
 

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BrigeEventLoggerLegacyImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BrigeEventLoggerLegacyImpl.java
@@ -39,7 +39,6 @@ import org.ethereum.vm.PrecompiledContracts;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Responsible for logging events triggered by BridgeContract in RLP format.
@@ -66,7 +65,7 @@ public class BrigeEventLoggerLegacyImpl implements BridgeEventLogger {
     public void logUpdateCollections(RskAddress sender) {
         if (activations.isActive(ConsensusRule.RSKIP146)) {
             throw new DeprecatedMethodCallException(
-                "Calling BrigeEventLoggerLegacyImpl.logUpdateCollections method after RSKIP146 activation"
+                "Calling BridgeEventLoggerLegacyImpl.logUpdateCollections method after RSKIP146 activation"
             );
         }
         this.logs.add(
@@ -81,7 +80,7 @@ public class BrigeEventLoggerLegacyImpl implements BridgeEventLogger {
     public void logAddSignature(FederationMember federationMember, BtcTransaction btcTx, byte[] rskTxHash) {
         if (activations.isActive(ConsensusRule.RSKIP146)) {
             throw new DeprecatedMethodCallException(
-                "Calling BrigeEventLoggerLegacyImpl.logAddSignature method after RSKIP146 activation"
+                "Calling BridgeEventLoggerLegacyImpl.logAddSignature method after RSKIP146 activation"
             );
         }
         List<DataWord> topics = Collections.singletonList(Bridge.ADD_SIGNATURE_TOPIC);
@@ -96,7 +95,7 @@ public class BrigeEventLoggerLegacyImpl implements BridgeEventLogger {
     public void logReleaseBtc(BtcTransaction btcTx, byte[] rskTxHash) {
         if (activations.isActive(ConsensusRule.RSKIP146)) {
             throw new DeprecatedMethodCallException(
-                "Calling BrigeEventLoggerLegacyImpl.logReleaseBtc method after RSKIP146 activation"
+                "Calling BridgeEventLoggerLegacyImpl.logReleaseBtc method after RSKIP146 activation"
             );
         }
         List<DataWord> topics = Collections.singletonList(Bridge.RELEASE_BTC_TOPIC);
@@ -109,7 +108,7 @@ public class BrigeEventLoggerLegacyImpl implements BridgeEventLogger {
     public void logCommitFederation(Block executionBlock, Federation oldFederation, Federation newFederation) {
         if (activations.isActive(ConsensusRule.RSKIP146)) {
             throw new DeprecatedMethodCallException(
-                "Calling BrigeEventLoggerLegacyImpl.logCommitFederation method after RSKIP146 activation"
+                "Calling BridgeEventLoggerLegacyImpl.logCommitFederation method after RSKIP146 activation"
             );
         }
         List<DataWord> topics = Collections.singletonList(Bridge.COMMIT_FEDERATION_TOPIC);
@@ -128,6 +127,13 @@ public class BrigeEventLoggerLegacyImpl implements BridgeEventLogger {
         this.logs.add(new LogInfo(BRIDGE_CONTRACT_ADDRESS, topics, data));
     }
 
+    @Override
+    public void logCommitFederationFailure(Block executionBlock, Federation proposedFederation) {
+        throw new UnsupportedOperationException(
+            "Calling BridgeEventLoggerLegacyImpl.logCommitFederationFailure is not allowed, since this event was created after deprecating the class."
+        );
+    }
+
     private byte[] flatKeysAsRlpCollection(List<BtcECKey> keys) {
         return flatKeys(keys, (k -> RLP.encodeElement(k.getPubKey())));
     }
@@ -135,7 +141,7 @@ public class BrigeEventLoggerLegacyImpl implements BridgeEventLogger {
     private byte[] flatKeys(List<BtcECKey> keys, Function<BtcECKey, byte[]> parser) {
         List<byte[]> pubKeys = keys.stream()
             .map(parser)
-            .collect(Collectors.toList());
+            .toList();
         int pubKeysLength = pubKeys.stream().mapToInt(key -> key.length).sum();
 
         byte[] flatPubKeys = new byte[pubKeysLength];

--- a/rskj-core/src/test/java/co/rsk/RskTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/RskTestUtils.java
@@ -1,17 +1,17 @@
 package co.rsk;
 
+import static org.mockito.Mockito.mock;
+
 import co.rsk.crypto.Keccak256;
-import org.ethereum.config.blockchain.upgrades.ActivationConfig;
-import org.ethereum.core.Block;
-import org.ethereum.core.BlockHeader;
-import org.ethereum.core.BlockHeaderBuilder;
-import org.ethereum.crypto.ECKey;
-import org.ethereum.crypto.HashUtil;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
-
-import static org.mockito.Mockito.mock;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.core.*;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.crypto.HashUtil;
 
 public class RskTestUtils {
 
@@ -34,10 +34,17 @@ public class RskTestUtils {
             .toList();
     }
 
-    public static Block createRskExecutionBlock(long rskExecutionBlockNumber, long rskExecutionBlockTimestamp) {
+    public static Block createRskBlock() {
+        final int defaultBlockNumber = 1001;
+        final Instant defaultBlockTimestamp = ZonedDateTime.parse("2020-01-20T12:00:08.400Z").toInstant();
+
+        return createRskBlock(defaultBlockNumber, defaultBlockTimestamp.toEpochMilli());
+    }
+
+    public static Block createRskBlock(long blockNumber, long blockTimestamp) {
         BlockHeader blockHeader = new BlockHeaderBuilder(mock(ActivationConfig.class))
-            .setNumber(rskExecutionBlockNumber)
-            .setTimestamp(rskExecutionBlockTimestamp)
+            .setNumber(blockNumber)
+            .setTimestamp(blockTimestamp)
             .build();
 
         return Block.createBlockFromHeader(blockHeader, true);

--- a/rskj-core/src/test/java/co/rsk/RskTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/RskTestUtils.java
@@ -1,11 +1,17 @@
 package co.rsk;
 
 import co.rsk.crypto.Keccak256;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockHeader;
+import org.ethereum.core.BlockHeaderBuilder;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
+
+import static org.mockito.Mockito.mock;
 
 public class RskTestUtils {
 
@@ -26,5 +32,14 @@ public class RskTestUtils {
         return Arrays.stream(seeds)
             .map(RskTestUtils::getEcKeyFromSeed)
             .toList();
+    }
+
+    public static Block createRskExecutionBlock(long rskExecutionBlockNumber, long rskExecutionBlockTimestamp) {
+        BlockHeader blockHeader = new BlockHeaderBuilder(mock(ActivationConfig.class))
+            .setNumber(rskExecutionBlockNumber)
+            .setTimestamp(rskExecutionBlockTimestamp)
+            .build();
+
+        return Block.createBlockFromHeader(blockHeader, true);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
@@ -17,10 +17,10 @@
  */
 package co.rsk.peg.utils;
 
+import static co.rsk.RskTestUtils.createRskExecutionBlock;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.coinListOf;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.flatKeysAsByteArray;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
 
 import co.rsk.RskTestUtils;
 import co.rsk.bitcoinj.core.*;
@@ -352,12 +352,7 @@ class BridgeEventLoggerImplTest {
     private Block arrangeRskExecutionBlock() {
         long rskExecutionBlockNumber = 15005L;
         long rskExecutionBlockTimestamp = 15L;
-        BlockHeader blockHeader = new BlockHeaderBuilder(mock(ActivationConfig.class))
-            .setNumber(rskExecutionBlockNumber)
-            .setTimestamp(rskExecutionBlockTimestamp)
-            .build();
-
-        return Block.createBlockFromHeader(blockHeader, true);
+        return createRskExecutionBlock(rskExecutionBlockNumber, rskExecutionBlockTimestamp);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
@@ -17,7 +17,7 @@
  */
 package co.rsk.peg.utils;
 
-import static co.rsk.RskTestUtils.createRskExecutionBlock;
+import static co.rsk.RskTestUtils.createRskBlock;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.coinListOf;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.flatKeysAsByteArray;
 import static org.junit.jupiter.api.Assertions.*;
@@ -352,7 +352,7 @@ class BridgeEventLoggerImplTest {
     private Block arrangeRskExecutionBlock() {
         long rskExecutionBlockNumber = 15005L;
         long rskExecutionBlockTimestamp = 15L;
-        return createRskExecutionBlock(rskExecutionBlockNumber, rskExecutionBlockTimestamp);
+        return createRskBlock(rskExecutionBlockNumber, rskExecutionBlockTimestamp);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
@@ -334,8 +334,8 @@ class BridgeEventLoggerImplTest {
         byte[] proposedFederationRedeemScriptSerialized = proposedFederation.getRedeemScript().getProgram();
 
         CallTransaction.Function event = BridgeEvents.COMMIT_FEDERATION_FAILED.getEvent();
-        Object[] topics = {};
-        Object[] data = new Object[]{
+        var topics = new Object[]{};
+        var data = new Object[]{
             proposedFederationRedeemScriptSerialized,
             executionBlockNumber
         };

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
@@ -324,6 +324,31 @@ class BridgeEventLoggerImplTest {
         return FederationFactory.buildStandardMultiSigFederation(federationArgs);
     }
 
+    @Test
+    void logCommitFederationFailed() {
+        // arrange
+        Block rskExecutionBlock = arrangeRskExecutionBlock();
+        long executionBlockNumber = rskExecutionBlock.getNumber();
+
+        Federation proposedFederation = P2shErpFederationBuilder.builder().build();
+        byte[] proposedFederationRedeemScriptSerialized = proposedFederation.getRedeemScript().getProgram();
+
+        CallTransaction.Function event = BridgeEvents.COMMIT_FEDERATION_FAILED.getEvent();
+        Object[] topics = {};
+        Object[] data = new Object[]{
+            proposedFederationRedeemScriptSerialized,
+            executionBlockNumber
+        };
+
+        // act
+        eventLogger.logCommitFederationFailure(rskExecutionBlock, proposedFederation);
+
+        // assert
+        commonAssertLogs();
+        assertTopics(1);
+        assertEvent(event, topics, data);
+    }
+
     private Block arrangeRskExecutionBlock() {
         long rskExecutionBlockNumber = 15005L;
         long rskExecutionBlockTimestamp = 15L;

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerLegacyImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerLegacyImplTest.java
@@ -29,6 +29,7 @@ import co.rsk.peg.PegTestUtils;
 import co.rsk.peg.federation.constants.FederationConstants;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.*;
 import org.ethereum.util.RLP;
@@ -282,6 +283,15 @@ class BridgeEventLoggerLegacyImplTest {
 
         // Act
         assertThrows(DeprecatedMethodCallException.class, () -> eventLogger.logCommitFederation(mock(Block.class), mock(Federation.class), mock(Federation.class)));
+    }
+
+    @Test
+    void testLogCommitFederationFailure_throwsUnsupportedOperationException() {
+        // Setup event logger
+        activations = ActivationConfigsForTest.all().forBlock(0);
+
+        // Act
+        assertThrows(UnsupportedOperationException.class, () -> eventLogger.logCommitFederationFailure(mock(Block.class), mock(Federation.class)));
     }
 
     /**********************************


### PR DESCRIPTION
**Background**

Since the `commitFederation` event was emitted at the beginning of the validation process, its failure means that we have to emit a new event to inform it with transparency.
A new `commitFederationFailed` event has to be created to be emitted if the validation is a failure.


_In this PR_
Create a new `commitFederationFailed(bytes proposedFederationRedeemScript, uint blockNumber)` to be emitted when concluding the validation was a failure, logging the redeem script of the proposed federation and the block number where this took place