### PR TITLE
Print warning message when we find any disabled network upgrade

### DIFF
--- a/rskj-core/src/main/java/co/rsk/NodeRunnerImpl.java
+++ b/rskj-core/src/main/java/co/rsk/NodeRunnerImpl.java
@@ -99,6 +99,10 @@ public class NodeRunnerImpl implements NodeRunner {
             SystemUtils.printSystemInfo(logger);
         }
 
+        if (nodeContext instanceof RskContext rskContext) {
+            SystemUtils.printDisabledNetworkUpgrades(logger, rskContext.getBlockchain(), rskSystemProperties.getActivationConfig());
+        }
+
         ArrayList<InternalService> startedServices = new ArrayList<>(internalServices.size());
         InternalService curService = null;
         try {

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -93,7 +93,6 @@ import co.rsk.trie.MultiTrieStore;
 import co.rsk.trie.TrieStore;
 import co.rsk.trie.TrieStoreImpl;
 import co.rsk.util.RskCustomCache;
-import co.rsk.util.SystemUtils;
 import co.rsk.validators.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
@@ -337,7 +336,6 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         if (blockchain == null) {
             blockchain = getBlockChainLoader().loadBlockchain();
-            SystemUtils.printDisabledNetworkUpgrades(logger, blockchain, getRskSystemProperties().getActivationConfig());
         }
 
         return blockchain;

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -93,6 +93,7 @@ import co.rsk.trie.MultiTrieStore;
 import co.rsk.trie.TrieStore;
 import co.rsk.trie.TrieStoreImpl;
 import co.rsk.util.RskCustomCache;
+import co.rsk.util.SystemUtils;
 import co.rsk.validators.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
@@ -336,6 +337,7 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         if (blockchain == null) {
             blockchain = getBlockChainLoader().loadBlockchain();
+            SystemUtils.printDisabledNetworkUpgrades(logger, blockchain, getRskSystemProperties().getActivationConfig());
         }
 
         return blockchain;

--- a/rskj-core/src/main/java/co/rsk/util/SystemUtils.java
+++ b/rskj-core/src/main/java/co/rsk/util/SystemUtils.java
@@ -24,6 +24,7 @@ import org.ethereum.config.blockchain.upgrades.NetworkUpgrade;
 import org.ethereum.core.Blockchain;
 import org.slf4j.Logger;
 
+import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -81,10 +82,15 @@ public class SystemUtils {
                 .toList();
     }
 
-    public static void printDisabledNetworkUpgrades(Logger logger,  Blockchain blockchain, ActivationConfig activationConfig) {
+    public static void printDisabledNetworkUpgrades(@Nonnull Logger logger, @Nonnull Blockchain blockchain, @Nonnull ActivationConfig activationConfig) {
         final var disabledNetworkUpgrades = getDisabledNetworkUpgrades(blockchain, activationConfig);
         final var latestBlock = blockchain.getBestBlock();
 
-        disabledNetworkUpgrades.forEach(disabledNetworkUpgrade -> logger.warn("WARNING: Network upgrade {} is DISABLED. Best block number is: {}.", disabledNetworkUpgrade.name(), latestBlock.getNumber()));
+        if (disabledNetworkUpgrades.isEmpty()) {
+            logger.info("All network upgrades are active.");
+        } else {
+            logger.warn("Total number of disabled network upgrades: {}", disabledNetworkUpgrades.size());
+            disabledNetworkUpgrades.forEach(disabledNetworkUpgrade -> logger.warn("WARNING: Network upgrade {} is DISABLED. Best block number is: {}.", disabledNetworkUpgrade.name(), latestBlock.getNumber()));
+        }
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ActivationConfig.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ActivationConfig.java
@@ -35,7 +35,7 @@ public class ActivationConfig {
 
     @VisibleForTesting
     ActivationConfig(Map<ConsensusRule, Long> activationHeights) {
-        this(activationHeights, null);
+        this(activationHeights, new HashMap<>());
     }
 
     public ActivationConfig(Map<ConsensusRule, Long> activationHeights, Map<NetworkUpgrade, Long> networkUpgrades) {

--- a/rskj-core/src/test/java/co/rsk/util/SystemUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/util/SystemUtilsTest.java
@@ -18,11 +18,18 @@
 
 package co.rsk.util;
 
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
+import org.ethereum.config.blockchain.upgrades.NetworkUpgrade;
+import org.ethereum.core.Block;
+import org.ethereum.core.Blockchain;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 
@@ -31,6 +38,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -74,5 +82,55 @@ class SystemUtilsTest {
         Assertions.assertTrue(params.containsKey("memory.free"));
         Assertions.assertTrue(params.containsKey("memory.max"));
         Assertions.assertTrue(params.containsKey("memory.total"));
+    }
+
+    @Test
+    void testPrintDisabledNetworkUpgrades() {
+        final var logger = mock(Logger.class);
+        final var blockchain = mock(Blockchain.class);
+        final var bestBlock = mock(Block.class);
+        final var bestBlockNumber = -1L;
+
+        Mockito.when(blockchain.getBestBlock()).thenReturn(bestBlock);
+        Mockito.when(bestBlock.getNumber()).thenReturn(bestBlockNumber);
+
+        final var activationConfig = ActivationConfigsForTest.regtest();
+
+        SystemUtils.printDisabledNetworkUpgrades(logger, blockchain, activationConfig);
+
+        verify(logger, times(1)).warn(Mockito.eq("WARNING: Network upgrade {} is DISABLED. Best block number is: {}."), Mockito.eq(NetworkUpgrade.GENESIS.name()),Mockito.eq(bestBlockNumber));
+        verify(logger, times(1)).warn(Mockito.eq("WARNING: Network upgrade {} is DISABLED. Best block number is: {}."), Mockito.eq(NetworkUpgrade.BAHAMAS.name()),Mockito.eq(bestBlockNumber));
+        verify(logger, times(1)).warn(Mockito.eq("WARNING: Network upgrade {} is DISABLED. Best block number is: {}."), Mockito.eq(NetworkUpgrade.AFTER_BRIDGE_SYNC.name()),Mockito.eq(bestBlockNumber));
+        verify(logger, times(1)).warn(Mockito.eq("WARNING: Network upgrade {} is DISABLED. Best block number is: {}."), Mockito.eq(NetworkUpgrade.ORCHID.name()),Mockito.eq(bestBlockNumber));
+        verify(logger, times(1)).warn(Mockito.eq("WARNING: Network upgrade {} is DISABLED. Best block number is: {}."), Mockito.eq(NetworkUpgrade.ORCHID_060.name()),Mockito.eq(bestBlockNumber));
+        verify(logger, times(1)).warn(Mockito.eq("WARNING: Network upgrade {} is DISABLED. Best block number is: {}."), Mockito.eq(NetworkUpgrade.WASABI_100.name()),Mockito.eq(bestBlockNumber));
+        verify(logger, times(1)).warn(Mockito.eq("WARNING: Network upgrade {} is DISABLED. Best block number is: {}."), Mockito.eq(NetworkUpgrade.PAPYRUS_200.name()),Mockito.eq(bestBlockNumber));
+        verify(logger, times(1)).warn(Mockito.eq("WARNING: Network upgrade {} is DISABLED. Best block number is: {}."), Mockito.eq(NetworkUpgrade.TWOTOTHREE.name()),Mockito.eq(bestBlockNumber));
+        verify(logger, times(1)).warn(Mockito.eq("WARNING: Network upgrade {} is DISABLED. Best block number is: {}."), Mockito.eq(NetworkUpgrade.IRIS300.name()),Mockito.eq(bestBlockNumber));
+        verify(logger, times(1)).warn(Mockito.eq("WARNING: Network upgrade {} is DISABLED. Best block number is: {}."), Mockito.eq(NetworkUpgrade.HOP400.name()),Mockito.eq(bestBlockNumber));
+        verify(logger, times(1)).warn(Mockito.eq("WARNING: Network upgrade {} is DISABLED. Best block number is: {}."), Mockito.eq(NetworkUpgrade.HOP401.name()),Mockito.eq(bestBlockNumber));
+        verify(logger, times(1)).warn(Mockito.eq("WARNING: Network upgrade {} is DISABLED. Best block number is: {}."), Mockito.eq(NetworkUpgrade.FINGERROOT500.name()),Mockito.eq(bestBlockNumber));
+        verify(logger, times(1)).warn(Mockito.eq("WARNING: Network upgrade {} is DISABLED. Best block number is: {}."), Mockito.eq(NetworkUpgrade.ARROWHEAD600.name()),Mockito.eq(bestBlockNumber));
+        verify(logger, times(1)).warn(Mockito.eq("WARNING: Network upgrade {} is DISABLED. Best block number is: {}."), Mockito.eq(NetworkUpgrade.ARROWHEAD631.name()),Mockito.eq(bestBlockNumber));
+        verify(logger, times(1)).warn(Mockito.eq("WARNING: Network upgrade {} is DISABLED. Best block number is: {}."), Mockito.eq(NetworkUpgrade.LOVELL700.name()),Mockito.eq(bestBlockNumber));
+    }
+
+    @Test
+    void testPrintDisabledNetworkUpgradesWithNoDisabledNetworkUpgrade() {
+        final var logger = mock(Logger.class);
+        final var blockchain = mock(Blockchain.class);
+        final var bestBlock = mock(Block.class);
+        final var bestBlockNumber = 10L;
+
+        Mockito.when(blockchain.getBestBlock()).thenReturn(bestBlock);
+        Mockito.when(bestBlock.getNumber()).thenReturn(bestBlockNumber);
+
+        final var activationConfig = ActivationConfigsForTest.regtest();
+
+        SystemUtils.printDisabledNetworkUpgrades(logger, blockchain, activationConfig);
+
+        verify(logger, times(1)).warn(Mockito.eq("WARNING: Network upgrade {} is DISABLED. Best block number is: {}."), Mockito.eq(NetworkUpgrade.GENESIS.name()),Mockito.eq(bestBlockNumber));
+        verify(logger, times(1)).warn(Mockito.eq("WARNING: Network upgrade {} is DISABLED. Best block number is: {}."), Mockito.eq(NetworkUpgrade.AFTER_BRIDGE_SYNC.name()),Mockito.eq(bestBlockNumber));
+        verify(logger, times(1)).warn(Mockito.eq("WARNING: Network upgrade {} is DISABLED. Best block number is: {}."), Mockito.eq(NetworkUpgrade.ARROWHEAD631.name()),Mockito.eq(bestBlockNumber));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We are printing a warning message when running the node so we know which NetworkUpgrade are disabled at the point of the node running.

## Motivation and Context

We had an issue where the node of a client was creating a hard fork due to client not having the latest network upgrade `LOVELL700` enabled / added to their config.

We spent a lot of time trying to investigate the issue and we found out it was a configuration issue. If have noticed the configuration issue before we wouldn't spend a lot of time debugging the problem.

## How Has This Been Tested?

We just ran a node from scratch. At the beginning since the block is at height of 0, all the existing network upgrades will be shown, even if they are added to the rsk config, because they will not be active due to the best block height.

Finally, the same node was restarted, so we were able to see how the number of network upgrades printed as disabled were decrease as the best block height was increasing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
