### PR TITLE
feat: added RSKIP305 to the new hard fork

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -80,6 +80,7 @@ public enum ConsensusRule {
     RSKIP297("rskip297"), // Increase max timestamp difference between btc and rsk blocks for Testnet
     RSKIP351("rskip351"), // block header extension v1
     RSKIP144("rskip144"), // Parallel tx execution
+    RSKIP305("rskip305"), // bridge segwit-compatible
     RSKIP326("rskip326"), // release_request_received event update to use base58 for btcDestinationAddress
     RSKIP353("rskip353"),
     RSKIP357("rskip357"),

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -80,6 +80,7 @@ blockchain = {
             rskip293 = <hardforkName>
             rskip294 = <hardforkName>
             rskip297 = <hardforkName>
+            rskip305 = <hardforkName>
             rskip351 = <hardforkName>
             rskip144 = <hardforkName>
             rskip326 = <hardforkName>

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -66,6 +66,7 @@ blockchain = {
             rskip297 = hop400
             rskip351 = -1
             rskip144 = -1
+            rskip305 = tbd800
             rskip326 = fingerroot500
             rskip353 = hop401
             rskip357 = hop401

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -107,6 +107,7 @@ class ActivationConfigTest {
         "    rskip293: hop400",
         "    rskip294: hop400",
         "    rskip297: hop400",
+        "    rskip305: tbd800",
         "    rskip326: fingerroot500",
         "    rskip351: arrowhead600",
         "    rskip353: hop401",

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
@@ -187,7 +187,9 @@ public class ActivationConfigsForTest {
     }
 
     private static List<ConsensusRule> getTbd800Rskips() {
-        return new ArrayList<>(List.of());
+        return new ArrayList<>(List.of(
+            ConsensusRule.RSKIP305
+        ));
     }
 
     public static ActivationConfig genesis() {


### PR DESCRIPTION
RSKIP305 introduces Segwit V0 (Bitcoin Soft Fork 2017) for use in peg-ins and peg-outs to improve performance, reduce costs, and improve security.