### PR TITLE
When rejected pegout is refunded, post RSKIP427 refund the total value sent in weis

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -850,10 +850,17 @@ public class BridgeSupport {
             senderAddress,
             reason
         );
+
+        // Prior to RSKIP427, the value was converted to BTC before doing the refund
+        // This could cause the original value to be rounded down to fit in satoshis value
+        co.rsk.core.Coin refundValue = activations.isActive(RSKIP427) ?
+            releaseRequestedValue :
+            co.rsk.core.Coin.fromBitcoin(releaseRequestedValue.toBitcoin());
+
         rskRepository.transfer(
             PrecompiledContracts.BRIDGE_ADDR,
             senderAddress,
-            releaseRequestedValue
+            refundValue
         );
         emitRejectEvent(releaseRequestedValue, senderAddress, reason);
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -1278,7 +1278,7 @@ class BridgeSupportReleaseBtcTest {
         co.rsk.core.Coin pegoutRequestValue = co.rsk.core.Coin.fromBitcoin(belowPegoutMinimumValue);
         // Add some extra weis to the value, but less than 1 satoshi.
         // To ensure that the pegout value is rounded down to fit in satoshis.
-        co.rsk.core.Coin oneSatoshiInWeis = co.rsk.core.Coin.valueOf(Denomination.satoshisToWeis(1).longValue());
+        co.rsk.core.Coin oneSatoshiInWeis = co.rsk.core.Coin.fromBitcoin(Coin.SATOSHI);
         co.rsk.core.Coin extraWeis = oneSatoshiInWeis.subtract(co.rsk.core.Coin.valueOf(1));
         pegoutRequestValue = pegoutRequestValue.add(extraWeis);
 
@@ -1374,7 +1374,7 @@ class BridgeSupportReleaseBtcTest {
         co.rsk.core.Coin pegoutRequestValue = co.rsk.core.Coin.fromBitcoin(BRIDGE_CONSTANTS.getMinimumPegoutTxValue());
         // Add some extra weis to the value, but less than 1 satoshi.
         // To ensure that the pegout value is rounded down to fit in satoshis.
-        co.rsk.core.Coin oneSatoshiInWeis = co.rsk.core.Coin.valueOf(Denomination.satoshisToWeis(1).longValue());
+        co.rsk.core.Coin oneSatoshiInWeis = co.rsk.core.Coin.fromBitcoin(Coin.SATOSHI);
         co.rsk.core.Coin extraWeis = oneSatoshiInWeis.subtract(co.rsk.core.Coin.valueOf(1));
         pegoutRequestValue = pegoutRequestValue.add(extraWeis);
 
@@ -1421,7 +1421,7 @@ class BridgeSupportReleaseBtcTest {
         co.rsk.core.Coin pegoutRequestValue = co.rsk.core.Coin.fromBitcoin(BRIDGE_CONSTANTS.getMinimumPegoutTxValue());
         // Add some extra weis to the value, but less than 1 satoshi.
         // To ensure that the pegout value is rounded down to fit in satoshis.
-        co.rsk.core.Coin oneSatoshiInWeis = co.rsk.core.Coin.valueOf(Denomination.satoshisToWeis(1).longValue());
+        co.rsk.core.Coin oneSatoshiInWeis = co.rsk.core.Coin.fromBitcoin(Coin.SATOSHI);
         co.rsk.core.Coin extraWeis = oneSatoshiInWeis.subtract(co.rsk.core.Coin.valueOf(1));
         pegoutRequestValue = pegoutRequestValue.add(extraWeis);
 
@@ -1479,7 +1479,7 @@ class BridgeSupportReleaseBtcTest {
         co.rsk.core.Coin pegoutRequestValue = co.rsk.core.Coin.fromBitcoin(pegoutRequestValueWithGapAboveFee);
         // Add some extra weis to the value, but less than 1 satoshi.
         // To ensure that the pegout value is rounded down to fit in satoshis.
-        co.rsk.core.Coin oneSatoshiInWeis = co.rsk.core.Coin.valueOf(Denomination.satoshisToWeis(1).longValue());
+        co.rsk.core.Coin oneSatoshiInWeis = co.rsk.core.Coin.fromBitcoin(Coin.SATOSHI);
         co.rsk.core.Coin extraWeis = oneSatoshiInWeis.subtract(co.rsk.core.Coin.valueOf(1));
         pegoutRequestValue = pegoutRequestValue.add(extraWeis);
 
@@ -1542,7 +1542,7 @@ class BridgeSupportReleaseBtcTest {
         co.rsk.core.Coin pegoutRequestValue = co.rsk.core.Coin.fromBitcoin(pegoutRequestValueWithGapAboveFee);
         // Add some extra weis to the value, but less than 1 satoshi.
         // To ensure that the pegout value is rounded down to fit in satoshis.
-        co.rsk.core.Coin oneSatoshiInWeis = co.rsk.core.Coin.valueOf(Denomination.satoshisToWeis(1).longValue());
+        co.rsk.core.Coin oneSatoshiInWeis = co.rsk.core.Coin.fromBitcoin(Coin.SATOSHI);
         co.rsk.core.Coin extraWeis = oneSatoshiInWeis.subtract(co.rsk.core.Coin.valueOf(1));
         pegoutRequestValue = pegoutRequestValue.add(extraWeis);
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -1279,7 +1279,8 @@ class BridgeSupportReleaseBtcTest {
         // Add some extra weis to the value, but less than 1 satoshi.
         // To ensure that the pegout value is rounded down to fit in satoshis.
         co.rsk.core.Coin oneSatoshiInWeis = co.rsk.core.Coin.fromBitcoin(Coin.SATOSHI);
-        co.rsk.core.Coin extraWeis = oneSatoshiInWeis.subtract(co.rsk.core.Coin.valueOf(1));
+        co.rsk.core.Coin oneWei = co.rsk.core.Coin.valueOf(Denomination.WEI.longValue());
+        co.rsk.core.Coin extraWeis = oneSatoshiInWeis.subtract(oneWei);
         pegoutRequestValue = pegoutRequestValue.add(extraWeis);
 
         bridgeSupport.releaseBtc(buildReleaseRskTx(pegoutRequestValue));
@@ -1375,7 +1376,8 @@ class BridgeSupportReleaseBtcTest {
         // Add some extra weis to the value, but less than 1 satoshi.
         // To ensure that the pegout value is rounded down to fit in satoshis.
         co.rsk.core.Coin oneSatoshiInWeis = co.rsk.core.Coin.fromBitcoin(Coin.SATOSHI);
-        co.rsk.core.Coin extraWeis = oneSatoshiInWeis.subtract(co.rsk.core.Coin.valueOf(1));
+        co.rsk.core.Coin oneWei = co.rsk.core.Coin.valueOf(Denomination.WEI.longValue());
+        co.rsk.core.Coin extraWeis = oneSatoshiInWeis.subtract(oneWei);
         pegoutRequestValue = pegoutRequestValue.add(extraWeis);
 
         bridgeSupport.releaseBtc(buildReleaseRskTx_fromContract(pegoutRequestValue));
@@ -1422,7 +1424,8 @@ class BridgeSupportReleaseBtcTest {
         // Add some extra weis to the value, but less than 1 satoshi.
         // To ensure that the pegout value is rounded down to fit in satoshis.
         co.rsk.core.Coin oneSatoshiInWeis = co.rsk.core.Coin.fromBitcoin(Coin.SATOSHI);
-        co.rsk.core.Coin extraWeis = oneSatoshiInWeis.subtract(co.rsk.core.Coin.valueOf(1));
+        co.rsk.core.Coin oneWei = co.rsk.core.Coin.valueOf(Denomination.WEI.longValue());
+        co.rsk.core.Coin extraWeis = oneSatoshiInWeis.subtract(oneWei);
         pegoutRequestValue = pegoutRequestValue.add(extraWeis);
 
         bridgeSupport.releaseBtc(buildReleaseRskTx_fromContract(pegoutRequestValue));
@@ -1480,7 +1483,8 @@ class BridgeSupportReleaseBtcTest {
         // Add some extra weis to the value, but less than 1 satoshi.
         // To ensure that the pegout value is rounded down to fit in satoshis.
         co.rsk.core.Coin oneSatoshiInWeis = co.rsk.core.Coin.fromBitcoin(Coin.SATOSHI);
-        co.rsk.core.Coin extraWeis = oneSatoshiInWeis.subtract(co.rsk.core.Coin.valueOf(1));
+        co.rsk.core.Coin oneWei = co.rsk.core.Coin.valueOf(Denomination.WEI.longValue());
+        co.rsk.core.Coin extraWeis = oneSatoshiInWeis.subtract(oneWei);
         pegoutRequestValue = pegoutRequestValue.add(extraWeis);
 
         bridgeSupport.releaseBtc(buildReleaseRskTx(pegoutRequestValue));
@@ -1543,7 +1547,8 @@ class BridgeSupportReleaseBtcTest {
         // Add some extra weis to the value, but less than 1 satoshi.
         // To ensure that the pegout value is rounded down to fit in satoshis.
         co.rsk.core.Coin oneSatoshiInWeis = co.rsk.core.Coin.fromBitcoin(Coin.SATOSHI);
-        co.rsk.core.Coin extraWeis = oneSatoshiInWeis.subtract(co.rsk.core.Coin.valueOf(1));
+        co.rsk.core.Coin oneWei = co.rsk.core.Coin.valueOf(Denomination.WEI.longValue());
+        co.rsk.core.Coin extraWeis = oneSatoshiInWeis.subtract(oneWei);
         pegoutRequestValue = pegoutRequestValue.add(extraWeis);
 
         bridgeSupport.releaseBtc(buildReleaseRskTx(pegoutRequestValue));


### PR DESCRIPTION
- Change pegout refund logic in BridgeSupport to return the total value sent to the Bridge post RSKIP427
- Add tests