### PR TITLE
Mark invalid pegin as processed

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -504,27 +504,15 @@ public class BridgeSupport {
 
         PeginProcessAction peginProcessAction = peginEvaluationResult.getPeginProcessAction();
 
-        if (peginProcessAction == PeginProcessAction.CAN_BE_REGISTERED) {
-            logger.debug("[{}] Peg-in is valid, going to register", METHOD_NAME);
-            executePegIn(btcTx, peginInformation, totalAmount);
-            return;
-        }
-
-        // If the peg-in cannot be registered means it should be rejected
-        RejectedPeginReason rejectedPeginReason = peginEvaluationResult.getRejectedPeginReason()
-            .map(reason -> {
-                logger.debug("[{}] Rejected peg-in, reason {}", METHOD_NAME, reason);
-                eventLogger.logRejectedPegin(btcTx, reason);
-                return reason;
-            }).orElseThrow(() -> {
-                // This flow should never be reached. There should always be a rejected pegin reason.
-                String message = "Invalid state. No rejected reason was returned for an invalid pegin.";
-                logger.error("[{}] {}", METHOD_NAME, message);
-                return new IllegalStateException(message);
-            });
-
         switch (peginProcessAction) {
+            case CAN_BE_REGISTERED -> {
+                logger.debug("[{}] Peg-in is valid, going to register", METHOD_NAME);
+                executePegIn(btcTx, peginInformation, totalAmount);
+            }
             case CAN_BE_REFUNDED -> {
+                // If the peg-in cannot be registered means it should be rejected
+                handleRejectedPegin(btcTx,
+                    peginEvaluationResult);
                 logger.debug("[{}] Refunding to address {} ", METHOD_NAME,
                     peginInformation.getBtcRefundAddress());
                 generateRejectionRelease(btcTx, peginInformation.getBtcRefundAddress(), rskTxHash,
@@ -532,18 +520,34 @@ public class BridgeSupport {
                 markTxAsProcessed(btcTx);
             }
             case CANNOT_BE_REFUNDED -> {
-                logger.debug("[{}] Nonrefundable transaction {}.", METHOD_NAME, btcTx.getHash());
+                // If the peg-in cannot be registered means it should be rejected
+                RejectedPeginReason rejectedPeginReason = handleRejectedPegin(btcTx,
+                    peginEvaluationResult);
+
                 handleNonRefundablePegin(btcTx, peginInformation.getProtocolVersion(),
                     rejectedPeginReason);
 
                 if (!activations.isActive(RSKIP459)) {
                     return;
                 }
-
                 // Since RSKIP459, rejected peg-ins should be marked as processed
                 markTxAsProcessed(btcTx);
             }
         }
+    }
+
+    private RejectedPeginReason handleRejectedPegin(BtcTransaction btcTx,
+        PeginEvaluationResult peginEvaluationResult) {
+        return peginEvaluationResult.getRejectedPeginReason().map(reason -> {
+            logger.debug("[{handleRejectedPegin}] Rejected peg-in, reason {}", reason);
+            eventLogger.logRejectedPegin(btcTx, reason);
+            return reason;
+        }).orElseThrow(() -> {
+            // This flow should never be reached. There should always be a rejected pegin reason.
+            String message = "Invalid state. No rejected reason was returned for an invalid pegin.";
+            logger.error("[{handleRejectedPegin}] {}", message);
+            return new IllegalStateException(message);
+        });
     }
 
     private void handleNonRefundablePegin(

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -503,42 +503,45 @@ public class BridgeSupport {
         );
 
         PeginProcessAction peginProcessAction = peginEvaluationResult.getPeginProcessAction();
+
+        if (peginProcessAction == PeginProcessAction.CAN_BE_REGISTERED){
+            logger.debug("[{}] Peg-in is valid, going to register", METHOD_NAME);
+            executePegIn(btcTx, peginInformation, totalAmount);
+            return;
+        }
+
+        // If the peg-in cannot be registered means it should be rejected
+        Optional<RejectedPeginReason> rejectedPeginReasonOptional = peginEvaluationResult.getRejectedPeginReason();
+        if (rejectedPeginReasonOptional.isEmpty()) {
+            // This flow should never be reached. There should always be a rejected pegin reason.
+            String message = "Invalid state. No rejected reason was returned for an invalid pegin.";
+            logger.error("[{}] {}", METHOD_NAME, message);
+            throw new IllegalStateException(message);
+        }
+        RejectedPeginReason rejectedPeginReason = rejectedPeginReasonOptional.get();
+        logger.debug("[{}] Rejected peg-in, reason {}", METHOD_NAME, rejectedPeginReason);
+        eventLogger.logRejectedPegin(btcTx, rejectedPeginReason);
+
         switch (peginProcessAction) {
-            case CAN_BE_REGISTERED -> {
-                logger.debug("[{}] Peg-in is valid, going to register", METHOD_NAME);
-                executePegIn(btcTx, peginInformation, totalAmount);
-            }
-            case CAN_BE_REFUNDED -> {
+            case CAN_BE_REFUNDED:
                 logger.debug("[{}] Refunding to address {} ", METHOD_NAME,
                     peginInformation.getBtcRefundAddress());
                 generateRejectionRelease(btcTx, peginInformation.getBtcRefundAddress(), rskTxHash,
                     totalAmount);
                 markTxAsProcessed(btcTx);
-            }
-            default -> {
-                Optional<RejectedPeginReason> rejectedPeginReasonOptional = peginEvaluationResult.getRejectedPeginReason();
-                if (rejectedPeginReasonOptional.isEmpty()) {
-                    // This flow should never be reached. There should always be a rejected pegin reason.
-                    String message = "Invalid state. No rejected reason was returned from evaluatePegin method";
-                    logger.error("[{}] {}", METHOD_NAME, message);
-                    throw new IllegalStateException(message);
-                }
-                RejectedPeginReason rejectedPeginReason = rejectedPeginReasonOptional.get();
-                logger.debug("[{}] Rejected peg-in, reason {}", METHOD_NAME, rejectedPeginReason);
-                eventLogger.logRejectedPegin(btcTx, rejectedPeginReason);
-                logger.debug("[{}] Unprocessable transaction {}.", METHOD_NAME, btcTx.getHash());
-                handleUnprocessableBtcTx(btcTx, peginInformation.getProtocolVersion(),
-                    rejectedPeginReason);
-
+                break;
+            case CANNOT_BE_REFUNDED:
+                logger.debug("[{}] Nonrefundable transaction {}.", METHOD_NAME, btcTx.getHash());
+                handleNonRefundablePegin(btcTx, peginInformation.getProtocolVersion(), rejectedPeginReason);
                 // Since RSKIP459, rejected peg-ins should be marked as processed
                 if (activations.isActive(RSKIP459)) {
                     markTxAsProcessed(btcTx);
                 }
-            }
+                break;
         }
     }
 
-    private void handleUnprocessableBtcTx(
+    private void handleNonRefundablePegin(
         BtcTransaction btcTx,
         int protocolVersion,
         RejectedPeginReason rejectedPeginReason

--- a/rskj-core/src/main/java/co/rsk/peg/PegUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/PegUtils.java
@@ -182,7 +182,7 @@ public class PegUtils {
 
         if(!allUTXOsToFedAreAboveMinimumPeginValue(btcTx, fedWallet, minimumPeginTxValue, activations)) {
             logger.debug("[evaluatePegin] Peg-in contains at least one utxo below the minimum value");
-            return new PeginEvaluationResult(PeginProcessAction.CANNOT_BE_PROCESSED, INVALID_AMOUNT);
+            return new PeginEvaluationResult(PeginProcessAction.CANNOT_BE_REFUNDED, INVALID_AMOUNT);
         }
 
         try {
@@ -197,7 +197,7 @@ public class PegUtils {
 
             PeginProcessAction peginProcessAction = hasRefundAddress ?
                                                         PeginProcessAction.CAN_BE_REFUNDED :
-                                                        PeginProcessAction.CANNOT_BE_PROCESSED;
+                                                        PeginProcessAction.CANNOT_BE_REFUNDED;
 
             return new PeginEvaluationResult(peginProcessAction, PEGIN_V1_INVALID_PAYLOAD);
         }
@@ -225,7 +225,7 @@ public class PegUtils {
             case P2SHP2WSH:
                 return new PeginEvaluationResult(PeginProcessAction.CAN_BE_REFUNDED, LEGACY_PEGIN_MULTISIG_SENDER);
             default:
-                return new PeginEvaluationResult(PeginProcessAction.CANNOT_BE_PROCESSED, LEGACY_PEGIN_UNDETERMINED_SENDER);
+                return new PeginEvaluationResult(PeginProcessAction.CANNOT_BE_REFUNDED, LEGACY_PEGIN_UNDETERMINED_SENDER);
         }
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/PegUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/PegUtils.java
@@ -182,7 +182,7 @@ public class PegUtils {
 
         if(!allUTXOsToFedAreAboveMinimumPeginValue(btcTx, fedWallet, minimumPeginTxValue, activations)) {
             logger.debug("[evaluatePegin] Peg-in contains at least one utxo below the minimum value");
-            return new PeginEvaluationResult(PeginProcessAction.CANNOT_BE_REFUNDED, INVALID_AMOUNT);
+            return new PeginEvaluationResult(PeginProcessAction.NO_REFUND, INVALID_AMOUNT);
         }
 
         try {
@@ -196,8 +196,8 @@ public class PegUtils {
             boolean hasRefundAddress = peginInformation.getBtcRefundAddress() != null;
 
             PeginProcessAction peginProcessAction = hasRefundAddress ?
-                                                        PeginProcessAction.CAN_BE_REFUNDED :
-                                                        PeginProcessAction.CANNOT_BE_REFUNDED;
+                                                        PeginProcessAction.REFUND :
+                                                        PeginProcessAction.NO_REFUND;
 
             return new PeginEvaluationResult(peginProcessAction, PEGIN_V1_INVALID_PAYLOAD);
         }
@@ -207,7 +207,7 @@ public class PegUtils {
             case 0:
                 return evaluateLegacyPeginSender(peginInformation.getSenderBtcAddressType());
             case 1:
-                return new PeginEvaluationResult(PeginProcessAction.CAN_BE_REGISTERED);
+                return new PeginEvaluationResult(PeginProcessAction.REGISTER);
             default:
                 // This flow should never be reached.
                 String message = String.format("Invalid state. Unexpected pegin protocol %d", protocolVersion);
@@ -220,12 +220,12 @@ public class PegUtils {
         switch (senderAddressType) {
             case P2PKH:
             case P2SHP2WPKH:
-                return new PeginEvaluationResult(PeginProcessAction.CAN_BE_REGISTERED);
+                return new PeginEvaluationResult(PeginProcessAction.REGISTER);
             case P2SHMULTISIG:
             case P2SHP2WSH:
-                return new PeginEvaluationResult(PeginProcessAction.CAN_BE_REFUNDED, LEGACY_PEGIN_MULTISIG_SENDER);
+                return new PeginEvaluationResult(PeginProcessAction.REFUND, LEGACY_PEGIN_MULTISIG_SENDER);
             default:
-                return new PeginEvaluationResult(PeginProcessAction.CANNOT_BE_REFUNDED, LEGACY_PEGIN_UNDETERMINED_SENDER);
+                return new PeginEvaluationResult(PeginProcessAction.NO_REFUND, LEGACY_PEGIN_UNDETERMINED_SENDER);
         }
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/pegin/PeginProcessAction.java
+++ b/rskj-core/src/main/java/co/rsk/peg/pegin/PeginProcessAction.java
@@ -3,5 +3,5 @@ package co.rsk.peg.pegin;
 public enum PeginProcessAction {
     CAN_BE_REGISTERED,
     CAN_BE_REFUNDED,
-    CANNOT_BE_PROCESSED
+    CANNOT_BE_REFUNDED
 }

--- a/rskj-core/src/main/java/co/rsk/peg/pegin/PeginProcessAction.java
+++ b/rskj-core/src/main/java/co/rsk/peg/pegin/PeginProcessAction.java
@@ -1,7 +1,7 @@
 package co.rsk.peg.pegin;
 
 public enum PeginProcessAction {
-    CAN_BE_REGISTERED,
-    CAN_BE_REFUNDED,
-    CANNOT_BE_REFUNDED
+    REGISTER,
+    REFUND,
+    NO_REFUND
 }

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLogger.java
@@ -60,7 +60,7 @@ public interface BridgeEventLogger {
         throw new UnsupportedOperationException();
     }
 
-    default void logUnrefundablePegin(BtcTransaction btcTx, UnrefundablePeginReason reason) {
+    default void logNonRefundablePegin(BtcTransaction btcTx, NonRefundablePeginReason reason) {
         throw new UnsupportedOperationException();
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/BridgeEventLoggerImpl.java
@@ -212,7 +212,7 @@ public class BridgeEventLoggerImpl implements BridgeEventLogger {
     }
 
     @Override
-    public void logUnrefundablePegin(BtcTransaction btcTx, UnrefundablePeginReason reason) {
+    public void logNonRefundablePegin(BtcTransaction btcTx, NonRefundablePeginReason reason) {
         CallTransaction.Function event = BridgeEvents.UNREFUNDABLE_PEGIN.getEvent();
 
         byte[] btcTxHashSerialized = btcTx.getHash().getBytes();

--- a/rskj-core/src/main/java/co/rsk/peg/utils/NonRefundablePeginReason.java
+++ b/rskj-core/src/main/java/co/rsk/peg/utils/NonRefundablePeginReason.java
@@ -1,13 +1,13 @@
 package co.rsk.peg.utils;
 
-public enum UnrefundablePeginReason {
+public enum NonRefundablePeginReason {
     LEGACY_PEGIN_UNDETERMINED_SENDER(1),
     PEGIN_V1_REFUND_ADDRESS_NOT_SET(2),
     INVALID_AMOUNT(3);
 
     private final int value;
 
-    UnrefundablePeginReason(int value) {
+    NonRefundablePeginReason(int value) {
         this.value = value;
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportRegisterBtcTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportRegisterBtcTransactionTest.java
@@ -4,7 +4,7 @@ import static co.rsk.peg.BridgeSupportTestUtil.*;
 import static co.rsk.peg.PegTestUtils.*;
 import static co.rsk.peg.bitcoin.UtxoUtils.extractOutpointValues;
 import static co.rsk.peg.pegin.RejectedPeginReason.*;
-import static co.rsk.peg.utils.UnrefundablePeginReason.LEGACY_PEGIN_UNDETERMINED_SENDER;
+import static co.rsk.peg.utils.NonRefundablePeginReason.LEGACY_PEGIN_UNDETERMINED_SENDER;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -31,7 +31,7 @@ import co.rsk.peg.pegininstructions.PeginInstructionsProvider;
 import co.rsk.peg.storage.BridgeStorageAccessorImpl;
 import co.rsk.peg.storage.StorageAccessor;
 import co.rsk.peg.utils.BridgeEventLogger;
-import co.rsk.peg.utils.UnrefundablePeginReason;
+import co.rsk.peg.utils.NonRefundablePeginReason;
 import co.rsk.peg.whitelist.LockWhitelist;
 import co.rsk.peg.whitelist.WhitelistStorageProvider;
 import co.rsk.peg.whitelist.WhitelistSupportImpl;
@@ -101,7 +101,7 @@ class BridgeSupportRegisterBtcTransactionTest {
     // Before peg-out tx index gets in use
     private void assertInvalidPeginIsIgnored() throws IOException {
         verify(bridgeEventLogger, never()).logRejectedPegin(any(), any());
-        verify(bridgeEventLogger, never()).logUnrefundablePegin(any(), any());
+        verify(bridgeEventLogger, never()).logNonRefundablePegin(any(), any());
         verify(bridgeEventLogger, never()).logPeginBtc(any(), any(), any(), anyInt());
         verify(provider, never()).setHeightBtcTxhashAlreadyProcessed(any(), anyLong());
         assertTrue(activeFederationUtxos.isEmpty());
@@ -111,7 +111,7 @@ class BridgeSupportRegisterBtcTransactionTest {
     // After peg-out tx index gets in use
     private void assertInvalidPeginIsRejectedWithInvalidAmountReason(BtcTransaction btcTransaction, ActivationConfig.ForBlock activations) throws IOException {
         verify(bridgeEventLogger, times(1)).logRejectedPegin(btcTransaction, INVALID_AMOUNT);
-        verify(bridgeEventLogger, times(1)).logUnrefundablePegin(btcTransaction, UnrefundablePeginReason.INVALID_AMOUNT);
+        verify(bridgeEventLogger, times(1)).logNonRefundablePegin(btcTransaction, NonRefundablePeginReason.INVALID_AMOUNT);
         verify(bridgeEventLogger, never()).logPeginBtc(any(), any(), any(), anyInt());
 
         var shouldMarkTxAsProcessed = activations == lovell700Activations? times(1) : never();
@@ -124,7 +124,7 @@ class BridgeSupportRegisterBtcTransactionTest {
     private void assertUnknownTxIsProcessedAsPegin(RskAddress expectedRskAddressToBeLogged, BtcTransaction btcTransaction, int protocolVersion) throws IOException {
         verify(bridgeEventLogger, times(1)).logPeginBtc(expectedRskAddressToBeLogged, btcTransaction, Coin.ZERO, protocolVersion);
         verify(bridgeEventLogger, never()).logRejectedPegin(any(), any());
-        verify(bridgeEventLogger, never()).logUnrefundablePegin(any(), any());
+        verify(bridgeEventLogger, never()).logNonRefundablePegin(any(), any());
         verify(provider, times(1)).setHeightBtcTxhashAlreadyProcessed(btcTransaction.getHash(false), rskExecutionBlock.getNumber());
         assertTrue(activeFederationUtxos.isEmpty());
         assertTrue(retiringFederationUtxos.isEmpty());
@@ -133,7 +133,7 @@ class BridgeSupportRegisterBtcTransactionTest {
     // After arrowhead600Activations but before grace period
     private void assertUnknownTxIsRejectedWithInvalidAmountReason(BtcTransaction btcTransaction) throws IOException {
         verify(bridgeEventLogger, times(1)).logRejectedPegin(btcTransaction, INVALID_AMOUNT);
-        verify(bridgeEventLogger, times(1)).logUnrefundablePegin(btcTransaction, UnrefundablePeginReason.INVALID_AMOUNT);
+        verify(bridgeEventLogger, times(1)).logNonRefundablePegin(btcTransaction, NonRefundablePeginReason.INVALID_AMOUNT);
         verify(bridgeEventLogger, never()).logPeginBtc(any(), any(), any(), anyInt());
         verify(provider, never()).setHeightBtcTxhashAlreadyProcessed(any(), anyLong());
         assertTrue(activeFederationUtxos.isEmpty());
@@ -143,7 +143,7 @@ class BridgeSupportRegisterBtcTransactionTest {
     // After arrowhead600Activations and grace period
     private void assertUnknownTxIsIgnored() throws IOException {
         verify(bridgeEventLogger, never()).logRejectedPegin(any(), any());
-        verify(bridgeEventLogger, never()).logUnrefundablePegin(any(), any());
+        verify(bridgeEventLogger, never()).logNonRefundablePegin(any(), any());
         verify(bridgeEventLogger, never()).logPeginBtc(any(), any(), any(), anyInt());
         verify(provider, never()).setHeightBtcTxhashAlreadyProcessed(any(), anyLong());
         assertTrue(activeFederationUtxos.isEmpty());
@@ -152,7 +152,7 @@ class BridgeSupportRegisterBtcTransactionTest {
 
     private void assertPeginIsRejectedAndRefunded(ActivationConfig.ForBlock activations, BtcTransaction btcTransaction, Coin sentAmount, RejectedPeginReason expectedRejectedPeginReason) throws IOException {
         verify(bridgeEventLogger, never()).logPeginBtc(any(), any(), any(), anyInt());
-        verify(bridgeEventLogger, never()).logUnrefundablePegin(any(), any());
+        verify(bridgeEventLogger, never()).logNonRefundablePegin(any(), any());
         assertTrue(activeFederationUtxos.isEmpty());
         assertTrue(retiringFederationUtxos.isEmpty());
 
@@ -180,7 +180,7 @@ class BridgeSupportRegisterBtcTransactionTest {
         verify(bridgeEventLogger, times(1)).logRejectedPegin(
             btcTransaction, PEGIN_V1_INVALID_PAYLOAD
         );
-        verify(bridgeEventLogger, times(1)).logUnrefundablePegin(
+        verify(bridgeEventLogger, times(1)).logNonRefundablePegin(
             btcTransaction,
             LEGACY_PEGIN_UNDETERMINED_SENDER
         );
@@ -207,7 +207,7 @@ class BridgeSupportRegisterBtcTransactionTest {
         verify(bridgeEventLogger, times(1)).logRejectedPegin(
             btcTransaction, RejectedPeginReason.LEGACY_PEGIN_UNDETERMINED_SENDER
         );
-        verify(bridgeEventLogger, times(1)).logUnrefundablePegin(
+        verify(bridgeEventLogger, times(1)).logNonRefundablePegin(
             btcTransaction,
             LEGACY_PEGIN_UNDETERMINED_SENDER
         );
@@ -229,7 +229,7 @@ class BridgeSupportRegisterBtcTransactionTest {
         verify(bridgeEventLogger, times(1)).logRejectedPegin(
             btcTransaction, PEGIN_V1_INVALID_PAYLOAD
         );
-        verify(bridgeEventLogger, times(1)).logUnrefundablePegin(
+        verify(bridgeEventLogger, times(1)).logNonRefundablePegin(
             btcTransaction,
             LEGACY_PEGIN_UNDETERMINED_SENDER
         );
@@ -785,7 +785,7 @@ class BridgeSupportRegisterBtcTransactionTest {
 
         // assert
         verify(bridgeEventLogger, never()).logRejectedPegin(any(), any());
-        verify(bridgeEventLogger, never()).logUnrefundablePegin(any(), any());
+        verify(bridgeEventLogger, never()).logNonRefundablePegin(any(), any());
 
         verify(bridgeEventLogger, times(1)).logPeginBtc(any(), eq(btcTransaction), eq(amountToSend), eq(0));
         verify(provider, times(1)).setHeightBtcTxhashAlreadyProcessed(btcTransaction.getHash(false), rskExecutionBlock.getNumber());
@@ -826,7 +826,7 @@ class BridgeSupportRegisterBtcTransactionTest {
 
         // assert
         verify(bridgeEventLogger, never()).logRejectedPegin(any(), any());
-        verify(bridgeEventLogger, never()).logUnrefundablePegin(any(), any());
+        verify(bridgeEventLogger, never()).logNonRefundablePegin(any(), any());
 
         verify(bridgeEventLogger, times(1)).logPeginBtc(any(), eq(btcTransaction), eq(minimumPeginTxValue.multiply(10)), eq(0));
         verify(provider, times(1)).setHeightBtcTxhashAlreadyProcessed(btcTransaction.getHash(false), rskExecutionBlock.getNumber());
@@ -866,7 +866,7 @@ class BridgeSupportRegisterBtcTransactionTest {
 
         // assert
         verify(bridgeEventLogger, never()).logRejectedPegin(any(), any());
-        verify(bridgeEventLogger, never()).logUnrefundablePegin(any(), any());
+        verify(bridgeEventLogger, never()).logNonRefundablePegin(any(), any());
 
         verify(bridgeEventLogger, times(1)).logPeginBtc(any(), eq(btcTransaction), eq(amountToSend), eq(0));
         verify(provider, times(1)).setHeightBtcTxhashAlreadyProcessed(btcTransaction.getHash(false), rskExecutionBlock.getNumber());
@@ -906,7 +906,7 @@ class BridgeSupportRegisterBtcTransactionTest {
 
         // assert
         verify(bridgeEventLogger, never()).logRejectedPegin(any(), any());
-        verify(bridgeEventLogger, never()).logUnrefundablePegin(any(), any());
+        verify(bridgeEventLogger, never()).logNonRefundablePegin(any(), any());
 
         verify(bridgeEventLogger, times(1)).logPeginBtc(any(), eq(btcTransaction), eq(minimumPeginTxValue), eq(0));
         verify(provider, times(1)).setHeightBtcTxhashAlreadyProcessed(btcTransaction.getHash(false), rskExecutionBlock.getNumber());
@@ -1059,7 +1059,7 @@ class BridgeSupportRegisterBtcTransactionTest {
 
         // assert
         verify(bridgeEventLogger, never()).logRejectedPegin(any(), any());
-        verify(bridgeEventLogger, never()).logUnrefundablePegin(any(), any());
+        verify(bridgeEventLogger, never()).logNonRefundablePegin(any(), any());
 
         verify(bridgeEventLogger, times(1)).logPeginBtc(any(), eq(btcTransaction), eq(minimumPeginTxValue.multiply(2)), eq(0));
         verify(provider, times(1)).setHeightBtcTxhashAlreadyProcessed(btcTransaction.getHash(false), rskExecutionBlock.getNumber());
@@ -1133,7 +1133,7 @@ class BridgeSupportRegisterBtcTransactionTest {
 
         // assert
         verify(bridgeEventLogger, never()).logRejectedPegin(any(), any());
-        verify(bridgeEventLogger, never()).logUnrefundablePegin(any(), any());
+        verify(bridgeEventLogger, never()).logNonRefundablePegin(any(), any());
 
         verify(bridgeEventLogger, times(1)).logPeginBtc(any(), eq(btcTransaction), eq(minimumPeginTxValue.multiply(2)), eq(0));
         verify(provider, times(1)).setHeightBtcTxhashAlreadyProcessed(btcTransaction.getHash(false), rskExecutionBlock.getNumber());
@@ -1178,7 +1178,7 @@ class BridgeSupportRegisterBtcTransactionTest {
 
         // assert
         verify(bridgeEventLogger, never()).logRejectedPegin(any(), any());
-        verify(bridgeEventLogger, never()).logUnrefundablePegin(any(), any());
+        verify(bridgeEventLogger, never()).logNonRefundablePegin(any(), any());
 
         verify(bridgeEventLogger, times(1)).logPeginBtc(any(), eq(btcTransaction), eq(amountToSend), eq(1));
         verify(provider, times(1)).setHeightBtcTxhashAlreadyProcessed(btcTransaction.getHash(false), rskExecutionBlock.getNumber());
@@ -1230,7 +1230,7 @@ class BridgeSupportRegisterBtcTransactionTest {
 
         // assert
         verify(bridgeEventLogger, never()).logPeginBtc(any(), any(), any(), anyInt());
-        verify(bridgeEventLogger, never()).logUnrefundablePegin(any(), any());
+        verify(bridgeEventLogger, never()).logNonRefundablePegin(any(), any());
 
         verify(bridgeEventLogger, times(1)).logRejectedPegin(btcTransaction, PEGIN_V1_INVALID_PAYLOAD);
         verify(provider, times(1)).setHeightBtcTxhashAlreadyProcessed(btcTransaction.getHash(false), rskExecutionBlock.getNumber());
@@ -1272,7 +1272,7 @@ class BridgeSupportRegisterBtcTransactionTest {
 
         // assert
         verify(bridgeEventLogger, never()).logPeginBtc(any(), any(), any(), anyInt());
-        verify(bridgeEventLogger, never()).logUnrefundablePegin(any(), any());
+        verify(bridgeEventLogger, never()).logNonRefundablePegin(any(), any());
 
         verify(bridgeEventLogger, times(1)).logRejectedPegin(btcTransaction, PEGIN_V1_INVALID_PAYLOAD);
 
@@ -1315,7 +1315,7 @@ class BridgeSupportRegisterBtcTransactionTest {
 
         // assert
         verify(bridgeEventLogger, never()).logRejectedPegin(any(), any());
-        verify(bridgeEventLogger, never()).logUnrefundablePegin(any(), any());
+        verify(bridgeEventLogger, never()).logNonRefundablePegin(any(), any());
 
         verify(bridgeEventLogger, times(1)).logPeginBtc(any(), eq(btcTransaction), eq(amountToSend), eq(0));
         verify(provider, times(1)).setHeightBtcTxhashAlreadyProcessed(btcTransaction.getHash(false), rskExecutionBlock.getNumber());
@@ -1366,7 +1366,7 @@ class BridgeSupportRegisterBtcTransactionTest {
 
         // assert
         verify(bridgeEventLogger, never()).logRejectedPegin(any(), any());
-        verify(bridgeEventLogger, never()).logUnrefundablePegin(any(), any());
+        verify(bridgeEventLogger, never()).logNonRefundablePegin(any(), any());
 
         verify(bridgeEventLogger, times(1)).logPeginBtc(any(), eq(btcTransaction), eq(amountToSend), eq(1));
         verify(provider, times(1)).setHeightBtcTxhashAlreadyProcessed(btcTransaction.getHash(false), rskExecutionBlock.getNumber());
@@ -1691,7 +1691,7 @@ class BridgeSupportRegisterBtcTransactionTest {
         );
 
         // assert
-        verify(bridgeEventLogger, never()).logUnrefundablePegin(any(), any());
+        verify(bridgeEventLogger, never()).logNonRefundablePegin(any(), any());
         verify(bridgeEventLogger, times(1)).logRejectedPegin(btcTransaction, LEGACY_PEGIN_MULTISIG_SENDER);
         verify(bridgeEventLogger, times(1)).logReleaseBtcRequested(eq(rskTx.getHash().getBytes()), any(BtcTransaction.class), eq(amountToSend));
 
@@ -2017,7 +2017,7 @@ class BridgeSupportRegisterBtcTransactionTest {
         // assert
         verify(bridgeEventLogger, times(1)).logRejectedPegin(btcTransaction, LEGACY_PEGIN_MULTISIG_SENDER);
         verify(bridgeEventLogger, times(1)).logReleaseBtcRequested(eq(rskTx.getHash().getBytes()), any(BtcTransaction.class), eq(amountToSend));
-        verify(bridgeEventLogger, never()).logUnrefundablePegin(any(), any());
+        verify(bridgeEventLogger, never()).logNonRefundablePegin(any(), any());
 
         verify(provider, times(1)).setHeightBtcTxhashAlreadyProcessed(btcTransaction.getHash(false), rskExecutionBlock.getNumber());
 
@@ -2654,7 +2654,7 @@ class BridgeSupportRegisterBtcTransactionTest {
         );
 
         // assert
-        verify(bridgeEventLogger, never()).logUnrefundablePegin(migrationTx, LEGACY_PEGIN_UNDETERMINED_SENDER);
+        verify(bridgeEventLogger, never()).logNonRefundablePegin(migrationTx, LEGACY_PEGIN_UNDETERMINED_SENDER);
         verify(bridgeEventLogger, never()).logPeginBtc(any(), any(), any(), anyInt());
         assertTrue(retiringFederationUtxos.isEmpty());
         verify(provider, times(1)).setHeightBtcTxhashAlreadyProcessed(migrationTx.getHash(false), rskExecutionBlock.getNumber());
@@ -2778,7 +2778,7 @@ class BridgeSupportRegisterBtcTransactionTest {
         // assert
         if (shouldUsePegoutTxIndex) {
             verify(bridgeEventLogger, never()).logPeginBtc(any(), any(), any(), anyInt());
-            verify(bridgeEventLogger, never()).logUnrefundablePegin(any(), any());
+            verify(bridgeEventLogger, never()).logNonRefundablePegin(any(), any());
             verify(bridgeEventLogger, never()).logRejectedPegin(any(), any());
             verify(bridgeEventLogger, never()).logReleaseBtcRequested(any(), any(), any());
             verify(provider, times(1)).setHeightBtcTxhashAlreadyProcessed(btcTransaction.getHash(false), rskExecutionBlock.getNumber());

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportRegisterBtcTransactionTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportRegisterBtcTransactionTest.java
@@ -1555,7 +1555,7 @@ class BridgeSupportRegisterBtcTransactionTest {
         );
 
         // assert
-        if (activations == fingerrootActivations){
+        if (activations == fingerrootActivations) {
             // BEFORE RSKIP379 REJECTED PEGIN WERE MARKED AS PROCESSED.
             assertLegacyUndeterminedSenderPeginIsRejectedAsPeginV1InvalidPayloadBeforeRSKIP379(btcTransaction);
         } else {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportRejectedPeginTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportRejectedPeginTest.java
@@ -1,0 +1,615 @@
+package co.rsk.peg;
+
+import static co.rsk.peg.BridgeSupportTestUtil.mockChainOfStoredBlocks;
+import static co.rsk.peg.pegin.RejectedPeginReason.INVALID_AMOUNT;
+import static co.rsk.peg.pegin.RejectedPeginReason.PEGIN_V1_INVALID_PAYLOAD;
+import static co.rsk.peg.utils.UnrefundablePeginReason.LEGACY_PEGIN_UNDETERMINED_SENDER;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import co.rsk.bitcoinj.core.Address;
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.core.PartialMerkleTree;
+import co.rsk.bitcoinj.core.Sha256Hash;
+import co.rsk.bitcoinj.core.StoredBlock;
+import co.rsk.bitcoinj.core.UTXO;
+import co.rsk.bitcoinj.script.Script;
+import co.rsk.bitcoinj.store.BlockStoreException;
+import co.rsk.core.RskAddress;
+import co.rsk.crypto.Keccak256;
+import co.rsk.peg.bitcoin.BitcoinTestUtils;
+import co.rsk.peg.btcLockSender.BtcLockSenderProvider;
+import co.rsk.peg.constants.BridgeConstants;
+import co.rsk.peg.constants.BridgeMainNetConstants;
+import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationArgs;
+import co.rsk.peg.federation.FederationFactory;
+import co.rsk.peg.federation.FederationMember;
+import co.rsk.peg.federation.FederationStorageProvider;
+import co.rsk.peg.federation.FederationSupport;
+import co.rsk.peg.federation.FederationTestUtils;
+import co.rsk.peg.federation.constants.FederationConstants;
+import co.rsk.peg.lockingcap.LockingCapSupport;
+import co.rsk.peg.pegin.PeginProcessAction;
+import co.rsk.peg.pegin.RejectedPeginReason;
+import co.rsk.peg.pegininstructions.PeginInstructionsProvider;
+import co.rsk.peg.utils.BridgeEventLogger;
+import co.rsk.peg.utils.UnrefundablePeginReason;
+import co.rsk.test.builders.BridgeSupportBuilder;
+import co.rsk.test.builders.FederationSupportBuilder;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
+import org.ethereum.core.Block;
+import org.ethereum.core.Repository;
+import org.ethereum.core.Transaction;
+import org.ethereum.vm.PrecompiledContracts;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class BridgeSupportRejectedPeginTest {
+
+    private static final BridgeConstants bridgeMainnetConstants = BridgeMainNetConstants.getInstance();
+    private static final FederationConstants federationMainnetConstants = bridgeMainnetConstants.getFederationConstants();
+    private static final NetworkParameters btcMainnetParams = bridgeMainnetConstants.getBtcParams();
+    private static final ActivationConfig.ForBlock arrowHeadActivations = ActivationConfigsForTest.arrowhead600().forBlock(0);
+    private static final ActivationConfig.ForBlock lovellActivations = ActivationConfigsForTest.lovell700().forBlock(0);
+    /*private static final ActivationConfig.ForBlock activations = ActivationConfigsForTest.all().forBlock(0);*/
+
+    private static final Coin minimumPeginTxValue = bridgeMainnetConstants.getMinimumPeginTxValue(
+        ActivationConfigsForTest.all().forBlock(0));
+    private static final Coin belowMinimumPeginTxValue = minimumPeginTxValue.minus(Coin.SATOSHI);
+
+    private static final int FIRST_OUTPUT_INDEX = 0;
+
+    private Repository repository;
+    private BridgeStorageProvider provider;
+    private FederationStorageProvider federationStorageProvider;
+
+    private Address userAddress;
+
+    private Federation activeFederation;
+    private Federation retiringFederation;
+
+    private BtcBlockStoreWithCache.Factory mockFactory;
+    private BridgeEventLogger bridgeEventLogger;
+    private BtcLockSenderProvider btcLockSenderProvider;
+    private PeginInstructionsProvider peginInstructionsProvider;
+
+    private final List<UTXO> retiringFederationUtxos = new ArrayList<>();
+    private final List<UTXO> activeFederationUtxos = new ArrayList<>();
+    private PegoutsWaitingForConfirmations pegoutsWaitingForConfirmations;
+    private Block rskExecutionBlock;
+    private Transaction rskTx;
+
+    private int heightAtWhichToStartUsingPegoutIndex;
+
+    private co.rsk.bitcoinj.core.BtcBlock registerHeader;
+
+    public static Stream<Arguments> activationsProvider() {
+        return Stream.of(
+            Arguments.of(lovellActivations),
+            Arguments.of(arrowHeadActivations)
+        );
+    }
+
+    @BeforeEach
+    void init() throws IOException {
+        registerHeader = null;
+
+        userAddress = BitcoinTestUtils.createP2PKHAddress(btcMainnetParams, "userAddress");
+        NetworkParameters btcParams = bridgeMainnetConstants.getBtcParams();
+
+
+        List<BtcECKey> erpPubKeys = federationMainnetConstants.getErpFedPubKeysList();
+        long activationDelay = federationMainnetConstants.getErpFedActivationDelay();
+
+        List<BtcECKey> retiringFedSigners = BitcoinTestUtils.getBtcEcKeysFromSeeds(
+            new String[]{"fa04", "fa05", "fa06"}, true
+        );
+        retiringFedSigners.sort(BtcECKey.PUBKEY_COMPARATOR);
+        List<FederationMember> retiringFedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(retiringFedSigners);
+        Instant retiringCreationTime = Instant.ofEpochMilli(1000L);
+        long retiringFedCreationBlockNumber = 1;
+
+        FederationArgs retiringFedArgs =
+            new FederationArgs(retiringFedMembers, retiringCreationTime, retiringFedCreationBlockNumber, btcParams);
+        retiringFederation = FederationFactory.buildP2shErpFederation(retiringFedArgs, erpPubKeys, activationDelay);
+
+        List<BtcECKey> activeFedSigners = BitcoinTestUtils.getBtcEcKeysFromSeeds(
+            new String[]{"fa07", "fa08", "fa09", "fa10", "fa11"}, true
+        );
+        activeFedSigners.sort(BtcECKey.PUBKEY_COMPARATOR);
+        List<FederationMember> activeFedMembers = FederationTestUtils.getFederationMembersWithBtcKeys(
+            activeFedSigners);
+        long activeFedCreationBlockNumber = 2L;
+        Instant creationTime = Instant.ofEpochMilli(1000L);
+        FederationArgs activeFedArgs =
+            new FederationArgs(activeFedMembers, creationTime, activeFedCreationBlockNumber,
+                btcParams);
+        activeFederation = FederationFactory.buildP2shErpFederation(activeFedArgs, erpPubKeys,
+            activationDelay);
+
+        mockFactory = mock(BtcBlockStoreWithCache.Factory.class);
+
+        bridgeEventLogger = mock(BridgeEventLogger.class);
+        btcLockSenderProvider = new BtcLockSenderProvider();
+
+        peginInstructionsProvider = new PeginInstructionsProvider();
+
+        provider = mock(BridgeStorageProvider.class);
+        when(provider.getHeightIfBtcTxhashIsAlreadyProcessed(any(Sha256Hash.class))).thenReturn(
+            Optional.empty());
+
+        repository = mock(Repository.class);
+        when(repository.getBalance(PrecompiledContracts.BRIDGE_ADDR)).thenReturn(
+            co.rsk.core.Coin.fromBitcoin(bridgeMainnetConstants.getMaxRbtc()));
+        LockingCapSupport lockingCapSupport = mock(LockingCapSupport.class);
+        when(lockingCapSupport.getLockingCap()).thenReturn(
+            Optional.of(bridgeMainnetConstants.getMaxRbtc()));
+
+        federationStorageProvider = mock(FederationStorageProvider.class);
+        when(federationStorageProvider.getOldFederationBtcUTXOs())
+            .thenReturn(retiringFederationUtxos);
+        when(federationStorageProvider.getNewFederationBtcUTXOs(any(NetworkParameters.class),
+            any(ActivationConfig.ForBlock.class)))
+            .thenReturn(activeFederationUtxos);
+
+        pegoutsWaitingForConfirmations = new PegoutsWaitingForConfirmations(new HashSet<>());
+        when(provider.getPegoutsWaitingForConfirmations()).thenReturn(
+            pegoutsWaitingForConfirmations);
+
+        when(federationStorageProvider.getNewFederation(any(FederationConstants.class),
+            any(ActivationConfig.ForBlock.class)))
+            .thenReturn(activeFederation);
+
+        // Set execution block right after the fed creation block
+        long executionBlockNumber = activeFederation.getCreationBlockNumber() + 1;
+        rskExecutionBlock = mock(Block.class);
+
+        when(rskExecutionBlock.getNumber()).thenReturn(executionBlockNumber);
+
+        rskTx = mock(Transaction.class);
+        when(rskTx.getHash()).thenReturn(PegTestUtils.createHash3(1));
+
+        int btcHeightWhenPegoutTxIndexActivates = bridgeMainnetConstants.getBtcHeightWhenPegoutTxIndexActivates();
+        int pegoutTxIndexGracePeriodInBtcBlocks = bridgeMainnetConstants.getPegoutTxIndexGracePeriodInBtcBlocks();
+
+        heightAtWhichToStartUsingPegoutIndex =
+            btcHeightWhenPegoutTxIndexActivates + pegoutTxIndexGracePeriodInBtcBlocks;
+    }
+
+    private PartialMerkleTree createPmtAndMockBlockStore(BtcTransaction btcTransaction)
+        throws BlockStoreException {
+        PartialMerkleTree pmt = new PartialMerkleTree(btcMainnetParams, new byte[]{0x3f},
+            Collections.singletonList(btcTransaction.getHash()), 1);
+        Sha256Hash blockMerkleRoot = pmt.getTxnHashAndMerkleRoot(new ArrayList<>());
+
+        registerHeader = new co.rsk.bitcoinj.core.BtcBlock(
+            btcMainnetParams,
+            1,
+            BitcoinTestUtils.createHash(1),
+            blockMerkleRoot,
+            1,
+            1,
+            1,
+            new ArrayList<>()
+        );
+
+        StoredBlock block = new StoredBlock(registerHeader, new BigInteger("0"),
+            heightAtWhichToStartUsingPegoutIndex);
+
+        BtcBlockStoreWithCache btcBlockStore = mock(BtcBlockStoreWithCache.class);
+
+        co.rsk.bitcoinj.core.BtcBlock headBlock = new co.rsk.bitcoinj.core.BtcBlock(
+            btcMainnetParams,
+            1,
+            BitcoinTestUtils.createHash(2),
+            Sha256Hash.of(new byte[]{1}),
+            1,
+            1,
+            1,
+            new ArrayList<>()
+        );
+
+        StoredBlock chainHead = new StoredBlock(headBlock, new BigInteger("0"),
+            heightAtWhichToStartUsingPegoutIndex
+                + bridgeMainnetConstants.getBtc2RskMinimumAcceptableConfirmations());
+        when(btcBlockStore.getChainHead()).thenReturn(chainHead);
+
+        when(btcBlockStore.getStoredBlockAtMainChainHeight(block.getHeight())).thenReturn(block);
+        when(mockFactory.newInstance(any(), any(), any(), any())).thenReturn(btcBlockStore);
+
+        co.rsk.bitcoinj.core.BtcBlock btcBlock = new co.rsk.bitcoinj.core.BtcBlock(
+            btcMainnetParams,
+            1,
+            BitcoinTestUtils.createHash(1),
+            blockMerkleRoot,
+            1,
+            1,
+            1,
+            new ArrayList<>()
+        );
+
+        mockChainOfStoredBlocks(
+            btcBlockStore,
+            btcBlock,
+            heightAtWhichToStartUsingPegoutIndex
+                + bridgeMainnetConstants.getBtc2RskMinimumAcceptableConfirmations(),
+            heightAtWhichToStartUsingPegoutIndex
+        );
+        return pmt;
+    }
+
+    @ParameterizedTest
+    @MethodSource("activationsProvider")
+    void registerBtcTransaction_whenBelowTheMinimum_shouldRejectPegin(ActivationConfig.ForBlock activations)
+        throws BlockStoreException, BridgeIllegalArgumentException, IOException {
+        // arrange
+        BtcTransaction btcTransaction = new BtcTransaction(btcMainnetParams);
+        btcTransaction.addInput(BitcoinTestUtils.createHash(1), FIRST_OUTPUT_INDEX, new Script(new byte[]{}));
+        btcTransaction.addOutput(belowMinimumPeginTxValue, activeFederation.getAddress());
+
+        FederationSupport federationSupport = FederationSupportBuilder.builder()
+            .withFederationConstants(federationMainnetConstants)
+            .withFederationStorageProvider(federationStorageProvider)
+            .withActivations(activations)
+            .withRskExecutionBlock(rskExecutionBlock)
+            .build();
+
+        BridgeSupport bridgeSupport = BridgeSupportBuilder.builder()
+            .withBtcBlockStoreFactory(mockFactory)
+            .withBridgeConstants(bridgeMainnetConstants)
+            .withRepository(repository)
+            .withProvider(provider)
+            .withActivations(activations)
+            .withEventLogger(bridgeEventLogger)
+            .withBtcLockSenderProvider(btcLockSenderProvider)
+            .withPeginInstructionsProvider(peginInstructionsProvider)
+            .withExecutionBlock(rskExecutionBlock)
+            .withFederationSupport(federationSupport)
+            .build();
+
+        // act
+        bridgeSupport.registerBtcTransaction(
+            rskTx,
+            btcTransaction.bitcoinSerialize(),
+            heightAtWhichToStartUsingPegoutIndex,
+            createPmtAndMockBlockStore(btcTransaction).bitcoinSerialize()
+        );
+
+        // assert
+
+        // tx should be marked as processed since RSKIP459 is active
+        var shouldMarkTxAsProcessed = activations == lovellActivations? times(1) : never();
+        verify(provider, shouldMarkTxAsProcessed).setHeightBtcTxhashAlreadyProcessed(any(), anyLong());
+
+        verify(bridgeEventLogger, times(1)).logRejectedPegin(btcTransaction, INVALID_AMOUNT);
+        verify(bridgeEventLogger, times(1)).logUnrefundablePegin(btcTransaction,
+            UnrefundablePeginReason.INVALID_AMOUNT);
+        verify(bridgeEventLogger, never()).logPeginBtc(any(), any(), any(), anyInt());
+        assertTrue(activeFederationUtxos.isEmpty());
+        assertTrue(retiringFederationUtxos.isEmpty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("activationsProvider")
+    void registerBtcTransaction_whenUndeterminedSender_shouldRejectPegin(ActivationConfig.ForBlock activations)
+        throws BlockStoreException, BridgeIllegalArgumentException, IOException {
+        // arrange
+        btcLockSenderProvider = mock(BtcLockSenderProvider.class);
+        // return empty to simulate undetermined sender
+        when(btcLockSenderProvider.tryGetBtcLockSender(any())).thenReturn(Optional.empty());
+
+        Coin amountToSend = Coin.COIN;
+        BtcTransaction btcTransaction = new BtcTransaction(btcMainnetParams);
+        btcTransaction.addInput(
+            BitcoinTestUtils.createHash(1),
+            FIRST_OUTPUT_INDEX,
+            new Script(new byte[]{})
+        );
+        btcTransaction.addOutput(amountToSend, activeFederation.getAddress());
+
+        FederationSupport federationSupport = FederationSupportBuilder.builder()
+            .withFederationConstants(federationMainnetConstants)
+            .withFederationStorageProvider(federationStorageProvider)
+            .withActivations(activations)
+            .withRskExecutionBlock(rskExecutionBlock)
+            .build();
+
+        BridgeSupport bridgeSupport = BridgeSupportBuilder.builder()
+            .withBtcBlockStoreFactory(mockFactory)
+            .withBridgeConstants(bridgeMainnetConstants)
+            .withRepository(repository)
+            .withProvider(provider)
+            .withActivations(activations)
+            .withEventLogger(bridgeEventLogger)
+            .withBtcLockSenderProvider(btcLockSenderProvider)
+            .withPeginInstructionsProvider(peginInstructionsProvider)
+            .withExecutionBlock(rskExecutionBlock)
+            .withFederationSupport(federationSupport)
+            .build();
+
+        // act
+        bridgeSupport.registerBtcTransaction(
+            rskTx,
+            btcTransaction.bitcoinSerialize(),
+            heightAtWhichToStartUsingPegoutIndex,
+            createPmtAndMockBlockStore(btcTransaction).bitcoinSerialize()
+        );
+
+        // assert
+        verify(bridgeEventLogger, times(1)).logRejectedPegin(
+            btcTransaction, RejectedPeginReason.LEGACY_PEGIN_UNDETERMINED_SENDER
+        );
+        verify(bridgeEventLogger, times(1)).logUnrefundablePegin(
+            btcTransaction,
+            LEGACY_PEGIN_UNDETERMINED_SENDER
+        );
+
+        verify(bridgeEventLogger, never()).logPeginBtc(any(), any(), any(), anyInt());
+        verify(bridgeEventLogger, never()).logReleaseBtcRequested(any(), any(), any());
+
+        // tx should be marked as processed since RSKIP459 is active
+        var shouldMarkTxAsProcessed = activations == lovellActivations? times(1) : never();
+        verify(provider, shouldMarkTxAsProcessed).setHeightBtcTxhashAlreadyProcessed(any(), anyLong());
+
+        Assertions.assertTrue(activeFederationUtxos.isEmpty());
+        Assertions.assertTrue(retiringFederationUtxos.isEmpty());
+        Assertions.assertTrue(pegoutsWaitingForConfirmations.getEntries().isEmpty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("activationsProvider")
+    void registerBtcTransaction_whenPeginV1WithInvalidPayloadAndUnderminedSender_shouldRejectPegin(ActivationConfig.ForBlock activations)
+        throws BlockStoreException, BridgeIllegalArgumentException, IOException {
+        // arrange
+        btcLockSenderProvider = mock(BtcLockSenderProvider.class);
+        // return empty to simulate undetermined sender
+        when(btcLockSenderProvider.tryGetBtcLockSender(any())).thenReturn(Optional.empty());
+
+        BtcTransaction btcTransaction = new BtcTransaction(btcMainnetParams);
+        btcTransaction.addInput(
+            BitcoinTestUtils.createHash(1),
+            FIRST_OUTPUT_INDEX,
+            new Script(new byte[]{})
+        );
+        btcTransaction.addOutput(Coin.COIN, activeFederation.getAddress());
+        btcTransaction.addOutput(Coin.ZERO, PegTestUtils.createOpReturnScriptForRskWithCustomPayload(1, new byte[]{}));
+
+        FederationSupport federationSupport = FederationSupportBuilder.builder()
+            .withFederationConstants(federationMainnetConstants)
+            .withFederationStorageProvider(federationStorageProvider)
+            .withActivations(activations)
+            .withRskExecutionBlock(rskExecutionBlock)
+            .build();
+
+        BridgeSupport bridgeSupport = BridgeSupportBuilder.builder()
+            .withBtcBlockStoreFactory(mockFactory)
+            .withBridgeConstants(bridgeMainnetConstants)
+            .withRepository(repository)
+            .withProvider(provider)
+            .withActivations(activations)
+            .withEventLogger(bridgeEventLogger)
+            .withBtcLockSenderProvider(btcLockSenderProvider)
+            .withPeginInstructionsProvider(peginInstructionsProvider)
+            .withExecutionBlock(rskExecutionBlock)
+            .withFederationSupport(federationSupport)
+            .build();
+
+        // act
+        bridgeSupport.registerBtcTransaction(
+            rskTx,
+            btcTransaction.bitcoinSerialize(),
+            heightAtWhichToStartUsingPegoutIndex,
+            createPmtAndMockBlockStore(btcTransaction).bitcoinSerialize()
+        );
+
+        // assert
+
+        // tx should be marked as processed since RSKIP459 is active
+        var shouldMarkTxAsProcessed = activations == lovellActivations? times(1) : never();
+        verify(provider, shouldMarkTxAsProcessed).setHeightBtcTxhashAlreadyProcessed(any(), anyLong());
+
+        verify(bridgeEventLogger, times(1)).logRejectedPegin(
+            btcTransaction, PEGIN_V1_INVALID_PAYLOAD
+        );
+        verify(bridgeEventLogger, times(1)).logUnrefundablePegin(
+            btcTransaction,
+            LEGACY_PEGIN_UNDETERMINED_SENDER
+        );
+
+        verify(bridgeEventLogger, never()).logPeginBtc(any(), any(), any(), anyInt());
+        verify(bridgeEventLogger, never()).logReleaseBtcRequested(any(), any(), any());
+        verify(bridgeEventLogger, never()).logPegoutTransactionCreated(any(), any());
+
+        assertTrue(activeFederationUtxos.isEmpty());
+        assertTrue(retiringFederationUtxos.isEmpty());
+        assertTrue(pegoutsWaitingForConfirmations.getEntries().isEmpty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("activationsProvider")
+    void registerBtcTransaction_whenUtxoToActiveFedBelowMinimumAndUtxoToRetiringFedAboveMinimum_shouldRejectPegin(
+        ActivationConfig.ForBlock activations
+    ) throws BlockStoreException, BridgeIllegalArgumentException, IOException {
+        // arrange
+        BtcTransaction btcTransaction = new BtcTransaction(btcMainnetParams);
+        btcTransaction.addInput(BitcoinTestUtils.createHash(1), FIRST_OUTPUT_INDEX, new Script(new byte[]{}));
+        btcTransaction.addOutput(belowMinimumPeginTxValue, activeFederation.getAddress());
+        btcTransaction.addOutput(minimumPeginTxValue, retiringFederation.getAddress());
+
+        when(federationStorageProvider.getOldFederation(federationMainnetConstants, activations)).thenReturn(retiringFederation);
+        FederationSupport federationSupport = FederationSupportBuilder.builder()
+            .withFederationConstants(federationMainnetConstants)
+            .withFederationStorageProvider(federationStorageProvider)
+            .withActivations(activations)
+            .withRskExecutionBlock(rskExecutionBlock)
+            .build();
+
+        BridgeSupport bridgeSupport = BridgeSupportBuilder.builder()
+            .withBtcBlockStoreFactory(mockFactory)
+            .withBridgeConstants(bridgeMainnetConstants)
+            .withRepository(repository)
+            .withProvider(provider)
+            .withActivations(activations)
+            .withEventLogger(bridgeEventLogger)
+            .withBtcLockSenderProvider(btcLockSenderProvider)
+            .withPeginInstructionsProvider(peginInstructionsProvider)
+            .withExecutionBlock(rskExecutionBlock)
+            .withFederationSupport(federationSupport)
+            .build();
+
+        // act
+        bridgeSupport.registerBtcTransaction(
+            rskTx,
+            btcTransaction.bitcoinSerialize(),
+            heightAtWhichToStartUsingPegoutIndex,
+            createPmtAndMockBlockStore(btcTransaction).bitcoinSerialize()
+        );
+
+        // assert
+        var shouldMarkTxAsProcessed = activations == lovellActivations? times(1) : never();
+        verify(provider, shouldMarkTxAsProcessed).setHeightBtcTxhashAlreadyProcessed(any(), anyLong());
+
+        verify(bridgeEventLogger, times(1)).logRejectedPegin(btcTransaction, RejectedPeginReason.LEGACY_PEGIN_UNDETERMINED_SENDER);
+        verify(bridgeEventLogger, times(1)).logUnrefundablePegin(btcTransaction,
+            UnrefundablePeginReason.LEGACY_PEGIN_UNDETERMINED_SENDER);
+        verify(bridgeEventLogger, never()).logPeginBtc(any(), any(), any(), anyInt());
+        assertTrue(activeFederationUtxos.isEmpty());
+        assertTrue(retiringFederationUtxos.isEmpty());
+    }
+
+    // flyover pegin
+    @ParameterizedTest
+    @MethodSource("activationsProvider")
+    void registerBtcTransaction_whenAttemptToRegisterFlyoverPegin_shouldIgnorePegin(ActivationConfig.ForBlock activations)
+        throws BlockStoreException, BridgeIllegalArgumentException, IOException {
+        // arrange
+        Address userRefundBtcAddress = BitcoinTestUtils.createP2PKHAddress(btcMainnetParams,
+            "userRefundBtcAddress");
+        Address lpBtcAddress = BitcoinTestUtils.createP2PKHAddress(btcMainnetParams,
+            "lpBtcAddress");
+        Keccak256 derivationArgumentsHash = PegTestUtils.createHash3(0);
+        RskAddress lbcAddress = PegTestUtils.createRandomRskAddress();
+
+        FederationSupport federationSupport = FederationSupportBuilder.builder()
+            .withFederationConstants(federationMainnetConstants)
+            .withFederationStorageProvider(federationStorageProvider)
+            .withActivations(activations)
+            .withRskExecutionBlock(rskExecutionBlock)
+            .build();
+
+        BridgeSupport bridgeSupport = BridgeSupportBuilder.builder()
+            .withBtcBlockStoreFactory(mockFactory)
+            .withBridgeConstants(bridgeMainnetConstants)
+            .withRepository(repository)
+            .withProvider(provider)
+            .withActivations(activations)
+            .withEventLogger(bridgeEventLogger)
+            .withBtcLockSenderProvider(btcLockSenderProvider)
+            .withPeginInstructionsProvider(peginInstructionsProvider)
+            .withExecutionBlock(rskExecutionBlock)
+            .withFederationSupport(federationSupport)
+            .build();
+
+        Keccak256 flyoverDerivationHash = bridgeSupport.getFlyoverDerivationHash(
+            derivationArgumentsHash,
+            userRefundBtcAddress,
+            lpBtcAddress,
+            lbcAddress
+        );
+
+        Address flyoverFederationAddress = PegTestUtils.getFlyoverAddressFromRedeemScript(
+            bridgeMainnetConstants,
+            activeFederation.getRedeemScript(),
+            Sha256Hash.wrap(flyoverDerivationHash.getBytes())
+        );
+
+        BtcTransaction btcTransaction = new BtcTransaction(bridgeMainnetConstants.getBtcParams());
+        btcTransaction.addInput(BitcoinTestUtils.createHash(1), FIRST_OUTPUT_INDEX, new Script(new byte[]{}));
+        btcTransaction.addOutput(minimumPeginTxValue, flyoverFederationAddress);
+
+        // act
+        bridgeSupport.registerBtcTransaction(
+            rskTx,
+            btcTransaction.bitcoinSerialize(),
+            heightAtWhichToStartUsingPegoutIndex,
+            createPmtAndMockBlockStore(btcTransaction).bitcoinSerialize()
+        );
+
+        assertUnknownTxIsIgnored();
+    }
+
+    private void assertUnknownTxIsIgnored() throws IOException {
+        verify(bridgeEventLogger, never()).logRejectedPegin(any(), any());
+        verify(bridgeEventLogger, never()).logUnrefundablePegin(any(), any());
+        verify(bridgeEventLogger, never()).logPeginBtc(any(), any(), any(), anyInt());
+        verify(provider, never()).setHeightBtcTxhashAlreadyProcessed(any(), anyLong());
+        assertTrue(activeFederationUtxos.isEmpty());
+        assertTrue(retiringFederationUtxos.isEmpty());
+    }
+
+    @ParameterizedTest
+    @MethodSource("activationsProvider")
+    void registerBtcTransaction_whenNoUtxoToFed_shouldIgnorePegin(ActivationConfig.ForBlock activations)
+        throws BlockStoreException, BridgeIllegalArgumentException, IOException {
+        // arrange
+        BtcTransaction btcTransaction = new BtcTransaction(btcMainnetParams);
+        btcTransaction.addInput(BitcoinTestUtils.createHash(1), FIRST_OUTPUT_INDEX, new Script(new byte[]{}));
+        btcTransaction.addOutput(minimumPeginTxValue, userAddress);
+
+        FederationSupport federationSupport = FederationSupportBuilder.builder()
+            .withFederationConstants(federationMainnetConstants)
+            .withFederationStorageProvider(federationStorageProvider)
+            .withActivations(activations)
+            .withRskExecutionBlock(rskExecutionBlock)
+            .build();
+
+        BridgeSupport bridgeSupport = BridgeSupportBuilder.builder()
+            .withBtcBlockStoreFactory(mockFactory)
+            .withBridgeConstants(bridgeMainnetConstants)
+            .withRepository(repository)
+            .withProvider(provider)
+            .withActivations(activations)
+            .withEventLogger(bridgeEventLogger)
+            .withBtcLockSenderProvider(btcLockSenderProvider)
+            .withPeginInstructionsProvider(peginInstructionsProvider)
+            .withExecutionBlock(rskExecutionBlock)
+            .withFederationSupport(federationSupport)
+            .build();
+
+        // act
+        bridgeSupport.registerBtcTransaction(
+            rskTx,
+            btcTransaction.bitcoinSerialize(),
+            heightAtWhichToStartUsingPegoutIndex,
+            createPmtAndMockBlockStore(btcTransaction).bitcoinSerialize()
+        );
+
+        // assert
+        assertUnknownTxIsIgnored();
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
@@ -992,7 +992,7 @@ public class BridgeSupportSvpTest {
         /*
          This is a hypothetical case, which is not realistic with the implementation of the svp.
          A btc tx hash that is not saved as a spend tx, is identified as a pegin, and will be
-         rejected due to invalid amount. This is because the pegin amount is below the minimum.
+         rejected due to invalid amount, since the pegin amount is below the minimum.
          Therefore, this tx should be rejected as pegin and mark as processed
          */
         @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
@@ -9,6 +9,7 @@ import static co.rsk.peg.bitcoin.BitcoinTestUtils.generateTransactionInputsSigHa
 import static co.rsk.peg.bitcoin.BitcoinUtils.*;
 import static co.rsk.peg.bitcoin.UtxoUtils.extractOutpointValues;
 import static co.rsk.peg.federation.FederationStorageIndexKey.NEW_FEDERATION_BTC_UTXOS_KEY;
+import static co.rsk.peg.pegin.RejectedPeginReason.INVALID_AMOUNT;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -30,6 +31,7 @@ import co.rsk.peg.storage.InMemoryStorage;
 import co.rsk.peg.storage.StorageAccessor;
 import co.rsk.peg.utils.BridgeEventLogger;
 import co.rsk.peg.utils.BridgeEventLoggerImpl;
+import co.rsk.peg.utils.UnrefundablePeginReason;
 import co.rsk.test.builders.BridgeSupportBuilder;
 import co.rsk.test.builders.FederationSupportBuilder;
 import java.io.IOException;
@@ -38,6 +40,7 @@ import java.util.stream.IntStream;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.core.*;
+import org.ethereum.core.CallTransaction.Function;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
@@ -986,8 +989,14 @@ public class BridgeSupportSvpTest {
             assertProposedFederationExists();
         }
 
+        /*
+         This is a hypothetical case, which is not realistic with the implementation of the svp.
+         A btc tx hash that is not saved as a spend tx, is identified as a pegin, and will be
+         rejected due to invalid amount. This is because the pegin amount is below the minimum.
+         Therefore, this tx should be rejected as pegin and mark as processed
+         */
         @Test
-        void registerBtcTransaction_whenSpendTransactionHashIsNotSaved_shouldNotProcessSpendTx() throws BlockStoreException, BridgeIllegalArgumentException, IOException {
+        void registerBtcTransaction_whenSpendTransactionHashIsNotSaved_shouldBeIdentifiedAsRejectedPeginAndMarkAsProcessed() throws BlockStoreException, BridgeIllegalArgumentException, IOException {
             // arrange
             recreateSvpSpendTransactionUnsigned();
             setUpForTransactionRegistration(svpSpendTransaction);
@@ -1006,7 +1015,8 @@ public class BridgeSupportSvpTest {
             // assert
             // spend tx was not registered
             assertActiveFederationUtxosSize(activeFederationUtxosSizeBeforeRegisteringTx);
-            assertTransactionWasNotProcessed(svpSpendTransaction.getHash());
+
+            assertTxIsRejectedPeginAndMarkedAsProcessed(svpSpendTransaction);
 
             // svp success was not processed
             assertNoHandoverToNewFederation();
@@ -1369,6 +1379,28 @@ public class BridgeSupportSvpTest {
     private void assertTransactionWasNotProcessed(Sha256Hash transactionHash) throws IOException {
         Optional<Long> rskBlockHeightAtWhichBtcTxWasProcessed = bridgeStorageProvider.getHeightIfBtcTxhashIsAlreadyProcessed(transactionHash);
         assertFalse(rskBlockHeightAtWhichBtcTxWasProcessed.isPresent());
+    }
+
+    private void assertTxIsRejectedPeginAndMarkedAsProcessed(BtcTransaction rejectedPegin)
+        throws IOException {
+        Optional<Long> rskBlockHeightAtWhichBtcTxWasProcessed = bridgeStorageProvider.getHeightIfBtcTxhashIsAlreadyProcessed(rejectedPegin.getHash());
+        assertTrue(rskBlockHeightAtWhichBtcTxWasProcessed.isPresent());
+
+        byte[] btcTxHashSerialized = rejectedPegin.getHash().getBytes();
+
+        Function rejectedPeginEvent = BridgeEvents.REJECTED_PEGIN.getEvent();
+        List<DataWord> rejectedPeginEncodedTopics = getEncodedTopics(rejectedPeginEvent, btcTxHashSerialized);
+        byte[] rejectedPeginEncodedData = getEncodedData(rejectedPeginEvent, INVALID_AMOUNT.getValue());
+
+        assertEventWasEmittedWithExpectedTopics(rejectedPeginEncodedTopics);
+        assertEventWasEmittedWithExpectedData(rejectedPeginEncodedData);
+
+        Function unrefundablePeginEvent = BridgeEvents.UNREFUNDABLE_PEGIN.getEvent();
+        List<DataWord> encodedTopics = getEncodedTopics(unrefundablePeginEvent, btcTxHashSerialized);
+        byte[] encodedData = getEncodedData(unrefundablePeginEvent, UnrefundablePeginReason.INVALID_AMOUNT.getValue());
+
+        assertEventWasEmittedWithExpectedTopics(encodedTopics);
+        assertEventWasEmittedWithExpectedData(encodedData);
     }
 
     private void assertNoSvpFundTxHashUnsigned() {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
@@ -31,7 +31,7 @@ import co.rsk.peg.storage.InMemoryStorage;
 import co.rsk.peg.storage.StorageAccessor;
 import co.rsk.peg.utils.BridgeEventLogger;
 import co.rsk.peg.utils.BridgeEventLoggerImpl;
-import co.rsk.peg.utils.UnrefundablePeginReason;
+import co.rsk.peg.utils.NonRefundablePeginReason;
 import co.rsk.test.builders.BridgeSupportBuilder;
 import co.rsk.test.builders.FederationSupportBuilder;
 import java.io.IOException;
@@ -1397,7 +1397,7 @@ public class BridgeSupportSvpTest {
 
         Function unrefundablePeginEvent = BridgeEvents.UNREFUNDABLE_PEGIN.getEvent();
         List<DataWord> encodedTopics = getEncodedTopics(unrefundablePeginEvent, btcTxHashSerialized);
-        byte[] encodedData = getEncodedData(unrefundablePeginEvent, UnrefundablePeginReason.INVALID_AMOUNT.getValue());
+        byte[] encodedData = getEncodedData(unrefundablePeginEvent, NonRefundablePeginReason.INVALID_AMOUNT.getValue());
 
         assertEventWasEmittedWithExpectedTopics(encodedTopics);
         assertEventWasEmittedWithExpectedData(encodedData);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -55,7 +55,7 @@ import co.rsk.peg.pegin.RejectedPeginReason;
 import co.rsk.peg.pegininstructions.*;
 import co.rsk.peg.storage.*;
 import co.rsk.peg.utils.*;
-import co.rsk.peg.utils.UnrefundablePeginReason;
+import co.rsk.peg.utils.NonRefundablePeginReason;
 import co.rsk.peg.vote.ABICallSpec;
 import co.rsk.peg.whitelist.*;
 import co.rsk.peg.whitelist.constants.WhitelistMainNetConstants;
@@ -1151,7 +1151,8 @@ class BridgeSupportTest {
         bridgeSupport.registerBtcTransaction(mock(Transaction.class), tx.bitcoinSerialize(), height, pmt.bitcoinSerialize());
 
         verify(mockedEventLogger, never()).logRejectedPegin(any(BtcTransaction.class), any(RejectedPeginReason.class));
-        verify(mockedEventLogger, never()).logUnrefundablePegin(any(BtcTransaction.class), any(UnrefundablePeginReason.class));
+        verify(mockedEventLogger, never()).logNonRefundablePegin(any(BtcTransaction.class), any(
+            NonRefundablePeginReason.class));
     }
 
     @Test
@@ -1247,7 +1248,8 @@ class BridgeSupportTest {
         );
 
         verify(mockedEventLogger, atLeastOnce()).logRejectedPegin(any(BtcTransaction.class), any(RejectedPeginReason.class));
-        verify(mockedEventLogger, atLeastOnce()).logUnrefundablePegin(any(BtcTransaction.class), any(UnrefundablePeginReason.class));
+        verify(mockedEventLogger, atLeastOnce()).logNonRefundablePegin(any(BtcTransaction.class), any(
+            NonRefundablePeginReason.class));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsEvaluatePeginTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsEvaluatePeginTest.java
@@ -54,7 +54,7 @@ class PegUtilsEvaluatePeginTest {
             Arguments.of(BtcLockSender.TxSenderAddressType.P2SHP2WPKH, PeginProcessAction.CAN_BE_REGISTERED, null),
             Arguments.of(BtcLockSender.TxSenderAddressType.P2SHMULTISIG, PeginProcessAction.CAN_BE_REFUNDED, RejectedPeginReason.LEGACY_PEGIN_MULTISIG_SENDER),
             Arguments.of(BtcLockSender.TxSenderAddressType.P2SHP2WSH, PeginProcessAction.CAN_BE_REFUNDED, RejectedPeginReason.LEGACY_PEGIN_MULTISIG_SENDER),
-            Arguments.of(BtcLockSender.TxSenderAddressType.UNKNOWN, PeginProcessAction.CANNOT_BE_PROCESSED, RejectedPeginReason.LEGACY_PEGIN_UNDETERMINED_SENDER)
+            Arguments.of(BtcLockSender.TxSenderAddressType.UNKNOWN, PeginProcessAction.CANNOT_BE_REFUNDED, RejectedPeginReason.LEGACY_PEGIN_UNDETERMINED_SENDER)
         );
     }
 
@@ -104,7 +104,7 @@ class PegUtilsEvaluatePeginTest {
             activations
         );
 
-        assertEquals(PeginProcessAction.CANNOT_BE_PROCESSED, peginEvaluationResult.getPeginProcessAction());
+        assertEquals(PeginProcessAction.CANNOT_BE_REFUNDED, peginEvaluationResult.getPeginProcessAction());
         assertTrue(peginEvaluationResult.getRejectedPeginReason().isPresent());
         assertEquals(RejectedPeginReason.INVALID_AMOUNT, peginEvaluationResult.getRejectedPeginReason().get());
     }
@@ -129,7 +129,7 @@ class PegUtilsEvaluatePeginTest {
             activations
         );
 
-        assertEquals(PeginProcessAction.CANNOT_BE_PROCESSED, peginEvaluationResult.getPeginProcessAction());
+        assertEquals(PeginProcessAction.CANNOT_BE_REFUNDED, peginEvaluationResult.getPeginProcessAction());
         assertTrue(peginEvaluationResult.getRejectedPeginReason().isPresent());
         assertEquals(RejectedPeginReason.PEGIN_V1_INVALID_PAYLOAD, peginEvaluationResult.getRejectedPeginReason().get());
     }

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsEvaluatePeginTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsEvaluatePeginTest.java
@@ -50,11 +50,11 @@ class PegUtilsEvaluatePeginTest {
 
     private static Stream<Arguments> argumentsForWhenProtocolVersionLegacyIs0AndDifferentAddressTypes() {
         return Stream.of(
-            Arguments.of(BtcLockSender.TxSenderAddressType.P2PKH, PeginProcessAction.CAN_BE_REGISTERED, null),
-            Arguments.of(BtcLockSender.TxSenderAddressType.P2SHP2WPKH, PeginProcessAction.CAN_BE_REGISTERED, null),
-            Arguments.of(BtcLockSender.TxSenderAddressType.P2SHMULTISIG, PeginProcessAction.CAN_BE_REFUNDED, RejectedPeginReason.LEGACY_PEGIN_MULTISIG_SENDER),
-            Arguments.of(BtcLockSender.TxSenderAddressType.P2SHP2WSH, PeginProcessAction.CAN_BE_REFUNDED, RejectedPeginReason.LEGACY_PEGIN_MULTISIG_SENDER),
-            Arguments.of(BtcLockSender.TxSenderAddressType.UNKNOWN, PeginProcessAction.CANNOT_BE_REFUNDED, RejectedPeginReason.LEGACY_PEGIN_UNDETERMINED_SENDER)
+            Arguments.of(BtcLockSender.TxSenderAddressType.P2PKH, PeginProcessAction.REGISTER, null),
+            Arguments.of(BtcLockSender.TxSenderAddressType.P2SHP2WPKH, PeginProcessAction.REGISTER, null),
+            Arguments.of(BtcLockSender.TxSenderAddressType.P2SHMULTISIG, PeginProcessAction.REFUND, RejectedPeginReason.LEGACY_PEGIN_MULTISIG_SENDER),
+            Arguments.of(BtcLockSender.TxSenderAddressType.P2SHP2WSH, PeginProcessAction.REFUND, RejectedPeginReason.LEGACY_PEGIN_MULTISIG_SENDER),
+            Arguments.of(BtcLockSender.TxSenderAddressType.UNKNOWN, PeginProcessAction.NO_REFUND, RejectedPeginReason.LEGACY_PEGIN_UNDETERMINED_SENDER)
         );
     }
 
@@ -104,7 +104,7 @@ class PegUtilsEvaluatePeginTest {
             activations
         );
 
-        assertEquals(PeginProcessAction.CANNOT_BE_REFUNDED, peginEvaluationResult.getPeginProcessAction());
+        assertEquals(PeginProcessAction.NO_REFUND, peginEvaluationResult.getPeginProcessAction());
         assertTrue(peginEvaluationResult.getRejectedPeginReason().isPresent());
         assertEquals(RejectedPeginReason.INVALID_AMOUNT, peginEvaluationResult.getRejectedPeginReason().get());
     }
@@ -129,7 +129,7 @@ class PegUtilsEvaluatePeginTest {
             activations
         );
 
-        assertEquals(PeginProcessAction.CANNOT_BE_REFUNDED, peginEvaluationResult.getPeginProcessAction());
+        assertEquals(PeginProcessAction.NO_REFUND, peginEvaluationResult.getPeginProcessAction());
         assertTrue(peginEvaluationResult.getRejectedPeginReason().isPresent());
         assertEquals(RejectedPeginReason.PEGIN_V1_INVALID_PAYLOAD, peginEvaluationResult.getRejectedPeginReason().get());
     }
@@ -156,7 +156,7 @@ class PegUtilsEvaluatePeginTest {
             activations
         );
 
-        assertEquals(PeginProcessAction.CAN_BE_REFUNDED, peginEvaluationResult.getPeginProcessAction());
+        assertEquals(PeginProcessAction.REFUND, peginEvaluationResult.getPeginProcessAction());
         assertTrue(peginEvaluationResult.getRejectedPeginReason().isPresent());
         assertEquals(RejectedPeginReason.PEGIN_V1_INVALID_PAYLOAD, peginEvaluationResult.getRejectedPeginReason().get());
     }
@@ -203,7 +203,7 @@ class PegUtilsEvaluatePeginTest {
             activations
         );
 
-        assertEquals(PeginProcessAction.CAN_BE_REGISTERED, peginEvaluationResult.getPeginProcessAction());
+        assertEquals(PeginProcessAction.REGISTER, peginEvaluationResult.getPeginProcessAction());
     }
 
     @Test()
@@ -255,7 +255,7 @@ class PegUtilsEvaluatePeginTest {
                 activations
         );
 
-        assertEquals(PeginProcessAction.CAN_BE_REGISTERED, peginEvaluationResult.getPeginProcessAction());
+        assertEquals(PeginProcessAction.REGISTER, peginEvaluationResult.getPeginProcessAction());
     }
 
     @Test
@@ -280,6 +280,6 @@ class PegUtilsEvaluatePeginTest {
             activations
         );
 
-        assertEquals(PeginProcessAction.CAN_BE_REGISTERED, peginEvaluationResult.getPeginProcessAction());
+        assertEquals(PeginProcessAction.REGISTER, peginEvaluationResult.getPeginProcessAction());
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerImplTest.java
@@ -398,9 +398,9 @@ class BridgeEventLoggerImplTest {
     }
 
     @Test
-    void logUnrefundablePegin() {
+    void logNonRefundablePegin() {
         // Setup event logger
-        eventLogger.logUnrefundablePegin(BTC_TRANSACTION, UnrefundablePeginReason.LEGACY_PEGIN_UNDETERMINED_SENDER);
+        eventLogger.logNonRefundablePegin(BTC_TRANSACTION, NonRefundablePeginReason.LEGACY_PEGIN_UNDETERMINED_SENDER);
 
         assertEquals(1, eventLogs.size());
         LogInfo entry = eventLogs.get(0);
@@ -423,7 +423,7 @@ class BridgeEventLoggerImplTest {
 
         // Assert log data
         assertArrayEquals(
-            event.encodeEventData(UnrefundablePeginReason.LEGACY_PEGIN_UNDETERMINED_SENDER.getValue()),
+            event.encodeEventData(NonRefundablePeginReason.LEGACY_PEGIN_UNDETERMINED_SENDER.getValue()),
             result.getData()
         );
     }

--- a/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/utils/BridgeEventLoggerTest.java
@@ -64,10 +64,10 @@ class BridgeEventLoggerTest {
     }
 
     @Test
-    void logUnrefundablePegin() {
-        assertThrows(UnsupportedOperationException.class, () -> eventLogger.logUnrefundablePegin(
+    void logNonRefundablePegin() {
+        assertThrows(UnsupportedOperationException.class, () -> eventLogger.logNonRefundablePegin(
             btcTxMock,
-            UnrefundablePeginReason.LEGACY_PEGIN_UNDETERMINED_SENDER
+            NonRefundablePeginReason.LEGACY_PEGIN_UNDETERMINED_SENDER
         ));
     }
 


### PR DESCRIPTION
Mark rejected pegins as processed once RSKIP459 is active.

## Motivation and Context

Peg-in transactions rejected by the Bridge should be marked as processed to ensure that the `rejected_pegin` event is emitted only once per transaction.

## How Has This Been Tested?

Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Requires Activation Code (Hard Fork)

