### PR TITLE
Eliminate legacy todo and update tests

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
@@ -1155,11 +1155,10 @@ class PegUtilsLegacyTest {
             false,
             false,
             activeFederationAddress,
-            true
+            false
         );
     }
 
-    // It shouldn't identify transactions sent to random addresses as peg-in, but it is the current behaviour
     @Test
     void testIsValidPegInTx_p2shErpScript_sends_funds_to_random_address_before_RSKIP353() {
         Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
@@ -1167,7 +1166,7 @@ class PegUtilsLegacyTest {
             false,
             false,
             randomAddress,
-            true
+            false
         );
     }
 
@@ -1202,7 +1201,7 @@ class PegUtilsLegacyTest {
             false,
             true,
             activeFederationAddress,
-            true
+            false
         );
     }
 
@@ -1214,7 +1213,7 @@ class PegUtilsLegacyTest {
             false,
             true,
             randomAddress,
-            true
+            false
         );
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
@@ -1148,29 +1148,6 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_p2shErpScript_sends_funds_to_federation_address_before_RSKIP353() {
-        Federation genesisFederation = FederationTestUtils.getGenesisFederation(federationConstantsMainnet);
-        Address activeFederationAddress = genesisFederation.getAddress();
-        testIsValidPegInTx_fromP2shErpScriptSender(
-            false,
-            false,
-            activeFederationAddress,
-            false
-        );
-    }
-
-    @Test
-    void testIsValidPegInTx_p2shErpScript_sends_funds_to_random_address_before_RSKIP353() {
-        Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
-        testIsValidPegInTx_fromP2shErpScriptSender(
-            false,
-            false,
-            randomAddress,
-            false
-        );
-    }
-
-    @Test
     void testIsValidPegInTx_p2shErpScript_sends_funds_to_federation_address_after_RSKIP353() {
         Federation genesisFederation = FederationTestUtils.getGenesisFederation(federationConstantsMainnet);
         Address activeFederationAddress = genesisFederation.getAddress();
@@ -1188,30 +1165,6 @@ class PegUtilsLegacyTest {
         testIsValidPegInTx_fromP2shErpScriptSender(
             true,
             false,
-            randomAddress,
-            false
-        );
-    }
-
-    @Test
-    void testIsValidPegInTx_flyoverP2shErpScript_sends_funds_to_federation_address_before_RSKIP353() {
-        Federation genesisFederation = FederationTestUtils.getGenesisFederation(federationConstantsMainnet);
-        Address activeFederationAddress = genesisFederation.getAddress();
-        testIsValidPegInTx_fromP2shErpScriptSender(
-            false,
-            true,
-            activeFederationAddress,
-            false
-        );
-    }
-
-    // It shouldn't identify transactions sent to random addresses as peg-in, but it is the current behaviour
-    @Test
-    void testIsValidPegInTx_flyoverP2shErpScript_sends_funds_to_random_address_before_RSKIP353() {
-        Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
-        testIsValidPegInTx_fromP2shErpScriptSender(
-            false,
-            true,
             randomAddress,
             false
         );


### PR DESCRIPTION
## Description

- Resolve pending `TODO` about removing legacy code once RSKIP353 gets activated and P2shErpRedeemScriptParser starts to be used
- A couple of tests had to be updated. 

-- When sending funds from a p2sh erp fed(using the active fed keys) to the active federation:

---Before removing the legacy code: the method `co.rsk.peg.PegUtilsLegacy#isValidPegInTx` was returning true because it was failing when parsing the script and then couldn't find any utxo below the minimum(this was a bug that got fixed later).

--- After removing the legacy code: now the method `co.rsk.peg.PegUtilsLegacy#isValidPegInTx is returning false since the sender is being identified as equal to the active federation. 

## How Has This Been Tested?

Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)
