### PR TITLE
Remove logs that are no longer necessary since the tx type is being logged above

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -432,8 +432,6 @@ public class BridgeSupport {
     }
 
     private void registerSvpFundTx(BtcTransaction btcTx) throws IOException {
-        logger.info("[registerSvpFundTx] This is an svp fund tx {}", btcTx.getHash());
-
         registerNewUtxos(btcTx); // Need to register the change UTXO
 
         // If the SVP validation period is over, SVP related values should be cleared in the next call to updateCollections
@@ -445,14 +443,10 @@ public class BridgeSupport {
     }
 
     private void registerSvpSpendTx(BtcTransaction btcTx) throws IOException {
-        logger.info(
-            "[registerSvpSpendTx] This is an svp spend tx {} (wtxid: {}). SVP was successful, going to commit the proposed federation",
-            btcTx.getHash(),
-            btcTx.getHash(true)
-        );
-
         registerNewUtxos(btcTx);
         provider.setSvpSpendTxHashUnsigned(null);
+
+        logger.info("[registerSvpSpendTx] Going to commit the proposed federation.");
         federationSupport.commitProposedFederation();
     }
 
@@ -478,7 +472,6 @@ public class BridgeSupport {
         int height
     ) throws IOException, RegisterBtcTransactionException {
         final String METHOD_NAME = "registerPegIn";
-        logger.info("[{}] This is a peg-in tx {}", METHOD_NAME, btcTx.getHash());
 
         if (!activations.isActive(ConsensusRule.RSKIP379)) {
             legacyRegisterPegin(btcTx, rskTxHash, height);


### PR DESCRIPTION
Since we added [this](https://github.com/rsksmart/rskj/compare/return_feds_creation_time_in_seconds...remove_unnecessary_logs?expand=1#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685R417) log, there is no need to log the peg tx type in the specific tx methods