### PR TITLE
Handling transaction revert in eth_estimateGas

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
@@ -146,7 +146,7 @@ public class EthModule
             } else {
                 res = callConstant(args, block);
             }
-            handleTransactionRevert(res);
+            handleTransactionRevertIfHappens(res);
             hReturn = HexUtils.toUnformattedJsonHex(res.getHReturn());
 
             return hReturn;
@@ -181,7 +181,7 @@ public class EthModule
             );
 
             ProgramResult res = executor.getResult();
-            handleTransactionRevert(res);
+            handleTransactionRevertIfHappens(res);
 
             estimation = internalEstimateGas(executor.getResult());
 
@@ -348,7 +348,7 @@ public class EthModule
         );
     }
 
-    private void handleTransactionRevert(ProgramResult res) {
+    private void handleTransactionRevertIfHappens(ProgramResult res) {
         if (res.isRevert()) {
             Pair<String, byte[]> programRevert = decodeProgramRevert(res);
             String revertReason = programRevert.getLeft();


### PR DESCRIPTION
## Align eth_estimateGas behavior with Geth for reverted transactions

## Description
This PR refactors the `eth_estimateGas` RPC call on RSK to handle reverted transactions similarly to Geth. Previously, the `eth_estimateGas` call on RSK did not return an error when a transaction was reverted. This change adds a missing check to ensure that when a transaction is reverted, the `eth_estimateGas` call returns an error, aligning with Geth’s behavior. Check this documentation for more info: https://www.notion.so/iovlabs/Analysis-of-eth_estimateGas-Behavior-on-RSKJ-Node-for-Reverted-Transactions-13cc132873f980c0aa87de78ed0f84a0

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
