### PR TITLE
Save release transaction outpoints values when creating pegout

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -509,10 +509,8 @@ public class BridgeSupport {
                 logger.debug("[{}] Peg-in is valid, going to register", METHOD_NAME);
                 executePegIn(btcTx, peginInformation, totalAmount);
             }
-            case REFUND -> handleRefundablePegin(btcTx, rskTxHash, peginEvaluationResult,
-                peginInformation.getBtcRefundAddress());
-            case NO_REFUND -> handleNonRefundablePegin(btcTx, peginInformation.getProtocolVersion(),
-                peginEvaluationResult);
+            case REFUND -> handleRefundablePegin(btcTx, rskTxHash, peginEvaluationResult, peginInformation.getBtcRefundAddress());
+            case NO_REFUND -> handleNonRefundablePegin(btcTx, peginInformation.getProtocolVersion(), peginEvaluationResult);
         }
     }
 
@@ -532,8 +530,7 @@ public class BridgeSupport {
 
         logger.debug("[{handleRefundablePegin}] Refunding to address {} ", btcRefundAddress);
         Coin totalAmount = computeTotalAmountSent(btcTx);
-        generateRejectionRelease(btcTx, btcRefundAddress, rskTxHash,
-            totalAmount);
+        generateRejectionRelease(btcTx, btcRefundAddress, rskTxHash, totalAmount);
         markTxAsProcessed(btcTx);
     }
 
@@ -3095,10 +3092,10 @@ public class BridgeSupport {
         settleReleaseRejection(pegoutsWaitingForConfirmations, refundPegoutTransaction, rskTxHash, totalAmount);
     }
 
-    private void settleReleaseRejection(PegoutsWaitingForConfirmations pegoutsWaitingForConfirmations, BtcTransaction pegoutTransaction, Keccak256 releaseCreationTxHash, Coin requestedAmount) {
-        addPegoutToPegoutsWaitingForConfirmations(pegoutsWaitingForConfirmations, pegoutTransaction, releaseCreationTxHash);
-        logReleaseRequested(releaseCreationTxHash, pegoutTransaction, requestedAmount);
-        processReleaseTransactionInfo(pegoutTransaction);
+    private void settleReleaseRejection(PegoutsWaitingForConfirmations pegoutsWaitingForConfirmations, BtcTransaction releaseRejectedTransaction, Keccak256 releaseCreationTxHash, Coin requestedAmount) {
+        addPegoutToPegoutsWaitingForConfirmations(pegoutsWaitingForConfirmations, releaseRejectedTransaction, releaseCreationTxHash);
+        logReleaseRequested(releaseCreationTxHash, releaseRejectedTransaction, requestedAmount);
+        processReleaseTransactionInfo(releaseRejectedTransaction);
     }
 
     private void generateRejectionRelease(
@@ -3123,7 +3120,8 @@ public class BridgeSupport {
                         btcTx.isCoinBase(),
                         output.getScriptPubKey()
                     )
-                ).collect(Collectors.toList());
+                )
+                .toList();
             // Use the list of UTXOs to build a transaction builder
             // for the return btc transaction generation
             return getUTXOBasedWalletForLiveFederations(utxosToUs, false);

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1179,7 +1179,7 @@ public class BridgeSupport {
 
         Coin amountSentToActiveFed = svpSpendTransactionUnsigned.getOutput(0).getValue();
         logReleaseRequested(rskTxHash, svpSpendTransactionUnsigned, amountSentToActiveFed);
-        logPegoutTransactionCreated(svpSpendTransactionUnsigned);
+        processReleaseTransactionInfo(svpSpendTransactionUnsigned);
     }
 
     private BtcTransaction createSvpSpendTransaction(BtcTransaction svpFundTxSigned, Federation proposedFederation) throws IllegalStateException {
@@ -1389,11 +1389,11 @@ public class BridgeSupport {
                 activations
         );
 
-        if (activations.isActive(RSKIP271)) {
-            processPegoutsInBatch(pegoutRequests, txBuilder, availableUTXOs, pegoutsWaitingForConfirmations, activeFederationWallet, rskTx);
-        } else {
+        if (!activations.isActive(RSKIP271)) {
             processPegoutsIndividually(pegoutRequests, txBuilder, availableUTXOs, pegoutsWaitingForConfirmations, activeFederationWallet);
+            return;
         }
+        processPegoutsInBatch(pegoutRequests, txBuilder, availableUTXOs, pegoutsWaitingForConfirmations, activeFederationWallet, rskTx);
     }
 
     private void settleReleaseRequest(List<UTXO> utxosToUse, PegoutsWaitingForConfirmations pegoutsWaitingForConfirmations, BtcTransaction releaseTransaction, Keccak256 releaseCreationTxHash, Coin requestedAmount) {
@@ -1401,7 +1401,7 @@ public class BridgeSupport {
         addPegoutToPegoutsWaitingForConfirmations(pegoutsWaitingForConfirmations, releaseTransaction, releaseCreationTxHash);
         savePegoutTxSigHash(releaseTransaction);
         logReleaseRequested(releaseCreationTxHash, releaseTransaction, requestedAmount);
-        logPegoutTransactionCreated(releaseTransaction);
+        processReleaseTransactionInfo(releaseTransaction);
     }
 
     private void removeSpentUtxos(List<UTXO> utxosToUse, BtcTransaction releaseTx) {
@@ -1457,14 +1457,19 @@ public class BridgeSupport {
         eventLogger.logReleaseBtcRequested(rskTxHashSerialized, pegoutTransaction, requestedAmount);
     }
 
-    private void logPegoutTransactionCreated(BtcTransaction pegoutTransaction) {
+    private void processReleaseTransactionInfo(BtcTransaction pegoutTransaction) {
+        Sha256Hash pegoutTransactionHash = pegoutTransaction.getHash();
+        List<Coin> outpointsValues = extractOutpointValues(pegoutTransaction);
+
         if (!activations.isActive(RSKIP428)) {
             return;
         }
+        eventLogger.logPegoutTransactionCreated(pegoutTransactionHash, outpointsValues);
 
-        List<Coin> outpointValues = extractOutpointValues(pegoutTransaction);
-        Sha256Hash pegoutTransactionHash = pegoutTransaction.getHash();
-        eventLogger.logPegoutTransactionCreated(pegoutTransactionHash, outpointValues);
+        if (!activations.isActive(RSKIP305)) {
+            return;
+        }
+        provider.setReleaseOutpointsValues(pegoutTransactionHash, outpointsValues);
     }
 
     private void processPegoutsIndividually(
@@ -3093,7 +3098,7 @@ public class BridgeSupport {
     private void settleReleaseRejection(PegoutsWaitingForConfirmations pegoutsWaitingForConfirmations, BtcTransaction pegoutTransaction, Keccak256 releaseCreationTxHash, Coin requestedAmount) {
         addPegoutToPegoutsWaitingForConfirmations(pegoutsWaitingForConfirmations, pegoutTransaction, releaseCreationTxHash);
         logReleaseRequested(releaseCreationTxHash, pegoutTransaction, requestedAmount);
-        logPegoutTransactionCreated(pegoutTransaction);
+        processReleaseTransactionInfo(pegoutTransaction);
     }
 
     private void generateRejectionRelease(

--- a/rskj-core/src/main/java/co/rsk/peg/bitcoin/UtxoUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/bitcoin/UtxoUtils.java
@@ -100,6 +100,7 @@ public final class UtxoUtils {
             return Collections.emptyList();
         }
 
-        return generatedTransaction.getInputs().stream().map(TransactionInput::getValue).toList();
+        return generatedTransaction.getInputs().stream().map(TransactionInput::getValue).collect(
+            Collectors.toList());
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/bitcoin/UtxoUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/bitcoin/UtxoUtils.java
@@ -100,7 +100,6 @@ public final class UtxoUtils {
             return Collections.emptyList();
         }
 
-        return generatedTransaction.getInputs().stream().map(TransactionInput::getValue).collect(
-            Collectors.toList());
+        return generatedTransaction.getInputs().stream().map(TransactionInput::getValue).toList();
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeStorageProviderTest.java
@@ -20,6 +20,7 @@ package co.rsk.peg;
 
 import static co.rsk.peg.BridgeSerializationUtils.deserializeOutpointsValues;
 import static co.rsk.peg.BridgeStorageIndexKey.*;
+import static co.rsk.peg.BridgeSupportTestUtil.getStorageKeyForReleaseOutpointsValues;
 import static org.ethereum.TestUtils.assertThrows;
 import static org.ethereum.TestUtils.mockAddress;
 import static org.hamcrest.CoreMatchers.is;

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestUtil.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestUtil.java
@@ -1,5 +1,6 @@
 package co.rsk.peg;
 
+import static co.rsk.peg.BridgeStorageIndexKey.RELEASES_OUTPOINTS_VALUES;
 import static org.mockito.Mockito.*;
 
 import co.rsk.bitcoinj.core.*;
@@ -162,5 +163,9 @@ public final class BridgeSupportTestUtil {
         );
 
         return new Keccak256(HashUtil.keccak256(result));
+    }
+
+    public static DataWord getStorageKeyForReleaseOutpointsValues(Sha256Hash releaseTxHash) {
+        return RELEASES_OUTPOINTS_VALUES.getCompoundKey("-", releaseTxHash.toString());
     }
 }


### PR DESCRIPTION
**Background**
The releases outpoints values should be saved every time a release request is created, i.e., every time the `pegoutTransactionCreated` event is emitted.

This happens in three scenarios:
1. A release is created (batch pegout / migration / spend tx)
2. A normal pegin should be refunded
3. A flyover pegin should be refunded (if it surpasses locking cap)

**Requirements**
-Set release outpoints values info every time a release transaction is created.
-Add tests for each different scenario