### PR TITLE
Add logic to extractWitnessCommitmentHash in the Bridge

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinTestUtils.java
@@ -14,6 +14,7 @@ import org.ethereum.crypto.HashUtil;
 import org.ethereum.util.ByteUtil;
 
 public class BitcoinTestUtils {
+    public static final Sha256Hash WITNESS_RESERVED_VALUE = Sha256Hash.ZERO_HASH;
 
     public static BtcECKey getBtcEcKeyFromSeed(String seed) {
         byte[] serializedSeed = HashUtil.keccak256(seed.getBytes(StandardCharsets.UTF_8));
@@ -215,7 +216,7 @@ public class BitcoinTestUtils {
         byte[] wrongWitnessCommitmentWithHeader = ByteUtil.merge(
             new byte[]{ScriptOpCodes.OP_RETURN},
             new byte[]{ScriptOpCodes.OP_PUSHDATA1},
-            new byte[]{BitcoinUtils.WITNESS_COMMITMENT_LENGTH},
+            new byte[]{(byte) BitcoinUtils.WITNESS_COMMITMENT_LENGTH},
             BitcoinUtils.WITNESS_COMMITMENT_HEADER,
             witnessCommitment.getBytes()
         );
@@ -230,7 +231,7 @@ public class BitcoinTestUtils {
         BtcTransaction coinbaseTx = createCoinbaseTransaction(networkParameters);
 
         TransactionWitness txWitness = new TransactionWitness(1);
-        txWitness.setPush(0, BitcoinUtils.WITNESS_RESERVED_VALUE.getBytes());
+        txWitness.setPush(0, WITNESS_RESERVED_VALUE.getBytes());
         coinbaseTx.setWitness(0, txWitness);
 
         return coinbaseTx;

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
@@ -33,7 +33,7 @@ class BitcoinUtilsTest {
         LinkedList<BtcECKey> keys = new LinkedList<>(pubKeys);
         LinkedList<BtcECKey.ECDSASignature> sigs = new LinkedList<>(signatures);
 
-        while (sigs.size() > 0){
+        while (!sigs.isEmpty()){
             BtcECKey pubKey = keys.pollFirst();
             BtcECKey.ECDSASignature signature = sigs.getFirst();
             if(pubKey.verify(sigHash, signature)){
@@ -272,7 +272,7 @@ class BitcoinUtilsTest {
         assertFalse(btcTx.getInputs().isEmpty());
 
         List<ScriptChunk> scriptSigChunks = scriptSig.getChunks();
-        Script expectedRedeemScript = new Script( scriptSigChunks.get(scriptSigChunks.size()- 1).data);
+        Script expectedRedeemScript = new Script(scriptSigChunks.get(scriptSigChunks.size()- 1).data);
 
         // Act
         Optional<Script> redeemScript = BitcoinUtils.extractRedeemScriptFromInput(btcTx.getInputs().get(FIRST_INPUT_INDEX));
@@ -512,7 +512,7 @@ class BitcoinUtilsTest {
         BtcTransaction btcTx = BitcoinTestUtils.createCoinbaseTransaction(btcMainnetParams);
 
         TransactionWitness txWitness = new TransactionWitness(1);
-        txWitness.setPush(0, BitcoinUtils.WITNESS_RESERVED_VALUE.getBytes());
+        txWitness.setPush(0, BitcoinTestUtils.WITNESS_RESERVED_VALUE.getBytes());
         btcTx.setWitness(0, txWitness);
 
         Sha256Hash witnessCommitment = BitcoinTestUtils.createHash(100);


### PR DESCRIPTION
Relates to https://github.com/rsksmart/bitcoinj-thin/pull/125

## Description
Since now the logic to get the witness commitment from a coinbase transaction is in the Bridge, it's necessary to also add `extractWitnessCommitmentHash` and avoid dependency to bitcoinj-thin

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
