### PR TITLE
Create processValidationFailure method

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -31,6 +31,8 @@ import java.util.*;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.Repository;
 import org.ethereum.vm.DataWord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.spongycastle.util.encoders.Hex;
 
 /**
@@ -40,6 +42,7 @@ import org.spongycastle.util.encoders.Hex;
  * @author Oscar Guindzberg
  */
 public class BridgeStorageProvider {
+    private static final Logger logger = LoggerFactory.getLogger(BridgeStorageProvider.class);
 
     // Dummy value to use when saving key only indexes
     private static final byte TRUE_VALUE = (byte) 1;
@@ -677,6 +680,33 @@ public class BridgeStorageProvider {
             svpSpendTxWaitingForSignatures,
             BridgeSerializationUtils::serializeRskTxWaitingForSignatures
         );
+    }
+
+    public void clearSvpValues() {
+        if (svpFundTxHashUnsigned != null) {
+            logger.warn("[clearSvpValues] Fund tx change {} was never registered.", svpFundTxHashUnsigned);
+            setSvpFundTxHashUnsigned(null);
+        }
+
+        if (svpFundTxSigned != null) {
+            logger.warn("[clearSvpValues] Spend tx was never created. Fund tx hash: {}", svpFundTxSigned.getHash());
+            setSvpFundTxSigned(null);
+        }
+
+        if (svpSpendTxWaitingForSignatures != null) {
+            Keccak256 rskCreationHash = svpSpendTxWaitingForSignatures.getKey();
+            BtcTransaction svpSpendTx = svpSpendTxWaitingForSignatures.getValue();
+
+            logger.warn("[clearSvpValues] Spend tx {} was not fully signed. Rsk creation hash: {}.",
+                svpSpendTx.getHash(), rskCreationHash);
+            setSvpSpendTxWaitingForSignatures(null);
+            setSvpSpendTxHashUnsigned(null);
+        }
+
+        if (svpSpendTxHashUnsigned != null) {
+            logger.warn("[clearSvpValues] Spend tx {} was not registered.", svpSpendTxHashUnsigned);
+            setSvpSpendTxHashUnsigned(null);
+        }
     }
 
     public void save() {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -684,27 +684,28 @@ public class BridgeStorageProvider {
 
     public void clearSvpValues() {
         if (svpFundTxHashUnsigned != null) {
-            logger.warn("[clearSvpValues] Fund tx change {} was never registered.", svpFundTxHashUnsigned);
+            logger.warn("[clearSvpValues] Clearing fund tx hash unsigned {} value.", svpFundTxHashUnsigned);
             setSvpFundTxHashUnsigned(null);
         }
 
         if (svpFundTxSigned != null) {
-            logger.warn("[clearSvpValues] Spend tx was never created. Fund tx hash: {}", svpFundTxSigned.getHash());
+            logger.warn("[clearSvpValues] Clearing fund tx signed {} value.", svpFundTxSigned.getHash());
             setSvpFundTxSigned(null);
         }
 
         if (svpSpendTxWaitingForSignatures != null) {
             Keccak256 rskCreationHash = svpSpendTxWaitingForSignatures.getKey();
             BtcTransaction svpSpendTx = svpSpendTxWaitingForSignatures.getValue();
-
-            logger.warn("[clearSvpValues] Spend tx {} was not fully signed. Rsk creation hash: {}.",
-                svpSpendTx.getHash(), rskCreationHash);
+            logger.warn(
+                "[clearSvpValues] Clearing spend tx waiting for signatures with spend tx {} and rsk creation hash {} value.",
+                svpSpendTx.getHash(), rskCreationHash
+            );
             setSvpSpendTxWaitingForSignatures(null);
             setSvpSpendTxHashUnsigned(null);
         }
 
         if (svpSpendTxHashUnsigned != null) {
-            logger.warn("[clearSvpValues] Spend tx {} was not registered.", svpSpendTxHashUnsigned);
+            logger.warn("[clearSvpValues] Clearing spend tx hash unsigned {} value.", svpSpendTxHashUnsigned);
             setSvpSpendTxHashUnsigned(null);
         }
     }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1019,17 +1019,16 @@ public class BridgeSupport {
 
     protected void processSVPFailure(Federation proposedFederation) {
         eventLogger.logCommitFederationFailure(rskExecutionBlock, proposedFederation);
-        logger.warn("[processSVPFailure] Proposed federation validation failed at block {}, so svp values will be cleared.", rskExecutionBlock.getNumber());
+        logger.warn(
+            "[processSVPFailure] Proposed federation validation failed at block {}, so federation election will be allowed again.",
+            rskExecutionBlock.getNumber()
+        );
 
-        clearProposedFederation();
-        clearSvpValues();
+        allowFederationElectionAgain();
     }
 
-    private void clearProposedFederation() {
+    private void allowFederationElectionAgain() {
         federationSupport.clearProposedFederation();
-    }
-
-    private void clearSvpValues() {
         provider.clearSvpValues();
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1019,7 +1019,7 @@ public class BridgeSupport {
 
     protected void processValidationFailure(Federation proposedFederation) {
         eventLogger.logCommitFederationFailure(rskExecutionBlock, proposedFederation);
-        logger.warn("[updateSvpState] Proposed federation validation failed so svp values will be cleared.");
+        logger.warn("[processValidationFailure] Proposed federation validation failed so svp values will be cleared.");
         clearSvpValues();
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1035,8 +1035,9 @@ public class BridgeSupport {
             return;
         }
 
-        if (provider.getSvpFundTxSigned().isPresent()) {
-            logger.warn("{} Spend tx was never created.", methodName);
+        Optional<BtcTransaction> svpFundTxSigned = provider.getSvpFundTxSigned();
+        if (svpFundTxSigned.isPresent()) {
+            logger.warn("{} Spend tx was never created. Fund tx hash: {}", methodName, svpFundTxSigned.get().getHash());
             provider.setSvpFundTxSigned(null);
             return;
         }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1017,47 +1017,20 @@ public class BridgeSupport {
         eventLogger.logUpdateCollections(sender);
     }
 
-    protected void processValidationFailure(Federation proposedFederation) {
+    protected void processSVPFailure(Federation proposedFederation) {
         eventLogger.logCommitFederationFailure(rskExecutionBlock, proposedFederation);
-        logger.warn("[processValidationFailure] Proposed federation validation failed so svp values will be cleared.");
+        logger.warn("[processSVPFailure] Proposed federation validation failed at block {}, so svp values will be cleared.", rskExecutionBlock.getNumber());
+
+        clearProposedFederation();
         clearSvpValues();
     }
 
-    private void clearSvpValues() {
+    private void clearProposedFederation() {
         federationSupport.clearProposedFederation();
+    }
 
-        provider.getSvpFundTxHashUnsigned().ifPresent(
-            svpFundTxHashUnsigned -> {
-                logger.warn("[clearSvpValues] Fund tx change {} was never registered.", svpFundTxHashUnsigned);
-                provider.setSvpFundTxHashUnsigned(null);
-            }
-        );
-
-        provider.getSvpFundTxSigned().ifPresent(
-            svpFundTxSigned -> {
-                logger.warn("[clearSvpValues] Spend tx was never created. Fund tx hash: {}", svpFundTxSigned.getHash());
-                provider.setSvpFundTxSigned(null);
-            }
-        );
-
-        provider.getSvpSpendTxWaitingForSignatures().ifPresent(
-            svpSpendTxWFS -> {
-                Keccak256 rskCreationHash = svpSpendTxWFS.getKey();
-                BtcTransaction svpSpendTx = svpSpendTxWFS.getValue();
-
-                logger.warn("[clearSvpValues] Spend tx {} was not fully signed. Rsk creation hash: {}.",
-                    svpSpendTx.getHash(), rskCreationHash);
-                provider.setSvpSpendTxWaitingForSignatures(null);
-                provider.setSvpSpendTxHashUnsigned(null);
-            }
-        );
-
-        provider.getSvpSpendTxHashUnsigned().ifPresent(
-            svpSpendTxHashUnsigned -> {
-                logger.warn("[clearSvpValues] Spend tx {} was not registered.", svpSpendTxHashUnsigned);
-                provider.setSvpSpendTxHashUnsigned(null);
-            }
-        );
+    private void clearSvpValues() {
+        provider.clearSvpValues();
     }
 
     private boolean svpIsOngoing() {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1017,6 +1017,22 @@ public class BridgeSupport {
         eventLogger.logUpdateCollections(sender);
     }
 
+    protected void processValidationFailure(Federation proposedFederation) {
+        eventLogger.logCommitFederationFailure(rskExecutionBlock, proposedFederation);
+        logger.warn("[updateSvpState] Proposed federation validation failed so svp values will be cleared.");
+        clearSvpValues();
+    }
+
+    private void clearSvpValues() {
+        federationSupport.clearProposedFederation();
+        // even if we know all these values cannot exist simultaneously,
+        // is easier to just clean them all.
+        provider.setSvpFundTxHashUnsigned(null);
+        provider.setSvpFundTxSigned(null);
+        provider.setSvpSpendTxHashUnsigned(null);
+        provider.setSvpSpendTxWaitingForSignatures(null);
+    }
+
     private boolean svpIsOngoing() {
         return federationSupport.getProposedFederation()
             .map(Federation::getCreationBlockNumber)

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupport.java
@@ -125,6 +125,8 @@ public interface FederationSupport {
      */
     Optional<byte[]> getProposedFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType);
 
+    void clearProposedFederation();
+
     int voteFederationChange(
         Transaction tx,
         ABICallSpec callSpec,

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupportImpl.java
@@ -399,6 +399,11 @@ public class FederationSupportImpl implements FederationSupport {
     }
 
     @Override
+    public void clearProposedFederation() {
+        provider.setProposedFederation(null);
+    }
+
+    @Override
     public int voteFederationChange(Transaction tx, ABICallSpec callSpec, SignatureCache signatureCache, BridgeEventLogger eventLogger) {
         String calledFunction = callSpec.getFunction();
         // Must be on one of the allowed functions

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -1162,6 +1162,76 @@ class BridgeStorageProviderTest {
         }
     }
 
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @Tag("clear svp values tests")
+    class ClearSvpValuesTests {
+        private BridgeStorageProvider bridgeStorageProvider;
+
+        @BeforeEach
+        void setup() {
+            Repository repository = createRepository();
+            bridgeStorageProvider = createBridgeStorageProvider(repository, mainnetBtcParams, activationsAllForks);
+        }
+
+        @Test
+        void clearSvpValues_whenFundTxHashUnsigned_shouldClearValue() {
+            // arrange
+            Sha256Hash svpFundTxHashUnsigned = BitcoinTestUtils.createHash(1);
+            bridgeStorageProvider.setSvpFundTxHashUnsigned(svpFundTxHashUnsigned);
+
+            // act
+            bridgeStorageProvider.clearSvpValues();
+
+            // assert
+            assertFalse(bridgeStorageProvider.getSvpFundTxHashUnsigned().isPresent());
+        }
+
+        @Test
+        void clearSvpValues_whenFundTxSigned_shouldClearValue() {
+            // arrange
+            BtcTransaction svpFundTxSigned = new BtcTransaction(mainnetBtcParams);
+            bridgeStorageProvider.setSvpFundTxSigned(svpFundTxSigned);
+
+            // act
+            bridgeStorageProvider.clearSvpValues();
+
+            // assert
+            assertFalse(bridgeStorageProvider.getSvpFundTxSigned().isPresent());
+        }
+
+        @Test
+        void clearSvpValues_whenSpendTxWFS_shouldClearSpendTxValues() {
+            // arrange
+            Keccak256 svpSpendTxCreationHash = RskTestUtils.createHash(1);
+            BtcTransaction svpSpendTx = new BtcTransaction(mainnetBtcParams);
+            Map.Entry<Keccak256, BtcTransaction> svpSpendTxWFS = new AbstractMap.SimpleEntry<>(svpSpendTxCreationHash, svpSpendTx);
+            bridgeStorageProvider.setSvpSpendTxWaitingForSignatures(svpSpendTxWFS);
+
+            // act
+            bridgeStorageProvider.clearSvpValues();
+
+            // assert
+            assertFalse(bridgeStorageProvider.getSvpSpendTxWaitingForSignatures().isPresent());
+            assertFalse(bridgeStorageProvider.getSvpSpendTxHashUnsigned().isPresent());
+        }
+
+        @Test
+        void clearSvpValues_whenSpendTxHashUnsigned_shouldClearValue() {
+            // arrange
+            Keccak256 svpSpendTxCreationHash = RskTestUtils.createHash(1);
+            BtcTransaction svpSpendTx = new BtcTransaction(mainnetBtcParams);
+            Map.Entry<Keccak256, BtcTransaction> svpSpendTxWFS = new AbstractMap.SimpleEntry<>(svpSpendTxCreationHash, svpSpendTx);
+            bridgeStorageProvider.setSvpSpendTxWaitingForSignatures(svpSpendTxWFS);
+
+            // act
+            bridgeStorageProvider.clearSvpValues();
+
+            // assert
+            assertFalse(bridgeStorageProvider.getSvpSpendTxHashUnsigned().isPresent());
+        }
+    }
+
     @Test
     void getReleaseRequestQueue_before_rskip_146_activation() throws IOException {
         Repository repositoryMock = mock(Repository.class);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -1184,7 +1184,7 @@ class BridgeStorageProviderTest {
             bridgeStorageProvider.clearSvpValues();
 
             // assert
-            assertFalse(bridgeStorageProvider.getSvpFundTxHashUnsigned().isPresent());
+            assertNoSVPValues();
         }
 
         @Test
@@ -1197,7 +1197,7 @@ class BridgeStorageProviderTest {
             bridgeStorageProvider.clearSvpValues();
 
             // assert
-            assertFalse(bridgeStorageProvider.getSvpFundTxSigned().isPresent());
+            assertNoSVPValues();
         }
 
         @Test
@@ -1212,8 +1212,7 @@ class BridgeStorageProviderTest {
             bridgeStorageProvider.clearSvpValues();
 
             // assert
-            assertFalse(bridgeStorageProvider.getSvpSpendTxWaitingForSignatures().isPresent());
-            assertFalse(bridgeStorageProvider.getSvpSpendTxHashUnsigned().isPresent());
+            assertNoSVPValues();
         }
 
         @Test
@@ -1228,6 +1227,13 @@ class BridgeStorageProviderTest {
             bridgeStorageProvider.clearSvpValues();
 
             // assert
+            assertNoSVPValues();
+        }
+
+        private void assertNoSVPValues() {
+            assertFalse(bridgeStorageProvider.getSvpFundTxHashUnsigned().isPresent());
+            assertFalse(bridgeStorageProvider.getSvpFundTxSigned().isPresent());
+            assertFalse(bridgeStorageProvider.getSvpSpendTxWaitingForSignatures().isPresent());
             assertFalse(bridgeStorageProvider.getSvpSpendTxHashUnsigned().isPresent());
         }
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
@@ -56,11 +56,12 @@ public class BridgeSupportSvpTest {
 
     private static final Coin spendableValueFromProposedFederation = bridgeMainNetConstants.getSpendableValueFromProposedFederation();
 
-    private final CallTransaction.Function releaseRequestedEvent = BridgeEvents.RELEASE_REQUESTED.getEvent();
-    private final CallTransaction.Function pegoutTransactionCreatedEvent = BridgeEvents.PEGOUT_TRANSACTION_CREATED.getEvent();
-    private final CallTransaction.Function addSignatureEvent = BridgeEvents.ADD_SIGNATURE.getEvent();
-    private final CallTransaction.Function releaseBtcEvent = BridgeEvents.RELEASE_BTC.getEvent();
-    private final CallTransaction.Function commitFederationFailedEvent = BridgeEvents.COMMIT_FEDERATION_FAILED.getEvent();
+    private static final CallTransaction.Function releaseRequestedEvent = BridgeEvents.RELEASE_REQUESTED.getEvent();
+    private static final CallTransaction.Function pegoutTransactionCreatedEvent = BridgeEvents.PEGOUT_TRANSACTION_CREATED.getEvent();
+    private static final CallTransaction.Function addSignatureEvent = BridgeEvents.ADD_SIGNATURE.getEvent();
+    private static final CallTransaction.Function releaseBtcEvent = BridgeEvents.RELEASE_BTC.getEvent();
+    private static final CallTransaction.Function commitFederationFailedEvent = BridgeEvents.COMMIT_FEDERATION_FAILED.getEvent();
+
     private final BridgeSupportBuilder bridgeSupportBuilder = BridgeSupportBuilder.builder();
 
     private List<LogInfo> logs;

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
@@ -226,6 +226,7 @@ public class BridgeSupportSvpTest {
         private void assertNoProposedFederation() {
             assertFalse(federationSupport.getProposedFederation().isPresent());
         }
+
         private void assertNoSVPValues() {
             assertFalse(bridgeStorageProvider.getSvpFundTxHashUnsigned().isPresent());
             assertFalse(bridgeStorageProvider.getSvpFundTxSigned().isPresent());

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
@@ -119,7 +119,7 @@ public class BridgeSupportSvpTest {
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     @Tag("update svp state tests")
-    class SvpUpdateCollectionsTests {
+    class UpdateSvpStateTests {
         @BeforeEach
         void setUp() {
             logs = new ArrayList<>();

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
@@ -118,8 +118,8 @@ public class BridgeSupportSvpTest {
 
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    @Tag("Validation failure tests")
-    class ValidationFailureTests {
+    @Tag("SVP failure tests")
+    class SVPFailureTests {
         @BeforeEach
         void setUp() {
             logs = new ArrayList<>();
@@ -158,45 +158,44 @@ public class BridgeSupportSvpTest {
             bridgeStorageProvider.setSvpFundTxHashUnsigned(svpFundTxHashUnsigned);
 
             // act
-            bridgeSupport.processValidationFailure(proposedFederation);
+            bridgeSupport.processSVPFailure(proposedFederation);
 
             // assert
             assertLogCommitFederationFailed();
-            assertProposedFederationWasCleared();
-            assertFalse(bridgeStorageProvider.getSvpFundTxHashUnsigned().isPresent());
+            assertNoProposedFederation();
+            assertNoSVPValues();
         }
 
         @Test
         void processValidationFailure_whenSvpFundTxSigned_shouldLogValidationFailureAndClearValue() {
             // arrange
-            BtcTransaction svpFundTx = mock(BtcTransaction.class);
+            BtcTransaction svpFundTx = new BtcTransaction(btcMainnetParams);
             bridgeStorageProvider.setSvpFundTxSigned(svpFundTx);
 
             // act
-            bridgeSupport.processValidationFailure(proposedFederation);
+            bridgeSupport.processSVPFailure(proposedFederation);
 
             // assert
             assertLogCommitFederationFailed();
-            assertProposedFederationWasCleared();
-            assertFalse(bridgeStorageProvider.getSvpFundTxSigned().isPresent());
+            assertNoProposedFederation();
+            assertNoSVPValues();
         }
 
         @Test
         void processValidationFailure_whenSvpSpendTxWFS_shouldLogValidationFailureAndClearSpendTxValues() {
             // arrange
             Keccak256 svpSpendTxCreationHash = RskTestUtils.createHash(1);
-            BtcTransaction svpSpendTx = mock(BtcTransaction.class);
+            BtcTransaction svpSpendTx = new BtcTransaction(btcMainnetParams);
             Map.Entry<Keccak256, BtcTransaction> svpSpendTxWFS = new AbstractMap.SimpleEntry<>(svpSpendTxCreationHash, svpSpendTx);
             bridgeStorageProvider.setSvpSpendTxWaitingForSignatures(svpSpendTxWFS);
 
             // act
-            bridgeSupport.processValidationFailure(proposedFederation);
+            bridgeSupport.processSVPFailure(proposedFederation);
 
             // assert
             assertLogCommitFederationFailed();
-            assertProposedFederationWasCleared();
-            assertFalse(bridgeStorageProvider.getSvpSpendTxWaitingForSignatures().isPresent());
-            assertFalse(bridgeStorageProvider.getSvpSpendTxHashUnsigned().isPresent());
+            assertNoProposedFederation();
+            assertNoSVPValues();
         }
 
         @Test
@@ -206,12 +205,12 @@ public class BridgeSupportSvpTest {
             bridgeStorageProvider.setSvpSpendTxHashUnsigned(svpSpendTxHash);
 
             // act
-            bridgeSupport.processValidationFailure(proposedFederation);
+            bridgeSupport.processSVPFailure(proposedFederation);
 
             // assert
             assertLogCommitFederationFailed();
-            assertProposedFederationWasCleared();
-            assertFalse(bridgeStorageProvider.getSvpSpendTxHashUnsigned().isPresent());
+            assertNoProposedFederation();
+            assertNoSVPValues();
         }
 
         private void assertLogCommitFederationFailed() {
@@ -224,8 +223,14 @@ public class BridgeSupportSvpTest {
             assertEventWasEmittedWithExpectedData(encodedData);
         }
 
-        private void assertProposedFederationWasCleared() {
+        private void assertNoProposedFederation() {
             assertFalse(federationSupport.getProposedFederation().isPresent());
+        }
+        private void assertNoSVPValues() {
+            assertFalse(bridgeStorageProvider.getSvpFundTxHashUnsigned().isPresent());
+            assertFalse(bridgeStorageProvider.getSvpFundTxSigned().isPresent());
+            assertFalse(bridgeStorageProvider.getSvpSpendTxWaitingForSignatures().isPresent());
+            assertFalse(bridgeStorageProvider.getSvpSpendTxHashUnsigned().isPresent());
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
@@ -2172,6 +2172,28 @@ class FederationSupportImplTest {
     }
 
     @Test
+    @Tag("clear proposed federation")
+    void clearProposedFederation_removesProposedFederation() {
+        // arrange
+        ActivationConfig.ForBlock activations = ActivationConfigsForTest.all().forBlock(0);
+
+        ErpFederation federation = P2shErpFederationBuilder.builder().build();
+        storageProvider.setProposedFederation(federation);
+
+        // first check the proposed federation was correctly saved
+        Optional<Federation> proposedFederation = storageProvider.getProposedFederation(federationMainnetConstants, activations);
+        assertTrue(proposedFederation.isPresent());
+        assertThat(proposedFederation.get(), is(federation));
+
+        // act
+        federationSupport.clearProposedFederation();
+
+        // assert
+        Optional<Federation> currentProposedFederation = storageProvider.getProposedFederation(federationMainnetConstants, activations);
+        assertFalse(currentProposedFederation.isPresent());
+    }
+
+    @Test
     @Tag("save")
     void save_callsStorageProviderSave() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);


### PR DESCRIPTION
After concluding the validation was a failure, we need to emit the `commitFederationFailed` event and reset all the values that are used in the process for the federation change to be allowed again.

In this pr, a new `processValidationFailure` method is created:

- emit the new `commitFederationFailed` Bridge event

- clear the proposedFederation storage entry
- clear the svp fund tx storage entries
- clear the expected svp spend tx storage entry/ies