### PR TITLE
Ignore non-standard outputs when searching for the witness commitment hash

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -2283,7 +2283,7 @@ public class BridgeSupport {
         Sha256Hash witnessMerkleRoot,
         byte[] witnessReservedValue
     ) throws BridgeIllegalArgumentException {
-        Optional<Sha256Hash> expectedWitnessCommitment = findWitnessCommitment(coinbaseTransaction);
+        Optional<Sha256Hash> expectedWitnessCommitment = findWitnessCommitment(coinbaseTransaction, activations);
         Sha256Hash calculatedWitnessCommitment = Sha256Hash.twiceOf(witnessMerkleRoot.getReversedBytes(), witnessReservedValue);
 
         if (expectedWitnessCommitment.isEmpty() || !expectedWitnessCommitment.get().equals(calculatedWitnessCommitment)) {

--- a/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
@@ -88,10 +88,18 @@ public class BitcoinUtils {
         List<TransactionOutput> outputsReversed = Lists.reverse(tx.getOutputs());
 
         for (TransactionOutput output : outputsReversed) {
-            Script scriptPubKey = output.getScriptPubKey();
-            if (isWitnessCommitment(scriptPubKey)) {
-                Sha256Hash witnessCommitment = extractWitnessCommitmentHash(scriptPubKey);
-                return Optional.of(witnessCommitment);
+            try {
+                Script scriptPubKey = output.getScriptPubKey();
+                if (isWitnessCommitment(scriptPubKey)) {
+                    Sha256Hash witnessCommitment = extractWitnessCommitmentHash(scriptPubKey);
+                    return Optional.of(witnessCommitment);
+                }
+            } catch (ScriptException e) {
+                logger.debug(
+                    "[findWitnessCommitment] Failed to extract witness commitment from output {}. {}",
+                    output,
+                    e.getMessage()
+                );
             }
         }
 

--- a/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
@@ -8,6 +8,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.util.*;
 import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,7 +84,7 @@ public class BitcoinUtils {
         }
     }
 
-    public static Optional<Sha256Hash> findWitnessCommitment(BtcTransaction tx) {
+    public static Optional<Sha256Hash> findWitnessCommitment(BtcTransaction tx, ActivationConfig.ForBlock activations) {
         Preconditions.checkState(tx.isCoinBase());
         // If more than one witness commitment, take the last one as the valid one
         List<TransactionOutput> outputsReversed = Lists.reverse(tx.getOutputs());
@@ -100,6 +102,11 @@ public class BitcoinUtils {
                     output,
                     e.getMessage()
                 );
+
+                if (!activations.isActive(ConsensusRule.RSKIP460)) {
+                    // Pre RSKIP460, the exception was not caught and the process could not continue
+                    throw e;
+                }
             }
         }
 

--- a/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 public class BitcoinUtils {
     protected static final byte[]  WITNESS_COMMITMENT_HEADER = Hex.decode("aa21a9ed");
     protected static final int WITNESS_COMMITMENT_LENGTH = WITNESS_COMMITMENT_HEADER.length + Sha256Hash.LENGTH;
-    private static final int MINIMUM_WITNESS_COMMITMENT_SIZE = WITNESS_COMMITMENT_LENGTH + 2; // 1 extra by for OP_RETURN and another one for data length
+    private static final int MINIMUM_WITNESS_COMMITMENT_SIZE = WITNESS_COMMITMENT_LENGTH + 2; // 1 extra byte for OP_RETURN and another one for data length
     private static final Logger logger = LoggerFactory.getLogger(BitcoinUtils.class);
     private static final int FIRST_INPUT_INDEX = 0;
 
@@ -97,7 +97,7 @@ public class BitcoinUtils {
                     return Optional.of(witnessCommitment);
                 }
             } catch (ScriptException e) {
-                logger.debug(
+                logger.warn(
                     "[findWitnessCommitment] Failed to extract witness commitment from output {}. {}",
                     output,
                     e.getMessage()

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
@@ -29,7 +29,7 @@ class BitcoinUtilsTest {
     private static final int FIRST_INPUT_INDEX = 0;
 
     private static final ActivationConfig.ForBlock arrowHeadActivations = ActivationConfigsForTest.arrowhead600().forBlock(0);
-    private static final ActivationConfig.ForBlock lovellActivations = ActivationConfigsForTest.lovell700().forBlock(0);
+    private static final ActivationConfig.ForBlock allActivations = ActivationConfigsForTest.all().forBlock(0);
 
     private Address destinationAddress;
 
@@ -413,7 +413,7 @@ class BitcoinUtilsTest {
         private static Stream<Arguments> activationsProvider() {
             return Stream.of(
                 Arguments.of(arrowHeadActivations),
-                Arguments.of(lovellActivations)
+                Arguments.of(allActivations)
             );
         }
 
@@ -523,7 +523,7 @@ class BitcoinUtilsTest {
 
         @ParameterizedTest
         @MethodSource("activationsProvider")
-        void findWitnessCommitment_withDataLargenThanExpected_shouldReturnEmpty(ActivationConfig.ForBlock activations) {
+        void findWitnessCommitment_withDataLargerThanExpected_shouldReturnEmpty(ActivationConfig.ForBlock activations) {
             // Arrange
             BtcTransaction btcTx = BitcoinTestUtils.createCoinbaseTransaction(btcMainnetParams);
 
@@ -576,7 +576,7 @@ class BitcoinUtilsTest {
             BtcTransaction malFormedCoinbaseTx, Sha256Hash expectedWitnessCommitment) {
             // Act
             Optional<Sha256Hash> witnessCommitment = BitcoinUtils.findWitnessCommitment(
-                malFormedCoinbaseTx, lovellActivations);
+                malFormedCoinbaseTx, allActivations);
 
             // Assert
             assertTrue(witnessCommitment.isPresent());

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
@@ -11,6 +11,8 @@ import co.rsk.peg.federation.P2shErpFederationBuilder;
 import java.util.*;
 import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.util.ByteUtil;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -18,9 +20,16 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class BitcoinUtilsTest {
+
+    private static final BridgeConstants bridgeTestnetConstants = BridgeMainNetConstants.getInstance();
+    private static final NetworkParameters btcTestnetParams = bridgeTestnetConstants.getBtcParams();
+
     private static final BridgeConstants bridgeMainnetConstants = BridgeMainNetConstants.getInstance();
     private static final NetworkParameters btcMainnetParams = bridgeMainnetConstants.getBtcParams();
     private static final int FIRST_INPUT_INDEX = 0;
+
+    private static final ActivationConfig.ForBlock arrowHeadActivations = ActivationConfigsForTest.arrowhead600().forBlock(0);
+    private static final ActivationConfig.ForBlock lovellActivations = ActivationConfigsForTest.lovell700().forBlock(0);
 
     private Address destinationAddress;
 
@@ -391,18 +400,26 @@ class BitcoinUtilsTest {
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     @Tag("test find witness commitment implementations")
     class FindWitnessCommitment {
-        @Test
-        void findWitnessCommitment_whenTxHasNoOutputs_shouldThrowException() {
+        @ParameterizedTest
+        @MethodSource("activationsProvider")
+        void findWitnessCommitment_whenTxHasNoOutputs_shouldThrowException(ActivationConfig.ForBlock activations) {
             // Arrange
             BtcTransaction btcTx = new BtcTransaction(btcMainnetParams);
 
             // Act
-            assertThrows(IllegalStateException.class, () -> BitcoinUtils.findWitnessCommitment(btcTx));
-            assertThrows(IllegalStateException.class, btcTx::findWitnessCommitment);
+            assertThrows(IllegalStateException.class, () -> BitcoinUtils.findWitnessCommitment(btcTx, activations));
         }
 
-        @Test
-        void findWitnessCommitment_whenTxIsNotCoinbase_shouldThrowException() {
+        private static Stream<Arguments> activationsProvider() {
+            return Stream.of(
+                Arguments.of(arrowHeadActivations),
+                Arguments.of(lovellActivations)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("activationsProvider")
+        void findWitnessCommitment_whenTxIsNotCoinbase_shouldThrowException(ActivationConfig.ForBlock activations) {
             // Arrange
             BtcTransaction btcTx = new BtcTransaction(btcMainnetParams);
 
@@ -416,25 +433,25 @@ class BitcoinUtilsTest {
             btcTx.addOutput(Coin.COIN, receiver2);
 
             // Act
-            assertThrows(IllegalStateException.class, () -> BitcoinUtils.findWitnessCommitment(btcTx));
-            assertThrows(IllegalStateException.class, btcTx::findWitnessCommitment);
+            assertThrows(IllegalStateException.class, () -> BitcoinUtils.findWitnessCommitment(btcTx, activations));
         }
 
-        @Test
-        void findWitnessCommitment_whenNoWitnessCommitment_shouldReturnEmpty() {
+        @ParameterizedTest
+        @MethodSource("activationsProvider")
+        void findWitnessCommitment_whenNoWitnessCommitment_shouldReturnEmpty(ActivationConfig.ForBlock activations) {
             // Arrange
             BtcTransaction btcTx = BitcoinTestUtils.createCoinbaseTransaction(btcMainnetParams);
 
             // Act
-            Optional<Sha256Hash> witnessCommitment = BitcoinUtils.findWitnessCommitment(btcTx);
+            Optional<Sha256Hash> witnessCommitment = BitcoinUtils.findWitnessCommitment(btcTx, activations);
 
             // Assert
             assertFalse(witnessCommitment.isPresent());
-            assertNull(btcTx.findWitnessCommitment());
         }
 
-        @Test
-        void findWitnessCommitment_withWitnessCommitment_shouldReturnExpectedValue() {
+        @ParameterizedTest
+        @MethodSource("activationsProvider")
+        void findWitnessCommitment_withWitnessCommitment_shouldReturnExpectedValue(ActivationConfig.ForBlock activations) {
             // Arrange
             Sha256Hash witnessCommitment = BitcoinTestUtils.createHash(100);
             BtcTransaction btcTx = BitcoinTestUtils.createCoinbaseTransactionWithWitnessCommitment(
@@ -443,16 +460,16 @@ class BitcoinUtilsTest {
             );
 
             // Act
-            Optional<Sha256Hash> witnessCommitmentFound = BitcoinUtils.findWitnessCommitment(btcTx);
+            Optional<Sha256Hash> witnessCommitmentFound = BitcoinUtils.findWitnessCommitment(btcTx, activations);
 
             // Assert
             assertTrue(witnessCommitmentFound.isPresent());
             assertEquals(witnessCommitment, witnessCommitmentFound.get());
-            assertEquals(witnessCommitment, btcTx.findWitnessCommitment());
         }
 
-        @Test
-        void findWitnessCommitment_withMultipleWitnessCommitments_shouldReturnLastOne() {
+        @ParameterizedTest
+        @MethodSource("activationsProvider")
+        void findWitnessCommitment_withMultipleWitnessCommitments_shouldReturnLastOne(ActivationConfig.ForBlock activations) {
             // Arrange
             Sha256Hash witnessCommitment1 = BitcoinTestUtils.createHash(100);
             Sha256Hash witnessCommitment2 = BitcoinTestUtils.createHash(200);
@@ -463,16 +480,16 @@ class BitcoinUtilsTest {
             );
 
             // Act
-            Optional<Sha256Hash> witnessCommitmentFound = BitcoinUtils.findWitnessCommitment(btcTx);
+            Optional<Sha256Hash> witnessCommitmentFound = BitcoinUtils.findWitnessCommitment(btcTx, activations);
 
             // Assert
             assertTrue(witnessCommitmentFound.isPresent());
             assertEquals(witnessCommitment3, witnessCommitmentFound.get());
-            assertEquals(witnessCommitment3, btcTx.findWitnessCommitment());
         }
 
-        @Test
-        void findWitnessCommitment_withWrongWitnessCommitment_shouldReturnEmpty() {
+        @ParameterizedTest
+        @MethodSource("activationsProvider")
+        void findWitnessCommitment_withWrongWitnessCommitment_shouldReturnEmpty(ActivationConfig.ForBlock activations) {
             // Arrange
             Sha256Hash fakeWitnessCommitment = BitcoinTestUtils.createHash(101);
             BtcTransaction btcTx = BitcoinTestUtils.createCoinbaseTransactionWithWrongWitnessCommitment(
@@ -481,15 +498,15 @@ class BitcoinUtilsTest {
             );
 
             // Act
-            Optional<Sha256Hash> witnessCommitment = BitcoinUtils.findWitnessCommitment(btcTx);
+            Optional<Sha256Hash> witnessCommitment = BitcoinUtils.findWitnessCommitment(btcTx, activations);
 
             // Assert
             assertFalse(witnessCommitment.isPresent());
-            assertEquals(fakeWitnessCommitment, btcTx.findWitnessCommitment()); // bitcoinj implementation detects it as a valid witness commitment
         }
 
-        @Test
-        void findWitnessCommitment_withRealTransaction_shouldReturnExpectedValue() {
+        @ParameterizedTest
+        @MethodSource("activationsProvider")
+        void findWitnessCommitment_withRealTransaction_shouldReturnExpectedValue(ActivationConfig.ForBlock activations) {
             // Arrange
             // https://mempool.space/tx/b6362fb1369a64c4ce4e0449dc9bd7ffc1ba4fa857fce8a502ff53e49a17c1a7
             String rawCoinbaseTx = "010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff5803143c0d1b4d696e656420627920416e74506f6f6c39363552000603188e2f24fabe6d6d0a2f234a30b96bbd9118e926736f18b85f55588455058335d2aa379604b51662100000000000000000004ca30900000000d18300ffffffff05220200000000000017a91442402a28dd61f2718a4b27ae72a4791d5bbdade787e3fd38130000000017a9145249bdf2c131d43995cff42e8feee293f79297a8870000000000000000266a24aa21a9ed434c56197e034947917a46b6c302671f952e0c0ce2ea794fad577b3bbdc0408400000000000000002f6a2d434f524501a37cf4faa0758b26dca666f3e36d42fa15cc01064e3ecda72cb7961caa4b541b1e322bcfe0b5a03000000000000000002b6a2952534b424c4f434b3aebe97391ca0a8447635a588b29295e1fa65aa4723216c21112051f1100683fa50120000000000000000000000000000000000000000000000000000000000000000000000000";
@@ -497,39 +514,88 @@ class BitcoinUtilsTest {
             Sha256Hash expectedWitnessCommitment = Sha256Hash.wrap("434c56197e034947917a46b6c302671f952e0c0ce2ea794fad577b3bbdc04084");
 
             // Act
-            Optional<Sha256Hash> witnessCommitment = BitcoinUtils.findWitnessCommitment(btcTx);
+            Optional<Sha256Hash> witnessCommitment = BitcoinUtils.findWitnessCommitment(btcTx, activations);
 
             // Assert
             assertTrue(witnessCommitment.isPresent());
             assertEquals(expectedWitnessCommitment, witnessCommitment.get());
-            assertEquals(expectedWitnessCommitment, btcTx.findWitnessCommitment());
         }
-    }
 
-    @Test
-    void findWitnessCommitment_withDataLargenThanExpected_shouldReturnEmpty() {
-        // Arrange
-        BtcTransaction btcTx = BitcoinTestUtils.createCoinbaseTransaction(btcMainnetParams);
+        @ParameterizedTest
+        @MethodSource("activationsProvider")
+        void findWitnessCommitment_withDataLargenThanExpected_shouldReturnEmpty(ActivationConfig.ForBlock activations) {
+            // Arrange
+            BtcTransaction btcTx = BitcoinTestUtils.createCoinbaseTransaction(btcMainnetParams);
 
-        TransactionWitness txWitness = new TransactionWitness(1);
-        txWitness.setPush(0, BitcoinTestUtils.WITNESS_RESERVED_VALUE.getBytes());
-        btcTx.setWitness(0, txWitness);
+            TransactionWitness txWitness = new TransactionWitness(1);
+            txWitness.setPush(0, BitcoinTestUtils.WITNESS_RESERVED_VALUE.getBytes());
+            btcTx.setWitness(0, txWitness);
 
-        Sha256Hash witnessCommitment = BitcoinTestUtils.createHash(100);
-        byte[] extraData = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
-        byte[] witnessCommitmentWithHeaderAndExtraData = ByteUtil.merge(
-            BitcoinUtils.WITNESS_COMMITMENT_HEADER,
-            witnessCommitment.getBytes(),
-            extraData
-        );
-        btcTx.addOutput(Coin.ZERO, ScriptBuilder.createOpReturnScript(witnessCommitmentWithHeaderAndExtraData));
-        btcTx.verify();
+            Sha256Hash witnessCommitment = BitcoinTestUtils.createHash(100);
+            byte[] extraData = new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+            byte[] witnessCommitmentWithHeaderAndExtraData = ByteUtil.merge(
+                BitcoinUtils.WITNESS_COMMITMENT_HEADER,
+                witnessCommitment.getBytes(),
+                extraData
+            );
+            btcTx.addOutput(Coin.ZERO, ScriptBuilder.createOpReturnScript(witnessCommitmentWithHeaderAndExtraData));
+            btcTx.verify();
 
-        // Act
-        Optional<Sha256Hash> obtainedWitnessCommitment = BitcoinUtils.findWitnessCommitment(btcTx);
+            // Act
+            Optional<Sha256Hash> obtainedWitnessCommitment = BitcoinUtils.findWitnessCommitment(btcTx, activations);
 
-        // Assert, should not find the commitment since the data length != 36 bytes
-        assertFalse(obtainedWitnessCommitment.isPresent());
-        assertNull(btcTx.findWitnessCommitment());
+            // Assert, should not find the commitment since the data length != 36 bytes
+            assertFalse(obtainedWitnessCommitment.isPresent());
+        }
+
+        @ParameterizedTest
+        @MethodSource("malFormedCoinbaseTxProvider")
+        void findWitnessCommitment_whenMalFormedTxBeforeRSKIP460_shouldThrowException(BtcTransaction malFormedCoinbaseTx) {
+            // Act & Assert
+            assertThrows(ScriptException.class, () -> BitcoinUtils.findWitnessCommitment(malFormedCoinbaseTx, arrowHeadActivations));
+        }
+
+        private static Stream<Arguments> malFormedCoinbaseTxProvider() {
+            // malformed coinbase tx from testnet: https://mempool.space/testnet/tx/ae0a6c774908d3ddd334d40cc385ef1c2ad7e6381a69058114899f5ce567f26c
+            String rawMalFormedTestnetCoinbaseTx = "010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff32030a0e250004fee5346404196a763b0cc3dd196400000000000000000a636b706f6f6c0e2f6d696e65642062792072736b2fffffffff039cce2a00000000001976a914ec2f9ffaba0d68ea6bd7c25cedfe2ae710938e6088ac0000000000000000266a24aa21a9ede46b6d3bc71412e8905cedfad91532bdccb693d93a1335fee0b6223a7ed1ee5b00000000000000002a6a52534b424c4f434b3a8bc552daa25a7a473ac4640ba2b9d621c95652c61488143ca02bbf1b00392fb10120000000000000000000000000000000000000000000000000000000000000000000000000";
+            BtcTransaction malFormedTestnetCoinbaseTx = new BtcTransaction(btcTestnetParams, Hex.decode(rawMalFormedTestnetCoinbaseTx));
+
+            // malformed coinbase tx from mainnet: https://mempool.space/tx/079e68032d9a4cdb222f464b9966756ccb749633aee678c6a51536b4fc38e29c
+            String rawMalFormedMainnetCoinbaseTx = "010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff3c03ebba0c040c93ef652f4d41524120506f6f6c202876303232373234292f76649b3c094f135bf4b83108c14ea85f12307cd4bf00d6010000ffffffffffffffff0371c71a27000000001976a9142fc701e2049ee4957b07134b6c1d771dd5a96b2188ac0000000000000000266a24aa21a9ed5e4aae37309d88e9f49d3a4c6fb424e491cbdbac754b8ef06bb90d2a149bd96900000000000000002cfabe6d6d9797129041127735e99e277241fbc539b327b16ad3e8537125cdc12ccf2d0586010000000000000001200000000000000000000000000000000000000000000000000000000000000000e5a28d27";
+            BtcTransaction malFormedMainnetCoinbaseTx = new BtcTransaction(btcMainnetParams, Hex.decode(rawMalFormedMainnetCoinbaseTx));
+
+            return Stream.of(
+                Arguments.of(malFormedTestnetCoinbaseTx),
+                Arguments.of(malFormedMainnetCoinbaseTx)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("malFormedCoinbaseTxAndExpectedWitnessProvider")
+        void findWitnessCommitment_whenMalFormedTxAfterRSKIP460_shouldIgnoreMalformedOutputAndReturnFoundWitnessCommitment(
+            BtcTransaction malFormedCoinbaseTx, Sha256Hash expectedWitnessCommitment) {
+            // Act
+            Optional<Sha256Hash> witnessCommitment = BitcoinUtils.findWitnessCommitment(
+                malFormedCoinbaseTx, lovellActivations);
+
+            // Assert
+            assertTrue(witnessCommitment.isPresent());
+            assertEquals(expectedWitnessCommitment, witnessCommitment.get());
+        }
+
+        private static Stream<Arguments> malFormedCoinbaseTxAndExpectedWitnessProvider() {
+            // malformed coinbase tx from testnet: https://mempool.space/testnet/tx/ae0a6c774908d3ddd334d40cc385ef1c2ad7e6381a69058114899f5ce567f26c
+            String rawMalFormedTestnetCoinbaseTx = "010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff32030a0e250004fee5346404196a763b0cc3dd196400000000000000000a636b706f6f6c0e2f6d696e65642062792072736b2fffffffff039cce2a00000000001976a914ec2f9ffaba0d68ea6bd7c25cedfe2ae710938e6088ac0000000000000000266a24aa21a9ede46b6d3bc71412e8905cedfad91532bdccb693d93a1335fee0b6223a7ed1ee5b00000000000000002a6a52534b424c4f434b3a8bc552daa25a7a473ac4640ba2b9d621c95652c61488143ca02bbf1b00392fb10120000000000000000000000000000000000000000000000000000000000000000000000000";
+            BtcTransaction malFormedTestnetCoinbaseTx = new BtcTransaction(btcTestnetParams, Hex.decode(rawMalFormedTestnetCoinbaseTx));
+
+            // malformed coinbase tx from mainnet: https://mempool.space/tx/079e68032d9a4cdb222f464b9966756ccb749633aee678c6a51536b4fc38e29c
+            String rawMalFormedMainnetCoinbaseTx = "010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff3c03ebba0c040c93ef652f4d41524120506f6f6c202876303232373234292f76649b3c094f135bf4b83108c14ea85f12307cd4bf00d6010000ffffffffffffffff0371c71a27000000001976a9142fc701e2049ee4957b07134b6c1d771dd5a96b2188ac0000000000000000266a24aa21a9ed5e4aae37309d88e9f49d3a4c6fb424e491cbdbac754b8ef06bb90d2a149bd96900000000000000002cfabe6d6d9797129041127735e99e277241fbc539b327b16ad3e8537125cdc12ccf2d0586010000000000000001200000000000000000000000000000000000000000000000000000000000000000e5a28d27";
+            BtcTransaction malFormedMainnetCoinbaseTx = new BtcTransaction(btcMainnetParams, Hex.decode(rawMalFormedMainnetCoinbaseTx));
+
+            return Stream.of(
+                Arguments.of(malFormedTestnetCoinbaseTx, Sha256Hash.wrap("e46b6d3bc71412e8905cedfad91532bdccb693d93a1335fee0b6223a7ed1ee5b")),
+                Arguments.of(malFormedMainnetCoinbaseTx, Sha256Hash.wrap("5e4aae37309d88e9f49d3a4c6fb424e491cbdbac754b8ef06bb90d2a149bd969"))
+            );
+        }
     }
 }


### PR DESCRIPTION
Ignore non-standard outputs when searching for the witness commitment hash

## ## Motivation and Context

Coinbase transactions may sometimes contain non-standard outputs that cause the Bridge to fail parsing them. When iterating through the outputs of a coinbase transaction in search for the witness commitment hash, non-standard outputs should be ignored and continue searching through the remaining outputs.

## How Has This Been Tested?

Unit tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Requires Activation Code (Hard Fork)
