### PR TITLE
Add svp spend tx signature

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1584,7 +1584,7 @@ public class BridgeSupport {
                 .ifPresent(svpSpendTxWFS -> {
                     logger.trace("Going to add federator public key {} to svp spend transaction", federatorBtcPublicKey);
                     BtcTransaction svpSpendTx = svpSpendTxWFS.getValue();
-                    if (!hasEnoughSignatures(svpSpendTx, signatures)) {
+                    if (!areSignaturesEnoughToSignAllTxInputs(svpSpendTx, signatures)) {
                         return;
                     }
                     addSvpSpendTxSignatures(federatorBtcPublicKey, signatures, rskTxHash, svpSpendTx);
@@ -1596,14 +1596,14 @@ public class BridgeSupport {
             logger.warn("No tx waiting for signature for hash {}. Probably fully signed already.", rskTxHash);
             return;
         }
-        if (!hasEnoughSignatures(releaseTx, signatures)) {
+        if (!areSignaturesEnoughToSignAllTxInputs(releaseTx, signatures)) {
             return;
         }
 
         addReleaseSignatures(federatorBtcPublicKey, signatures, rskTxHash, releaseTx);
     }
 
-    private boolean hasEnoughSignatures(BtcTransaction releaseTx, List<byte[]> signatures) {
+    private boolean areSignaturesEnoughToSignAllTxInputs(BtcTransaction releaseTx, List<byte[]> signatures) {
         int inputsSize = releaseTx.getInputs().size();
         int signaturesSize = signatures.size();
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1580,6 +1580,7 @@ public class BridgeSupport {
 
         if (svpIsOngoing() && isSvpSpendTx(releaseCreationRskTxHash)) {
             addSvpSpendTxSignatures(federatorBtcPublicKey, signatures);
+            return;
         }
 
         addReleaseSignatures(federatorBtcPublicKey, signatures, releaseCreationRskTxHash);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
@@ -1,7 +1,9 @@
 package co.rsk.peg;
 
+import co.rsk.RskTestUtils;
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.script.Script;
+import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.script.ScriptChunk;
 import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.core.RskAddress;
@@ -11,10 +13,7 @@ import co.rsk.peg.bitcoin.BitcoinUtils;
 import co.rsk.peg.bitcoin.UtxoUtils;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.constants.BridgeMainNetConstants;
-import co.rsk.peg.federation.Federation;
-import co.rsk.peg.federation.FederationSupport;
-import co.rsk.peg.federation.FederationTestUtils;
-import co.rsk.peg.federation.P2shErpFederationBuilder;
+import co.rsk.peg.federation.*;
 import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.feeperkb.FeePerKbSupport;
 import co.rsk.peg.utils.BridgeEventLogger;
@@ -23,6 +22,8 @@ import co.rsk.test.builders.BridgeSupportBuilder;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.core.*;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.LogInfo;
 import org.ethereum.vm.PrecompiledContracts;
@@ -32,10 +33,14 @@ import java.io.IOException;
 import java.util.*;
 import java.util.stream.IntStream;
 
+import static co.rsk.RskTestUtils.createRskBlock;
 import static co.rsk.peg.BridgeSupportTestUtil.*;
 import static co.rsk.peg.PegUtils.getFlyoverRedeemScript;
-import static co.rsk.peg.bitcoin.BitcoinUtils.createBaseP2SHInputScriptThatSpendsFromRedeemScript;
-import static co.rsk.peg.bitcoin.BitcoinUtils.searchForOutput;
+import static co.rsk.peg.ReleaseTransactionBuilder.BTC_TX_VERSION_2;
+import static co.rsk.peg.bitcoin.BitcoinTestUtils.generateSignerEncodedSignatures;
+import static co.rsk.peg.bitcoin.BitcoinTestUtils.generateTransactionInputsSigHashes;
+import static co.rsk.peg.bitcoin.BitcoinUtils.*;
+import static co.rsk.peg.bitcoin.BitcoinUtils.addInputFromMatchingOutputScript;
 import static co.rsk.peg.bitcoin.UtxoUtils.extractOutpointValues;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
@@ -45,6 +50,8 @@ public class BridgeSupportSvpTest {
     private static final RskAddress bridgeContractAddress = PrecompiledContracts.BRIDGE_ADDR;
     private final CallTransaction.Function releaseRequestedEvent = BridgeEvents.RELEASE_REQUESTED.getEvent();
     private final CallTransaction.Function pegoutTransactionCreatedEvent = BridgeEvents.PEGOUT_TRANSACTION_CREATED.getEvent();
+    private final CallTransaction.Function addSignatureEvent = BridgeEvents.ADD_SIGNATURE.getEvent();
+    private final CallTransaction.Function releaseBtcEvent = BridgeEvents.RELEASE_BTC.getEvent();
     private static final ActivationConfig.ForBlock allActivations = ActivationConfigsForTest.all().forBlock(0);
 
     private static final BridgeConstants bridgeMainNetConstants = BridgeMainNetConstants.getInstance();
@@ -314,15 +321,7 @@ public class BridgeSupportSvpTest {
         @Test
         void registerBtcTransaction_forSvpFundTransactionChange_whenValidationPeriodEnded_shouldRegisterTransactionButNotUpdateSvpFundTransactionValues() throws Exception {
             // arrange
-            // make rsk execution block to be after validation period ended
-            long validationPeriodEndBlock = proposedFederation.getCreationBlockNumber()
-                + bridgeMainNetConstants.getFederationConstants().getValidationPeriodDurationInBlocks();
-            long rskExecutionBlockTimestamp = 10L;
-            BlockHeader blockHeader = new BlockHeaderBuilder(mock(ActivationConfig.class))
-                .setNumber(validationPeriodEndBlock + 1) // adding one more block to ensure validation period is ended
-                .setTimestamp(rskExecutionBlockTimestamp)
-                .build();
-            rskExecutionBlock = Block.createBlockFromHeader(blockHeader, true);
+            arrangeExecutionBlockIsAfterValidationPeriodEnded();
 
             BtcTransaction svpFundTransaction = arrangeSvpFundTransactionUnsignedWithChange();
             signInputs(svpFundTransaction); // a transaction trying to be registered should be signed
@@ -349,7 +348,7 @@ public class BridgeSupportSvpTest {
             // Arrange
             arrangeSvpFundTransactionUnsignedWithChange();
 
-            BtcTransaction pegout = createPegout();
+            BtcTransaction pegout = createPegout(proposedFederation.getRedeemScript());
             savePegoutIndex(pegout);
             signInputs(pegout); // a transaction trying to be registered should be signed
             setUpForTransactionRegistration(pegout);
@@ -435,21 +434,6 @@ public class BridgeSupportSvpTest {
         private void saveSvpFundTransactionHashUnsigned(Sha256Hash svpFundTransactionHashUnsigned) {
             bridgeStorageProvider.setSvpFundTxHashUnsigned(svpFundTransactionHashUnsigned);
             bridgeSupport.save();
-        }
-
-        private BtcTransaction createPegout() {
-            BtcTransaction pegout = new BtcTransaction(btcMainnetParams);
-            Sha256Hash parentTxHash = BitcoinTestUtils.createHash(2);
-            addInput(pegout, parentTxHash);
-            addOutputChange(pegout);
-
-            return pegout;
-        }
-
-        private void addOutputChange(BtcTransaction transaction) {
-            // add output to the active fed
-            Script activeFederationP2SHScript = activeFederation.getP2SHScript();
-            transaction.addOutput(Coin.COIN.multiply(10), activeFederationP2SHScript);
         }
 
         private void savePegoutIndex(BtcTransaction pegout) {
@@ -569,7 +553,7 @@ public class BridgeSupportSvpTest {
         @Test
         void processSvpSpendTransaction_createsExpectedTransactionAndSavesTheValuesAndLogsExpectedEvents() {
             // arrange
-            arrangeSvpFundTransactionSigned();
+            svpFundTransaction = arrangeSvpFundTransactionSigned();
 
             // act
             bridgeSupport.processSvpSpendTransactionUnsigned(rskTx);
@@ -585,14 +569,6 @@ public class BridgeSupportSvpTest {
             assertLogPegoutTransactionCreated(logs, svpSpendTransactionUnsigned);
             Coin valueSentToActiveFed = Coin.valueOf(1762);
             assertLogReleaseRequested(logs, rskTx.getHash(), svpSpendTransactionHashUnsigned, valueSentToActiveFed);
-        }
-
-        private void arrangeSvpFundTransactionSigned() {
-            svpFundTransaction = recreateSvpFundTransactionUnsigned();
-            signInputs(svpFundTransaction);
-
-            bridgeStorageProvider.setSvpFundTxSigned(svpFundTransaction);
-            bridgeStorageProvider.save();
         }
 
         private void assertSvpSpendTxHashUnsignedWasSavedInStorage() {
@@ -662,11 +638,296 @@ public class BridgeSupportSvpTest {
         }
     }
 
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @Tag("svp spend transaction signing tests")
+    class SvpSpendTxSigning {
+        private static final List<BtcECKey> PROPOSED_FEDERATION_SIGNERS_KEYS =
+            BitcoinTestUtils.getBtcEcKeysFromSeeds(new String[]{"member01", "member02", "member03", "member04", "member05"}, true); // this is needed to have the private keys too
+
+        private static final Keccak256 svpSpendTxCreationHash = RskTestUtils.createHash(1);
+
+        private BtcTransaction svpSpendTx;
+        private List<Sha256Hash> svpSpendTxSigHashes;
+        private List<LogInfo> logs;
+        private BridgeEventLogger bridgeEventLogger;
+
+        @BeforeEach
+        void setUp() {
+            logs = new ArrayList<>();
+            bridgeEventLogger = new BridgeEventLoggerImpl(
+                bridgeMainNetConstants,
+                allActivations,
+                logs
+            );
+
+            bridgeSupport = bridgeSupportBuilder
+                .withBridgeConstants(bridgeMainNetConstants)
+                .withProvider(bridgeStorageProvider)
+                .withActivations(allActivations)
+                .withFederationSupport(federationSupport)
+                .withFeePerKbSupport(feePerKbSupport)
+                .withEventLogger(bridgeEventLogger)
+                .withExecutionBlock(rskExecutionBlock)
+                .build();
+
+            arrangeSvpSpendTransaction();
+            svpSpendTxSigHashes = generateTransactionInputsSigHashes(svpSpendTx);
+        }
+
+        @Test
+        void addSignature_forSvpSpendTx_withWrongKeys_shouldThrowIllegalStateExceptionAndNotAddProposedFederatorSignatures() {
+            // arrange
+            List<BtcECKey> WRONG_KEYS =
+                BitcoinTestUtils.getBtcEcKeysFromSeeds(new String[]{"wrong01", "wrong02", "wrong03", "wrong04", "wrong05"}, true);
+
+            // act & assert
+            for (BtcECKey key : WRONG_KEYS) {
+                List<byte[]> signerEncodedSignatures = generateSignerEncodedSignatures(key, svpSpendTxSigHashes);
+                assertThrows(IllegalStateException.class,
+                    () -> bridgeSupport.addSignature(key, signerEncodedSignatures, svpSpendTxCreationHash));
+            }
+
+            // assert
+            for (BtcECKey key : WRONG_KEYS) {
+                assertFederatorDidNotSignInputs(svpSpendTx.getInputs(), svpSpendTxSigHashes, key);
+            }
+
+            assertAddSignatureWasNotLogged();
+            assertSvpSpendTxWFSWasNotRemoved();
+        }
+
+        @Test
+        void addSignature_forSvpSpendTx_whenProposedFederationDoesNotExist_shouldNotAddProposedFederatorSignatures() throws Exception {
+            // arrange
+            when(federationSupport.getProposedFederation()).thenReturn(Optional.empty());
+
+            // act
+            for (BtcECKey key : PROPOSED_FEDERATION_SIGNERS_KEYS) {
+                List<byte[]> signerEncodedSignatures = generateSignerEncodedSignatures(key, svpSpendTxSigHashes);
+                bridgeSupport.addSignature(key, signerEncodedSignatures, svpSpendTxCreationHash);
+            }
+
+            // assert
+            for (BtcECKey key : PROPOSED_FEDERATION_SIGNERS_KEYS) {
+                assertFederatorDidNotSignInputs(svpSpendTx.getInputs(), svpSpendTxSigHashes, key);
+            }
+
+            assertAddSignatureWasNotLogged();
+            assertSvpSpendTxWFSWasNotRemoved();
+        }
+
+        @Test
+        void addSignature_forSvpSpendTx_whenValidationPeriodEnded_shouldNotAddProposedFederatorsSignatures() throws Exception {
+            // arrange
+            arrangeExecutionBlockIsAfterValidationPeriodEnded();
+            bridgeSupport = bridgeSupportBuilder
+                .withBridgeConstants(bridgeMainNetConstants)
+                .withProvider(bridgeStorageProvider)
+                .withActivations(allActivations)
+                .withFederationSupport(federationSupport)
+                .withFeePerKbSupport(feePerKbSupport)
+                .withEventLogger(bridgeEventLogger)
+                .withExecutionBlock(rskExecutionBlock)
+                .build();
+
+            // act
+            for (BtcECKey key : PROPOSED_FEDERATION_SIGNERS_KEYS) {
+                List<byte[]> signerEncodedSignatures = generateSignerEncodedSignatures(key, svpSpendTxSigHashes);
+                bridgeSupport.addSignature(key, signerEncodedSignatures, svpSpendTxCreationHash);
+            }
+
+            // assert
+            for (BtcECKey key : PROPOSED_FEDERATION_SIGNERS_KEYS) {
+                assertFederatorDidNotSignInputs(svpSpendTx.getInputs(), svpSpendTxSigHashes, key);
+            }
+
+            assertAddSignatureWasNotLogged();
+            assertSvpSpendTxWFSWasNotRemoved();
+        }
+
+        private void assertFederatorDidNotSignInputs(List<TransactionInput> inputs, List<Sha256Hash> sigHashes, BtcECKey key) {
+            for (TransactionInput input : inputs) {
+                Sha256Hash sigHash = sigHashes.get(inputs.indexOf(input));
+                assertFalse(BridgeUtils.isInputSignedByThisFederator(key, sigHash, input));
+            }
+        }
+
+        private void assertAddSignatureWasNotLogged() {
+            assertEquals(0, logs.size());
+        }
+
+        private void assertSvpSpendTxWFSWasNotRemoved() {
+            assertTrue(bridgeStorageProvider.getSvpSpendTxWaitingForSignatures().isPresent());
+        }
+
+        @Test
+        void addSignature_forSvpSpendTx_shouldAddProposedFederatorsSignatures() throws Exception {
+            // act
+            for (BtcECKey key : PROPOSED_FEDERATION_SIGNERS_KEYS) {
+                List<byte[]> signerEncodedSignatures = generateSignerEncodedSignatures(key, svpSpendTxSigHashes);
+                bridgeSupport.addSignature(key, signerEncodedSignatures, svpSpendTxCreationHash);
+            }
+
+            // assert
+            for (BtcECKey key : PROPOSED_FEDERATION_SIGNERS_KEYS) {
+                assertFederatorSigning(
+                    svpSpendTxCreationHash.getBytes(),
+                    svpSpendTx.getInputs(),
+                    svpSpendTxSigHashes,
+                    proposedFederation,
+                    key
+                );
+            }
+            assertLogReleaseBtc(svpSpendTxCreationHash, svpSpendTx);
+            assertLogsSize(PROPOSED_FEDERATION_SIGNERS_KEYS.size() + 1); // proposedFedSigners size for addSignature, +1 for release btc
+            assertFalse(bridgeStorageProvider.getSvpSpendTxWaitingForSignatures().isPresent());
+        }
+
+        @Test
+        void addSignature_forNormalPegout_whenSvpIsOngoing_shouldAddJustActiveFederatorsSignaturesToPegout() throws Exception {
+            Keccak256 rskTxHash = RskTestUtils.createHash(2);
+
+            BtcTransaction pegout = createPegout(activeFederation.getRedeemScript());
+            SortedMap<Keccak256, BtcTransaction> pegoutsWFS = bridgeStorageProvider.getPegoutsWaitingForSignatures();
+            pegoutsWFS.put(rskTxHash, pegout);
+
+            List<BtcECKey> activeFedSigners =
+                BitcoinTestUtils.getBtcEcKeysFromSeeds(new String[]{"fa01", "fa02", "fa03", "fa04", "fa05"}, true);
+
+            List<Sha256Hash> pegoutTxSigHashes = generateTransactionInputsSigHashes(pegout);
+
+            // act
+            for (BtcECKey key : activeFedSigners) {
+                List<byte[]> signerEncodedSignatures = generateSignerEncodedSignatures(key, pegoutTxSigHashes);
+                bridgeSupport.addSignature(key, signerEncodedSignatures, rskTxHash);
+            }
+
+            // assert
+            List<TransactionInput> pegoutInputs = pegout.getInputs();
+            for (BtcECKey key : activeFedSigners) {
+                assertFederatorSigning(
+                    rskTxHash.getBytes(),
+                    pegout.getInputs(),
+                    pegoutTxSigHashes,
+                    activeFederation,
+                    key
+                );
+            }
+
+            assertLogReleaseBtc(rskTxHash, pegout);
+            assertLogsSize(activeFedSigners.size() + 1); // activeFedSigners size for addSignature, +1 for release btc
+
+            for (BtcECKey key : PROPOSED_FEDERATION_SIGNERS_KEYS) {
+                assertFederatorDidNotSignInputs(pegoutInputs, pegoutTxSigHashes, key);
+            }
+            assertSvpSpendTxWFSWasNotRemoved();
+        }
+
+        private void assertLogsSize(int expectedLogs) {
+            assertEquals(expectedLogs, logs.size());
+        }
+
+        private void assertFederatorSigning(
+            byte[] rskTxHashSerialized,
+            List<TransactionInput> inputs,
+            List<Sha256Hash> sigHashes,
+            Federation federation,
+            BtcECKey key
+        ) {
+            Optional<FederationMember> federationMember = federation.getMemberByBtcPublicKey(key);
+            assertTrue(federationMember.isPresent());
+            assertLogAddSignature(federationMember.get(), rskTxHashSerialized);
+            assertFederatorSignedInputs(inputs, sigHashes, key);
+        }
+
+        private void assertLogAddSignature(FederationMember federationMember, byte[] rskTxHash) {
+            ECKey federatorRskPublicKey = federationMember.getRskPublicKey();
+            String federatorRskAddress = ByteUtil.toHexString(federatorRskPublicKey.getAddress());
+
+            List<DataWord> encodedTopics = getEncodedTopics(addSignatureEvent, rskTxHash, federatorRskAddress);
+
+            BtcECKey federatorBtcPublicKey = federationMember.getBtcPublicKey();
+            byte[] encodedData = getEncodedData(addSignatureEvent, federatorBtcPublicKey.getPubKey());
+
+            assertEventWasEmittedWithExpectedTopics(logs, encodedTopics);
+            assertEventWasEmittedWithExpectedData(logs, encodedData);
+        }
+
+        private void assertLogReleaseBtc(Keccak256 rskTxHash, BtcTransaction btcTx) {
+            byte[] rskTxHashSerialized = rskTxHash.getBytes();
+            List<DataWord> encodedTopics = getEncodedTopics(releaseBtcEvent, rskTxHashSerialized);
+
+            byte[] btcTxSerialized = btcTx.bitcoinSerialize();
+            byte[] encodedData = getEncodedData(releaseBtcEvent, btcTxSerialized);
+
+            assertEventWasEmittedWithExpectedTopics(logs, encodedTopics);
+            assertEventWasEmittedWithExpectedData(logs, encodedData);
+        }
+
+        private void assertFederatorSignedInputs(List<TransactionInput> inputs, List<Sha256Hash> sigHashes, BtcECKey key) {
+            for (TransactionInput input : inputs) {
+                Sha256Hash sigHash = sigHashes.get(inputs.indexOf(input));
+                assertTrue(BridgeUtils.isInputSignedByThisFederator(key, sigHash, input));
+            }
+        }
+
+        private void arrangeSvpSpendTransaction() {
+            recreateSvpSpendTransaction();
+            saveSvpSpendTransactionWFSValues();
+        }
+
+        private void recreateSvpSpendTransaction() {
+            svpSpendTx = new BtcTransaction(btcMainnetParams);
+            svpSpendTx.setVersion(BTC_TX_VERSION_2);
+
+            BtcTransaction svpFundTx = arrangeSvpFundTransactionSigned();
+            // add inputs
+            addInputFromMatchingOutputScript(svpSpendTx, svpFundTx, proposedFederation.getP2SHScript());
+            Script proposedFederationRedeemScript = proposedFederation.getRedeemScript();
+            svpSpendTx.getInput(0)
+                .setScriptSig(createBaseP2SHInputScriptThatSpendsFromRedeemScript(proposedFederationRedeemScript));
+
+            Script flyoverRedeemScript = getFlyoverRedeemScript(bridgeMainNetConstants.getProposedFederationFlyoverPrefix(), proposedFederationRedeemScript);
+            addInputFromMatchingOutputScript(svpSpendTx, svpFundTx, ScriptBuilder.createP2SHOutputScript(flyoverRedeemScript));
+            svpSpendTx.getInput(1)
+                .setScriptSig(createBaseP2SHInputScriptThatSpendsFromRedeemScript(flyoverRedeemScript));
+
+            // add output
+            svpSpendTx.addOutput(Coin.valueOf(1762), federationSupport.getActiveFederationAddress());
+        }
+
+        private void saveSvpSpendTransactionWFSValues() {
+            Map.Entry<Keccak256, BtcTransaction> svpSpendTxWaitingForSignatures = new AbstractMap.SimpleEntry<>(svpSpendTxCreationHash, svpSpendTx);
+            bridgeStorageProvider.setSvpSpendTxWaitingForSignatures(svpSpendTxWaitingForSignatures);
+            bridgeStorageProvider.save();
+        }
+    }
+
+    private void arrangeExecutionBlockIsAfterValidationPeriodEnded() {
+        long validationPeriodEndBlock = proposedFederation.getCreationBlockNumber()
+            + bridgeMainNetConstants.getFederationConstants().getValidationPeriodDurationInBlocks();
+        long rskExecutionBlockNumber = validationPeriodEndBlock + 1; // adding one more block to ensure validation period is ended
+        long rskExecutionBlockTimestamp = 10L;
+
+        rskExecutionBlock = createRskBlock(rskExecutionBlockNumber, rskExecutionBlockTimestamp);
+    }
+
+    private BtcTransaction arrangeSvpFundTransactionSigned() {
+        BtcTransaction svpFundTransaction = recreateSvpFundTransactionUnsigned();
+        signInputs(svpFundTransaction);
+
+        bridgeStorageProvider.setSvpFundTxSigned(svpFundTransaction);
+        bridgeStorageProvider.save();
+
+        return svpFundTransaction;
+    }
+
     private BtcTransaction recreateSvpFundTransactionUnsigned() {
         BtcTransaction svpFundTransaction = new BtcTransaction(btcMainnetParams);
 
         Sha256Hash parentTxHash = BitcoinTestUtils.createHash(1);
-        addInput(svpFundTransaction, parentTxHash);
+        addInput(svpFundTransaction, parentTxHash, proposedFederation.getRedeemScript());
 
         svpFundTransaction.addOutput(spendableValueFromProposedFederation, proposedFederation.getAddress());
         Address flyoverProposedFederationAddress =
@@ -676,15 +937,28 @@ public class BridgeSupportSvpTest {
         return svpFundTransaction;
     }
 
-    private void addInput(BtcTransaction transaction, Sha256Hash parentTxHash) {
-        // we need to add an input that we can actually sign,
-        // and we know the private keys for the following scriptSig
-        Federation federation = P2shErpFederationBuilder.builder().build();
+    private BtcTransaction createPegout(Script redeemScript) {
+        BtcTransaction pegout = new BtcTransaction(btcMainnetParams);
+        Sha256Hash parentTxHash = BitcoinTestUtils.createHash(2);
+        addInput(pegout, parentTxHash, redeemScript);
+        addOutputChange(pegout);
+
+        return pegout;
+    }
+
+    private void addInput(BtcTransaction transaction, Sha256Hash parentTxHash, Script redeemScript) {
+        // we need to add an input that we can actually sign
         transaction.addInput(
             parentTxHash,
             0,
-            createBaseP2SHInputScriptThatSpendsFromRedeemScript(federation.getRedeemScript())
+            createBaseP2SHInputScriptThatSpendsFromRedeemScript(redeemScript)
         );
+    }
+
+    private void addOutputChange(BtcTransaction transaction) {
+        // add output to the active fed
+        Script activeFederationP2SHScript = activeFederation.getP2SHScript();
+        transaction.addOutput(Coin.COIN.multiply(10), activeFederationP2SHScript);
     }
 
     private void signInputs(BtcTransaction transaction) {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
@@ -678,18 +678,18 @@ public class BridgeSupportSvpTest {
         @Test
         void addSignature_forSvpSpendTx_withWrongKeys_shouldThrowIllegalStateExceptionAndNotAddProposedFederatorSignatures() {
             // arrange
-            List<BtcECKey> WRONG_KEYS =
+            List<BtcECKey> wrongKeys =
                 BitcoinTestUtils.getBtcEcKeysFromSeeds(new String[]{"wrong01", "wrong02", "wrong03", "wrong04", "wrong05"}, true);
 
             // act & assert
-            for (BtcECKey key : WRONG_KEYS) {
+            for (BtcECKey key : wrongKeys) {
                 List<byte[]> signerEncodedSignatures = generateSignerEncodedSignatures(key, svpSpendTxSigHashes);
                 assertThrows(IllegalStateException.class,
                     () -> bridgeSupport.addSignature(key, signerEncodedSignatures, svpSpendTxCreationHash));
             }
 
             // assert
-            for (BtcECKey key : WRONG_KEYS) {
+            for (BtcECKey key : wrongKeys) {
                 assertFederatorDidNotSignInputs(svpSpendTx.getInputs(), svpSpendTxSigHashes, key);
             }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
@@ -732,14 +732,32 @@ public class BridgeSupportSvpTest {
                 .build();
 
             // act
-            for (BtcECKey key : PROPOSED_FEDERATION_SIGNERS_KEYS) {
-                List<byte[]> signatures = generateSignerEncodedSignatures(key, svpSpendTxSigHashes);
-                bridgeSupport.addSignature(key, signatures, svpSpendTxCreationHash);
+            for (BtcECKey proposedFederatorSignerKeys : PROPOSED_FEDERATION_SIGNERS_KEYS) {
+                List<byte[]> signatures = generateSignerEncodedSignatures(proposedFederatorSignerKeys, svpSpendTxSigHashes);
+                bridgeSupport.addSignature(proposedFederatorSignerKeys, signatures, svpSpendTxCreationHash);
             }
 
             // assert
-            for (BtcECKey key : PROPOSED_FEDERATION_SIGNERS_KEYS) {
-                assertFederatorDidNotSignInputs(svpSpendTx.getInputs(), svpSpendTxSigHashes, key);
+            for (BtcECKey proposedFederatorSignerKeys : PROPOSED_FEDERATION_SIGNERS_KEYS) {
+                assertFederatorDidNotSignInputs(svpSpendTx.getInputs(), svpSpendTxSigHashes, proposedFederatorSignerKeys);
+            }
+
+            assertAddSignatureWasNotLogged();
+            assertSvpSpendTxWFSWasNotRemoved();
+        }
+
+        @Test
+        void addSignature_forSvpSpendTx_withoutEnoughSignatures_shouldNotAddProposedFederatorsSignatures() throws Exception {
+            // act
+            for (BtcECKey proposedFederatorSignerKey : PROPOSED_FEDERATION_SIGNERS_KEYS) {
+                List<byte[]> signatures = generateSignerEncodedSignatures(proposedFederatorSignerKey, svpSpendTxSigHashes);
+                List<byte[]> notEnoughSignatures = signatures.subList(0, signatures.size() - 1);
+                bridgeSupport.addSignature(proposedFederatorSignerKey, notEnoughSignatures, svpSpendTxCreationHash);
+            }
+
+            // assert
+            for (BtcECKey proposedFederatorSignerKeys : PROPOSED_FEDERATION_SIGNERS_KEYS) {
+                assertFederatorDidNotSignInputs(svpSpendTx.getInputs(), svpSpendTxSigHashes, proposedFederatorSignerKeys);
             }
 
             assertAddSignatureWasNotLogged();

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinTestUtils.java
@@ -160,13 +160,13 @@ public class BitcoinTestUtils {
     public static List<Sha256Hash> generateTransactionInputsSigHashes(BtcTransaction btcTx) {
         return IntStream.range(0, btcTx.getInputs().size())
             .mapToObj(i -> generateSigHashForP2SHTransactionInput(btcTx, i))
-            .collect(Collectors.toList());
+            .toList();
     }
 
     public static List<byte[]> generateSignerEncodedSignatures(BtcECKey signingKey, List<Sha256Hash> sigHashes) {
         return sigHashes.stream()
             .map(signingKey::sign)
             .map(BtcECKey.ECDSASignature::encodeToDER)
-            .collect(Collectors.toList());
+            .toList();
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinTestUtils.java
@@ -2,6 +2,7 @@ package co.rsk.peg.bitcoin;
 
 import static co.rsk.bitcoinj.script.ScriptBuilder.createP2SHOutputScript;
 import static co.rsk.peg.bitcoin.BitcoinUtils.extractRedeemScriptFromInput;
+import static co.rsk.peg.bitcoin.BitcoinUtils.generateSigHashForP2SHTransactionInput;
 
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.crypto.TransactionSignature;
@@ -153,5 +154,24 @@ public class BitcoinTestUtils {
             inputScriptSig = outputScript.getScriptSigWithSignature(inputScriptSig, txSigEncoded, keyIndex);
             input.setScriptSig(inputScriptSig);
         }
+    }
+
+    public static List<Sha256Hash> generateTransactionInputsSigHashes(BtcTransaction btcTx) {
+        List<Sha256Hash> sigHashes = new ArrayList<>();
+        List<TransactionInput> inputs = btcTx.getInputs();
+        for (TransactionInput input : inputs) {
+            Sha256Hash sigHash = generateSigHashForP2SHTransactionInput(btcTx, inputs.indexOf(input));
+            sigHashes.add(sigHash);
+        }
+        return sigHashes;
+    }
+
+    public static List<byte[]> generateSignerEncodedSignatures(BtcECKey signingKey, List<Sha256Hash> sigHashes) {
+        List<byte[]> encodedSignatures = new ArrayList<>();
+        for (Sha256Hash sigHash : sigHashes) {
+            BtcECKey.ECDSASignature signature = signingKey.sign(sigHash);
+            encodedSignatures.add(signature.encodeToDER());
+        }
+        return encodedSignatures;
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinTestUtils.java
@@ -10,6 +10,7 @@ import co.rsk.bitcoinj.script.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.HashUtil;
 
@@ -157,21 +158,15 @@ public class BitcoinTestUtils {
     }
 
     public static List<Sha256Hash> generateTransactionInputsSigHashes(BtcTransaction btcTx) {
-        List<Sha256Hash> sigHashes = new ArrayList<>();
-        List<TransactionInput> inputs = btcTx.getInputs();
-        for (TransactionInput input : inputs) {
-            Sha256Hash sigHash = generateSigHashForP2SHTransactionInput(btcTx, inputs.indexOf(input));
-            sigHashes.add(sigHash);
-        }
-        return sigHashes;
+        return IntStream.range(0, btcTx.getInputs().size())
+            .mapToObj(i -> generateSigHashForP2SHTransactionInput(btcTx, i))
+            .collect(Collectors.toList());
     }
 
     public static List<byte[]> generateSignerEncodedSignatures(BtcECKey signingKey, List<Sha256Hash> sigHashes) {
-        List<byte[]> encodedSignatures = new ArrayList<>();
-        for (Sha256Hash sigHash : sigHashes) {
-            BtcECKey.ECDSASignature signature = signingKey.sign(sigHash);
-            encodedSignatures.add(signature.encodeToDER());
-        }
-        return encodedSignatures;
+        return sigHashes.stream()
+            .map(signingKey::sign)
+            .map(BtcECKey.ECDSASignature::encodeToDER)
+            .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
For the validation protocol to be successful, we need the spend transaction to be signed and broadcasted by the proposed pegnatories.

Requirements
-Create a new `addSvpSpendTxSignature` method that would add the signatures from the proposed pegnatories to the svp spend transaction.

This method should also remove the spend transaction from the map once is fully signed, and emit the `release_btc` event so the federators can proceed with the broadcast.