### PR TITLE
Create updateSvpState method

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1032,19 +1032,15 @@ public class BridgeSupport {
             return;
         }
 
-        // if the unsigned fund tx hash is not present, we will proceed with the fund tx creation
-        // if it is, we keep waiting for the change to be registered.
-
-        // if the fund tx signed is present, then the change was registered,
+        // if the fund tx signed is present, then the fund transaction change was registered,
         // meaning we can create the spend tx.
-
-        // if none of those values are present, we keep waiting for the spend tx to be registered.
         Optional<BtcTransaction> svpFundTxSigned = provider.getSvpFundTxSigned();
         if (svpFundTxSigned.isPresent()) {
             processSvpSpendTransactionUnsigned(rskTxHash, proposedFederation, svpFundTxSigned.get());
             return;
         }
 
+        // if the unsigned fund tx hash is not present, meaning we can proceed with the fund tx creation
         Optional<Sha256Hash> svpFundTxHashUnsigned = provider.getSvpFundTxHashUnsigned();
         if (svpFundTxHashUnsigned.isEmpty()) {
             try {


### PR DESCRIPTION
**Background**
In order to keep going with the validation process, in every `updateCollections` we will call a new validation-related method, `updateSvpState`, that will update the state of the svp process to see if the validation failed, or if conditions are met for creating the fund or the spend transaction.

 
IN THIS PR
Create a new `updateSvpState` method that will:
- If a proposed federation does not exist, do nothing.

- If a proposed federation exists and the validation period is ended, we can conclude that the validation failed.

-If a proposed federation exists, the validation period is not ended and the `svpFundTxHashUnigned` entry is empty, we have to proceed with the fund transaction creation and processing.

-If a proposed federation exists, the validation period is not ended and the `svpFundTxSigned` has a value stored, we will proceed with the spend tx creation.

