### PR TITLE
Make Federation Regtest Constants use a Lazy Singleton Pattern

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
@@ -46,7 +46,7 @@ public class BridgeRegTestConstants extends BridgeConstants {
         btcParamsString = NetworkParameters.ID_REGTEST;
         feePerKbConstants = FeePerKbRegTestConstants.getInstance();
         whitelistConstants = WhitelistRegTestConstants.getInstance();
-        federationConstants = new FederationRegTestConstants(federationPublicKeys);
+        federationConstants = FederationRegTestConstants.getInstance(federationPublicKeys);
         lockingCapConstants = LockingCapRegTestConstants.getInstance();
 
         btc2RskMinimumAcceptableConfirmations = 3;

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
@@ -25,21 +25,22 @@ import co.rsk.peg.federation.constants.FederationRegTestConstants;
 import co.rsk.peg.feeperkb.constants.FeePerKbRegTestConstants;
 import co.rsk.peg.lockingcap.constants.LockingCapRegTestConstants;
 import co.rsk.peg.whitelist.constants.WhitelistRegTestConstants;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
 
 public class BridgeRegTestConstants extends BridgeConstants {
-    private static final List<BtcECKey> defaultFederationPublicKeys = Collections.unmodifiableList(Stream.of(
+
+    private static final List<BtcECKey> DEFAULT_FEDERATION_PUBLIC_KEYS = Stream.of(
         "0362634ab57dae9cb373a5d536e66a8c4f67468bbcfb063809bab643072d78a124",
         "03c5946b3fbae03a654237da863c9ed534e0878657175b132b8ca630f245df04db",
-        "02cd53fc53a07f211641a677d250f6de99caf620e8e77071e811a28b3bcddf0be1"
-    ).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList()));
+        "02cd53fc53a07f211641a677d250f6de99caf620e8e77071e811a28b3bcddf0be1")
+        .map(Hex::decode)
+        .map(BtcECKey::fromPublicOnly)
+        .toList();
 
     public BridgeRegTestConstants() {
-        this(defaultFederationPublicKeys);
+        this(DEFAULT_FEDERATION_PUBLIC_KEYS);
     }
 
     public BridgeRegTestConstants(List<BtcECKey> federationPublicKeys) {

--- a/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationConstants.java
@@ -3,14 +3,13 @@ package co.rsk.peg.federation.constants;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.List;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 
-import java.time.Instant;
-import java.util.List;
-
-public class FederationConstants {
+public abstract class FederationConstants {
     protected NetworkParameters btcParams;
 
     protected List<BtcECKey> genesisFederationPublicKeys;

--- a/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationMainNetConstants.java
@@ -3,18 +3,17 @@ package co.rsk.peg.federation.constants;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
-import org.bouncycastle.util.encoders.Hex;
-import org.ethereum.crypto.ECKey;
-
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.ECKey;
 
 public class FederationMainNetConstants extends FederationConstants {
 
-    private static final FederationMainNetConstants instance = new FederationMainNetConstants();
+    private static final FederationMainNetConstants INSTANCE = new FederationMainNetConstants();
 
     private FederationMainNetConstants() {
         btcParams = NetworkParameters.fromID(NetworkParameters.ID_MAINNET);
@@ -66,6 +65,6 @@ public class FederationMainNetConstants extends FederationConstants {
     }
 
     public static FederationMainNetConstants getInstance() {
-        return instance;
+        return INSTANCE;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationRegTestConstants.java
@@ -13,7 +13,9 @@ import java.util.stream.Stream;
 
 public class FederationRegTestConstants extends FederationConstants {
 
-    public FederationRegTestConstants(List<BtcECKey> federationPublicKeys) {
+    private static FederationRegTestConstants instance;
+
+    private FederationRegTestConstants(List<BtcECKey> federationPublicKeys) {
         btcParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
 
         // IMPORTANT: BTC, RSK and MST keys are the same.
@@ -55,5 +57,27 @@ public class FederationRegTestConstants extends FederationConstants {
         // 9f72d27ba603cfab5a0201974a6783ca2476ec3d6b4e2625282c682e0e5f1c35
         // e1b17fcd0ef1942465eee61b20561b16750191143d365e71de08b33dd84a9788
         oldFederationAddress = "2N7ZgQyhFKm17RbaLqygYbS7KLrQfapyZzu";
+    }
+
+    public static synchronized FederationRegTestConstants getInstance(List<BtcECKey> federationPublicKeys) {
+        if (federationPublicKeys == null || federationPublicKeys.isEmpty()) {
+            throw new IllegalArgumentException("Federation regtest public keys must not be null or empty.");
+        }
+
+        if (instance == null) {
+            instance = new FederationRegTestConstants(federationPublicKeys);
+        } else if (!federationPublicKeys.equals(instance.getGenesisFederationPublicKeys())) {
+            throw new IllegalStateException("Federation regtest constants is already initialized with different keys.");
+        }
+
+        return instance;
+    }
+
+    public static synchronized FederationRegTestConstants getInstance() {
+        if (instance == null) {
+            throw new IllegalStateException("Federation regtest constants is not initialized. Call getInstance(List<BtcECKey>) first.");
+        }
+
+        return instance;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationRegTestConstants.java
@@ -59,6 +59,16 @@ public class FederationRegTestConstants extends FederationConstants {
         oldFederationAddress = "2N7ZgQyhFKm17RbaLqygYbS7KLrQfapyZzu";
     }
 
+    /**
+     * Returns the singleton instance of {@code FederationRegTestConstants} initialized with the provided federation public keys.
+     * If the instance has already been initialized, this method ensures the provided keys match the existing instance's keys.
+     *
+     * @param federationPublicKeys the list of {@code BtcECKey} public keys used to initialize the federation.
+     *                             Must not be {@code null} or empty.
+     * @return the singleton instance of {@code FederationRegTestConstants}.
+     * @throws IllegalArgumentException if the provided {@code federationPublicKeys} is {@code null} or empty.
+     * @throws IllegalStateException if the instance is already initialized with different keys.
+     */
     public static synchronized FederationRegTestConstants getInstance(List<BtcECKey> federationPublicKeys) {
         if (federationPublicKeys == null || federationPublicKeys.isEmpty()) {
             throw new IllegalArgumentException("Federation regtest public keys must not be null or empty.");
@@ -73,6 +83,13 @@ public class FederationRegTestConstants extends FederationConstants {
         return instance;
     }
 
+    /**
+     * Returns the singleton instance of {@code FederationRegTestConstants} if it has already been initialized.
+     *
+     * @return the singleton instance of {@code FederationRegTestConstants}.
+     * @throws IllegalStateException if the instance has not been initialized yet.
+     *                               Ensure {@code getInstance(List<BtcECKey>)} is called first to initialize the instance.
+     */
     public static synchronized FederationRegTestConstants getInstance() {
         if (instance == null) {
             throw new IllegalStateException("Federation regtest constants is not initialized. Call getInstance(List<BtcECKey>) first.");

--- a/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationTestNetConstants.java
@@ -14,7 +14,7 @@ import java.util.stream.Stream;
 
 public class FederationTestNetConstants extends FederationConstants {
 
-    private static final FederationTestNetConstants instance = new FederationTestNetConstants();
+    private static final FederationTestNetConstants INSTANCE = new FederationTestNetConstants();
 
     private FederationTestNetConstants() {
         btcParams = NetworkParameters.fromID(NetworkParameters.ID_TESTNET);
@@ -58,5 +58,7 @@ public class FederationTestNetConstants extends FederationConstants {
         oldFederationAddress = "2N7ZgQyhFKm17RbaLqygYbS7KLrQfapyZzu";
     }
 
-    public static FederationTestNetConstants getInstance() { return instance; }
+    public static FederationTestNetConstants getInstance() {
+        return INSTANCE;
+    }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/constants/BridgeConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/constants/BridgeConstantsTest.java
@@ -186,7 +186,7 @@ class BridgeConstantsTest {
         return Stream.of(
             Arguments.of(BridgeMainNetConstants.getInstance(), FederationMainNetConstants.getInstance()),
             Arguments.of(BridgeTestNetConstants.getInstance(), FederationTestNetConstants.getInstance()),
-            Arguments.of(bridgeRegTestConstants, new FederationRegTestConstants(federationRegTestConstants.getGenesisFederationPublicKeys()))
+            Arguments.of(bridgeRegTestConstants, FederationRegTestConstants.getInstance(federationRegTestConstants.getGenesisFederationPublicKeys()))
         );
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/federation/constants/FederationConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/constants/FederationConstantsTest.java
@@ -318,6 +318,7 @@ class FederationConstantsTest {
 
     @Test
     void getInstance_whenKeysAreNull_shouldThrowIllegalArgumentException() {
+        // Act & Assert
         assertThrows(IllegalArgumentException.class, () ->
             FederationRegTestConstants.getInstance(null)
         );
@@ -325,6 +326,7 @@ class FederationConstantsTest {
 
     @Test
     void getInstance_whenKeysAreEmpty_shouldThrowIllegalArgumentException() {
+        // Act & Assert
         assertThrows(IllegalArgumentException.class, () ->
             FederationRegTestConstants.getInstance(List.of())
         );

--- a/rskj-core/src/test/java/co/rsk/peg/federation/constants/FederationConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/constants/FederationConstantsTest.java
@@ -3,9 +3,6 @@ package co.rsk.peg.federation.constants;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -22,7 +19,6 @@ import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.crypto.ECKey;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -314,92 +310,5 @@ class FederationConstantsTest {
             Arguments.of(TESTNET, oldFederationAddressTestnet),
             Arguments.of(REGTEST, oldFederationAddressRegtest)
         );
-    }
-
-    @Test
-    void getInstance_whenKeysAreNull_shouldThrowIllegalArgumentException() {
-        // Act & Assert
-        assertThrows(IllegalArgumentException.class, () ->
-            FederationRegTestConstants.getInstance(null)
-        );
-    }
-
-    @Test
-    void getInstance_whenKeysAreEmpty_shouldThrowIllegalArgumentException() {
-        // Act & Assert
-        assertThrows(IllegalArgumentException.class, () ->
-            FederationRegTestConstants.getInstance(List.of())
-        );
-    }
-
-    @Test
-    void getInstance_whenCalledWithValidKeys_shouldCreateInstance() {
-        // Arrange
-        var key1 = mock(BtcECKey.class);
-        var key2 = mock(BtcECKey.class);
-        var key3 = mock(BtcECKey.class);
-        var validKeys = List.of(key1, key2, key3);
-
-        // Act
-        var instance = FederationRegTestConstants.getInstance(validKeys);
-      
-        // Assert
-        assertNotNull(instance);
-    }
-
-    @Test
-    void getInstance_whenCalledTwiceWithSameKeys_shouldReturnSameInstance() {
-        // Arrange
-        var key1 = mock(BtcECKey.class);
-        var key2 = mock(BtcECKey.class);
-        var key3 = mock(BtcECKey.class);
-        var validKeys = List.of(key1, key2, key3);
-      
-        // Act
-        var instance1 = FederationRegTestConstants.getInstance(validKeys);
-        var instance2 = FederationRegTestConstants.getInstance(validKeys);
-
-        // Assert
-        assertSame(instance1, instance2);
-    }
-
-    @Test
-    void getInstance_whenCalledWithDifferentKeysAfterInitialization_shouldThrowIllegalStateException() {
-        // Arrange
-        var key1 = mock(BtcECKey.class);
-        var key2 = mock(BtcECKey.class);
-        var key3 = mock(BtcECKey.class);
-        var validKeys = List.of(key1, key2, key3);
-        var differentKeys = List.of(key1);
-
-        // Act
-        FederationRegTestConstants.getInstance(validKeys);
-     
-        // Assert
-        assertThrows(IllegalStateException.class, () ->
-            FederationRegTestConstants.getInstance(differentKeys)
-        );
-    }
-
-    @Test
-    void getInstanceNoArgs_whenCalledBeforeInitialization_shouldThrowIllegalStateException() {
-        // Act & Assert
-        assertThrows(IllegalStateException.class, FederationRegTestConstants::getInstance);
-    }
-
-    @Test
-    void getInstanceNoArgs_whenCalledAfterInitialization_shouldReturnSameInstance() {
-        // Arrange
-        var key1 = mock(BtcECKey.class);
-        var key2 = mock(BtcECKey.class);
-        var key3 = mock(BtcECKey.class);
-        var validKeys = List.of(key1, key2, key3);
-
-        // Act
-        var expectedInstance = FederationRegTestConstants.getInstance(validKeys);
-        var actualInstance = FederationRegTestConstants.getInstance();
-
-        // Assert
-        assertSame(expectedInstance, actualInstance);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/federation/constants/FederationConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/constants/FederationConstantsTest.java
@@ -3,6 +3,9 @@ package co.rsk.peg.federation.constants;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -19,11 +22,13 @@ import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.crypto.ECKey;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class FederationConstantsTest {
+
     private static final FederationConstants MAINNET = FederationMainNetConstants.getInstance();
     private static final FederationConstants TESTNET = FederationTestNetConstants.getInstance();
     private static final FederationConstants REGTEST = new BridgeRegTestConstants().getFederationConstants();
@@ -309,5 +314,90 @@ class FederationConstantsTest {
             Arguments.of(TESTNET, oldFederationAddressTestnet),
             Arguments.of(REGTEST, oldFederationAddressRegtest)
         );
+    }
+
+    @Test
+    void getInstance_whenKeysAreNull_shouldThrowIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () ->
+            FederationRegTestConstants.getInstance(null)
+        );
+    }
+
+    @Test
+    void getInstance_whenKeysAreEmpty_shouldThrowIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () ->
+            FederationRegTestConstants.getInstance(List.of())
+        );
+    }
+
+    @Test
+    void getInstance_whenCalledWithValidKeys_shouldCreateInstance() {
+        // Arrange
+        var key1 = mock(BtcECKey.class);
+        var key2 = mock(BtcECKey.class);
+        var key3 = mock(BtcECKey.class);
+        var validKeys = List.of(key1, key2, key3);
+
+        // Act
+        var instance = FederationRegTestConstants.getInstance(validKeys);
+      
+        // Assert
+        assertNotNull(instance);
+    }
+
+    @Test
+    void getInstance_whenCalledTwiceWithSameKeys_shouldReturnSameInstance() {
+        // Arrange
+        var key1 = mock(BtcECKey.class);
+        var key2 = mock(BtcECKey.class);
+        var key3 = mock(BtcECKey.class);
+        var validKeys = List.of(key1, key2, key3);
+      
+        // Act
+        var instance1 = FederationRegTestConstants.getInstance(validKeys);
+        var instance2 = FederationRegTestConstants.getInstance(validKeys);
+
+        // Assert
+        assertSame(instance1, instance2);
+    }
+
+    @Test
+    void getInstance_whenCalledWithDifferentKeysAfterInitialization_shouldThrowIllegalStateException() {
+        // Arrange
+        var key1 = mock(BtcECKey.class);
+        var key2 = mock(BtcECKey.class);
+        var key3 = mock(BtcECKey.class);
+        var validKeys = List.of(key1, key2, key3);
+        var differentKeys = List.of(key1);
+
+        // Act
+        FederationRegTestConstants.getInstance(validKeys);
+     
+        // Assert
+        assertThrows(IllegalStateException.class, () ->
+            FederationRegTestConstants.getInstance(differentKeys)
+        );
+    }
+
+    @Test
+    void getInstanceNoArgs_whenCalledBeforeInitialization_shouldThrowIllegalStateException() {
+        // Act & Assert
+        assertThrows(IllegalStateException.class, FederationRegTestConstants::getInstance);
+    }
+
+    @Test
+    void getInstanceNoArgs_whenCalledAfterInitialization_shouldReturnSameInstance() {
+        // Arrange
+        var key1 = mock(BtcECKey.class);
+        var key2 = mock(BtcECKey.class);
+        var key3 = mock(BtcECKey.class);
+        var validKeys = List.of(key1, key2, key3);
+
+        // Act
+        var expectedInstance = FederationRegTestConstants.getInstance(validKeys);
+        var actualInstance = FederationRegTestConstants.getInstance();
+
+        // Assert
+        assertSame(expectedInstance, actualInstance);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/federation/constants/FederationConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/constants/FederationConstantsTest.java
@@ -6,16 +6,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.peg.constants.*;
+import co.rsk.peg.vote.AddressBasedAuthorizer;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import co.rsk.bitcoinj.core.BtcECKey;
-import co.rsk.bitcoinj.core.NetworkParameters;
-import co.rsk.peg.constants.*;
-import co.rsk.peg.vote.AddressBasedAuthorizer;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
@@ -25,9 +24,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class FederationConstantsTest {
-    private static final FederationConstants mainnet = FederationMainNetConstants.getInstance();
-    private static final FederationConstants testnet = FederationTestNetConstants.getInstance();
-    private static final FederationConstants regtest = new BridgeRegTestConstants().getFederationConstants();
+    private static final FederationConstants MAINNET = FederationMainNetConstants.getInstance();
+    private static final FederationConstants TESTNET = FederationTestNetConstants.getInstance();
+    private static final FederationConstants REGTEST = new BridgeRegTestConstants().getFederationConstants();
 
     @ParameterizedTest
     @MethodSource("networkArgs")
@@ -37,9 +36,9 @@ class FederationConstantsTest {
 
     private static Stream<Arguments> networkArgs() {
         return Stream.of(
-            Arguments.of(mainnet, NetworkParameters.fromID(NetworkParameters.ID_MAINNET)),
-            Arguments.of(testnet, NetworkParameters.fromID(NetworkParameters.ID_TESTNET)),
-            Arguments.of(regtest, NetworkParameters.fromID(NetworkParameters.ID_REGTEST))
+            Arguments.of(MAINNET, NetworkParameters.fromID(NetworkParameters.ID_MAINNET)),
+            Arguments.of(TESTNET, NetworkParameters.fromID(NetworkParameters.ID_TESTNET)),
+            Arguments.of(REGTEST, NetworkParameters.fromID(NetworkParameters.ID_REGTEST))
         );
     }
 
@@ -82,9 +81,9 @@ class FederationConstantsTest {
         ).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
 
         return Stream.of(
-            Arguments.of(mainnet, genesisFederationPublicKeysMainnet),
-            Arguments.of(testnet, genesisFederationPublicKeysTestnet),
-            Arguments.of(regtest, genesisFederationPublicKeysRegtest)
+            Arguments.of(MAINNET, genesisFederationPublicKeysMainnet),
+            Arguments.of(TESTNET, genesisFederationPublicKeysTestnet),
+            Arguments.of(REGTEST, genesisFederationPublicKeysRegtest)
         );
     }
 
@@ -100,9 +99,9 @@ class FederationConstantsTest {
         Instant genesisFedCreationTimeRegtest = ZonedDateTime.parse("2016-01-01T00:00:00Z").toInstant();
 
         return Stream.of(
-            Arguments.of(mainnet, genesisFedCreationTimeMainnet),
-            Arguments.of(testnet, genesisFedCreationTimeTestnet),
-            Arguments.of(regtest, genesisFedCreationTimeRegtest)
+            Arguments.of(MAINNET, genesisFedCreationTimeMainnet),
+            Arguments.of(TESTNET, genesisFedCreationTimeTestnet),
+            Arguments.of(REGTEST, genesisFedCreationTimeRegtest)
         );
     }
 
@@ -114,9 +113,9 @@ class FederationConstantsTest {
 
     private static Stream<Arguments> validationPeriodDurationArgs() {
         return Stream.of(
-            Arguments.of(mainnet, 16000L),
-            Arguments.of(testnet, 80L),
-            Arguments.of(regtest, 125L)
+            Arguments.of(MAINNET, 16000L),
+            Arguments.of(TESTNET, 80L),
+            Arguments.of(REGTEST, 125L)
         );
     }
 
@@ -140,12 +139,12 @@ class FederationConstantsTest {
         when(activationsPostRSKIP383.isActive(ConsensusRule.RSKIP383)).thenReturn(true);
 
         return Stream.of(
-            Arguments.of(mainnet, activationsPreRSKIP383, fedActivationAgeLegacyMainnet),
-            Arguments.of(testnet, activationsPreRSKIP383, fedActivationAgeLegacyTestnet),
-            Arguments.of(regtest, activationsPreRSKIP383, fedActivationAgeLegacyRegtest),
-            Arguments.of(mainnet, activationsPostRSKIP383, fedActivationAgeMainnet),
-            Arguments.of(testnet, activationsPostRSKIP383, fedActivationAgeTestnet),
-            Arguments.of(regtest, activationsPostRSKIP383, fedActivationAgeRegtest)
+            Arguments.of(MAINNET, activationsPreRSKIP383, fedActivationAgeLegacyMainnet),
+            Arguments.of(TESTNET, activationsPreRSKIP383, fedActivationAgeLegacyTestnet),
+            Arguments.of(REGTEST, activationsPreRSKIP383, fedActivationAgeLegacyRegtest),
+            Arguments.of(MAINNET, activationsPostRSKIP383, fedActivationAgeMainnet),
+            Arguments.of(TESTNET, activationsPostRSKIP383, fedActivationAgeTestnet),
+            Arguments.of(REGTEST, activationsPostRSKIP383, fedActivationAgeRegtest)
         );
     }
 
@@ -161,9 +160,9 @@ class FederationConstantsTest {
         long fundsMigrationAgeSinceActivationBeginRegtest = 15L;
 
         return Stream.of(
-            Arguments.of(mainnet, fundsMigrationAgeSinceActivationBeginMainnet),
-            Arguments.of(testnet, fundsMigrationAgeSinceActivationBeginTestnet),
-            Arguments.of(regtest, fundsMigrationAgeSinceActivationBeginRegtest)
+            Arguments.of(MAINNET, fundsMigrationAgeSinceActivationBeginMainnet),
+            Arguments.of(TESTNET, fundsMigrationAgeSinceActivationBeginTestnet),
+            Arguments.of(REGTEST, fundsMigrationAgeSinceActivationBeginRegtest)
         );
     }
 
@@ -192,15 +191,15 @@ class FederationConstantsTest {
         when(activationsPostRSKIP374.isActive(ConsensusRule.RSKIP374)).thenReturn(true);
 
         return Stream.of(
-            Arguments.of(mainnet, activationsPreRSKIP357, fundsMigrationAgeSinceActivationEndMainnet),
-            Arguments.of(testnet, activationsPreRSKIP357, fundsMigrationAgeSinceActivationEndTestnet),
-            Arguments.of(regtest, activationsPreRSKIP357, fundsMigrationAgeSinceActivationEndRegtest),
-            Arguments.of(mainnet, activationsSpecialCase, specialCaseFundsMigrationAgeSinceActivationEndMainnet),
-            Arguments.of(testnet, activationsSpecialCase, fundsMigrationAgeSinceActivationEndTestnet),
-            Arguments.of(regtest, activationsSpecialCase, fundsMigrationAgeSinceActivationEndRegtest),
-            Arguments.of(mainnet, activationsPostRSKIP374, fundsMigrationAgeSinceActivationEndMainnet),
-            Arguments.of(testnet, activationsPostRSKIP374, fundsMigrationAgeSinceActivationEndTestnet),
-            Arguments.of(regtest, activationsPostRSKIP374, fundsMigrationAgeSinceActivationEndRegtest)
+            Arguments.of(MAINNET, activationsPreRSKIP357, fundsMigrationAgeSinceActivationEndMainnet),
+            Arguments.of(TESTNET, activationsPreRSKIP357, fundsMigrationAgeSinceActivationEndTestnet),
+            Arguments.of(REGTEST, activationsPreRSKIP357, fundsMigrationAgeSinceActivationEndRegtest),
+            Arguments.of(MAINNET, activationsSpecialCase, specialCaseFundsMigrationAgeSinceActivationEndMainnet),
+            Arguments.of(TESTNET, activationsSpecialCase, fundsMigrationAgeSinceActivationEndTestnet),
+            Arguments.of(REGTEST, activationsSpecialCase, fundsMigrationAgeSinceActivationEndRegtest),
+            Arguments.of(MAINNET, activationsPostRSKIP374, fundsMigrationAgeSinceActivationEndMainnet),
+            Arguments.of(TESTNET, activationsPostRSKIP374, fundsMigrationAgeSinceActivationEndTestnet),
+            Arguments.of(REGTEST, activationsPostRSKIP374, fundsMigrationAgeSinceActivationEndRegtest)
         );
     }
 
@@ -235,9 +234,9 @@ class FederationConstantsTest {
         ).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
 
         return Stream.of(
-            Arguments.of(mainnet, fedChangeAuthorizedKeysMainnet),
-            Arguments.of(testnet, fedChangeAuthorizedKeysTestnet),
-            Arguments.of(regtest, fedChangeAuthorizedKeysRegtest)
+            Arguments.of(MAINNET, fedChangeAuthorizedKeysMainnet),
+            Arguments.of(TESTNET, fedChangeAuthorizedKeysTestnet),
+            Arguments.of(REGTEST, fedChangeAuthorizedKeysRegtest)
         );
     }
 
@@ -253,9 +252,9 @@ class FederationConstantsTest {
         long erpActivationDelayRegtest = 500;
 
         return Stream.of(
-            Arguments.of(mainnet, erpActivationDelayMainnet),
-            Arguments.of(testnet, erpActivationDelayTestnet),
-            Arguments.of(regtest, erpActivationDelayRegtest)
+            Arguments.of(MAINNET, erpActivationDelayMainnet),
+            Arguments.of(TESTNET, erpActivationDelayTestnet),
+            Arguments.of(REGTEST, erpActivationDelayRegtest)
         );
     }
 
@@ -288,9 +287,9 @@ class FederationConstantsTest {
         ).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList());
 
         return Stream.of(
-            Arguments.of(mainnet, erpFedPubKeysMainnet),
-            Arguments.of(testnet, erpFedPubKeysTestnet),
-            Arguments.of(regtest, erpFedPubKeysRegtest)
+            Arguments.of(MAINNET, erpFedPubKeysMainnet),
+            Arguments.of(TESTNET, erpFedPubKeysTestnet),
+            Arguments.of(REGTEST, erpFedPubKeysRegtest)
         );
     }
 
@@ -306,9 +305,9 @@ class FederationConstantsTest {
         String oldFederationAddressRegtest = "2N7ZgQyhFKm17RbaLqygYbS7KLrQfapyZzu";
 
         return Stream.of(
-            Arguments.of(mainnet, oldFederationAddressMainnet),
-            Arguments.of(testnet, oldFederationAddressTestnet),
-            Arguments.of(regtest, oldFederationAddressRegtest)
+            Arguments.of(MAINNET, oldFederationAddressMainnet),
+            Arguments.of(TESTNET, oldFederationAddressTestnet),
+            Arguments.of(REGTEST, oldFederationAddressRegtest)
         );
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/federation/constants/FederationRegTestConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/constants/FederationRegTestConstantsTest.java
@@ -1,0 +1,123 @@
+package co.rsk.peg.federation.constants;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.peg.bitcoin.BitcoinTestUtils;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FederationRegTestConstantsTest {
+
+    @BeforeEach
+    void setUp() throws Exception {
+        resetInstance();
+    }
+
+    @AfterAll
+    static void cleanUp() throws Exception {
+        resetInstance();
+    }
+
+    @Test
+    void getInstance_whenKeysAreNull_shouldThrowIllegalArgumentException() {
+        // Act & Assert
+        assertThrows(IllegalArgumentException.class, () ->
+            FederationRegTestConstants.getInstance(null)
+        );
+    }
+
+    @Test
+    void getInstance_whenKeysAreEmpty_shouldThrowIllegalArgumentException() {
+        // Arrange
+        List<BtcECKey> emptyList = List.of();
+
+        // Act & Assert
+        assertThrows(IllegalArgumentException.class, () ->
+            FederationRegTestConstants.getInstance(emptyList)
+        );
+    }
+
+    @Test
+    void getInstance_whenCalledWithValidKeys_shouldCreateInstance() {
+        // Arrange
+        var key1 = BitcoinTestUtils.getBtcEcKeyFromSeed("1");
+        var key2 = BitcoinTestUtils.getBtcEcKeyFromSeed("2");
+        var key3 = BitcoinTestUtils.getBtcEcKeyFromSeed("3");
+        var validKeys = List.of(key1, key2, key3);
+
+        // Act
+        var instance = FederationRegTestConstants.getInstance(validKeys);
+      
+        // Assert
+        assertNotNull(instance);
+    }
+
+    @Test
+    void getInstance_whenCalledTwiceWithSameKeys_shouldReturnSameInstance() {
+        // Arrange
+        var key1 = BitcoinTestUtils.getBtcEcKeyFromSeed("1");
+        var key2 = BitcoinTestUtils.getBtcEcKeyFromSeed("2");
+        var key3 = BitcoinTestUtils.getBtcEcKeyFromSeed("3");
+        var validKeys = List.of(key1, key2, key3);
+      
+        // Act
+        var instance1 = FederationRegTestConstants.getInstance(validKeys);
+        var instance2 = FederationRegTestConstants.getInstance(validKeys);
+
+        // Assert
+        assertSame(instance1, instance2);
+    }
+
+    @Test
+    void getInstance_whenCalledWithDifferentKeysAfterInitialization_shouldThrowIllegalStateException() {
+        // Arrange
+        var key1 = BitcoinTestUtils.getBtcEcKeyFromSeed("1");
+        var key2 = BitcoinTestUtils.getBtcEcKeyFromSeed("2");
+        var key3 = BitcoinTestUtils.getBtcEcKeyFromSeed("3");
+        var validKeys = List.of(key1, key2, key3);
+        var differentKeys = List.of(key1);
+
+        // Act
+        FederationRegTestConstants.getInstance(validKeys);
+     
+        // Assert
+        assertThrows(IllegalStateException.class, () ->
+            FederationRegTestConstants.getInstance(differentKeys)
+        );
+    }
+
+    @Test
+    void getInstanceNoArgs_whenCalledBeforeInitialization_shouldThrowIllegalStateException() {
+        // Act & Assert
+        assertThrows(IllegalStateException.class, FederationRegTestConstants::getInstance);
+    }
+
+    @Test
+    void getInstanceNoArgs_whenCalledAfterInitialization_shouldReturnSameInstance() {
+        // Arrange
+        var key1 = BitcoinTestUtils.getBtcEcKeyFromSeed("1");
+        var key2 = BitcoinTestUtils.getBtcEcKeyFromSeed("2");
+        var key3 = BitcoinTestUtils.getBtcEcKeyFromSeed("3");
+        var validKeys = List.of(key1, key2, key3);
+
+        // Act
+        var expectedInstance = FederationRegTestConstants.getInstance(validKeys);
+        var actualInstance = FederationRegTestConstants.getInstance();
+
+        // Assert
+        assertSame(expectedInstance, actualInstance);
+    }
+
+    private static void resetInstance() throws Exception {
+        // reset singleton instance
+        Field instanceField = FederationRegTestConstants.class.getDeclaredField("instance");
+        instanceField.setAccessible(true);
+        instanceField.set(null, null);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make Federation Regtest Constants use a Lazy Singleton Pattern.

## Motivation and Context
Refactor

## How Has This Been Tested?
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
