### PR TITLE
Update testnet validation period duration and activation age

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationConstants.java
@@ -40,7 +40,11 @@ public abstract class FederationConstants {
     public long getValidationPeriodDurationInBlocks() { return validationPeriodDurationInBlocks; }
 
     public long getFederationActivationAge(ActivationConfig.ForBlock activations) {
-        return activations.isActive(ConsensusRule.RSKIP383) ? federationActivationAge  : federationActivationAgeLegacy;
+        if (!activations.isActive(ConsensusRule.RSKIP383)) {
+            return federationActivationAgeLegacy;
+        }
+
+        return federationActivationAge;
     }
 
     public long getFundsMigrationAgeSinceActivationBegin() {

--- a/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationMainNetConstants.java
@@ -4,9 +4,7 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
 import java.time.ZonedDateTime;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.ECKey;
@@ -18,7 +16,7 @@ public class FederationMainNetConstants extends FederationConstants {
     private FederationMainNetConstants() {
         btcParams = NetworkParameters.fromID(NetworkParameters.ID_MAINNET);
 
-        genesisFederationPublicKeys = Collections.unmodifiableList(Stream.of(
+        genesisFederationPublicKeys = Stream.of(
             "03b53899c390573471ba30e5054f78376c5f797fda26dde7a760789f02908cbad2",
             "027319afb15481dbeb3c426bcc37f9a30e7f51ceff586936d85548d9395bcc2344",
             "0355a2e9bf100c00fc0a214afd1bf272647c7824eb9cb055480962f0c382596a70",
@@ -34,14 +32,14 @@ public class FederationMainNetConstants extends FederationConstants {
             "03f909ae15558c70cc751aff9b1f495199c325b13a9e5b934fd6299cd30ec50be8",
             "02c6018fcbd3e89f3cf9c7f48b3232ea3638eb8bf217e59ee290f5f0cfb2fb9259",
             "03b65694ccccda83cbb1e56b31308acd08e993114c33f66a456b627c2c1c68bed6"
-        ).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList()));
+        ).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).toList();
         genesisFederationCreationTime = ZonedDateTime.parse("1970-01-18T12:49:08.400Z").toInstant();
 
-        List<ECKey> federationChangeAuthorizedKeys =  Collections.unmodifiableList(Stream.of(
+        List<ECKey> federationChangeAuthorizedKeys = Stream.of(
             "04e593d4cde25137b13f19462bc4c02e97ba2ed5a3860813497abf9b4eeb9259e37e0384d12cfd2d9a7a0ba606b31ee34317a9d7f4a8591c6bcf5dfd5563248b2f",
             "045e7f2563e73d44d149c19cffca36e1898597dc759d76166b8104103c0d3f351a8a48e3a224544e9a649ad8ebcfdbd6c39744ddb85925f19c7e3fd48f07fc1c06",
             "0441945e4e272936106f6200b36162f3510e8083535c15e175ac82deaf828da955b85fd72b7534f2a34cedfb45fa63b728cc696a2bd3c5d39ec799ec2618e9aa9f"
-        ).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList()));
+        ).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).toList();
         federationChangeAuthorizer = new AddressBasedAuthorizer(federationChangeAuthorizedKeys, AddressBasedAuthorizer.MinimumRequiredCalculation.MAJORITY);
 
         validationPeriodDurationInBlocks = 16000L;
@@ -53,12 +51,12 @@ public class FederationMainNetConstants extends FederationConstants {
         fundsMigrationAgeSinceActivationEnd = 10585L;
         specialCaseFundsMigrationAgeSinceActivationEnd = 172_800L; // 60 days, considering 1 block every 30 seconds
 
-        erpFedPubKeysList = Collections.unmodifiableList(Stream.of(
+        erpFedPubKeysList = Stream.of(
             "0257c293086c4d4fe8943deda5f890a37d11bebd140e220faa76258a41d077b4d4",
             "03c2660a46aa73078ee6016dee953488566426cf55fc8011edd0085634d75395f9",
             "03cd3e383ec6e12719a6c69515e5559bcbe037d0aa24c187e1e26ce932e22ad7b3",
             "02370a9838e4d15708ad14a104ee5606b36caaaaf739d833e67770ce9fd9b3ec80"
-        ).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList()));
+        ).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).toList();
         erpFedActivationDelay = 52_560; // 1 year in BTC blocks (considering 1 block every 10 minutes)
 
         oldFederationAddress = "35JUi1FxabGdhygLhnNUEFG4AgvpNMgxK1";

--- a/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationRegTestConstants.java
@@ -3,13 +3,11 @@ package co.rsk.peg.federation.constants;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
-import java.util.Collections;
-import org.bouncycastle.util.encoders.Hex;
-import org.ethereum.crypto.ECKey;
 import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.crypto.ECKey;
 
 public class FederationRegTestConstants extends FederationConstants {
 
@@ -24,13 +22,13 @@ public class FederationRegTestConstants extends FederationConstants {
         genesisFederationCreationTime = ZonedDateTime.parse("2016-01-01T00:00:00Z").toInstant();
 
         // Keys generated with GenNodeKey using generators 'auth-a' through 'auth-e'
-        List<ECKey> federationChangeAuthorizedKeys = Collections.unmodifiableList(Stream.of(
+        List<ECKey> federationChangeAuthorizedKeys = Stream.of(
             "04dde17c5fab31ffc53c91c2390136c325bb8690dc135b0840075dd7b86910d8ab9e88baad0c32f3eea8833446a6bc5ff1cd2efa99ecb17801bcb65fc16fc7d991",
             "04af886c67231476807e2a8eee9193878b9d94e30aa2ee469a9611d20e1e1c1b438e5044148f65e6e61bf03e9d72e597cb9cdea96d6fc044001b22099f9ec403e2",
             "045d4dedf9c69ab3ea139d0f0da0ad00160b7663d01ce7a6155cd44a3567d360112b0480ab6f31cac7345b5f64862205ea7ccf555fcf218f87fa0d801008fecb61",
             "04709f002ac4642b6a87ea0a9dc76eeaa93f71b3185985817ec1827eae34b46b5d869320efb5c5cbe2a5c13f96463fe0210710b53352a4314188daffe07bd54154",
             "04aff62315e9c18004392a5d9e39496ff5794b2d9f43ab4e8ade64740d7fdfe896969be859b43f26ef5aa4b5a0d11808277b4abfa1a07cc39f2839b89cc2bc6b4c"
-        ).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList()));
+        ).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).toList();
         federationChangeAuthorizer = new AddressBasedAuthorizer(federationChangeAuthorizedKeys, AddressBasedAuthorizer.MinimumRequiredCalculation.MAJORITY);
 
         validationPeriodDurationInBlocks = 125L;
@@ -43,13 +41,13 @@ public class FederationRegTestConstants extends FederationConstants {
         specialCaseFundsMigrationAgeSinceActivationEnd = 150L;
 
         // Keys generated with GenNodeKey using generators 'erp-fed-01' through 'erp-fed-05'
-        erpFedPubKeysList = Collections.unmodifiableList(Stream.of(
+        erpFedPubKeysList = Stream.of(
             "03b9fc46657cf72a1afa007ecf431de1cd27ff5cc8829fa625b66ca47b967e6b24",
             "029cecea902067992d52c38b28bf0bb2345bda9b21eca76b16a17c477a64e43301",
             "03284178e5fbcc63c54c3b38e3ef88adf2da6c526313650041b0ef955763634ebd",
             "03776b1fd8f86da3c1db3d69699e8250a15877d286734ea9a6da8e9d8ad25d16c1",
             "03ab0e2cd7ed158687fc13b88019990860cdb72b1f5777b58513312550ea1584bc"
-        ).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList()));
+        ).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).toList();
         erpFedActivationDelay = 500;
 
         // Multisig address created in bitcoind with the following private keys:

--- a/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationTestNetConstants.java
@@ -4,6 +4,8 @@ import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
 import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.crypto.ECKey;
 
 import java.time.ZonedDateTime;
@@ -35,7 +37,7 @@ public class FederationTestNetConstants extends FederationConstants {
         ).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList()));
         federationChangeAuthorizer = new AddressBasedAuthorizer(federationChangeAuthorizedKeys, AddressBasedAuthorizer.MinimumRequiredCalculation.MAJORITY);
 
-        validationPeriodDurationInBlocks = 80L;
+        validationPeriodDurationInBlocks = 2000L;
 
         federationActivationAgeLegacy = 60L;
         federationActivationAge = 120L;
@@ -60,5 +62,20 @@ public class FederationTestNetConstants extends FederationConstants {
 
     public static FederationTestNetConstants getInstance() {
         return INSTANCE;
+    }
+
+    @Override
+    public long getFederationActivationAge(ActivationConfig.ForBlock activations) {
+        if (!activations.isActive(ConsensusRule.RSKIP383)) {
+            return federationActivationAgeLegacy;
+        }
+
+        if (!activations.isActive(ConsensusRule.RSKIP419)) {
+            return federationActivationAge;
+        }
+
+        // after lovell, we have to consider the activation age
+        // to be more blocks than the validation period duration
+        return validationPeriodDurationInBlocks + 400L;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/constants/FederationTestNetConstants.java
@@ -3,54 +3,53 @@ package co.rsk.peg.federation.constants;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.crypto.ECKey;
 
-import java.time.ZonedDateTime;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 public class FederationTestNetConstants extends FederationConstants {
 
     private static final FederationTestNetConstants INSTANCE = new FederationTestNetConstants();
+    private final long preLovellActivationAge;
 
     private FederationTestNetConstants() {
         btcParams = NetworkParameters.fromID(NetworkParameters.ID_TESTNET);
 
-        genesisFederationPublicKeys = Collections.unmodifiableList(Stream.of(
+        genesisFederationPublicKeys = Stream.of(
             "039a060badbeb24bee49eb2063f616c0f0f0765d4ca646b20a88ce828f259fcdb9",
             "02afc230c2d355b1a577682b07bc2646041b5d0177af0f98395a46018da699b6da",
             "0344a3c38cd59afcba3edcebe143e025574594b001700dec41e59409bdbd0f2a09",
             "034844a99cd7028aa319476674cc381df006628be71bc5593b8b5fdb32bb42ef85"
-        ).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList()));
+        ).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).toList();
         genesisFederationCreationTime = ZonedDateTime.parse("1970-01-18T19:29:27.600Z").toInstant();
 
         // Passphrases are kept private
-        List<ECKey> federationChangeAuthorizedKeys = Collections.unmodifiableList(Stream.of(
+        List<ECKey> federationChangeAuthorizedKeys = Stream.of(
             "04d9052c2022f6f35da53f04f02856ff5e59f9836eec03daad0328d12c5c66140205da540498e46cd05bf63c1201382dd84c100f0d52a10654159965aea452c3f2",
             "04bf889f2035c8c441d7d1054b6a449742edd04d202f44a29348b4140b34e2a81ce66e388f40046636fd012bd7e3cecd9b951ffe28422334722d20a1cf6c7926fb",
             "047e707e4f67655c40c539363fb435d89574b8fe400971ba0290de9c2adbb2bd4e1e5b35a2188b9409ff2cc102292616efc113623483056bb8d8a02bf7695670ea"
-        ).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList()));
+        ).map(hex -> ECKey.fromPublicOnly(Hex.decode(hex))).toList();
         federationChangeAuthorizer = new AddressBasedAuthorizer(federationChangeAuthorizedKeys, AddressBasedAuthorizer.MinimumRequiredCalculation.MAJORITY);
 
         validationPeriodDurationInBlocks = 2000L;
 
         federationActivationAgeLegacy = 60L;
-        federationActivationAge = 120L;
+        preLovellActivationAge = 120L;
+        federationActivationAge = 2400L;
 
         fundsMigrationAgeSinceActivationBegin = 60L;
         fundsMigrationAgeSinceActivationEnd = 900L;
         specialCaseFundsMigrationAgeSinceActivationEnd = 900L;
 
-        erpFedPubKeysList = Collections.unmodifiableList(Stream.of(
+        erpFedPubKeysList = Stream.of(
             "0216c23b2ea8e4f11c3f9e22711addb1d16a93964796913830856b568cc3ea21d3",
             "034db69f2112f4fb1bb6141bf6e2bd6631f0484d0bd95b16767902c9fe219d4a6f",
             "0275562901dd8faae20de0a4166362a4f82188db77dbed4ca887422ea1ec185f14"
-        ).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).collect(Collectors.toList()));
+        ).map(hex -> BtcECKey.fromPublicOnly(Hex.decode(hex))).toList();
         erpFedActivationDelay = 52_560; // 1 year in BTC blocks (considering 1 block every 10 minutes)
 
         // Multisig address created in bitcoind with the following private keys:
@@ -64,6 +63,8 @@ public class FederationTestNetConstants extends FederationConstants {
         return INSTANCE;
     }
 
+    // After lovell, we have to consider the activation age
+    // to be more blocks than the validation period duration
     @Override
     public long getFederationActivationAge(ActivationConfig.ForBlock activations) {
         if (!activations.isActive(ConsensusRule.RSKIP383)) {
@@ -71,11 +72,9 @@ public class FederationTestNetConstants extends FederationConstants {
         }
 
         if (!activations.isActive(ConsensusRule.RSKIP419)) {
-            return federationActivationAge;
+            return preLovellActivationAge;
         }
 
-        // after lovell, we have to consider the activation age
-        // to be more blocks than the validation period duration
-        return validationPeriodDurationInBlocks + 400L;
+        return federationActivationAge;
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/federation/constants/FederationConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/constants/FederationConstantsTest.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.crypto.ECKey;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -115,7 +116,7 @@ class FederationConstantsTest {
     private static Stream<Arguments> validationPeriodDurationArgs() {
         return Stream.of(
             Arguments.of(MAINNET, 16000L),
-            Arguments.of(TESTNET, 80L),
+            Arguments.of(TESTNET, 2000L),
             Arguments.of(REGTEST, 125L)
         );
     }
@@ -130,22 +131,26 @@ class FederationConstantsTest {
         long fedActivationAgeLegacyMainnet = 18500L;
         long fedActivationAgeLegacyTestnet = 60L;
         long fedActivationAgeLegacyRegtest = 10L;
-        ActivationConfig.ForBlock activationsPreRSKIP383 = mock(ActivationConfig.ForBlock.class);
-        when(activationsPreRSKIP383.isActive(ConsensusRule.RSKIP383)).thenReturn(false);
+        ActivationConfig.ForBlock activationsPreRSKIP383 = ActivationConfigsForTest.hop401().forBlock(0L);
 
         long fedActivationAgeMainnet = 40320L;
         long fedActivationAgeTestnet = 120L;
         long fedActivationAgeRegtest = 150L;
-        ActivationConfig.ForBlock activationsPostRSKIP383 = mock(ActivationConfig.ForBlock.class);
-        when(activationsPostRSKIP383.isActive(ConsensusRule.RSKIP383)).thenReturn(true);
+        ActivationConfig.ForBlock activationsPostRSKIP383PreRSKIP419 = ActivationConfigsForTest.fingerroot500().forBlock(0L);
+
+        long fedActivationAgeTestnetPostLovell = 2400L;
+        ActivationConfig.ForBlock activationsPostRSKIP419 = ActivationConfigsForTest.all().forBlock(0L);
 
         return Stream.of(
             Arguments.of(MAINNET, activationsPreRSKIP383, fedActivationAgeLegacyMainnet),
             Arguments.of(TESTNET, activationsPreRSKIP383, fedActivationAgeLegacyTestnet),
             Arguments.of(REGTEST, activationsPreRSKIP383, fedActivationAgeLegacyRegtest),
-            Arguments.of(MAINNET, activationsPostRSKIP383, fedActivationAgeMainnet),
-            Arguments.of(TESTNET, activationsPostRSKIP383, fedActivationAgeTestnet),
-            Arguments.of(REGTEST, activationsPostRSKIP383, fedActivationAgeRegtest)
+            Arguments.of(MAINNET, activationsPostRSKIP383PreRSKIP419, fedActivationAgeMainnet),
+            Arguments.of(TESTNET, activationsPostRSKIP383PreRSKIP419, fedActivationAgeTestnet),
+            Arguments.of(REGTEST, activationsPostRSKIP383PreRSKIP419, fedActivationAgeRegtest),
+            Arguments.of(MAINNET, activationsPostRSKIP419, fedActivationAgeMainnet),
+            Arguments.of(TESTNET, activationsPostRSKIP419, fedActivationAgeTestnetPostLovell),
+            Arguments.of(REGTEST, activationsPostRSKIP419, fedActivationAgeRegtest)
         );
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/federation/constants/FederationConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/constants/FederationConstantsTest.java
@@ -131,26 +131,26 @@ class FederationConstantsTest {
         long fedActivationAgeLegacyMainnet = 18500L;
         long fedActivationAgeLegacyTestnet = 60L;
         long fedActivationAgeLegacyRegtest = 10L;
-        ActivationConfig.ForBlock activationsPreRSKIP383 = ActivationConfigsForTest.hop401().forBlock(0L);
+        ActivationConfig.ForBlock hopActivations = ActivationConfigsForTest.hop401().forBlock(0L);
 
         long fedActivationAgeMainnet = 40320L;
         long fedActivationAgeTestnet = 120L;
         long fedActivationAgeRegtest = 150L;
-        ActivationConfig.ForBlock activationsPostRSKIP383PreRSKIP419 = ActivationConfigsForTest.fingerroot500().forBlock(0L);
+        ActivationConfig.ForBlock fingerrootActivations = ActivationConfigsForTest.fingerroot500().forBlock(0L);
 
         long fedActivationAgeTestnetPostLovell = 2400L;
-        ActivationConfig.ForBlock activationsPostRSKIP419 = ActivationConfigsForTest.all().forBlock(0L);
+        ActivationConfig.ForBlock allActivations = ActivationConfigsForTest.all().forBlock(0L);
 
         return Stream.of(
-            Arguments.of(MAINNET, activationsPreRSKIP383, fedActivationAgeLegacyMainnet),
-            Arguments.of(TESTNET, activationsPreRSKIP383, fedActivationAgeLegacyTestnet),
-            Arguments.of(REGTEST, activationsPreRSKIP383, fedActivationAgeLegacyRegtest),
-            Arguments.of(MAINNET, activationsPostRSKIP383PreRSKIP419, fedActivationAgeMainnet),
-            Arguments.of(TESTNET, activationsPostRSKIP383PreRSKIP419, fedActivationAgeTestnet),
-            Arguments.of(REGTEST, activationsPostRSKIP383PreRSKIP419, fedActivationAgeRegtest),
-            Arguments.of(MAINNET, activationsPostRSKIP419, fedActivationAgeMainnet),
-            Arguments.of(TESTNET, activationsPostRSKIP419, fedActivationAgeTestnetPostLovell),
-            Arguments.of(REGTEST, activationsPostRSKIP419, fedActivationAgeRegtest)
+            Arguments.of(MAINNET, hopActivations, fedActivationAgeLegacyMainnet),
+            Arguments.of(TESTNET, hopActivations, fedActivationAgeLegacyTestnet),
+            Arguments.of(REGTEST, hopActivations, fedActivationAgeLegacyRegtest),
+            Arguments.of(MAINNET, fingerrootActivations, fedActivationAgeMainnet),
+            Arguments.of(TESTNET, fingerrootActivations, fedActivationAgeTestnet),
+            Arguments.of(REGTEST, fingerrootActivations, fedActivationAgeRegtest),
+            Arguments.of(MAINNET, allActivations, fedActivationAgeMainnet),
+            Arguments.of(TESTNET, allActivations, fedActivationAgeTestnetPostLovell),
+            Arguments.of(REGTEST, allActivations, fedActivationAgeRegtest)
         );
     }
 


### PR DESCRIPTION
The current activation age in testnet is set to 120 RSK blocks, and the svp validation period to 80 blocks. This is going to be insufficient to complete the SVP validations.

A safe value to ensure that the SVP has enough time to be validated is 2000 RSK blocks.
This change implies also update the activation age just for testnet.