### PR TITLE
Include SVP transactions as possible transaction types to be used by the Bridge

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -444,14 +444,6 @@ public class BridgeSupport {
         }
     }
 
-    private boolean isTheSvpFundTransaction(BtcTransaction transaction) {
-        return provider.getSvpFundTxHashUnsigned()
-            .map(svpFundTransactionHashUnsigned ->
-                getMultiSigTransactionHashWithoutSignatures(networkParameters, transaction).equals(svpFundTransactionHashUnsigned)
-            )
-            .orElse(false);
-    }
-
     private void updateSvpFundTransactionValues(BtcTransaction transaction) {
         logger.debug(
             "[updateSvpFundTransactionValues] Transaction {} is the svp fund transaction. Going to update its values.", transaction
@@ -459,14 +451,6 @@ public class BridgeSupport {
 
         provider.setSvpFundTxSigned(transaction);
         provider.setSvpFundTxHashUnsigned(null);
-    }
-
-    private boolean isTheSvpSpendTransaction(BtcTransaction transaction) {
-        return provider.getSvpSpendTxHashUnsigned()
-            .filter(svpSpendTransactionHashUnsigned ->
-                getMultiSigTransactionHashWithoutSignatures(networkParameters, transaction).equals(svpSpendTransactionHashUnsigned)
-            )
-            .isPresent();
     }
 
     private void registerSvpSpendTransaction(BtcTransaction svpSpendTx) throws IOException {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -2258,131 +2258,65 @@ public class BridgeSupport {
         return federationSupport.getActiveFederation();
     }
 
-    /**
-     * Returns the currently retiring federation.
-     * See getRetiringFederationReference() for details.
-     * @return the retiring federation.
-     */
+
     @Nullable
     public Federation getRetiringFederation() {
         return federationSupport.getRetiringFederation();
     }
 
-    /**
-     * Returns the active federation bitcoin address.
-     * @return the active federation bitcoin address.
-     */
     public Address getActiveFederationAddress() {
         return federationSupport.getActiveFederationAddress();
     }
 
-    /**
-     * Returns the active federation's size
-     * @return the active federation size
-     */
     public Integer getActiveFederationSize() {
         return federationSupport.getActiveFederationSize();
     }
 
-    /**
-     * Returns the active federation's minimum required signatures
-     * @return the active federation minimum required signatures
-     */
     public Integer getActiveFederationThreshold() {
         return federationSupport.getActiveFederationThreshold();
     }
 
-    /**
-     * Returns the public key of the active federation's federator at the given index
-     * @param index the federator's index (zero-based)
-     * @return the federator's public key
-     */
     public byte[] getActiveFederatorBtcPublicKey(int index) {
         return federationSupport.getActiveFederatorBtcPublicKey(index);
     }
 
-    /**
-     * Returns the public key of given type of the active federation's federator at the given index
-     * @param index the federator's index (zero-based)
-     * @param keyType the key type
-     * @return the federator's public key
-     */
     public byte[] getActiveFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType) {
         return federationSupport.getActiveFederatorPublicKeyOfType(index, keyType);
     }
 
-    /**
-     * Returns the active federation's creation time
-     * @return the active federation creation time
-     */
     public Instant getActiveFederationCreationTime() {
         return federationSupport.getActiveFederationCreationTime();
     }
 
-    /**
-     * Returns the active federation's creation block number
-     * @return the active federation creation block number
-     */
     public long getActiveFederationCreationBlockNumber() {
         return federationSupport.getActiveFederationCreationBlockNumber();
     }
 
-    /**
-     * Returns the retiring federation bitcoin address.
-     * @return the retiring federation bitcoin address, null if no retiring federation exists
-     */
     public Address getRetiringFederationAddress() {
         return federationSupport.getRetiringFederationAddress();
     }
 
-    /**
-     * Returns the retiring federation's size
-     * @return the retiring federation size, -1 if no retiring federation exists
-     */
+
     public Integer getRetiringFederationSize() {
         return federationSupport.getRetiringFederationSize();
     }
 
-    /**
-     * Returns the retiring federation's minimum required signatures
-     * @return the retiring federation minimum required signatures, -1 if no retiring federation exists
-     */
     public Integer getRetiringFederationThreshold() {
         return federationSupport.getRetiringFederationThreshold();
     }
 
-    /**
-     * Returns the public key of the retiring federation's federator at the given index
-     * @param index the retiring federator's index (zero-based)
-     * @return the retiring federator's public key, null if no retiring federation exists
-     */
     public byte[] getRetiringFederatorBtcPublicKey(int index) {
         return federationSupport.getRetiringFederatorBtcPublicKey(index);
     }
 
-    /**
-     * Returns the public key of the given type of the retiring federation's federator at the given index
-     * @param index the retiring federator's index (zero-based)
-     * @param keyType the key type
-     * @return the retiring federator's public key of the given type, null if no retiring federation exists
-     */
     public byte[] getRetiringFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType) {
         return federationSupport.getRetiringFederatorPublicKeyOfType(index, keyType);
     }
 
-    /**
-     * Returns the retiring federation's creation time
-     * @return the retiring federation creation time, null if no retiring federation exists
-     */
     public Instant getRetiringFederationCreationTime() {
         return federationSupport.getRetiringFederationCreationTime();
     }
 
-    /**
-     * Returns the retiring federation's creation block number
-     * @return the retiring federation creation block number,
-     * -1 if no retiring federation exists
-     */
     public long getRetiringFederationCreationBlockNumber() {
         return federationSupport.getRetiringFederationCreationBlockNumber();
     }
@@ -2391,37 +2325,18 @@ public class BridgeSupport {
         return federationSupport.voteFederationChange(tx, callSpec, signatureCache, eventLogger);
     }
 
-    /**
-     * Returns the currently pending federation hash, or null if none exists
-     * @return the currently pending federation hash, or null if none exists
-     */
     public Keccak256 getPendingFederationHash() {
         return federationSupport.getPendingFederationHash();
     }
 
-    /**
-     * Returns the currently pending federation size, or -1 if none exists
-     * @return the currently pending federation size, or -1 if none exists
-     */
     public Integer getPendingFederationSize() {
         return federationSupport.getPendingFederationSize();
     }
 
-    /**
-     * Returns the currently pending federation federator's public key at the given index, or null if none exists
-     * @param index the federator's index (zero-based)
-     * @return the pending federation's federator public key
-     */
     public byte[] getPendingFederatorBtcPublicKey(int index) {
         return federationSupport.getPendingFederatorBtcPublicKey(index);
     }
 
-    /**
-     * Returns the public key of the given type of the pending federation's federator at the given index
-     * @param index the federator's index (zero-based)
-     * @param keyType the key type
-     * @return the pending federation's federator public key of given type
-     */
     public byte[] getPendingFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType) {
         return federationSupport.getPendingFederatorPublicKeyOfType(index, keyType);
     }
@@ -2488,11 +2403,6 @@ public class BridgeSupport {
         return lockingCapSupport.getLockingCap().orElse(null);
     }
 
-    /**
-     * Returns the redeemScript of the current active federation
-     *
-     * @return Returns the redeemScript of the current active federation
-     */
     public Optional<Script> getActiveFederationRedeemScript() {
         return federationSupport.getActiveFederationRedeemScript();
     }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -402,11 +402,6 @@ public class BridgeSupport {
                 throw new RegisterBtcTransactionException("Transaction already processed");
             }
 
-            if (isSvpOngoing() && isTheSvpSpendTransaction(btcTx)) {
-                registerSvpSpendTransaction(btcTx);
-                return;
-            }
-
             FederationContext federationContext = federationSupport.getFederationContext();
             PegTxType pegTxType = PegUtils.getTransactionType(
                 activations,
@@ -418,21 +413,28 @@ public class BridgeSupport {
             );
 
             switch (pegTxType) {
-                case PEGIN:
+                case PEGIN -> {
                     logger.debug("[registerBtcTransaction] This is a peg-in tx {}", btcTx.getHash());
                     processPegIn(btcTx, rskTxHash, height);
-                    break;
-                case PEGOUT_OR_MIGRATION:
+                }
+                case PEGOUT_OR_MIGRATION -> {
                     logger.debug("[registerBtcTransaction] This is a peg-out or migration tx {}", btcTx.getHash());
                     processPegoutOrMigration(btcTx);
-                    if (isSvpOngoing() && isTheSvpFundTransaction(btcTx)) {
-                        updateSvpFundTransactionValues(btcTx);
-                    }
-                    break;
-                default:
+                }
+                case SVP_FUND_TX -> {
+                    logger.debug("[registerBtcTransaction] This is an svp fund tx {}", btcTx.getHash());
+                    processPegoutOrMigration(btcTx); // Need to register the change UTXO
+                    updateSvpFundTransactionValues(btcTx);
+                }
+                case SVP_SPEND_TX -> {
+                    logger.debug("[registerBtcTransaction] This is an svp spend tx {}", btcTx.getHash());
+                    registerSvpSpendTransaction(btcTx);
+                }
+                default -> {
                     String message = String.format("This is not a peg-in, a peg-out nor a migration tx %s", btcTx.getHash());
                     logger.warn("[registerBtcTransaction][rsk tx {}] {}", rskTxHash, message);
                     panicProcessor.panic("btclock", message);
+                }
             }
         } catch (RegisterBtcTransactionException e) {
             logger.warn(

--- a/rskj-core/src/main/java/co/rsk/peg/PegTxType.java
+++ b/rskj-core/src/main/java/co/rsk/peg/PegTxType.java
@@ -3,5 +3,7 @@ package co.rsk.peg;
 enum PegTxType {
     PEGIN,
     PEGOUT_OR_MIGRATION,
+    SVP_FUND_TX,
+    SVP_SPEND_TX,
     UNKNOWN
 }

--- a/rskj-core/src/main/java/co/rsk/peg/PegUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/PegUtils.java
@@ -15,11 +15,11 @@ import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.bitcoin.BitcoinUtils;
 import co.rsk.peg.btcLockSender.BtcLockSender.TxSenderAddressType;
 import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationContext;
 import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.pegin.PeginEvaluationResult;
 import co.rsk.peg.pegin.PeginProcessAction;
 import co.rsk.peg.pegininstructions.PeginInstructionsException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
@@ -89,17 +89,11 @@ public class PegUtils {
         ActivationConfig.ForBlock activations,
         BridgeStorageProvider provider,
         BridgeConstants bridgeConstants,
-        Federation activeFederation,
-        Federation retiringFederation,
-        Script retiredFederationP2SHScript,
+        FederationContext federationContext,
         BtcTransaction btcTransaction,
         long btcTransactionHeight
     ) {
-        List<Federation> liveFeds = new ArrayList<>();
-        liveFeds.add(activeFederation);
-        if (retiringFederation != null){
-            liveFeds.add(retiringFederation);
-        }
+        List<Federation> liveFeds = federationContext.getLiveFederations();
         Context context = Context.getOrCreate(bridgeConstants.getBtcParams());
         Wallet liveFederationsWallet = new BridgeBtcWallet(context, liveFeds);
 
@@ -126,9 +120,7 @@ public class PegUtils {
 
             return PegUtilsLegacy.getTransactionType(
                 btcTransaction,
-                activeFederation,
-                retiringFederation,
-                retiredFederationP2SHScript,
+                federationContext,
                 oldFederationAddress,
                 activations,
                 minimumPeginTxValue,

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationContext.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationContext.java
@@ -1,0 +1,49 @@
+package co.rsk.peg.federation;
+
+import co.rsk.bitcoinj.script.Script;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class FederationContext {
+    private final Federation activeFederation;
+    private Federation retiringFederation;
+    private Script lastRetiredFederationP2SHScript;
+
+    public FederationContext(Federation activeFederation) {
+        this.activeFederation = activeFederation;
+    }
+
+    public FederationContext(Federation activeFederation, Federation retiringFederation, Script lastRetiredFederationP2SHScript) {
+        this.activeFederation = activeFederation;
+        this.retiringFederation = retiringFederation;
+        this.lastRetiredFederationP2SHScript = lastRetiredFederationP2SHScript;
+    }
+
+    public Federation getActiveFederation() {
+        return activeFederation;
+    }
+
+    public Optional<Federation> getRetiringFederation() {
+        return Optional.ofNullable(retiringFederation);
+    }
+
+    public void setRetiringFederation(Federation retiringFederation) {
+        this.retiringFederation = retiringFederation;
+    }
+
+    public Optional<Script> getLastRetiredFederationP2SHScript() {
+        return Optional.ofNullable(lastRetiredFederationP2SHScript);
+    }
+
+    public void setLastRetiredFederationP2SHScript(Script lastRetiredFederationP2SHScript) {
+        this.lastRetiredFederationP2SHScript = lastRetiredFederationP2SHScript;
+    }
+
+    public List<Federation> getLiveFederations() {
+        return Stream.of(activeFederation, retiringFederation)
+            .filter(Objects::nonNull)
+            .toList();
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationContext.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationContext.java
@@ -15,12 +15,6 @@ public class FederationContext {
         this.activeFederation = activeFederation;
     }
 
-    public FederationContext(Federation activeFederation, Federation retiringFederation, Script lastRetiredFederationP2SHScript) {
-        this.activeFederation = activeFederation;
-        this.retiringFederation = retiringFederation;
-        this.lastRetiredFederationP2SHScript = lastRetiredFederationP2SHScript;
-    }
-
     public Federation getActiveFederation() {
         return activeFederation;
     }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupport.java
@@ -16,26 +16,115 @@ import org.ethereum.core.Transaction;
 public interface FederationSupport {
 
     Federation getActiveFederation();
+
+    /**
+     * Returns the redeemScript of the current active federation
+     *
+     * @return Returns the redeemScript of the current active federation
+     */
     Optional<Script> getActiveFederationRedeemScript();
+
+    /**
+     * Returns the active federation bitcoin address.
+     * @return the active federation bitcoin address.
+     */
     Address getActiveFederationAddress();
+
+    /**
+     * Returns the active federation's size
+     * @return the active federation size
+     */
     int getActiveFederationSize();
+
+    /**
+     * Returns the active federation's minimum required signatures
+     * @return the active federation minimum required signatures
+     */
     int getActiveFederationThreshold();
+
+    /**
+     * Returns the active federation's creation time
+     * @return the active federation creation time
+     */
     Instant getActiveFederationCreationTime();
+
+    /**
+     * Returns the active federation's creation block number
+     * @return the active federation creation block number
+     */
     long getActiveFederationCreationBlockNumber();
+
+    /**
+     * Returns the public key of the active federation's federator at the given index
+     * @param index the federator's index (zero-based)
+     * @return the federator's public key
+     */
     byte[] getActiveFederatorBtcPublicKey(int index);
+
+    /**
+     * Returns the public key of given type of the active federation's federator at the given index
+     * @param index the federator's index (zero-based)
+     * @param keyType the key type
+     * @return the federator's public key
+     */
     byte[] getActiveFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType);
+
     List<UTXO> getActiveFederationBtcUTXOs();
 
     void clearRetiredFederation();
 
+    /**
+     * Returns the currently retiring federation.
+     * See getRetiringFederationReference() for details.
+     * @return the retiring federation.
+     */
     @Nullable
     Federation getRetiringFederation();
+
+    /**
+     * Returns the retiring federation bitcoin address.
+     * @return the retiring federation bitcoin address, null if no retiring federation exists
+     */
     Address getRetiringFederationAddress();
+
+    /**
+     * Returns the retiring federation's size
+     * @return the retiring federation size, -1 if no retiring federation exists
+     */
     int getRetiringFederationSize();
+
+    /**
+     * Returns the retiring federation's minimum required signatures
+     * @return the retiring federation minimum required signatures, -1 if no retiring federation exists
+     */
     int getRetiringFederationThreshold();
+
+    /**
+     * Returns the retiring federation's creation time
+     * @return the retiring federation creation time, null if no retiring federation exists
+     */
     Instant getRetiringFederationCreationTime();
+
+    /**
+     * Returns the retiring federation's creation block number
+     * @return the retiring federation creation block number,
+     * -1 if no retiring federation exists
+     */
     long getRetiringFederationCreationBlockNumber();
+
+    /**
+     * Returns the public key of the retiring federation's federator at the given index
+     * @param index the retiring federator's index (zero-based)
+     * @return the retiring federator's public key, null if no retiring federation exists
+     */
     byte[] getRetiringFederatorBtcPublicKey(int index);
+
+    /**
+     * Returns the public key of the given type of the retiring federation's federator at the given index
+     * @param index the retiring federator's index (zero-based)
+     * @param keyType the key type
+     * @return the retiring federator's public key of the given type, null if no retiring federation exists
+     */
     byte[] getRetiringFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType);
 
     /**
@@ -50,9 +139,31 @@ public interface FederationSupport {
     List<UTXO> getNewFederationBtcUTXOs();
     List<UTXO> getRetiringFederationBtcUTXOs();
 
+    /**
+     * Returns the currently pending federation hash, or null if none exists
+     * @return the currently pending federation hash, or null if none exists
+     */
     Keccak256 getPendingFederationHash();
+
+    /**
+     * Returns the currently pending federation size, or -1 if none exists
+     * @return the currently pending federation size, or -1 if none exists
+     */
     int getPendingFederationSize();
+
+    /**
+     * Returns the currently pending federation federator's public key at the given index, or null if none exists
+     * @param index the federator's index (zero-based)
+     * @return the pending federation's federator public key
+     */
     byte[] getPendingFederatorBtcPublicKey(int index);
+
+    /**
+     * Returns the public key of the given type of the pending federation's federator at the given index
+     * @param index the federator's index (zero-based)
+     * @param keyType the key type
+     * @return the pending federation's federator public key of given type
+     */
     byte[] getPendingFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType);
 
     Optional<Federation> getProposedFederation();

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupport.java
@@ -37,9 +37,18 @@ public interface FederationSupport {
     long getRetiringFederationCreationBlockNumber();
     byte[] getRetiringFederatorBtcPublicKey(int index);
     byte[] getRetiringFederatorPublicKeyOfType(int index, FederationMember.KeyType keyType);
-    List<UTXO> getRetiringFederationBtcUTXOs();
+
+    /**
+     * Returns the currently live federations
+     * This would be the active federation plus potentially the retiring federation
+     * @return a list of live federations
+     */
+    List<Federation> getLiveFederations();
+
+    FederationContext getFederationContext();
 
     List<UTXO> getNewFederationBtcUTXOs();
+    List<UTXO> getRetiringFederationBtcUTXOs();
 
     Keccak256 getPendingFederationHash();
     int getPendingFederationSize();
@@ -134,7 +143,6 @@ public interface FederationSupport {
         BridgeEventLogger eventLogger
     );
     long getActiveFederationCreationBlockHeight();
-    Optional<Script> getLastRetiredFederationP2SHScript();
 
     void updateFederationCreationBlockHeights();
 

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupportImpl.java
@@ -183,11 +183,11 @@ public class FederationSupportImpl implements FederationSupport {
     public Federation getRetiringFederation() {
         StorageFederationReference retiringFederationReference = getRetiringFederationReference();
 
-        if (retiringFederationReference == StorageFederationReference.OLD) {
-            return provider.getOldFederation(constants, activations);
+        if (retiringFederationReference != StorageFederationReference.OLD) {
+            return null; // TODO Make this method Optional to avoid returning null
         }
 
-        return null; // TODO Make this method Optional to avoid returning null
+        return provider.getOldFederation(constants, activations);
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationSupportImpl.java
@@ -181,13 +181,13 @@ public class FederationSupportImpl implements FederationSupport {
     @Override
     @Nullable
     public Federation getRetiringFederation() {
-        switch (getRetiringFederationReference()) {
-            case OLD:
-                return provider.getOldFederation(constants, activations);
-            case NONE:
-            default:
-                return null;
+        StorageFederationReference retiringFederationReference = getRetiringFederationReference();
+
+        if (retiringFederationReference == StorageFederationReference.OLD) {
+            return provider.getOldFederation(constants, activations);
         }
+
+        return null; // TODO Make this method Optional to avoid returning null
     }
 
     /**
@@ -296,6 +296,32 @@ public class FederationSupportImpl implements FederationSupport {
     }
 
     @Override
+    public List<Federation> getLiveFederations() {
+        return getFederationContext().getLiveFederations();
+    }
+
+    @Override
+    public FederationContext getFederationContext() {
+        Federation activeFederation = getActiveFederation();
+        Federation retiringFederation = getRetiringFederation();
+        Optional<Script> lastRetiredFederationP2SHScript = provider.getLastRetiredFederationP2SHScript(activations);
+
+        FederationContext federationContext = new FederationContext(activeFederation);
+
+        if (retiringFederation != null) {
+            federationContext.setRetiringFederation(retiringFederation);
+        }
+        lastRetiredFederationP2SHScript.ifPresent(federationContext::setLastRetiredFederationP2SHScript);
+
+        return federationContext;
+    }
+
+    @Override
+    public List<UTXO> getNewFederationBtcUTXOs() {
+        return provider.getNewFederationBtcUTXOs(constants.getBtcParams(), activations);
+    }
+
+    @Override
     public List<UTXO> getRetiringFederationBtcUTXOs() {
         switch (getRetiringFederationReference()) {
             case OLD:
@@ -304,11 +330,6 @@ public class FederationSupportImpl implements FederationSupport {
             default:
                 return Collections.emptyList();
         }
-    }
-
-    @Override
-    public List<UTXO> getNewFederationBtcUTXOs() {
-        return provider.getNewFederationBtcUTXOs(constants.getBtcParams(), activations);
     }
 
     @Nullable
@@ -851,11 +872,6 @@ public class FederationSupportImpl implements FederationSupport {
         }
 
         return members.get(index).getPublicKey(keyType).getPubKey(true);
-    }
-
-    @Override
-    public Optional<Script> getLastRetiredFederationP2SHScript() {
-        return provider.getLastRetiredFederationP2SHScript(activations);
     }
 
     @Override

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportFlyoverTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportFlyoverTest.java
@@ -3046,6 +3046,10 @@ class BridgeSupportFlyoverTest {
 
         when(lockingCapSupport.getLockingCap()).thenReturn(Optional.of(Coin.COIN));
 
+        Federation genesisFederation = FederationTestUtils.getGenesisFederation(federationConstantsRegtest);
+        FederationSupport federationSupport = mock(FederationSupport.class);
+        when(federationSupport.getFederationContext()).thenReturn(new FederationContext(genesisFederation));
+
         BridgeSupport bridgeSupport = spy(new BridgeSupport(
             bridgeConstantsRegtest,
             provider,
@@ -3057,18 +3061,17 @@ class BridgeSupportFlyoverTest {
             btcContext,
             feePerKbSupport,
             whitelistSupport,
-            mock(FederationSupport.class),
+            federationSupport,
             lockingCapSupport,
             mock(BtcBlockStoreWithCache.Factory.class),
             activations,
             signatureCache
         ));
-        Federation genesisFederation = FederationTestUtils.getGenesisFederation(federationConstantsRegtest);
 
-        doReturn(genesisFederation).when(bridgeSupport).getActiveFederation();
-        doReturn(true).when(bridgeSupport).validationsForRegisterBtcTransaction(any(), anyInt(), any(), any());
+        when(bridgeSupport.getActiveFederation()).thenReturn(genesisFederation);
+        when(bridgeSupport.validationsForRegisterBtcTransaction(any(), anyInt(), any(), any())).thenReturn(true);
 
-        doReturn(PegTestUtils.createHash3(1)).when(bridgeSupport).getFlyoverDerivationHash(
+        doReturn(RskTestUtils.createHash(1)).when(bridgeSupport).getFlyoverDerivationHash(
             any(Keccak256.class),
             any(Address.class),
             any(Address.class),
@@ -3104,7 +3107,7 @@ class BridgeSupportFlyoverTest {
             tx.bitcoinSerialize(),
             100,
             pmtSerialized,
-            PegTestUtils.createHash3(0),
+            RskTestUtils.createHash(0),
             btcAddress,
             lbcAddress,
             btcAddress,

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
@@ -108,6 +108,7 @@ public class BridgeSupportSvpTest {
         when(federationSupport.getActiveFederationAddress()).thenReturn(activeFederation.getAddress());
         when(federationSupport.getActiveFederationBtcUTXOs()).thenReturn(activeFederationUTXOs);
         when(federationSupport.getProposedFederation()).thenReturn(Optional.of(proposedFederation));
+        when(federationSupport.getFederationContext()).thenReturn(new FederationContext(activeFederation));
 
         feePerKbSupport = mock(FeePerKbSupport.class);
         when(feePerKbSupport.getFeePerKb()).thenReturn(feePerKb);

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsGetTransactionTypeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsGetTransactionTypeTest.java
@@ -193,11 +193,8 @@ class PegUtilsGetTransactionTypeTest {
         btcTransaction.addOutput(shouldSendAmountBelowMinimum? belowMinimumPeginTxValue: minimumPeginTxValue, userAddress);
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            null,
-            lastRetiredFederationP2SHScript
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setLastRetiredFederationP2SHScript(lastRetiredFederationP2SHScript);
         if (existsRetiringFederation) {
             federationContext.setRetiringFederation(retiringFederation);
         }
@@ -497,11 +494,9 @@ class PegUtilsGetTransactionTypeTest {
         btcTransaction.addOutput(Coin.COIN, BitcoinTestUtils.createP2PKHAddress(btcMainnetParams, "unknown2"));
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            retiringFederation,
-            null
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(retiringFederation);
+
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
@@ -527,11 +522,9 @@ class PegUtilsGetTransactionTypeTest {
         btcTransaction.addOutput(Coin.COIN, retiringFederation.getAddress());
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            retiringFederation,
-            null
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(retiringFederation);
+
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
@@ -583,11 +576,9 @@ class PegUtilsGetTransactionTypeTest {
         Script lastRetiredFederationP2SHScript = retiredFed.getP2SHScript();
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            null,
-            lastRetiredFederationP2SHScript
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setLastRetiredFederationP2SHScript(lastRetiredFederationP2SHScript);
+
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
@@ -616,11 +607,9 @@ class PegUtilsGetTransactionTypeTest {
         }
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            retiringFederation,
-            null
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(retiringFederation);
+
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
@@ -648,11 +637,9 @@ class PegUtilsGetTransactionTypeTest {
         btcTransaction.addOutput(Coin.COIN, retiringFederation.getAddress());
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            retiringFederation,
-            null
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(retiringFederation);
+
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
@@ -682,11 +669,9 @@ class PegUtilsGetTransactionTypeTest {
         btcTransaction.addOutput(Coin.COIN, userAddress);
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            retiringFederation,
-            null
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(retiringFederation);
+
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
@@ -1305,11 +1290,9 @@ class PegUtilsGetTransactionTypeTest {
         when(provider.hasPegoutTxSigHash(firstInputSigHash)).thenReturn(true);
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            retiringFederation,
-            null
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(retiringFederation);
+
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
@@ -1339,11 +1322,9 @@ class PegUtilsGetTransactionTypeTest {
         btcTransaction.getInput(FIRST_INPUT_INDEX).setScriptSig(inputScript);
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            retiringFederation,
-            null
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(retiringFederation);
+
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
@@ -1464,11 +1445,9 @@ class PegUtilsGetTransactionTypeTest {
         }
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            retiringFederation,
-            null
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(retiringFederation);
+
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
@@ -1529,11 +1508,9 @@ class PegUtilsGetTransactionTypeTest {
         }
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            retiringFederation,
-            null
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(retiringFederation);
+
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
@@ -1580,11 +1557,9 @@ class PegUtilsGetTransactionTypeTest {
         }
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            retiringFederation,
-            null
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(retiringFederation);
+
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
@@ -1739,14 +1714,12 @@ class PegUtilsGetTransactionTypeTest {
         btcTransaction.addOutput(shouldSendAmountBelowMinimum? belowMinimumPeginTxValue: minimumPeginTxValue, flyoverFederationAddress);
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            null,
-            lastRetiredFederationP2SHScript
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setLastRetiredFederationP2SHScript(lastRetiredFederationP2SHScript);
         if (existsRetiringFederation) {
             federationContext.setRetiringFederation(retiringFederation);
         }
+
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
@@ -1806,14 +1779,12 @@ class PegUtilsGetTransactionTypeTest {
         btcTransaction.addOutput(createBech32Output(bridgeMainnetConstants.getBtcParams(), minimumPeginTxValue));
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            null,
-            lastRetiredFederationP2SHScript
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setLastRetiredFederationP2SHScript(lastRetiredFederationP2SHScript);
         if (existsRetiringFederation) {
             federationContext.setRetiringFederation(retiringFederation);
         }
+
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
@@ -1906,11 +1877,9 @@ class PegUtilsGetTransactionTypeTest {
         }
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            retiringFederation,
-            null
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(retiringFederation);
+
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
@@ -1989,11 +1958,9 @@ class PegUtilsGetTransactionTypeTest {
         }
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            retiringFederation,
-            null
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(retiringFederation);
+
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
@@ -2073,11 +2040,9 @@ class PegUtilsGetTransactionTypeTest {
         }
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            retiringFederation,
-            null
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(retiringFederation);
+
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
@@ -2151,11 +2116,9 @@ class PegUtilsGetTransactionTypeTest {
         assertTrue(PegUtilsLegacy.txIsFromOldFederation(migrationTx, oldFederation.getAddress()));
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            retiringFederation,
-            null
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(retiringFederation);
+
         PegTxType transactionType = PegUtils.getTransactionType(
             activations,
             provider,
@@ -2221,11 +2184,9 @@ class PegUtilsGetTransactionTypeTest {
         when(provider.hasPegoutTxSigHash(firstInputSigHash.get())).thenReturn(true);
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            null,
-            lastRetiredFederationP2SHScript
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setLastRetiredFederationP2SHScript(lastRetiredFederationP2SHScript);
+
         PegTxType transactionType = PegUtils.getTransactionType(
             activations,
             provider,

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsGetTransactionTypeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsGetTransactionTypeTest.java
@@ -1,8 +1,6 @@
 package co.rsk.peg;
 
-import static co.rsk.peg.PegTestUtils.createBaseInputScriptThatSpendsFromTheFederation;
-import static co.rsk.peg.PegTestUtils.createBech32Output;
-import static co.rsk.peg.PegTestUtils.createFederation;
+import static co.rsk.peg.PegTestUtils.*;
 import static co.rsk.peg.federation.FederationTestUtils.createP2shErpFederation;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -195,13 +193,19 @@ class PegUtilsGetTransactionTypeTest {
         btcTransaction.addOutput(shouldSendAmountBelowMinimum? belowMinimumPeginTxValue: minimumPeginTxValue, userAddress);
 
         // Act
+        FederationContext federationContext = new FederationContext(
+            activeFederation,
+            null,
+            lastRetiredFederationP2SHScript
+        );
+        if (existsRetiringFederation) {
+            federationContext.setRetiringFederation(retiringFederation);
+        }
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            existsRetiringFederation? retiringFederation: null,
-            lastRetiredFederationP2SHScript,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -251,13 +255,12 @@ class PegUtilsGetTransactionTypeTest {
         btcTransaction.addOutput(Coin.ZERO, opReturnScript);
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -288,13 +291,12 @@ class PegUtilsGetTransactionTypeTest {
         FederationTestUtils.addSignatures(unknownFed, signers, btcTransaction);
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex ? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -327,13 +329,12 @@ class PegUtilsGetTransactionTypeTest {
         FederationTestUtils.addSignatures(unknownFed, unknownFedSigners, btcTransaction);
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex ? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -354,13 +355,12 @@ class PegUtilsGetTransactionTypeTest {
         btcTransaction.addOutput(Coin.COIN, activeFederation.getAddress());
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex ? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -384,13 +384,12 @@ class PegUtilsGetTransactionTypeTest {
         btcTransaction.addOutput(Coin.COIN, BitcoinTestUtils.createP2PKHAddress(btcMainnetParams, "unknown2"));
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex ? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -414,13 +413,12 @@ class PegUtilsGetTransactionTypeTest {
         }
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex ? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -471,13 +469,12 @@ class PegUtilsGetTransactionTypeTest {
         }
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex ? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -500,13 +497,16 @@ class PegUtilsGetTransactionTypeTest {
         btcTransaction.addOutput(Coin.COIN, BitcoinTestUtils.createP2PKHAddress(btcMainnetParams, "unknown2"));
 
         // Act
+        FederationContext federationContext = new FederationContext(
+            activeFederation,
+            retiringFederation,
+            null
+        );
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            retiringFederation,
-            null,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -527,13 +527,16 @@ class PegUtilsGetTransactionTypeTest {
         btcTransaction.addOutput(Coin.COIN, retiringFederation.getAddress());
 
         // Act
+        FederationContext federationContext = new FederationContext(
+            activeFederation,
+            retiringFederation,
+            null
+        );
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            retiringFederation,
-            null,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -580,13 +583,16 @@ class PegUtilsGetTransactionTypeTest {
         Script lastRetiredFederationP2SHScript = retiredFed.getP2SHScript();
 
         // Act
+        FederationContext federationContext = new FederationContext(
+            activeFederation,
+            null,
+            lastRetiredFederationP2SHScript
+        );
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            lastRetiredFederationP2SHScript,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -610,13 +616,16 @@ class PegUtilsGetTransactionTypeTest {
         }
 
         // Act
+        FederationContext federationContext = new FederationContext(
+            activeFederation,
+            retiringFederation,
+            null
+        );
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            retiringFederation,
-            null,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -639,13 +648,16 @@ class PegUtilsGetTransactionTypeTest {
         btcTransaction.addOutput(Coin.COIN, retiringFederation.getAddress());
 
         // Act
+        FederationContext federationContext = new FederationContext(
+            activeFederation,
+            retiringFederation,
+            null
+        );
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            retiringFederation,
-            null,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -670,13 +682,16 @@ class PegUtilsGetTransactionTypeTest {
         btcTransaction.addOutput(Coin.COIN, userAddress);
 
         // Act
+        FederationContext federationContext = new FederationContext(
+            activeFederation,
+            retiringFederation,
+            null
+        );
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            retiringFederation,
-            null,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -696,13 +711,12 @@ class PegUtilsGetTransactionTypeTest {
         btcTransaction.addOutput(minimumPeginTxValue.minus(Coin.SATOSHI), activeFederation.getAddress());
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             btcTransaction,
             heightAtWhichToStartUsingPegoutIndex
         );
@@ -723,13 +737,12 @@ class PegUtilsGetTransactionTypeTest {
         anyToAnyTx.addOutput(minimumPeginTxValue, new Script(new byte[]{}) );
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType transactionType = PegUtils.getTransactionType(
             fingerrootActivations,
             mock(BridgeStorageProvider.class),
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             anyToAnyTx,
             1
         );
@@ -750,13 +763,12 @@ class PegUtilsGetTransactionTypeTest {
         anyToAnyTx.addOutput(belowMinimum, new Script(new byte[]{}));
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType transactionType = PegUtils.getTransactionType(
             fingerrootActivations,
             mock(BridgeStorageProvider.class),
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             anyToAnyTx,
             1
         );
@@ -777,13 +789,12 @@ class PegUtilsGetTransactionTypeTest {
         anyToAnyTx.addOutput(minimumPeginTxValue, new Script(new byte[]{}) );
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType transactionType = PegUtils.getTransactionType(
             arrowheadActivations,
             mock(BridgeStorageProvider.class),
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             anyToAnyTx,
             heightAtWhichToStartUsingPegoutIndex
         );
@@ -804,13 +815,12 @@ class PegUtilsGetTransactionTypeTest {
         anyToAnyTx.addOutput(belowMinimum, new Script(new byte[]{}));
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType transactionType = PegUtils.getTransactionType(
             arrowheadActivations,
             mock(BridgeStorageProvider.class),
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             anyToAnyTx,
             heightAtWhichToStartUsingPegoutIndex
         );
@@ -860,13 +870,12 @@ class PegUtilsGetTransactionTypeTest {
         }
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType transactionType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             peginTx,
             shouldUsePegoutTxIndex? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -895,13 +904,12 @@ class PegUtilsGetTransactionTypeTest {
         peginTx.addOutput(Coin.COIN, activeFederation.getAddress());
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType transactionType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             peginTx,
             shouldUsePegoutTxIndex? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -944,13 +952,12 @@ class PegUtilsGetTransactionTypeTest {
         peginTx.addOutput(minimumPeginTxValue, activeFederation.getAddress());
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType transactionType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             peginTx,
             shouldUsePegoutTxIndex? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -973,13 +980,12 @@ class PegUtilsGetTransactionTypeTest {
         peginTx.addOutput(minimumPeginTxValue, activeFederation.getAddress());
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType transactionType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             peginTx,
             shouldUsePegoutTxIndex? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -1039,13 +1045,12 @@ class PegUtilsGetTransactionTypeTest {
         }
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -1067,13 +1072,12 @@ class PegUtilsGetTransactionTypeTest {
         btcTransaction.getInput(FIRST_INPUT_INDEX).setScriptSig(inputScript);
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             btcTransaction,
             heightAtWhichToStartUsingPegoutIndex
         );
@@ -1129,13 +1133,12 @@ class PegUtilsGetTransactionTypeTest {
         }
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -1189,13 +1192,12 @@ class PegUtilsGetTransactionTypeTest {
         }
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -1236,13 +1238,12 @@ class PegUtilsGetTransactionTypeTest {
         }
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -1265,13 +1266,12 @@ class PegUtilsGetTransactionTypeTest {
         btcTransaction.getInput(FIRST_INPUT_INDEX).setScriptSig(inputScript);
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             btcTransaction,
             heightAtWhichToStartUsingPegoutIndex
         );
@@ -1305,13 +1305,16 @@ class PegUtilsGetTransactionTypeTest {
         when(provider.hasPegoutTxSigHash(firstInputSigHash)).thenReturn(true);
 
         // Act
+        FederationContext federationContext = new FederationContext(
+            activeFederation,
+            retiringFederation,
+            null
+        );
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            retiringFederation,
-            null,
+            federationContext,
             btcTransaction,
             heightAtWhichToStartUsingPegoutIndex
         );
@@ -1336,13 +1339,16 @@ class PegUtilsGetTransactionTypeTest {
         btcTransaction.getInput(FIRST_INPUT_INDEX).setScriptSig(inputScript);
 
         // Act
+        FederationContext federationContext = new FederationContext(
+            activeFederation,
+            retiringFederation,
+            null
+        );
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            retiringFederation,
-            null,
+            federationContext,
             btcTransaction,
             heightAtWhichToStartUsingPegoutIndex
         );
@@ -1373,13 +1379,12 @@ class PegUtilsGetTransactionTypeTest {
         when(provider.hasPegoutTxSigHash(firstInputSigHash)).thenReturn(true);
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             btcTransaction,
             heightAtWhichToStartUsingPegoutIndex
         );
@@ -1459,13 +1464,16 @@ class PegUtilsGetTransactionTypeTest {
         }
 
         // Act
+        FederationContext federationContext = new FederationContext(
+            activeFederation,
+            retiringFederation,
+            null
+        );
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            retiringFederation,
-            null,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex ? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -1521,13 +1529,16 @@ class PegUtilsGetTransactionTypeTest {
         }
 
         // Act
+        FederationContext federationContext = new FederationContext(
+            activeFederation,
+            retiringFederation,
+            null
+        );
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            retiringFederation,
-            null,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex ? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -1569,13 +1580,16 @@ class PegUtilsGetTransactionTypeTest {
         }
 
         // Act
+        FederationContext federationContext = new FederationContext(
+            activeFederation,
+            retiringFederation,
+            null
+        );
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            retiringFederation,
-            null,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -1725,13 +1739,19 @@ class PegUtilsGetTransactionTypeTest {
         btcTransaction.addOutput(shouldSendAmountBelowMinimum? belowMinimumPeginTxValue: minimumPeginTxValue, flyoverFederationAddress);
 
         // Act
+        FederationContext federationContext = new FederationContext(
+            activeFederation,
+            null,
+            lastRetiredFederationP2SHScript
+        );
+        if (existsRetiringFederation) {
+            federationContext.setRetiringFederation(retiringFederation);
+        }
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            existsRetiringFederation? retiringFederation: null,
-            lastRetiredFederationP2SHScript,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex ? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -1786,13 +1806,19 @@ class PegUtilsGetTransactionTypeTest {
         btcTransaction.addOutput(createBech32Output(bridgeMainnetConstants.getBtcParams(), minimumPeginTxValue));
 
         // Act
+        FederationContext federationContext = new FederationContext(
+            activeFederation,
+            null,
+            lastRetiredFederationP2SHScript
+        );
+        if (existsRetiringFederation) {
+            federationContext.setRetiringFederation(retiringFederation);
+        }
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            existsRetiringFederation ? retiringFederation : null,
-            lastRetiredFederationP2SHScript,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex ? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -1880,13 +1906,16 @@ class PegUtilsGetTransactionTypeTest {
         }
 
         // Act
+        FederationContext federationContext = new FederationContext(
+            activeFederation,
+            retiringFederation,
+            null
+        );
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            retiringFederation,
-            null,
+            federationContext,
             migrationTx,
             shouldUsePegoutTxIndex? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -1960,13 +1989,16 @@ class PegUtilsGetTransactionTypeTest {
         }
 
         // Act
+        FederationContext federationContext = new FederationContext(
+            activeFederation,
+            retiringFederation,
+            null
+        );
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            retiringFederation,
-            null,
+            federationContext,
             migrationTx,
             shouldUsePegoutTxIndex? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -2041,13 +2073,16 @@ class PegUtilsGetTransactionTypeTest {
         }
 
         // Act
+        FederationContext federationContext = new FederationContext(
+            activeFederation,
+            retiringFederation,
+            null
+        );
         PegTxType pegTxType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            retiringFederation,
-            null,
+            federationContext,
             btcTransaction,
             shouldUsePegoutTxIndex? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -2116,13 +2151,16 @@ class PegUtilsGetTransactionTypeTest {
         assertTrue(PegUtilsLegacy.txIsFromOldFederation(migrationTx, oldFederation.getAddress()));
 
         // Act
+        FederationContext federationContext = new FederationContext(
+            activeFederation,
+            retiringFederation,
+            null
+        );
         PegTxType transactionType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeRegTestConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             migrationTx,
             shouldUsePegoutTxIndex ? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -2183,13 +2221,16 @@ class PegUtilsGetTransactionTypeTest {
         when(provider.hasPegoutTxSigHash(firstInputSigHash.get())).thenReturn(true);
 
         // Act
+        FederationContext federationContext = new FederationContext(
+            activeFederation,
+            null,
+            lastRetiredFederationP2SHScript
+        );
         PegTxType transactionType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            lastRetiredFederationP2SHScript,
+            federationContext,
             migrationTx,
             shouldUsePegoutTxIndex ? heightAtWhichToStartUsingPegoutIndex : 0
         );
@@ -2252,13 +2293,12 @@ class PegUtilsGetTransactionTypeTest {
         when(provider.hasPegoutTxSigHash(firstInputSigHash.get())).thenReturn(true);
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType transactionType = PegUtils.getTransactionType(
             activations,
             provider,
             bridgeMainnetConstants,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             migrationTx,
             shouldUsePegoutTxIndex ? heightAtWhichToStartUsingPegoutIndex : 0
         );

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyGetTransactionTypeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyGetTransactionTypeTest.java
@@ -102,11 +102,14 @@ class PegUtilsLegacyGetTransactionTypeTest {
         FederationTestUtils.addSignatures(p2shRetiringFederation, fedKeys, migrationTx);
 
         // Act
-        PegTxType transactionType = PegUtilsLegacy.getTransactionType(
-            migrationTx,
+        FederationContext federationContext = new FederationContext(
             activeFederation,
             p2shRetiringFederation,
-            null,
+            null
+        );
+        PegTxType transactionType = PegUtilsLegacy.getTransactionType(
+            migrationTx,
+            federationContext,
             oldFederationAddress,
             activations,
             minimumPeginTxValue,
@@ -163,11 +166,13 @@ class PegUtilsLegacyGetTransactionTypeTest {
         FederationTestUtils.addSignatures(retiredFederation, REGTEST_OLD_FEDERATION_PRIVATE_KEYS, migrationTx);
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
+        if (activations.isActive(RSKIP186)) {
+            federationContext.setLastRetiredFederationP2SHScript(retiredFederation.getP2SHScript());
+        }
         PegTxType transactionType = PegUtilsLegacy.getTransactionType(
             migrationTx,
-            activeFederation,
-            null,
-            activations.isActive(RSKIP186) ? retiredFederation.getP2SHScript() : null,
+            federationContext,
             oldFederationAddress,
             activations,
             bridgeRegTestConstants.getMinimumPeginTxValue(activations),
@@ -208,11 +213,10 @@ class PegUtilsLegacyGetTransactionTypeTest {
         FederationTestUtils.addSignatures(unknownFed, unknownFedSigners, peginTx);
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType transactionType = PegUtilsLegacy.getTransactionType(
             peginTx,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             oldFederationAddress,
             activations,
             bridgeMainnetConstants.getMinimumPeginTxValue(activations),
@@ -364,11 +368,14 @@ class PegUtilsLegacyGetTransactionTypeTest {
         peginTx.addOutput(amountToSend, activeFederation.getAddress());
 
         // Act
-        PegTxType transactionType = PegUtilsLegacy.getTransactionType(
-            peginTx,
+        FederationContext federationContext = new FederationContext(
             activeFederation,
             retiringFederation,
-            retiredFederationP2SHScript,
+            retiredFederationP2SHScript
+        );
+        PegTxType transactionType = PegUtilsLegacy.getTransactionType(
+            peginTx,
+            federationContext,
             oldFederationAddress,
             activations,
             bridgeMainnetConstants.getMinimumPeginTxValue(activations),
@@ -407,11 +414,10 @@ class PegUtilsLegacyGetTransactionTypeTest {
         FederationTestUtils.addSignatures(activeFederation, fedKeys, pegoutBtcTx);
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType transactionType = PegUtilsLegacy.getTransactionType(
             pegoutBtcTx,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             oldFederationAddress,
             activations,
             bridgeMainnetConstants.getMinimumPeginTxValue(activations),
@@ -450,11 +456,14 @@ class PegUtilsLegacyGetTransactionTypeTest {
         FederationTestUtils.addSignatures(retiringFederation, retiringFedKeys, migrationTx);
 
         // Act
-        PegTxType transactionType = PegUtilsLegacy.getTransactionType(
-            migrationTx,
+        FederationContext federationContext = new FederationContext(
             activeFederation,
             retiringFederation,
-            null,
+            null
+        );
+        PegTxType transactionType = PegUtilsLegacy.getTransactionType(
+            migrationTx,
+            federationContext,
             oldFederationAddress,
             activations,
             bridgeMainnetConstants.getMinimumPeginTxValue(activations),
@@ -499,11 +508,14 @@ class PegUtilsLegacyGetTransactionTypeTest {
         FederationTestUtils.addSignatures(retiringFederation, retiringFedKeys, migrationTx);
 
         // Act
-        PegTxType transactionType = PegUtilsLegacy.getTransactionType(
-            migrationTx,
+        FederationContext federationContext = new FederationContext(
             activeFederation,
             retiringFederation,
-            null,
+            null
+        );
+        PegTxType transactionType = PegUtilsLegacy.getTransactionType(
+            migrationTx,
+            federationContext,
             oldFederationAddress,
             activations,
             bridgeMainnetConstants.getMinimumPeginTxValue(activations),
@@ -538,11 +550,14 @@ class PegUtilsLegacyGetTransactionTypeTest {
         FederationTestUtils.addSignatures(retiringFederation, retiringFedKeys, migrationTx);
 
         // Act
-        PegTxType transactionType = PegUtilsLegacy.getTransactionType(
-            migrationTx,
+        FederationContext federationContext = new FederationContext(
             activeFederation,
             retiringFederation,
-            null,
+            null
+        );
+        PegTxType transactionType = PegUtilsLegacy.getTransactionType(
+            migrationTx,
+            federationContext,
             oldFederationAddress,
             activations,
             bridgeMainnetConstants.getMinimumPeginTxValue(activations),
@@ -567,11 +582,10 @@ class PegUtilsLegacyGetTransactionTypeTest {
         unknownPegTx.addOutput(Coin.COIN, unknownAddress);
 
         // Act
+        FederationContext federationContext = new FederationContext(activeFederation);
         PegTxType transactionType = PegUtilsLegacy.getTransactionType(
             unknownPegTx,
-            activeFederation,
-            null,
-            null,
+            federationContext,
             oldFederationAddress,
             activations,
             bridgeMainnetConstants.getMinimumPeginTxValue(activations),

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyGetTransactionTypeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyGetTransactionTypeTest.java
@@ -102,18 +102,16 @@ class PegUtilsLegacyGetTransactionTypeTest {
         FederationTestUtils.addSignatures(p2shRetiringFederation, fedKeys, migrationTx);
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            p2shRetiringFederation,
-            null
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(p2shRetiringFederation);
+
         PegTxType transactionType = PegUtilsLegacy.getTransactionType(
             migrationTx,
             federationContext,
             oldFederationAddress,
             activations,
             minimumPeginTxValue,
-            new BridgeBtcWallet(btcContext, Arrays.asList(activeFederation, p2shRetiringFederation))
+            new BridgeBtcWallet(btcContext, federationContext.getLiveFederations())
         );
 
         // Assert
@@ -368,11 +366,10 @@ class PegUtilsLegacyGetTransactionTypeTest {
         peginTx.addOutput(amountToSend, activeFederation.getAddress());
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            retiringFederation,
-            retiredFederationP2SHScript
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(retiringFederation);
+        federationContext.setLastRetiredFederationP2SHScript(retiredFederationP2SHScript);
+
         PegTxType transactionType = PegUtilsLegacy.getTransactionType(
             peginTx,
             federationContext,
@@ -456,18 +453,16 @@ class PegUtilsLegacyGetTransactionTypeTest {
         FederationTestUtils.addSignatures(retiringFederation, retiringFedKeys, migrationTx);
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            retiringFederation,
-            null
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(retiringFederation);
+
         PegTxType transactionType = PegUtilsLegacy.getTransactionType(
             migrationTx,
             federationContext,
             oldFederationAddress,
             activations,
             bridgeMainnetConstants.getMinimumPeginTxValue(activations),
-            new BridgeBtcWallet(btcContext, Arrays.asList(activeFederation, retiringFederation))
+            new BridgeBtcWallet(btcContext, federationContext.getLiveFederations())
         );
 
         // Assert
@@ -508,18 +503,16 @@ class PegUtilsLegacyGetTransactionTypeTest {
         FederationTestUtils.addSignatures(retiringFederation, retiringFedKeys, migrationTx);
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            retiringFederation,
-            null
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(retiringFederation);
+
         PegTxType transactionType = PegUtilsLegacy.getTransactionType(
             migrationTx,
             federationContext,
             oldFederationAddress,
             activations,
             bridgeMainnetConstants.getMinimumPeginTxValue(activations),
-            new BridgeBtcWallet(btcContext, Arrays.asList(activeFederation, retiringFederation))
+            new BridgeBtcWallet(btcContext, federationContext.getLiveFederations())
         );
 
         // Assert
@@ -550,18 +543,16 @@ class PegUtilsLegacyGetTransactionTypeTest {
         FederationTestUtils.addSignatures(retiringFederation, retiringFedKeys, migrationTx);
 
         // Act
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            retiringFederation,
-            null
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(retiringFederation);
+
         PegTxType transactionType = PegUtilsLegacy.getTransactionType(
             migrationTx,
             federationContext,
             oldFederationAddress,
             activations,
             bridgeMainnetConstants.getMinimumPeginTxValue(activations),
-            new BridgeBtcWallet(btcContext, Arrays.asList(activeFederation, retiringFederation))
+            new BridgeBtcWallet(btcContext, federationContext.getLiveFederations())
         );
 
         // Assert

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
@@ -1293,27 +1293,21 @@ class PegUtilsLegacyTest {
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
 
-        FederationContext federationContextWithP2shScript = new FederationContext(
-            activeFederation,
-            null,
-            retiredFederation.getP2SHScript()
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setLastRetiredFederationP2SHScript(retiredFederation.getP2SHScript());
+
         assertFalse(isMigrationTx(
             migrationTx,
-            federationContextWithP2shScript,
+            federationContext,
             federationWallet,
             bridgeConstantsMainnet.getMinimumPeginTxValue(activations),
             activations
         ));
 
-        FederationContext federationContextWithDefaultP2shScript = new FederationContext(
-            activeFederation,
-            null,
-            retiredFederation.getDefaultP2SHScript()
-        );
+        federationContext.setLastRetiredFederationP2SHScript(retiredFederation.getDefaultP2SHScript());
         assertTrue(isMigrationTx(
             migrationTx,
-            federationContextWithDefaultP2shScript,
+            federationContext,
             federationWallet,
             bridgeConstantsMainnet.getMinimumPeginTxValue(activations),
             activations
@@ -1362,11 +1356,8 @@ class PegUtilsLegacyTest {
         migrationTx.addInput(migrationTxInput);
         signWithNecessaryKeys(retiringFederation, retiringFedKeys, migrationTxInput, migrationTx);
 
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            retiringFederation,
-            null
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(retiringFederation);
         Wallet federationsWallet = new BridgeBtcWallet(btcContext, federationContext.getLiveFederations());
 
         assertTrue(isMigrationTx(
@@ -1429,13 +1420,10 @@ class PegUtilsLegacyTest {
         migrationTx.addInput(migrationTxInput);
         signWithNecessaryKeys(retiredFederation, retiredFederationKeys, migrationTxInput, migrationTx);
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setLastRetiredFederationP2SHScript(retiredFederation.getP2SHScript());
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, federationContext.getLiveFederations());
 
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            null,
-            retiredFederation.getP2SHScript()
-        );
         assertTrue(isMigrationTx(
             migrationTx,
             federationContext,
@@ -1488,11 +1476,9 @@ class PegUtilsLegacyTest {
 
         Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
 
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            retiringFederation,
-            null
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(retiringFederation);
+
         assertTrue(isMigrationTx(
             migrationTx,
             federationContext,
@@ -1549,12 +1535,9 @@ class PegUtilsLegacyTest {
         migrationTx.addInput(migrationTxInput);
         signWithNecessaryKeys(retiredFederation, retiredFederationKeys, migrationTxInput, migrationTx);
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            null,
-            retiredFederation.getP2SHScript()
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setLastRetiredFederationP2SHScript(retiredFederation.getP2SHScript());
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, federationContext.getLiveFederations());
 
         assertTrue(isMigrationTx(
             migrationTx,
@@ -1613,11 +1596,8 @@ class PegUtilsLegacyTest {
         migrationTx.addInput(migrationTxInput);
         signWithNecessaryKeys(retiringFederation, retiringFederationKeys, migrationTxInput, migrationTx);
 
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            retiringFederation,
-            null
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(retiringFederation);
         Wallet federationsWallet = new BridgeBtcWallet(btcContext, federationContext.getLiveFederations());
 
         assertTrue(isMigrationTx(
@@ -1688,11 +1668,8 @@ class PegUtilsLegacyTest {
         migrationTx.addInput(migrationTxInput);
         signWithNecessaryKeys(retiringFederation, retiringFederationKeys, migrationTxInput, migrationTx);
 
-        FederationContext federationContext = new FederationContext(
-            activeFederation,
-            retiringFederation,
-            null
-        );
+        FederationContext federationContext = new FederationContext(activeFederation);
+        federationContext.setRetiringFederation(retiringFederation);
         Wallet federationsWallet = new BridgeBtcWallet(btcContext, federationContext.getLiveFederations());
 
         assertTrue(isMigrationTx(

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationContextTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationContextTest.java
@@ -1,0 +1,109 @@
+package co.rsk.peg.federation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.script.Script;
+import co.rsk.peg.bitcoin.BitcoinTestUtils;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FederationContextTest {
+
+    private Federation activeFederation;
+    private Federation retiringFederation;
+    private FederationContext federationContext;
+
+    @BeforeEach
+    void setup() {
+        activeFederation = buildActiveFederation();
+        retiringFederation = buildRetiringFederation();
+        federationContext = new FederationContext(activeFederation);
+    }
+
+    @Test
+    void getActiveFederation() {
+        assertEquals(activeFederation, federationContext.getActiveFederation());
+    }
+
+    @Test
+    void getRetiringFederation() {
+        assertTrue(federationContext.getRetiringFederation().isEmpty());
+    }
+
+    @Test
+    void setRetiringFederation() {
+        federationContext.setRetiringFederation(retiringFederation);
+
+        assertTrue(federationContext.getRetiringFederation().isPresent());
+        assertEquals(retiringFederation, federationContext.getRetiringFederation().get());
+    }
+
+    @Test
+    void getLastRetiredFederationP2SHScript() {
+        assertTrue(federationContext.getLastRetiredFederationP2SHScript().isEmpty());
+    }
+
+    @Test
+    void setLastRetiredFederationP2SHScript() {
+        Script lastRetiredFederationP2SHScript = retiringFederation.getP2SHScript();
+        federationContext.setLastRetiredFederationP2SHScript(lastRetiredFederationP2SHScript);
+
+        assertTrue(federationContext.getLastRetiredFederationP2SHScript().isPresent());
+        assertEquals(lastRetiredFederationP2SHScript, federationContext.getLastRetiredFederationP2SHScript().get());
+    }
+
+    @Test
+    void getLiveFederations_withOnlyActiveFederation() {
+        List<Federation> liveFederations = federationContext.getLiveFederations();
+
+        assertEquals(1, liveFederations.size());
+        assertEquals(activeFederation, liveFederations.get(0));
+    }
+
+    @Test
+    void getLiveFederations_withActiveAndRetiringFederations() {
+        federationContext.setRetiringFederation(retiringFederation);
+        List<Federation> liveFederations = federationContext.getLiveFederations();
+
+        assertEquals(2, liveFederations.size());
+        assertEquals(activeFederation, liveFederations.get(0));
+        assertEquals(retiringFederation, liveFederations.get(1));
+    }
+
+    private Federation buildActiveFederation() {
+        String[] seeds = new String[] {
+            "activeFederationMember1",
+            "activeFederationMember2",
+            "activeFederationMember3",
+            "activeFederationMember4",
+            "activeFederationMember5",
+            "activeFederationMember6",
+            "activeFederationMember7",
+            "activeFederationMember8",
+            "activeFederationMember9"
+        };
+        List<BtcECKey> activeFederationKeys = BitcoinTestUtils.getBtcEcKeysFromSeeds(seeds, true);
+
+        return P2shErpFederationBuilder.builder().withMembersBtcPublicKeys(activeFederationKeys).build();
+    }
+
+    private Federation buildRetiringFederation() {
+        String[] seeds = new String[] {
+            "retiringFederationMember1",
+            "retiringFederationMember2",
+            "retiringFederationMember3",
+            "retiringFederationMember4",
+            "retiringFederationMember5",
+            "retiringFederationMember6",
+            "retiringFederationMember7",
+            "retiringFederationMember8",
+            "retiringFederationMember9"
+        };
+        List<BtcECKey> retiringFederationKeys = BitcoinTestUtils.getBtcEcKeysFromSeeds(seeds, true);
+
+        return P2shErpFederationBuilder.builder().withMembersBtcPublicKeys(retiringFederationKeys).build();
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationSupportImplTest.java
@@ -2099,61 +2099,6 @@ class FederationSupportImplTest {
     }
 
     @Test
-    @Tag("last retired federation p2sh script")
-    void getLastRetiredFederationP2SHScript_beforeRSKIP186_returnsOptionalEmpty() {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP186)).thenReturn(false);
-
-        federationSupport = federationSupportBuilder
-            .withFederationConstants(federationMainnetConstants)
-            .withFederationStorageProvider(storageProvider)
-            .withActivations(activations)
-            .build();
-
-        Optional<Script> lastRetiredFederationP2SHScript = federationSupport.getLastRetiredFederationP2SHScript();
-        assertThat(lastRetiredFederationP2SHScript, is(Optional.empty()));
-    }
-
-    @Test
-    @Tag("last retired federation p2sh script")
-    void getLastRetiredFederationP2SHScript_afterRSKIP186_whenNoScriptWasSaved_returnsOptionalEmpty() {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP186)).thenReturn(true);
-
-        federationSupport = federationSupportBuilder
-            .withFederationConstants(federationMainnetConstants)
-            .withFederationStorageProvider(storageProvider)
-            .withActivations(activations)
-            .build();
-
-        Optional<Script> lastRetiredFederationP2SHScript = federationSupport.getLastRetiredFederationP2SHScript();
-        assertThat(lastRetiredFederationP2SHScript, is(Optional.empty()));
-    }
-
-    @Test
-    @Tag("last retired federation p2sh script")
-    void getLastRetiredFederationP2SHScript_afterRSKIP186_whenSavingScript_returnsScript() {
-        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
-        when(activations.isActive(ConsensusRule.RSKIP186)).thenReturn(true);
-
-        federationSupport = federationSupportBuilder
-            .withFederationConstants(federationMainnetConstants)
-            .withFederationStorageProvider(storageProvider)
-            .withActivations(activations)
-            .build();
-
-        // get a real p2sh script
-        ErpFederation federation = P2shErpFederationBuilder.builder().build();
-        Script p2shScript = federation.getDefaultP2SHScript();
-
-        storageProvider.setLastRetiredFederationP2SHScript(p2shScript);
-        Optional<Script> lastRetiredFederationP2SHScript = federationSupport.getLastRetiredFederationP2SHScript();
-
-        assertTrue(lastRetiredFederationP2SHScript.isPresent());
-        assertThat(lastRetiredFederationP2SHScript.get(), is(p2shScript));
-    }
-
-    @Test
     @Tag("clear retired federation")
     void clearRetiredFederation_whenHavingOldFederation_removesOldFederation() {
         ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Create a FederationContext class, to hold information about active and retiring federations
- Refactor PegUtils methods to receive a FederationContext object instead of each element separately
- Update getTransactionType method to detect SVP related transactions
- Update PegTxType enum to add SVP types
- Update registerBtcTransaction to detect and process SVP related transactions

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
