### PR TITLE
Return null early in public method instead of in private one.

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -19,6 +19,7 @@
 package co.rsk.peg;
 
 import static co.rsk.peg.federation.FederationFormatVersion.*;
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.isNull;
 
 import co.rsk.bitcoinj.core.*;
@@ -193,6 +194,7 @@ public class BridgeSerializationUtils {
 
     private static Map.Entry<Keccak256, BtcTransaction> deserializeRskTxWaitingForSignaturesEntry(
             RLPList rlpList, int index, NetworkParameters networkParameters) {
+        checkArgument(rlpList.size() > 0, "RLPList cannot be empty when deserializing an rsk tx WFS entry.");
 
         RLPElement rskTxHashRLPElement = rlpList.get(index * 2);
         byte[] rskTxHashData = rskTxHashRLPElement.getRLPData();

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -163,6 +163,9 @@ public class BridgeSerializationUtils {
         }
 
         RLPList rlpList = (RLPList) RLP.decode2(data).get(0);
+        if (rlpList.size() == 0) {
+            return null;
+        }
         return deserializeRskTxWaitingForSignaturesEntry(rlpList, 0, networkParameters);
     }
 
@@ -190,9 +193,6 @@ public class BridgeSerializationUtils {
 
     private static Map.Entry<Keccak256, BtcTransaction> deserializeRskTxWaitingForSignaturesEntry(
             RLPList rlpList, int index, NetworkParameters networkParameters) {
-        if (rlpList.size() == 0) {
-            return null;
-        }
 
         RLPElement rskTxHashRLPElement = rlpList.get(index * 2);
         byte[] rskTxHashData = rskTxHashRLPElement.getRLPData();


### PR DESCRIPTION
Return _null_ early in public method when having an empty RLPList