### PR TITLE
Feat/add svp spend tx signature

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1575,7 +1575,7 @@ public class BridgeSupport {
      * @param rskTxHashSerialized            The id of the rsk tx
      */
     public void addSignature(BtcECKey federatorBtcPublicKey, List<byte[]> signatures, byte[] rskTxHashSerialized) throws Exception {
-        if (signatures.isEmpty()) {
+        if (signatures == null || signatures.isEmpty()) {
             return;
         }
 

--- a/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
@@ -97,17 +97,7 @@ public class BitcoinUtils {
             .findFirst();
     }
 
-    public static List<Sha256Hash> generateTransactionInputsSigHashes(BtcTransaction btcTx) {
-        List<Sha256Hash> sigHashes = new ArrayList<>();
-        List<TransactionInput> inputs = btcTx.getInputs();
-        for (TransactionInput input : inputs) {
-            Sha256Hash sigHash = generateSigHashForP2SHInput(btcTx, inputs.indexOf(input));
-            sigHashes.add(sigHash);
-        }
-        return sigHashes;
-    }
-
-    private static Sha256Hash generateSigHashForP2SHInput(BtcTransaction btcTx, int inputIndex) {
+    public static Sha256Hash generateSigHashForP2SHInput(BtcTransaction btcTx, int inputIndex) {
         TransactionInput input = btcTx.getInput(inputIndex);
         Optional<Script> redeemScript = extractRedeemScriptFromInput(input);
         if (redeemScript.isEmpty()) {

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -31,8 +31,6 @@ import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.Block;
 import org.ethereum.core.CallTransaction;
-import org.ethereum.core.SignatureCache;
-import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
@@ -72,13 +70,14 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
 
     @Override
     public void logAddSignature(FederationMember federationMember, BtcTransaction btcTx, byte[] rskTxHash) {
-        ECKey federatorPublicKey = getFederatorPublicKey(federationMember);
-        String federatorRskAddress = ByteUtil.toHexString(federatorPublicKey.getAddress());
+        ECKey federatorRskPublicKey = getFederatorRskPublicKey(federationMember);
+        String federatorRskAddress = ByteUtil.toHexString(federatorRskPublicKey.getAddress());
+        BtcECKey federatorBtcPublicKey = federationMember.getBtcPublicKey();
 
-        logAddSignatureInSolidityFormat(rskTxHash, federatorRskAddress, federationMember.getBtcPublicKey());
+        logAddSignatureInSolidityFormat(rskTxHash, federatorRskAddress, federatorBtcPublicKey);
     }
 
-    private ECKey getFederatorPublicKey(FederationMember federationMember) {
+    private ECKey getFederatorRskPublicKey(FederationMember federationMember) {
         if (!shouldUseRskPublicKey()) {
             return ECKey.fromPublicOnly(federationMember.getBtcPublicKey().getPubKey());
         }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
@@ -136,11 +136,11 @@ class BridgeSupportAddSignatureTest {
 
         bridgeSupport.addSignature(
             BtcECKey.fromPrivate(Hex.decode("fa01")),
-            null,
+            new ArrayList<>(),
             createHash3(1).getBytes()
         );
 
-        verify(provider, times(1)).getPegoutsWaitingForSignatures();
+        verify(provider, times(0)).getPegoutsWaitingForSignatures();
     }
 
     @Test
@@ -203,11 +203,11 @@ class BridgeSupportAddSignatureTest {
 
         bridgeSupport.addSignature(
             BtcECKey.fromPrivate(Hex.decode("fa01")),
-            null,
+            new ArrayList<>(),
             createHash3(1).getBytes()
         );
 
-        verify(provider, times(1)).getPegoutsWaitingForSignatures();
+        verify(provider, times(0)).getPegoutsWaitingForSignatures();
     }
 
     @Test
@@ -270,7 +270,7 @@ class BridgeSupportAddSignatureTest {
 
         bridgeSupport.addSignature(
             BtcECKey.fromPrivate(Hex.decode("fa05")),
-            null,
+            new ArrayList<>(),
             createHash3(1).getBytes()
         );
 
@@ -292,7 +292,7 @@ class BridgeSupportAddSignatureTest {
 
         bridgeSupport.addSignature(
             BtcECKey.fromPrivate(Hex.decode("fa03")),
-            null,
+            new ArrayList<>(),
             createHash3(1).getBytes()
         );
 
@@ -323,7 +323,7 @@ class BridgeSupportAddSignatureTest {
 
         bridgeSupport.addSignature(
             genesisFederation.getBtcPublicKeys().get(0),
-            null,
+            new ArrayList<>(),
             BitcoinTestUtils.createHash(1).getBytes()
         );
         bridgeSupport.save();
@@ -354,7 +354,7 @@ class BridgeSupportAddSignatureTest {
 
         bridgeSupport.addSignature(
             new BtcECKey(),
-            null,
+            new ArrayList<>(),
             BitcoinTestUtils.createHash(1).getBytes()
         );
         bridgeSupport.save();

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
@@ -136,7 +136,7 @@ class BridgeSupportAddSignatureTest {
 
         bridgeSupport.addSignature(
             BtcECKey.fromPrivate(Hex.decode("fa01")),
-            new ArrayList<>(),
+            null,
             createHash3(1).getBytes()
         );
 
@@ -203,7 +203,7 @@ class BridgeSupportAddSignatureTest {
 
         bridgeSupport.addSignature(
             BtcECKey.fromPrivate(Hex.decode("fa01")),
-            new ArrayList<>(),
+            null,
             createHash3(1).getBytes()
         );
 
@@ -270,7 +270,7 @@ class BridgeSupportAddSignatureTest {
 
         bridgeSupport.addSignature(
             BtcECKey.fromPrivate(Hex.decode("fa05")),
-            new ArrayList<>(),
+            null,
             createHash3(1).getBytes()
         );
 
@@ -292,7 +292,7 @@ class BridgeSupportAddSignatureTest {
 
         bridgeSupport.addSignature(
             BtcECKey.fromPrivate(Hex.decode("fa03")),
-            new ArrayList<>(),
+            null,
             createHash3(1).getBytes()
         );
 
@@ -323,7 +323,7 @@ class BridgeSupportAddSignatureTest {
 
         bridgeSupport.addSignature(
             genesisFederation.getBtcPublicKeys().get(0),
-            new ArrayList<>(),
+            null,
             BitcoinTestUtils.createHash(1).getBytes()
         );
         bridgeSupport.save();
@@ -354,7 +354,7 @@ class BridgeSupportAddSignatureTest {
 
         bridgeSupport.addSignature(
             new BtcECKey(),
-            new ArrayList<>(),
+            null,
             BitcoinTestUtils.createHash(1).getBytes()
         );
         bridgeSupport.save();

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
@@ -712,6 +712,7 @@ public class BridgeSupportSvpTest {
             for (BtcECKey key : PROPOSED_FEDERATION_SIGNERS_KEYS) {
                 assertFederatorDidNotSignInputs(pegoutInputs, pegoutTxSigHashes, key);
             }
+            assertTrue(bridgeStorageProvider.getSvpSpendTxWaitingForSignatures().isPresent());
         }
 
         private void assertLogReleaseBtc(List<LogInfo> logs, Keccak256 rskTxHash, BtcTransaction btcTx) {
@@ -754,7 +755,9 @@ public class BridgeSupportSvpTest {
                 assertTrue(federationMember.isPresent());
                 assertFederatorDidNotSignInputs(svpSpendTx.getInputs(), svpSpendTxSigHashes, key);
             }
+
             assertAddSignatureWasNotLogged();
+            assertTrue(bridgeStorageProvider.getSvpSpendTxWaitingForSignatures().isPresent());
         }
 
         @Test
@@ -777,7 +780,16 @@ public class BridgeSupportSvpTest {
                 assertFalse(federationMember.isPresent());
                 assertFederatorDidNotSignInputs(svpSpendTx.getInputs(), svpSpendTxSigHashes, key);
             }
+
             assertAddSignatureWasNotLogged();
+            assertTrue(bridgeStorageProvider.getSvpSpendTxWaitingForSignatures().isPresent());
+        }
+
+        private void assertFederatorDidNotSignInputs(List<TransactionInput> inputs, List<Sha256Hash> sigHashes, BtcECKey key) {
+            for (TransactionInput input : inputs) {
+                Sha256Hash sigHash = sigHashes.get(inputs.indexOf(input));
+                assertFalse(BridgeUtils.isInputSignedByThisFederator(key, sigHash, input));
+            }
         }
 
         private void assertAddSignatureWasNotLogged() {
@@ -802,13 +814,8 @@ public class BridgeSupportSvpTest {
                 assertLogAddSignature(logs, federationMember.get(), rskTxHashSerialized);
                 assertFederatorSignedInputs(svpSpendTx.getInputs(), svpSpendTxSigHashes, key);
             }
-        }
 
-        private void assertFederatorDidNotSignInputs(List<TransactionInput> inputs, List<Sha256Hash> sigHashes, BtcECKey key) {
-            for (TransactionInput input : inputs) {
-                Sha256Hash sigHash = sigHashes.get(inputs.indexOf(input));
-                assertFalse(BridgeUtils.isInputSignedByThisFederator(key, sigHash, input));
-            }
+            assertFalse(bridgeStorageProvider.getSvpSpendTxWaitingForSignatures().isPresent());
         }
 
         private void arrangeSvpSpendTransaction() {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
@@ -715,17 +715,6 @@ public class BridgeSupportSvpTest {
             assertTrue(bridgeStorageProvider.getSvpSpendTxWaitingForSignatures().isPresent());
         }
 
-        private void assertLogReleaseBtc(List<LogInfo> logs, Keccak256 rskTxHash, BtcTransaction btcTx) {
-            byte[] rskTxHashSerialized = rskTxHash.getBytes();
-            List<DataWord> encodedTopics = getEncodedTopics(releaseBtcEvent, rskTxHashSerialized);
-
-            byte[] btcTxSerialized = btcTx.bitcoinSerialize();
-            byte[] encodedData = getEncodedData(releaseBtcEvent, btcTxSerialized);
-
-            assertEventWasEmittedWithExpectedTopics(logs, encodedTopics);
-            assertEventWasEmittedWithExpectedData(logs, encodedData);
-        }
-
         @Test
         void addSignature_forSvpSpendTx_withWrongKeys_shouldThrowIllegalStateExceptionAndNotAddProposedFederatorSignatures() {
             // arrange
@@ -903,6 +892,17 @@ public class BridgeSupportSvpTest {
 
             BtcECKey federatorBtcPublicKey = federationMember.getBtcPublicKey();
             byte[] encodedData = getEncodedData(addSignatureEvent, federatorBtcPublicKey.getPubKey());
+
+            assertEventWasEmittedWithExpectedTopics(logs, encodedTopics);
+            assertEventWasEmittedWithExpectedData(logs, encodedData);
+        }
+
+        private void assertLogReleaseBtc(List<LogInfo> logs, Keccak256 rskTxHash, BtcTransaction btcTx) {
+            byte[] rskTxHashSerialized = rskTxHash.getBytes();
+            List<DataWord> encodedTopics = getEncodedTopics(releaseBtcEvent, rskTxHashSerialized);
+
+            byte[] btcTxSerialized = btcTx.bitcoinSerialize();
+            byte[] encodedData = getEncodedData(releaseBtcEvent, btcTxSerialized);
 
             assertEventWasEmittedWithExpectedTopics(logs, encodedTopics);
             assertEventWasEmittedWithExpectedData(logs, encodedData);

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinTestUtils.java
@@ -2,6 +2,7 @@ package co.rsk.peg.bitcoin;
 
 import static co.rsk.bitcoinj.script.ScriptBuilder.createP2SHOutputScript;
 import static co.rsk.peg.bitcoin.BitcoinUtils.extractRedeemScriptFromInput;
+import static co.rsk.peg.bitcoin.BitcoinUtils.generateSigHashForP2SHInput;
 
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.crypto.TransactionSignature;
@@ -153,5 +154,15 @@ public class BitcoinTestUtils {
             inputScriptSig = outputScript.getScriptSigWithSignature(inputScriptSig, txSigEncoded, keyIndex);
             input.setScriptSig(inputScriptSig);
         }
+    }
+
+    public static List<Sha256Hash> generateTransactionInputsSigHashes(BtcTransaction btcTx) {
+        List<Sha256Hash> sigHashes = new ArrayList<>();
+        List<TransactionInput> inputs = btcTx.getInputs();
+        for (TransactionInput input : inputs) {
+            Sha256Hash sigHash = generateSigHashForP2SHInput(btcTx, inputs.indexOf(input));
+            sigHashes.add(sigHash);
+        }
+        return sigHashes;
     }
 }


### PR DESCRIPTION
For the validation protocol to be successful, we need the spend transaction to be signed and broadcasted by the proposed pegnatories.

**Requirements**
-Create a new `addSvpSpendTxSignature(bytes federatorPublicKeySerialized, bytes[] signatures)` private method that would add the signatures from the proposed pegnatories to the svp spend transaction.

This method should also remove the spend transaction from the map once is fully signed, and emit the release_btc event so the federators can proceed with the broadcast.