### PR TITLE
SVP spend tx waiting for signatures default double serialization

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -120,6 +120,10 @@ public class BridgeSerializationUtils {
 
     public static byte[] serializeRskTxWaitingForSignatures(
           Map.Entry<Keccak256, BtcTransaction> rskTxWaitingForSignaturesEntry) {
+        if (rskTxWaitingForSignaturesEntry == null) {
+            return RLP.encodedEmptyList();
+        }
+
         byte[][] serializedRskTxWaitingForSignaturesEntry =
             serializeRskTxWaitingForSignaturesEntry(rskTxWaitingForSignaturesEntry);
         return RLP.encodeList(serializedRskTxWaitingForSignaturesEntry);
@@ -154,7 +158,6 @@ public class BridgeSerializationUtils {
 
     public static Map.Entry<Keccak256, BtcTransaction> deserializeRskTxWaitingForSignatures(
             byte[] data, NetworkParameters networkParameters) {
-
         if (data == null || data.length == 0) {
             return null;
         }
@@ -187,6 +190,9 @@ public class BridgeSerializationUtils {
 
     private static Map.Entry<Keccak256, BtcTransaction> deserializeRskTxWaitingForSignaturesEntry(
             RLPList rlpList, int index, NetworkParameters networkParameters) {
+        if (rlpList.size() == 0) {
+            return null;
+        }
 
         RLPElement rskTxHashRLPElement = rlpList.get(index * 2);
         byte[] rskTxHashData = rskTxHashRLPElement.getRLPData();

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1939,19 +1939,20 @@ public class BridgeSupport {
 
    /**
      * Retrieves the current SVP spend transaction state for the SVP client.
+     *
      * <p>
      * This method checks if there is an SVP spend transaction waiting for signatures, and if so, it serializes 
      * the state into RLP format. If no transaction is waiting, it returns an encoded empty RLP list.
      * </p>
      *
      * @return A byte array representing the RLP-encoded state of the SVP spend transaction. If no transaction 
-     *         is waiting, returns an RLP-encoded empty list.
+     *         is waiting, returns a double RLP-encoded empty list.
      */
     public byte[] getStateForSvpClient() {
         return provider.getSvpSpendTxWaitingForSignatures()
             .map(StateForProposedFederator::new)
             .map(StateForProposedFederator::encodeToRlp)
-            .orElse(RLP.encodedEmptyList());
+            .orElse(RLP.encodeList(RLP.encodedEmptyList()));
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/peg/StateForFederator.java
+++ b/rskj-core/src/main/java/co/rsk/peg/StateForFederator.java
@@ -43,6 +43,18 @@ public class StateForFederator {
                 decodeRlpToMap(rlpData), networkParameters));
     }
 
+    /**
+     * Retrieves a sorted map of RSK transactions that are waiting for signatures.
+     *
+     * <p>
+     * The returned {@code SortedMap<Keccak256, BtcTransaction>} contains entries where the key
+     * is the hash of the RSK transaction, and the value is the {@code BtcTransaction} object.
+     * This method guarantees a non-null result, returning an empty map if no transactions are pending.
+     * </p>
+     *
+     * @return a non-null {@code SortedMap<Keccak256, BtcTransaction>} of transactions waiting for signatures;
+     *         if no transactions are pending, an empty map is returned.
+     */
     public SortedMap<Keccak256, BtcTransaction> getRskTxsWaitingForSignatures() {
         return rskTxsWaitingForSignatures;
     }

--- a/rskj-core/src/main/java/co/rsk/peg/StateForProposedFederator.java
+++ b/rskj-core/src/main/java/co/rsk/peg/StateForProposedFederator.java
@@ -21,7 +21,6 @@ package co.rsk.peg;
 import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.crypto.Keccak256;
-import java.util.AbstractMap;
 import java.util.Map;
 import java.util.Objects;
 import org.ethereum.util.RLP;
@@ -32,10 +31,7 @@ public class StateForProposedFederator {
     private final Map.Entry<Keccak256, BtcTransaction> svpSpendTxWaitingForSignatures;
 
     public StateForProposedFederator(Map.Entry<Keccak256, BtcTransaction> svpSpendTxWaitingForSignatures) {
-        Objects.requireNonNull(svpSpendTxWaitingForSignatures);
-
-        this.svpSpendTxWaitingForSignatures = 
-            new AbstractMap.SimpleImmutableEntry<>(svpSpendTxWaitingForSignatures);
+        this.svpSpendTxWaitingForSignatures = svpSpendTxWaitingForSignatures;
     }
 
     public StateForProposedFederator(byte[] rlpData, NetworkParameters networkParameters) {
@@ -44,6 +40,18 @@ public class StateForProposedFederator {
                 decodeRlpToEntry(rlpData), networkParameters));
     }
 
+    /**
+     * Retrieves the SVP spend transaction waiting for signatures.
+     *
+     * <p>
+     * This method returns a {@code Map.Entry<Keccak256, BtcTransaction>} representing
+     * the transaction waiting for signatures, with the hash of the transaction as the key
+     * and the {@code BtcTransaction} object as the value.
+     * </p>
+     *
+     * @return a {@code Map.Entry<Keccak256, BtcTransaction>} if a transaction is pending
+     * for signatures, or {@code null} if no such transaction exists.
+     */
     public Map.Entry<Keccak256, BtcTransaction> getSvpSpendTxWaitingForSignatures() {
         return svpSpendTxWaitingForSignatures;
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -73,11 +73,9 @@ import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
-
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -213,9 +211,18 @@ class BridgeSerializationUtilsTest {
         assertArrayEquals(pegoutTx.bitcoinSerialize(), deserializedEntry.getValue().bitcoinSerialize());
     }
 
+    @Test
+    void serializeRskTxWaitingForSignatures_whenNullValuePassed_shouldReturnEmptyResult() {
+        // Act
+        byte[] result =
+            BridgeSerializationUtils.serializeRskTxWaitingForSignatures(null);
+
+        // Assert
+        assertArrayEquals(RLP.encodedEmptyList(), result);
+    }
+
     @ParameterizedTest
-    @NullSource
-    @EmptySource
+    @MethodSource("provideInvalidData")
     void deserializeRskTxWaitingForSignatures_whenInvalidData_shouldReturnEmptyResult(byte[] data) {
         // Act
         Map.Entry<Keccak256, BtcTransaction> result =
@@ -223,6 +230,13 @@ class BridgeSerializationUtilsTest {
 
         // Assert
         assertNull(result);
+    }
+    
+    private static Stream<byte[]> provideInvalidData() {
+        return Stream.of(
+            null,
+            new byte[]{},
+            RLP.encodedEmptyList());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/StateForProposedFederatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/StateForProposedFederatorTest.java
@@ -15,19 +15,20 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package co.rsk.peg;
 
 import static co.rsk.RskTestUtils.createHash;
 import static org.ethereum.TestUtils.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.crypto.Keccak256;
 import java.util.AbstractMap;
 import java.util.Map;
+import org.ethereum.util.RLP;
 import org.junit.jupiter.api.Test;
 
 class StateForProposedFederatorTest {
@@ -53,9 +54,15 @@ class StateForProposedFederatorTest {
     }
 
     @Test
-    void stateForProposedFederator_whenNullValueAndSerializeAndDeserialize_shouldThrowNullPointerException() {
+    void stateForProposedFederator_whenEmptyDoubleRLPEncodedList_shouldReturnEmptySvpSpendTxWaitingForSignatures() {
+        // Arrange
+        var doubleEncodedEmptyList = RLP.encodeList(RLP.encodedEmptyList());
+
+        // Act
+        StateForProposedFederator deserializedStateForProposedFederator =
+            new StateForProposedFederator(doubleEncodedEmptyList, NETWORK_PARAMETERS);
+       
         // Assert
-        assertThrows(NullPointerException.class, () -> new StateForProposedFederator(null));
-        assertThrows(NullPointerException.class, () -> new StateForProposedFederator(null, NETWORK_PARAMETERS));
+        assertNull(deserializedStateForProposedFederator.getSvpSpendTxWaitingForSignatures());
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In this PR we address a fix that was caught when running the `powpeg-node` locally. When there is no SVP spend tx waiting for signatures, the `Bridge` currently returns an single serialized empty array. The problem is that the DTO used (`StateForProposedFederator`) assumes that as its predecessor (`StateForFederator`) it should be double serialized. So this change also returns an empty double serialized array using the RLP format. 

The error thrown by the listener in the powpeg-node:

```
2024-11-14-10:52:55.206 TRACE [c.r.f.BridgeTransactionSender]  Bridge call - method: getStateForSvpClient
2024-11-14-10:52:55.207 ERROR [events]  Listener callback failed with exception
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
        at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100)
        at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106)
        at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302)
        at java.base/java.util.Objects.checkIndex(Objects.java:385)
        at java.base/java.util.ArrayList.get(ArrayList.java:427)
        at org.ethereum.util.RLPList.get(RLPList.java:48)
        at co.rsk.peg.StateForProposedFederator.decodeRlpToEntry(StateForProposedFederator.java:66)
        at co.rsk.peg.StateForProposedFederator.<init>(StateForProposedFederator.java:44)
        at co.rsk.federate.FederatorSupport.lambda$getStateForProposedFederator$0(FederatorSupport.java:155)
        at java.base/java.util.Optional.map(Optional.java:260)
        at co.rsk.federate.FederatorSupport.getStateForProposedFederator(FederatorSupport.java:155)
        at co.rsk.federate.btcreleaseclient.BtcReleaseClient$BtcReleaseEthereumListener.onBestBlock(BtcReleaseClient.java:243)
        at org.ethereum.listener.CompositeEthereumListener.lambda$onBestBlock$2(CompositeEthereumListener.java:71)
        at org.ethereum.listener.CompositeEthereumListener.scheduleListenerCallbacks(CompositeEthereumListener.java:132)
        at org.ethereum.listener.CompositeEthereumListener.onBestBlock(CompositeEthereumListener.java:71)
        at co.rsk.core.bc.BlockChainImpl.onBestBlock(BlockChainImpl.java:513)
        at co.rsk.core.bc.BlockChainImpl.internalTryToConnect(BlockChainImpl.java:304)
        at co.rsk.core.bc.BlockChainImpl.tryToConnect(BlockChainImpl.java:158)
        at org.ethereum.facade.EthereumImpl.addNewMinedBlock(EthereumImpl.java:62)
        at co.rsk.mine.MinerServerImpl.processSolution(MinerServerImpl.java:346)
        at co.rsk.mine.MinerServerImpl.submitBitcoinBlock(MinerServerImpl.java:291)
        at co.rsk.mine.MinerServerImpl.submitBitcoinBlock(MinerServerImpl.java:285)
        at co.rsk.mine.MinerClientImpl.mineBlock(MinerClientImpl.java:146)
        at co.rsk.mine.MinerClientImpl.doWork(MinerClientImpl.java:102)
        at co.rsk.mine.MinerClientImpl$1.run(MinerClientImpl.java:88)
```


## Motivation and Context
https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP419.md

## How Has This Been Tested?
This has been tested locally in regtest. The powpeg-node is able to process new blocks without error when the SVP spend tx is not present. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X ] I have updated the documentation accordingly.
- [ X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
