### PR TITLE
Create method to remove utxos used for a release transaction

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1094,16 +1094,8 @@ public class BridgeSupport {
             provider.setSvpFundTxHashUnsigned(svpFundTransactionUnsigned.getHash());
             PegoutsWaitingForConfirmations pegoutsWaitingForConfirmations = provider.getPegoutsWaitingForConfirmations();
 
-            Wallet activeFederationWallet = getActiveFederationWallet(true);
-            List<UTXO> utxosToUse = activeFederationWallet
-                .getUTXOProvider()
-                .getOpenTransactionOutputs(activeFederationWallet.getWatchedAddresses());
+            List<UTXO> utxosToUse = federationSupport.getActiveFederationBtcUTXOs();
             settleReleaseRequest(utxosToUse, pegoutsWaitingForConfirmations, svpFundTransactionUnsigned, rskTxHash, spendableValueFromProposedFederation);
-        } catch (UTXOProviderException e) {
-            logger.error(
-                "[processSvpFundTransactionUnsigned] Error when trying to remove spent utxos. Error message: {}",
-                e.getMessage()
-            );
         } catch (InsufficientMoneyException e) {
             logger.error(
                 "[processSvpFundTransactionUnsigned] Insufficient funds for creating the fund transaction. Error message: {}",

--- a/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
@@ -92,12 +92,6 @@ public class BitcoinUtils {
         }
     }
 
-    public static void addInputFromMatchingOutputScript(BtcTransaction transaction, BtcTransaction sourceTransaction, Script expectedOutputScript) {
-        List<TransactionOutput> outputs = sourceTransaction.getOutputs();
-        searchForOutput(outputs, expectedOutputScript)
-            .ifPresent(transaction::addInput);
-    }
-
     public static Script createBaseP2SHInputScriptThatSpendsFromRedeemScript(Script redeemScript) {
         Script outputScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
         return outputScript.createEmptyInputScript(null, redeemScript);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
@@ -291,6 +291,9 @@ public class BridgeSupportSvpTest {
 
         @Test
         void updateCollections_whenFundTxCanBeCreated_createsExpectedFundTxAndSavesTheHashInStorageEntryAndPerformsPegoutActions() throws Exception {
+            // arrange
+            int activeFederationUtxosSizeBeforeCreatingFundTx = federationSupport.getActiveFederationBtcUTXOs().size();
+
             // act
             bridgeSupport.updateCollections(rskTx);
             bridgeStorageProvider.save();
@@ -298,6 +301,7 @@ public class BridgeSupportSvpTest {
             // assert
             Sha256Hash svpFundTxHashUnsigned = assertSvpFundTxHashUnsignedIsInStorage();
             assertSvpFundTxReleaseWasSettled(svpFundTxHashUnsigned);
+            assertActiveFederationUtxosSize(activeFederationUtxosSizeBeforeCreatingFundTx - 1);
             assertSvpFundTransactionHasExpectedInputsAndOutputs();
         }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
@@ -4,8 +4,7 @@ import static co.rsk.RskTestUtils.createRskBlock;
 import static co.rsk.peg.BridgeSupportTestUtil.*;
 import static co.rsk.peg.PegUtils.getFlyoverRedeemScript;
 import static co.rsk.peg.ReleaseTransactionBuilder.BTC_TX_VERSION_2;
-import static co.rsk.peg.bitcoin.BitcoinTestUtils.generateSignerEncodedSignatures;
-import static co.rsk.peg.bitcoin.BitcoinTestUtils.generateTransactionInputsSigHashes;
+import static co.rsk.peg.bitcoin.BitcoinTestUtils.*;
 import static co.rsk.peg.bitcoin.BitcoinUtils.*;
 import static co.rsk.peg.bitcoin.UtxoUtils.extractOutpointValues;
 import static co.rsk.peg.federation.FederationStorageIndexKey.NEW_FEDERATION_BTC_UTXOS_KEY;
@@ -661,10 +660,14 @@ public class BridgeSupportSvpTest {
             assertEquals(1, outputs.size());
 
             long calculatedTransactionSize = 1762L; // using calculatePegoutTxSize method
-            Coin expectedAmount = feePerKb
+            Coin fees = feePerKb
                 .multiply(calculatedTransactionSize * 12L / 10L) // back up calculation
                 .divide(1000);
-            assertOutputWasSentToExpectedScriptWithExpectedAmount(outputs, activeFederation.getP2SHScript(), expectedAmount);
+
+            Coin valueToSend = spendableValueFromProposedFederation
+                .multiply(2)
+                .minus(fees);
+            assertOutputWasSentToExpectedScriptWithExpectedAmount(outputs, activeFederation.getP2SHScript(), valueToSend);
         }
 
         private void assertInputsHaveExpectedScriptSig(List<TransactionInput> inputs) {

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinTestUtils.java
@@ -1,8 +1,7 @@
 package co.rsk.peg.bitcoin;
 
 import static co.rsk.bitcoinj.script.ScriptBuilder.createP2SHOutputScript;
-import static co.rsk.peg.bitcoin.BitcoinUtils.extractRedeemScriptFromInput;
-import static co.rsk.peg.bitcoin.BitcoinUtils.generateSigHashForP2SHTransactionInput;
+import static co.rsk.peg.bitcoin.BitcoinUtils.*;
 
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.crypto.TransactionSignature;
@@ -250,5 +249,11 @@ public class BitcoinTestUtils {
         coinbaseTx.setWitness(0, txWitness);
 
         return coinbaseTx;
+    }
+
+    public static void addInputFromMatchingOutputScript(BtcTransaction transaction, BtcTransaction sourceTransaction, Script expectedOutputScript) {
+        List<TransactionOutput> outputs = sourceTransaction.getOutputs();
+        searchForOutput(outputs, expectedOutputScript)
+            .ifPresent(transaction::addInput);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
@@ -1,5 +1,6 @@
 package co.rsk.peg.bitcoin;
 
+import static co.rsk.peg.bitcoin.BitcoinTestUtils.addInputFromMatchingOutputScript;
 import static co.rsk.peg.bitcoin.BitcoinUtils.*;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -413,47 +414,6 @@ class BitcoinUtilsTest {
         // the tx hash emitted in the release_requested event does not have the signatures
         Sha256Hash hashFromReleaseRequestedEvent = Sha256Hash.wrap("7fba184a41c4ca22e2b806bdd961c4e52b1bd2a1d2552bbe61cbba4d56c00fae");
         assertEquals(hashFromReleaseRequestedEvent, btcTxHashWithoutSigs);
-    }
-
-    @Test
-    void addInputFromOutputSentToScript_withNoMatchingOutputScript_shouldNotAddInput() {
-        // arrange
-        Federation federation = P2shErpFederationBuilder.builder().build();
-        Script redeemScript = federation.getRedeemScript();
-        Script outputScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
-        BtcTransaction sourceTransaction = new BtcTransaction(btcMainnetParams);
-        sourceTransaction.addOutput(Coin.valueOf(1000L), outputScript);
-
-        // act
-        BtcTransaction newTransaction = new BtcTransaction(btcMainnetParams);
-
-        Federation anotherFederation = StandardMultiSigFederationBuilder.builder().build();
-        Script anotherRedeemScript = anotherFederation.getRedeemScript();
-        Script anotherOutputScript = ScriptBuilder.createP2SHOutputScript(anotherRedeemScript);
-        addInputFromMatchingOutputScript(newTransaction, sourceTransaction, anotherOutputScript);
-
-        // assert
-        assertEquals(0, newTransaction.getInputs().size());
-    }
-
-    @Test
-    void addInputFromOutputSentToScript_withMatchingOutputScript_shouldAddInputWithOutpointFromOutput() {
-        // arrange
-        Federation federation = P2shErpFederationBuilder.builder().build();
-        Script redeemScript = federation.getRedeemScript();
-        Script outputScript = ScriptBuilder.createP2SHOutputScript(redeemScript);
-
-        BtcTransaction sourceTransaction = new BtcTransaction(btcMainnetParams);
-        sourceTransaction.addOutput(Coin.valueOf(1000L), outputScript);
-
-        // act
-        BtcTransaction newTransaction = new BtcTransaction(btcMainnetParams);
-        addInputFromMatchingOutputScript(newTransaction, sourceTransaction, outputScript);
-
-        // assert
-        TransactionInput newTransactionInput = newTransaction.getInput(0);
-        TransactionOutput sourceTransactionOutput = sourceTransaction.getOutput(0);
-        assertEquals(newTransactionInput.getOutpoint().getHash(), sourceTransactionOutput.getParentTransactionHash());
     }
 
     @Test


### PR DESCRIPTION
Consumed UTXOs after creating a release transaction were being removed separately in each method.
This should be happening in `settleReleaseRequest` method, since it is where all the release-releated actions happen. 

This pr does that.