### PR TITLE
Use trace() logs to increase node perf

### DIFF
--- a/rskj-core/src/main/java/co/rsk/net/sync/PeerAndModeDecidingSyncState.java
+++ b/rskj-core/src/main/java/co/rsk/net/sync/PeerAndModeDecidingSyncState.java
@@ -88,7 +88,7 @@ public class PeerAndModeDecidingSyncState extends BaseSyncState {
 
     private boolean tryStartSnapshotSync() {
         if (!syncConfiguration.isClientSnapSyncEnabled()) {
-            logger.debug("Snap syncing disabled");
+            logger.trace("Snap syncing disabled");
             return false;
         }
 
@@ -96,13 +96,13 @@ public class PeerAndModeDecidingSyncState extends BaseSyncState {
         Optional<Long> peerBestBlockNumOpt = bestPeerOpt.flatMap(this::getPeerBestBlockNumber);
 
         if (bestPeerOpt.isEmpty() || peerBestBlockNumOpt.isEmpty()) {
-            logger.info("Snap syncing not possible, no snap-capable peer available");
+            logger.trace("Snap syncing not possible, no snap-capable peer available");
             return false;
         }
 
         // we consider Snap as part of the Long Sync
         if (!isValidSnapDistance(peerBestBlockNumOpt.get())) {
-            logger.info("Snap syncing not required");
+            logger.trace("Snap syncing not required");
             return false;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We fixed a performance issues directly related to some logging within `PeerAndModeDecidingSyncState.java`.

We added some boton instances to test this specially from [master branch](https://github.com/rsksmart/rskj/tree/master) and [snap-v4-final](https://github.com/rsksmart/rskj/tree/snap-v4-final). With the help of Grafana + Prometheus we noticed the problem here:

Without snap sync:

![Screenshot 2025-03-15 at 2 33 32 PM](https://github.com/user-attachments/assets/bfe52fb1-d6b4-4b03-8804-931c6b0841af)

With Snap sync:

![Screenshot 2025-03-15 at 2 33 43 PM](https://github.com/user-attachments/assets/1c9c81b3-e2e4-4f2e-a49c-d16469b244e6)

After more investigation in the codebase we noticed that printing the logs was time consuming for a method that is concurrently called per each node sync, so we needed to update it to use `trace()` method instead, so this is not logged as default.

After using `trace()` instead, we can see the following improvement in the node with Snap Sync:

![Screenshot 2025-03-15 at 3 23 40 PM](https://github.com/user-attachments/assets/9a2a1c2c-6115-4f12-9dde-592ce1e73fd6)

## Motivation and Context

### Peer discovery

When experimenting with baseline, the node sends many messages sharing a list of peers as part of the peer discovery protocol. This results in a higher CPU consumption (around 20%) than expected.

Deactivating the peer discovery feature and manually setting the bootstrap nodes as active peers mitigates the issue. Conducting a thorough investigation is essential to detect the correctness of this behavior.

## How Has This Been Tested?

We added 4 boton instances:

1. One with peer discovery on from [master branch](https://github.com/rsksmart/rskj/tree/master) + Prometheus setup
2. One with peer discovery off from [master branch](https://github.com/rsksmart/rskj/tree/master) + Prometheus setup
3. [SERVER ]One with snap boot nodes on from [snap-v4-final](https://github.com/rsksmart/rskj/tree/snap-v4-final) + Prometheus setup
4. [CLIENT ]One with snap boot nodes on from [snap-v4-final](https://github.com/rsksmart/rskj/tree/snap-v4-final) + Prometheus setup

By setting up Grafana locally, we noticed that the only instance with performance issues was the #3. 

After some investigations and testing, we applied some fixes and tried these steps again, then the performance got more stable and pretty similar to other instances.

For more information about these tests technically speaking you take a look to these PRs:

master with prometheus
https://github.com/rsksmart/rskj/pull/3028

snapv-v4-final with prometheus
https://github.com/rsksmart/rskj/pull/3034

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
