### PR TITLE
Do not set last retired fed p2sh script in new commitFederation impl

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupportImpl.java
@@ -702,8 +702,9 @@ public class FederationSupportImpl implements FederationSupport {
         clearPendingFederationVoting();
 
         if (activations.isActive(RSKIP186)) {
-            setNewActiveFederationCreationBlockHeight();
-            preserveLastRetiredFederationScript();
+            // since we are creating the to-be-active-fed in this block,
+            // its creation block height is this block number
+            saveFederationChangeInfo(rskExecutionBlock.getNumber());
         }
 
         Federation currentOldFederation = provider.getOldFederation(constants, activations);
@@ -734,7 +735,6 @@ public class FederationSupportImpl implements FederationSupport {
         // set proposed federation
         Federation proposedFederation = buildFederationFromPendingFederation(currentPendingFederation);
         provider.setProposedFederation(proposedFederation);
-        setNewActiveFederationCreationBlockHeight();
 
         clearPendingFederationVoting();
 
@@ -756,17 +756,15 @@ public class FederationSupportImpl implements FederationSupport {
         provider.getFederationElection(constants.getFederationChangeAuthorizer()).clear();
     }
 
-    private void preserveLastRetiredFederationScript() {
+    private void saveFederationChangeInfo(long newActiveFederationCreationBlockHeight) {
+        saveLastRetiredFederationScript();
+        provider.setNextFederationCreationBlockHeight(newActiveFederationCreationBlockHeight);
+    }
+
+    private void saveLastRetiredFederationScript() {
         Federation activeFederation = getActiveFederation();
         Script activeFederationMembersP2SHScript = getFederationMembersP2SHScript(activeFederation);
         provider.setLastRetiredFederationP2SHScript(activeFederationMembersP2SHScript);
-    }
-
-    private void setNewActiveFederationCreationBlockHeight() {
-        // since we are creating the to-be-active-fed in this block,
-        // its creation block height is this block number
-        long newActiveFederationCreationBlockHeight = rskExecutionBlock.getNumber();
-        provider.setNextFederationCreationBlockHeight(newActiveFederationCreationBlockHeight);
     }
 
     private Script getFederationMembersP2SHScript(Federation federation) {

--- a/rskj-core/src/test/java/co/rsk/peg/federation/VoteFederationChangeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/VoteFederationChangeTest.java
@@ -415,7 +415,8 @@ class VoteFederationChangeTest {
 
         assertPendingFederationVotingWasCleaned();
 
-        assertFederationChangeInfoWasSet();
+        assertNewActiveFederationCreationBlockHeightWasSet();
+        assertLastRetiredFederationScriptWasSet();
 
         Federation oldFederation = storageProvider.getOldFederation(federationMainnetConstants, activations);
         Federation newFederation = storageProvider.getNewFederation(federationMainnetConstants, activations);
@@ -443,7 +444,7 @@ class VoteFederationChangeTest {
 
         assertPendingFederationVotingWasCleaned();
 
-        assertFederationChangeInfoWasSet();
+        assertNewActiveFederationCreationBlockHeightWasSet();
 
         assertLogCommitFederation(activeFederation, proposedFederation.get());
 
@@ -509,13 +510,13 @@ class VoteFederationChangeTest {
         assertTrue(federationElectionVotes.isEmpty());
     }
 
-    private void assertFederationChangeInfoWasSet() {
-        // assert federation creation block height was set correctly
+    private void assertNewActiveFederationCreationBlockHeightWasSet() {
         Optional<Long> nextFederationCreationBlockHeight = storageProvider.getNextFederationCreationBlockHeight(activations);
         assertTrue(nextFederationCreationBlockHeight.isPresent());
         assertEquals(RSK_EXECUTION_BLOCK_NUMBER, nextFederationCreationBlockHeight.get());
+    }
 
-        // assert last retired federation p2sh script was set correctly
+    private void assertLastRetiredFederationScriptWasSet() {
         Script activeFederationMembersP2SHScript = getFederationMembersP2SHScript(activations, federationSupport.getActiveFederation());
         Optional<Script> lastRetiredFederationP2SHScript = storageProvider.getLastRetiredFederationP2SHScript(activations);
         assertTrue(lastRetiredFederationP2SHScript.isPresent());

--- a/rskj-core/src/test/java/co/rsk/peg/federation/VoteFederationChangeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/VoteFederationChangeTest.java
@@ -444,11 +444,11 @@ class VoteFederationChangeTest {
 
         assertPendingFederationVotingWasCleaned();
 
-        assertNewActiveFederationCreationBlockHeightWasSet();
-
         assertLogCommitFederation(activeFederation, proposedFederation.get());
 
-        // assert new and old federation were not set and utxos were not moved
+        // assert some values were not set
+        assertNewActiveFederationCreationBlockHeightWasNotSet();
+        assertLastRetiredFederationScriptWasNotSet();
         assertNewAndOldFederationsWereNotSet();
         assertUTXOsWereNotMovedFromNewToOldFederation();
     }
@@ -516,11 +516,21 @@ class VoteFederationChangeTest {
         assertEquals(RSK_EXECUTION_BLOCK_NUMBER, nextFederationCreationBlockHeight.get());
     }
 
+    private void assertNewActiveFederationCreationBlockHeightWasNotSet() {
+        Optional<Long> nextFederationCreationBlockHeight = storageProvider.getNextFederationCreationBlockHeight(activations);
+        assertFalse(nextFederationCreationBlockHeight.isPresent());
+    }
+
     private void assertLastRetiredFederationScriptWasSet() {
         Script activeFederationMembersP2SHScript = getFederationMembersP2SHScript(activations, federationSupport.getActiveFederation());
         Optional<Script> lastRetiredFederationP2SHScript = storageProvider.getLastRetiredFederationP2SHScript(activations);
         assertTrue(lastRetiredFederationP2SHScript.isPresent());
         assertEquals(activeFederationMembersP2SHScript, lastRetiredFederationP2SHScript.get());
+    }
+
+    private void assertLastRetiredFederationScriptWasNotSet() {
+        Optional<Script> lastRetiredFederationP2SHScript = storageProvider.getLastRetiredFederationP2SHScript(activations);
+        assertFalse(lastRetiredFederationP2SHScript.isPresent());
     }
 
     private Script getFederationMembersP2SHScript(ActivationConfig.ForBlock activations, Federation federation) {


### PR DESCRIPTION
Last-retired-federation script shouldn't be set in new commitFederation implementation, since we will set the to-be-active-federation after its validation.