### PR TITLE
Ignore non-standard outputs when searching for the witness commitment hash

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -2569,7 +2569,7 @@ public class BridgeSupport {
         Sha256Hash witnessMerkleRoot,
         byte[] witnessReservedValue
     ) throws BridgeIllegalArgumentException {
-        Optional<Sha256Hash> expectedWitnessCommitment = findWitnessCommitment(coinbaseTransaction);
+        Optional<Sha256Hash> expectedWitnessCommitment = findWitnessCommitment(coinbaseTransaction, activations);
         Sha256Hash calculatedWitnessCommitment = Sha256Hash.twiceOf(witnessMerkleRoot.getReversedBytes(), witnessReservedValue);
 
         if (expectedWitnessCommitment.isEmpty() || !expectedWitnessCommitment.get().equals(calculatedWitnessCommitment)) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -2553,7 +2553,6 @@ public class BridgeSupport {
                 blockHeader.getMerkleRoot()
             );
             logger.warn("{} {}", LOG_PREFIX, panicMessage);
-            panicProcessor.panic("btclock", panicMessage);
             return;
         }
 
@@ -3192,7 +3191,6 @@ public class BridgeSupport {
         } catch (Exception e) {
             String panicMessage = String.format("[validationsForRegisterBtcTransaction] Btc Tx %s Supplied Height is %d but should be greater than 0", btcTxHash, height);
             logger.warn(panicMessage);
-            panicProcessor.panic("btclock", panicMessage);
             return false;
         }
 
@@ -3231,7 +3229,6 @@ public class BridgeSupport {
                 blockHeader.getMerkleRoot()
             );
             logger.warn(panicMessage);
-            panicProcessor.panic("btclock", panicMessage);
             return false;
         }
 

--- a/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 public class BitcoinUtils {
     protected static final byte[]  WITNESS_COMMITMENT_HEADER = Hex.decode("aa21a9ed");
     protected static final int WITNESS_COMMITMENT_LENGTH = WITNESS_COMMITMENT_HEADER.length + Sha256Hash.LENGTH;
-    private static final int MINIMUM_WITNESS_COMMITMENT_SIZE = WITNESS_COMMITMENT_LENGTH + 2; // 1 extra by for OP_RETURN and another one for data length
+    private static final int MINIMUM_WITNESS_COMMITMENT_SIZE = WITNESS_COMMITMENT_LENGTH + 2; // 1 extra byte for OP_RETURN and another one for data length
     private static final Logger logger = LoggerFactory.getLogger(BitcoinUtils.class);
     private static final int FIRST_INPUT_INDEX = 0;
 
@@ -125,7 +125,7 @@ public class BitcoinUtils {
                     return Optional.of(witnessCommitment);
                 }
             } catch (ScriptException e) {
-                logger.debug(
+                logger.warn(
                     "[findWitnessCommitment] Failed to extract witness commitment from output {}. {}",
                     output,
                     e.getMessage()

--- a/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
@@ -116,10 +116,18 @@ public class BitcoinUtils {
         List<TransactionOutput> outputsReversed = Lists.reverse(tx.getOutputs());
 
         for (TransactionOutput output : outputsReversed) {
-            Script scriptPubKey = output.getScriptPubKey();
-            if (isWitnessCommitment(scriptPubKey)) {
-                Sha256Hash witnessCommitment = extractWitnessCommitmentHash(scriptPubKey);
-                return Optional.of(witnessCommitment);
+            try {
+                Script scriptPubKey = output.getScriptPubKey();
+                if (isWitnessCommitment(scriptPubKey)) {
+                    Sha256Hash witnessCommitment = extractWitnessCommitmentHash(scriptPubKey);
+                    return Optional.of(witnessCommitment);
+                }
+            } catch (ScriptException e) {
+                logger.debug(
+                    "[findWitnessCommitment] Failed to extract witness commitment from output {}. {}",
+                    output,
+                    e.getMessage()
+                );
             }
         }
 

--- a/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
@@ -8,6 +8,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.util.*;
 import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -110,7 +112,7 @@ public class BitcoinUtils {
             .orElseThrow(() -> new IllegalArgumentException("Couldn't extract redeem script from p2sh input"));
     }
 
-    public static Optional<Sha256Hash> findWitnessCommitment(BtcTransaction tx) {
+    public static Optional<Sha256Hash> findWitnessCommitment(BtcTransaction tx, ActivationConfig.ForBlock activations) {
         Preconditions.checkState(tx.isCoinBase());
         // If more than one witness commitment, take the last one as the valid one
         List<TransactionOutput> outputsReversed = Lists.reverse(tx.getOutputs());
@@ -128,6 +130,11 @@ public class BitcoinUtils {
                     output,
                     e.getMessage()
                 );
+
+                if (!activations.isActive(ConsensusRule.RSKIP460)) {
+                    // Pre RSKIP460, the exception was not caught and the process could not continue
+                    throw e;
+                }
             }
         }
 

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -105,6 +105,7 @@ public enum ConsensusRule {
     RSKIP453("rskip453"),
     RSKIP454("rskip454"),
     RSKIP459("rskip459"),
+    RSKIP460("rskip460")
     ;
 
     private final String configKey;

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -106,6 +106,7 @@ blockchain = {
             rskip453 = <hardforkName>
             rskip454 = <hardforkName>
             rskip459 = <hardforkName>
+            rskip460 = <hardforkName>
         }
     }
     gc = {

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -91,6 +91,7 @@ blockchain = {
             rskip453 = lovell700
             rskip454 = lovell700
             rskip459 = lovell700
+            rskip460 = lovell700
         }
     }
     gc = {

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
@@ -35,6 +35,15 @@ class BitcoinUtilsTest {
 
     private Address destinationAddress;
 
+    // malformed coinbase tx from testnet: https://mempool.space/testnet/tx/ae0a6c774908d3ddd334d40cc385ef1c2ad7e6381a69058114899f5ce567f26c
+    private static final BtcTransaction malFormedTestnetCoinbaseTx = new BtcTransaction(btcTestnetParams, Hex.decode("010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff32030a0e250004fee5346404196a763b0cc3dd196400000000000000000a636b706f6f6c0e2f6d696e65642062792072736b2fffffffff039cce2a00000000001976a914ec2f9ffaba0d68ea6bd7c25cedfe2ae710938e6088ac0000000000000000266a24aa21a9ede46b6d3bc71412e8905cedfad91532bdccb693d93a1335fee0b6223a7ed1ee5b00000000000000002a6a52534b424c4f434b3a8bc552daa25a7a473ac4640ba2b9d621c95652c61488143ca02bbf1b00392fb10120000000000000000000000000000000000000000000000000000000000000000000000000"));
+
+    // malformed coinbase tx from mainnet: https://mempool.space/tx/079e68032d9a4cdb222f464b9966756ccb749633aee678c6a51536b4fc38e29c
+    private static final BtcTransaction malFormedMainnetCoinbaseTx = new BtcTransaction(btcMainnetParams, Hex.decode("010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff3c03ebba0c040c93ef652f4d41524120506f6f6c202876303232373234292f76649b3c094f135bf4b83108c14ea85f12307cd4bf00d6010000ffffffffffffffff0371c71a27000000001976a9142fc701e2049ee4957b07134b6c1d771dd5a96b2188ac0000000000000000266a24aa21a9ed5e4aae37309d88e9f49d3a4c6fb424e491cbdbac754b8ef06bb90d2a149bd96900000000000000002cfabe6d6d9797129041127735e99e277241fbc539b327b16ad3e8537125cdc12ccf2d0586010000000000000001200000000000000000000000000000000000000000000000000000000000000000e5a28d27"));
+
+    // witness commitment output script in non-standard format
+    private static final BtcTransaction coinbaseTxWithWitnessCommitmentOutputInNonStandardFormat = new BtcTransaction(btcMainnetParams, Hex.decode("010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff32030a0e250004fee5346404196a763b0cc3dd196400000000000000000a636b706f6f6c0e2f6d696e65642062792072736b2fffffffff039cce2a00000000001976a914ec2f9ffaba0d68ea6bd7c25cedfe2ae710938e6088ac0000000000000000266a24aa21a9ede46b6d3bc71412e8905cedfad91532bdccb693d93a1335fee0b6223a7ed1ee5b00000000000000002a6a24aa21a9ed4f434b3a8bc552daa25a7a473ac4640ba2b9d621c95652c61488143ca02bbf1b00392fb10120000000000000000000000000000000000000000000000000000000000000000000000000"));
+
     @BeforeEach
     void init() {
         destinationAddress = BitcoinTestUtils.createP2PKHAddress(btcMainnetParams, "destinationAddress");
@@ -630,10 +639,10 @@ class BitcoinUtilsTest {
         @MethodSource("activationsProvider")
         void findWitnessCommitment_withWrongWitnessCommitment_shouldReturnEmpty(ActivationConfig.ForBlock activations) {
             // Arrange
-            Sha256Hash fakeWitnessCommitment = BitcoinTestUtils.createHash(101);
+            Sha256Hash wrongWitnessCommitment = BitcoinTestUtils.createHash(101);
             BtcTransaction btcTx = BitcoinTestUtils.createCoinbaseTransactionWithWrongWitnessCommitment(
                 btcMainnetParams,
-                fakeWitnessCommitment
+                wrongWitnessCommitment
             );
 
             // Act
@@ -695,17 +704,10 @@ class BitcoinUtilsTest {
         }
 
         private static Stream<Arguments> malFormedCoinbaseTxProvider() {
-            // malformed coinbase tx from testnet: https://mempool.space/testnet/tx/ae0a6c774908d3ddd334d40cc385ef1c2ad7e6381a69058114899f5ce567f26c
-            String rawMalFormedTestnetCoinbaseTx = "010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff32030a0e250004fee5346404196a763b0cc3dd196400000000000000000a636b706f6f6c0e2f6d696e65642062792072736b2fffffffff039cce2a00000000001976a914ec2f9ffaba0d68ea6bd7c25cedfe2ae710938e6088ac0000000000000000266a24aa21a9ede46b6d3bc71412e8905cedfad91532bdccb693d93a1335fee0b6223a7ed1ee5b00000000000000002a6a52534b424c4f434b3a8bc552daa25a7a473ac4640ba2b9d621c95652c61488143ca02bbf1b00392fb10120000000000000000000000000000000000000000000000000000000000000000000000000";
-            BtcTransaction malFormedTestnetCoinbaseTx = new BtcTransaction(btcTestnetParams, Hex.decode(rawMalFormedTestnetCoinbaseTx));
-
-            // malformed coinbase tx from mainnet: https://mempool.space/tx/079e68032d9a4cdb222f464b9966756ccb749633aee678c6a51536b4fc38e29c
-            String rawMalFormedMainnetCoinbaseTx = "010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff3c03ebba0c040c93ef652f4d41524120506f6f6c202876303232373234292f76649b3c094f135bf4b83108c14ea85f12307cd4bf00d6010000ffffffffffffffff0371c71a27000000001976a9142fc701e2049ee4957b07134b6c1d771dd5a96b2188ac0000000000000000266a24aa21a9ed5e4aae37309d88e9f49d3a4c6fb424e491cbdbac754b8ef06bb90d2a149bd96900000000000000002cfabe6d6d9797129041127735e99e277241fbc539b327b16ad3e8537125cdc12ccf2d0586010000000000000001200000000000000000000000000000000000000000000000000000000000000000e5a28d27";
-            BtcTransaction malFormedMainnetCoinbaseTx = new BtcTransaction(btcMainnetParams, Hex.decode(rawMalFormedMainnetCoinbaseTx));
-
             return Stream.of(
                 Arguments.of(malFormedTestnetCoinbaseTx),
-                Arguments.of(malFormedMainnetCoinbaseTx)
+                Arguments.of(malFormedMainnetCoinbaseTx),
+                Arguments.of(coinbaseTxWithWitnessCommitmentOutputInNonStandardFormat)
             );
         }
 
@@ -723,17 +725,13 @@ class BitcoinUtilsTest {
         }
 
         private static Stream<Arguments> malFormedCoinbaseTxAndExpectedWitnessProvider() {
-            // malformed coinbase tx from testnet: https://mempool.space/testnet/tx/ae0a6c774908d3ddd334d40cc385ef1c2ad7e6381a69058114899f5ce567f26c
-            String rawMalFormedTestnetCoinbaseTx = "010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff32030a0e250004fee5346404196a763b0cc3dd196400000000000000000a636b706f6f6c0e2f6d696e65642062792072736b2fffffffff039cce2a00000000001976a914ec2f9ffaba0d68ea6bd7c25cedfe2ae710938e6088ac0000000000000000266a24aa21a9ede46b6d3bc71412e8905cedfad91532bdccb693d93a1335fee0b6223a7ed1ee5b00000000000000002a6a52534b424c4f434b3a8bc552daa25a7a473ac4640ba2b9d621c95652c61488143ca02bbf1b00392fb10120000000000000000000000000000000000000000000000000000000000000000000000000";
-            BtcTransaction malFormedTestnetCoinbaseTx = new BtcTransaction(btcTestnetParams, Hex.decode(rawMalFormedTestnetCoinbaseTx));
-
-            // malformed coinbase tx from mainnet: https://mempool.space/tx/079e68032d9a4cdb222f464b9966756ccb749633aee678c6a51536b4fc38e29c
-            String rawMalFormedMainnetCoinbaseTx = "010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff3c03ebba0c040c93ef652f4d41524120506f6f6c202876303232373234292f76649b3c094f135bf4b83108c14ea85f12307cd4bf00d6010000ffffffffffffffff0371c71a27000000001976a9142fc701e2049ee4957b07134b6c1d771dd5a96b2188ac0000000000000000266a24aa21a9ed5e4aae37309d88e9f49d3a4c6fb424e491cbdbac754b8ef06bb90d2a149bd96900000000000000002cfabe6d6d9797129041127735e99e277241fbc539b327b16ad3e8537125cdc12ccf2d0586010000000000000001200000000000000000000000000000000000000000000000000000000000000000e5a28d27";
-            BtcTransaction malFormedMainnetCoinbaseTx = new BtcTransaction(btcMainnetParams, Hex.decode(rawMalFormedMainnetCoinbaseTx));
-
             return Stream.of(
-                Arguments.of(malFormedTestnetCoinbaseTx, Sha256Hash.wrap("e46b6d3bc71412e8905cedfad91532bdccb693d93a1335fee0b6223a7ed1ee5b")),
-                Arguments.of(malFormedMainnetCoinbaseTx, Sha256Hash.wrap("5e4aae37309d88e9f49d3a4c6fb424e491cbdbac754b8ef06bb90d2a149bd969"))
+                Arguments.of(malFormedTestnetCoinbaseTx, Sha256Hash.wrap(
+                    "e46b6d3bc71412e8905cedfad91532bdccb693d93a1335fee0b6223a7ed1ee5b")),
+                Arguments.of(malFormedMainnetCoinbaseTx, Sha256Hash.wrap(
+                    "5e4aae37309d88e9f49d3a4c6fb424e491cbdbac754b8ef06bb90d2a149bd969")),
+                Arguments.of(coinbaseTxWithWitnessCommitmentOutputInNonStandardFormat, Sha256Hash.wrap(
+                    "4f434b3a8bc552daa25a7a473ac4640ba2b9d621c95652c61488143ca02bbf1b"))
             );
         }
     }

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
@@ -31,7 +31,7 @@ class BitcoinUtilsTest {
     private static final int FIRST_INPUT_INDEX = 0;
 
     private static final ActivationConfig.ForBlock arrowHeadActivations = ActivationConfigsForTest.arrowhead600().forBlock(0);
-    private static final ActivationConfig.ForBlock lovellActivations = ActivationConfigsForTest.lovell700().forBlock(0);
+    private static final ActivationConfig.ForBlock allActivations = ActivationConfigsForTest.all().forBlock(0);
 
     private Address destinationAddress;
 
@@ -552,7 +552,7 @@ class BitcoinUtilsTest {
         private static Stream<Arguments> activationsProvider() {
             return Stream.of(
                 Arguments.of(arrowHeadActivations),
-                Arguments.of(lovellActivations)
+                Arguments.of(allActivations)
             );
         }
 
@@ -662,7 +662,7 @@ class BitcoinUtilsTest {
 
         @ParameterizedTest
         @MethodSource("activationsProvider")
-        void findWitnessCommitment_withDataLargenThanExpected_shouldReturnEmpty(ActivationConfig.ForBlock activations) {
+        void findWitnessCommitment_withDataLargerThanExpected_shouldReturnEmpty(ActivationConfig.ForBlock activations) {
             // Arrange
             BtcTransaction btcTx = BitcoinTestUtils.createCoinbaseTransaction(btcMainnetParams);
 
@@ -715,7 +715,7 @@ class BitcoinUtilsTest {
             BtcTransaction malFormedCoinbaseTx, Sha256Hash expectedWitnessCommitment) {
             // Act
             Optional<Sha256Hash> witnessCommitment = BitcoinUtils.findWitnessCommitment(
-                malFormedCoinbaseTx, lovellActivations);
+                malFormedCoinbaseTx, allActivations);
 
             // Assert
             assertTrue(witnessCommitment.isPresent());

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -132,6 +132,7 @@ class ActivationConfigTest {
         "    rskip453: lovell700",
         "    rskip454: lovell700",
         "    rskip459: lovell700",
+        "    rskip460: lovell700",
         "}"
     ));
 

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
@@ -181,7 +181,8 @@ public class ActivationConfigsForTest {
             ConsensusRule.RSKIP428,
             ConsensusRule.RSKIP438,
             ConsensusRule.RSKIP454,
-            ConsensusRule.RSKIP459
+            ConsensusRule.RSKIP459,
+            ConsensusRule.RSKIP460
         ));
     }
 


### PR DESCRIPTION
Ignore non-standard outputs when searching for the witness commitment hash.

## ## Motivation and Context

Coinbase transactions may sometimes contain non-standard outputs that cause the Bridge to fail parsing them. When iterating through the outputs of a coinbase transaction in search for the witness commitment hash, non-standard outputs should be ignored and continue searching through the remaining outputs.

## How Has This Been Tested?

Unit tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Requires Activation Code (Hard Fork)

`fed:coinbase-parsing-integration-rebased`