### PR TITLE
Add state override support to EthModule for eth_call

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
@@ -141,7 +141,7 @@ public class EthModule
 
     public String call(CallArgumentsParam argsParam, BlockIdentifierParam bnOrId, List<AccountOverride> accountOverrideList) {
 
-        MutableRepository mutableRepository;
+        MutableRepository mutableRepository = null;
         ExecutionBlockRetriever.Result result = executionBlockRetriever.retrieveExecutionBlock(bnOrId.getIdentifier());
         Block block = result.getBlock();
 
@@ -149,9 +149,9 @@ public class EthModule
             mutableRepository = new MutableRepository(new TrieStoreImpl(new HashMapDB()), result.getFinalState());
         } else if (accountOverrideList != null && !accountOverrideList.isEmpty()) {
             mutableRepository = (MutableRepository) repositoryLocator.snapshotAt(block.getHeader());
-            accountOverrideList.forEach(accountOverride -> stateOverrideApplier.applyToRepository(mutableRepository, accountOverride));
-        } else {
-            mutableRepository = null;
+            for(AccountOverride accountOverride : accountOverrideList) {
+               stateOverrideApplier.applyToRepository(mutableRepository,accountOverride);
+            }
         }
         CallArguments callArgs = argsParam.toCallArguments();
 

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
@@ -29,7 +29,6 @@ import co.rsk.peg.BridgeState;
 import co.rsk.peg.BridgeSupport;
 import co.rsk.peg.BridgeSupportFactory;
 import co.rsk.rpc.ExecutionBlockRetriever;
-import co.rsk.rpc.modules.eth.subscribe.AccountOverride;
 import co.rsk.trie.Trie;
 import co.rsk.trie.TrieStoreImpl;
 import co.rsk.util.HexUtils;
@@ -60,6 +59,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -134,35 +134,40 @@ public class EthModule
         return state.stateToMap();
     }
 
-    public String call(CallArgumentsParam argsParam, BlockIdentifierParam bnOrId, List<AccountOverride> accountOverrideList) {
-        if (accountOverrideList != null && !accountOverrideList.isEmpty()) {
-            throw new UnsupportedOperationException("Not implemented yet");
-        } else {
-            return call(argsParam, bnOrId);
-        }
+    public String call(CallArgumentsParam argsParam, BlockIdentifierParam bnOrId) {
+        return call(argsParam, bnOrId, Collections.emptyList());
     }
 
-    public String call(CallArgumentsParam argsParam, BlockIdentifierParam bnOrId) {
-        String hReturn = null;
-        CallArguments args = argsParam.toCallArguments();
-        try {
-            ExecutionBlockRetriever.Result result = executionBlockRetriever.retrieveExecutionBlock(bnOrId.getIdentifier());
-            Block block = result.getBlock();
-            Trie finalState = result.getFinalState();
-            ProgramResult res;
-            if (finalState != null) {
-                res = callConstantWithState(args, block, finalState);
-            } else {
-                res = callConstant(args, block);
-            }
-            handleTransactionRevertIfHappens(res);
-            hReturn = HexUtils.toUnformattedJsonHex(res.getHReturn());
+    public String call(CallArgumentsParam argsParam, BlockIdentifierParam bnOrId, List<AccountOverride> accountOverrideList) {
 
+        MutableRepository mutableRepository;
+        ExecutionBlockRetriever.Result result = executionBlockRetriever.retrieveExecutionBlock(bnOrId.getIdentifier());
+        Block block = result.getBlock();
+
+        if (result.getFinalState() != null) {
+            mutableRepository = new MutableRepository(new TrieStoreImpl(new HashMapDB()), result.getFinalState());
+        } else if (accountOverrideList != null && !accountOverrideList.isEmpty()) {
+            mutableRepository = (MutableRepository) repositoryLocator.snapshotAt(block.getHeader());
+            accountOverrideList.forEach(accountOverride -> accountOverride.applyToRepository(mutableRepository));
+        } else {
+            mutableRepository = null;
+        }
+        CallArguments callArgs = argsParam.toCallArguments();
+
+        String hReturn = null;
+        try {
+            ProgramResult programResult = mutableRepository != null ?
+                    callConstant(callArgs, block, mutableRepository) :
+                    callConstant(callArgs, block);
+
+            handleTransactionRevertIfHappens(programResult);
+            hReturn = HexUtils.toUnformattedJsonHex(programResult.getHReturn());
             return hReturn;
         } finally {
             LOGGER.debug("eth_call(): {}", hReturn);
         }
     }
+
 
     public String estimateGas(CallArgumentsParam args, @Nonnull BlockIdentifierParam bnOrId) {
         ExecutionBlockRetriever.Result result = executionBlockRetriever.retrieveExecutionBlock(bnOrId.getIdentifier());
@@ -296,6 +301,21 @@ public class EthModule
     public ProgramResult callConstant(CallArguments args, Block executionBlock) {
         CallArgumentsToByteArray hexArgs = new CallArgumentsToByteArray(args);
         return reversibleTransactionExecutor.executeTransaction(
+                executionBlock,
+                executionBlock.getCoinbase(),
+                hexArgs.getGasPrice(),
+                hexArgs.gasLimitForCall(this.gasCallCap),
+                hexArgs.getToAddress(),
+                hexArgs.getValue(),
+                hexArgs.getData(),
+                hexArgs.getFromAddress()
+        );
+    }
+
+    public ProgramResult callConstant(CallArguments args, Block executionBlock, RepositorySnapshot snapshot) {
+        CallArgumentsToByteArray hexArgs = new CallArgumentsToByteArray(args);
+        return reversibleTransactionExecutor.executeTransaction(
+                snapshot,
                 executionBlock,
                 executionBlock.getCoinbase(),
                 hexArgs.getGasPrice(),

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleDSLTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleDSLTest.java
@@ -18,10 +18,13 @@
 
 package co.rsk.rpc.modules.eth;
 
+import co.rsk.core.RskAddress;
 import co.rsk.test.World;
 import co.rsk.test.dsl.DslParser;
 import co.rsk.test.dsl.DslProcessorException;
 import co.rsk.test.dsl.WorldDslProcessor;
+import co.rsk.util.HexUtils;
+import org.ethereum.core.Account;
 import org.ethereum.core.Transaction;
 import org.ethereum.core.TransactionReceipt;
 import org.ethereum.rpc.CallArguments;
@@ -30,12 +33,16 @@ import org.ethereum.rpc.parameters.BlockIdentifierParam;
 import org.ethereum.rpc.parameters.CallArgumentsParam;
 import org.ethereum.util.EthModuleTestUtils;
 import org.ethereum.util.TransactionFactoryHelper;
+import org.ethereum.vm.DataWord;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.FileNotFoundException;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -77,5 +84,113 @@ class EthModuleDSLTest {
         args.setData("0xd96a094a0000000000000000000000000000000000000000000000000000000000000001"); // call to contract with param value = 1
         final String call = eth.call(TransactionFactoryHelper.toCallArgumentsParam(args), new BlockIdentifierParam("0x2"));
         assertEquals("0x", call);
+    }
+
+    @Test
+    void testCall_StateOverride_stateIsOverride() throws DslProcessorException, FileNotFoundException {
+        DslParser parser = DslParser.fromResource("dsl/eth_module/simple_contract.txt");
+        World world = new World();
+
+        WorldDslProcessor processor = new WorldDslProcessor(world);
+        processor.processCommands(parser);
+
+        final Transaction tx01 = world.getTransactionByName("tx01");
+        String contractAddress = tx01.getContractAddress().toHexString();
+
+
+        EthModule eth = EthModuleTestUtils.buildBasicEthModule(world);
+        final CallArguments args = new CallArguments();
+        args.setTo("0x" + contractAddress);
+        args.setData("0x6d4ce63c"); //call  get() function
+        BlockIdentifierParam blockIdentifierParam = new BlockIdentifierParam("latest");
+        CallArgumentsParam callArgumentsParam = TransactionFactoryHelper.toCallArgumentsParam(args);
+
+        String result = eth.call(callArgumentsParam, blockIdentifierParam);
+        assertEquals(10, HexUtils.jsonHexToInt(result));
+
+        AccountOverride accountOverride = new AccountOverride();
+        accountOverride.setAddress(new RskAddress(contractAddress));
+        DataWord key = DataWord.valueFromHex("0000000000000000000000000000000000000000000000000000000000000000");
+        DataWord value = DataWord.valueFromHex("0000000000000000000000000000000000000000000000000000000000000014");
+        accountOverride.setState(Map.of(key, value));
+
+        String result2 = eth.call(callArgumentsParam, blockIdentifierParam, List.of(accountOverride));
+        assertEquals(20, HexUtils.jsonHexToInt(result2));
+    }
+
+    @Test
+    void testCall_StateOverride_codeOverride() throws DslProcessorException, FileNotFoundException {
+        /**
+         * Runtime bytecode of the contract:
+         *
+         * // SPDX-License-Identifier: MIT
+         * pragma solidity ^0.8.0;
+         *
+         * contract FakeContract {
+         *     function get() public pure returns (uint) {
+         *         return 999;
+         *     }
+         * }
+         */
+        String runtimeByteCode = "0x6103e760005260206000f3";
+        DslParser parser = DslParser.fromResource("dsl/eth_module/simple_contract.txt");
+        World world = new World();
+
+        WorldDslProcessor processor = new WorldDslProcessor(world);
+        processor.processCommands(parser);
+
+        final Transaction tx01 = world.getTransactionByName("tx01");
+        String contractAddress = tx01.getContractAddress().toHexString();
+
+
+        EthModule eth = EthModuleTestUtils.buildBasicEthModule(world);
+        final CallArguments args = new CallArguments();
+        args.setTo("0x" + contractAddress);
+        args.setData("0x6d4ce63c"); //call  get() function
+        BlockIdentifierParam blockIdentifierParam = new BlockIdentifierParam("latest");
+        CallArgumentsParam callArgumentsParam = TransactionFactoryHelper.toCallArgumentsParam(args);
+
+        String result = eth.call(callArgumentsParam, blockIdentifierParam);
+        assertEquals(10, HexUtils.jsonHexToInt(result));
+
+        AccountOverride accountOverride = new AccountOverride();
+        accountOverride.setAddress(new RskAddress(contractAddress));
+        byte[] newCode = HexUtils.stringHexToByteArray(runtimeByteCode);
+        accountOverride.setCode(newCode);
+
+        String result2 = eth.call(callArgumentsParam, blockIdentifierParam, List.of(accountOverride));
+        assertEquals(999, HexUtils.jsonHexToInt(result2));
+    }
+
+    @Test
+    void testCall_StateOverride_balanceOverride()throws DslProcessorException, FileNotFoundException {
+        long defaultBalance = 30000L;
+        DslParser parser = DslParser.fromResource("dsl/eth_module/check_balance.txt");
+        World world = new World();
+
+        WorldDslProcessor processor = new WorldDslProcessor(world);
+        processor.processCommands(parser);
+
+        final Transaction tx01 = world.getTransactionByName("tx01");
+        String contractAddress = tx01.getContractAddress().toHexString();
+        Account acc = world.getAccountByName("acc1");
+
+        EthModule eth = EthModuleTestUtils.buildBasicEthModule(world);
+        final CallArguments args = new CallArguments();
+        args.setFrom(acc.getAddress().toHexString());
+        args.setTo("0x" + contractAddress);
+        args.setData("0x4c738909"); //call  getMyBalance() function
+        BlockIdentifierParam blockIdentifierParam = new BlockIdentifierParam("latest");
+        CallArgumentsParam callArgumentsParam = TransactionFactoryHelper.toCallArgumentsParam(args);
+
+        String result = eth.call(callArgumentsParam, blockIdentifierParam);
+        assertNotEquals(defaultBalance, HexUtils.jsonHexToInt(result));
+
+        AccountOverride accountOverride = new AccountOverride();
+        accountOverride.setAddress(acc.getAddress());
+        accountOverride.setBalance(BigInteger.valueOf(defaultBalance));
+        String result2 = eth.call(callArgumentsParam, blockIdentifierParam, List.of(accountOverride));
+
+        assertEquals(defaultBalance, HexUtils.jsonHexToInt(result2));
     }
 }

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
@@ -1024,9 +1024,6 @@ class EthModuleTest {
         assertTrue(result.isEmpty(), "Expected no transactions as wallet is disabled");
     }
 
-    
-
-
     private Transaction createMockTransaction(String fromAddress) {
         Transaction transaction = mock(Transaction.class);
         RskAddress address = new RskAddress(fromAddress);

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/AccountOverrideTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/subscribe/AccountOverrideTest.java
@@ -1,0 +1,157 @@
+package co.rsk.rpc.modules.eth.subscribe;
+
+
+import co.rsk.core.Coin;
+import co.rsk.core.RskAddress;
+import co.rsk.core.bc.IReadWrittenKeysTracker;
+import co.rsk.core.bc.ReadWrittenKeysTracker;
+import co.rsk.db.MutableTrieImpl;
+import co.rsk.rpc.modules.eth.AccountOverride;
+import co.rsk.trie.Trie;
+import co.rsk.trie.TrieStore;
+import co.rsk.trie.TrieStoreImpl;
+import org.ethereum.TestUtils;
+import org.ethereum.core.Repository;
+import org.ethereum.datasource.HashMapDB;
+import org.ethereum.db.MutableRepository;
+import org.ethereum.vm.DataWord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AccountOverrideTest {
+    private static final BigInteger DEFAULT_BALANCE = BigInteger.valueOf(1000);
+    private static final byte[] DEFAULT_CODE = TestUtils.generateBytes(1,10);
+    private static final BigInteger DEFAULT_NONCE = BigInteger.valueOf(5);
+    private static final DataWord DEFAULT_STORAGE_KEY_ONE = DataWord.valueOf(1);
+    private static final DataWord DEFAULT_STORAGE_KEY_TWO = DataWord.valueOf(2);
+    private static final DataWord DEFAULT_STORAGE_VALUE_ONE = DataWord.valueOf(100);
+    private static final DataWord DEFAULT_STORAGE_VALUE_TWO = DataWord.valueOf(200);
+
+    private AccountOverride accountOverride;
+    private MutableRepository repository;
+    private RskAddress address;
+
+    @BeforeEach
+    void setup() {
+        address = TestUtils.generateAddress("address");
+
+        TrieStore trieStore = new TrieStoreImpl(new HashMapDB());
+        MutableTrieImpl mutableTrie = new MutableTrieImpl(trieStore, new Trie(trieStore));
+        IReadWrittenKeysTracker tracker = new ReadWrittenKeysTracker();
+        repository = new MutableRepository(mutableTrie, tracker);
+
+        populateRepository(repository, address);
+
+        accountOverride = new AccountOverride();
+        accountOverride.setAddress(address);
+    }
+
+    private void populateRepository(Repository repository, RskAddress address) {
+        repository.addBalance(address, new Coin(DEFAULT_BALANCE));
+        repository.setNonce(address, DEFAULT_NONCE);
+        repository.saveCode(address, DEFAULT_CODE);
+        repository.addStorageRow(address, DEFAULT_STORAGE_KEY_ONE, DEFAULT_STORAGE_VALUE_ONE);
+        repository.addStorageRow(address, DEFAULT_STORAGE_KEY_TWO, DEFAULT_STORAGE_VALUE_TWO);
+    }
+
+    @Test
+    void applyWithBalance() {
+        BigInteger balance = BigInteger.TEN;
+        accountOverride.setBalance(balance);
+        accountOverride.applyToRepository(repository);
+        assertEquals(accountOverride.getBalance(), repository.getBalance(address).asBigInteger());
+    }
+
+    @Test
+    void applyWithNonce() {
+        long nonce = 7L;
+        accountOverride.setNonce(nonce);
+        accountOverride.applyToRepository(repository);
+        assertEquals(accountOverride.getNonce(), repository.getNonce(address).longValue());
+    }
+
+    @Test
+    void applyWithCode() {
+        byte[] code = new byte[]{0x1, 0x2};
+        accountOverride.setCode(code);
+        accountOverride.applyToRepository(repository);
+        assertArrayEquals(accountOverride.getCode(), repository.getCode(address));
+    }
+
+    @Test
+    void applyWithStateMustResetOtherValues() {
+        Map<DataWord, DataWord> state = new HashMap<>();
+        state.put(DEFAULT_STORAGE_KEY_ONE, DataWord.valueOf(10));
+        accountOverride.setState(state);
+
+        assertNotNull(repository.getStorageValue(address, DEFAULT_STORAGE_KEY_TWO));
+
+        // Add an existing key to ensure it is cleared
+        accountOverride.applyToRepository(repository);
+
+        assertEquals(accountOverride.getState().get(DEFAULT_STORAGE_KEY_ONE), repository.getStorageValue(address, DEFAULT_STORAGE_KEY_ONE));
+        assertNull(repository.getStorageValue(address, DEFAULT_STORAGE_KEY_TWO));
+
+    }
+
+    @Test
+    void applyWithStateDiffDoNotAlterOtherValues() {
+
+        Map<DataWord, DataWord> stateDiff = new HashMap<>();
+        stateDiff.put(DEFAULT_STORAGE_KEY_ONE, DataWord.valueOf(10));
+        accountOverride.setStateDiff(stateDiff);
+
+        // Add an existing key to ensure it is cleared
+        accountOverride.applyToRepository(repository);
+
+        assertEquals(accountOverride.getStateDiff().get(DEFAULT_STORAGE_KEY_ONE), repository.getStorageValue(address, DEFAULT_STORAGE_KEY_ONE));
+        assertEquals(DEFAULT_STORAGE_VALUE_TWO, repository.getStorageValue(address, DEFAULT_STORAGE_KEY_TWO));
+    }
+
+    @Test
+    void applyWithoutAddressThrowsException() {
+        accountOverride.setAddress(null);
+        Exception exception = assertThrows(IllegalStateException.class, () -> {
+            accountOverride.applyToRepository(repository);
+        });
+        assertTrue(exception.getMessage().contains("AccountOverride.address must be set"));
+    }
+
+    @Test
+    void applyStateAndStateDiffThrowsException(){
+        Map<DataWord, DataWord> state = new HashMap<>();
+        state.put(DEFAULT_STORAGE_KEY_ONE, DataWord.valueOf(10));
+        accountOverride.setStateDiff(state);
+        accountOverride.setState(state);
+        assertThrows(IllegalStateException.class, () -> {
+            accountOverride.applyToRepository(repository);
+        });
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        AccountOverride other = new AccountOverride();
+        other.setBalance(BigInteger.TEN);
+        other.setNonce(1L);
+        other.setCode(new byte[]{1});
+        other.setState(Map.of(DataWord.valueOf(1), DataWord.valueOf(2)));
+        other.setStateDiff(Map.of(DataWord.valueOf(3), DataWord.valueOf(4)));
+        other.setAddress(address);
+
+        accountOverride.setBalance(BigInteger.TEN);
+        accountOverride.setNonce(1L);
+        accountOverride.setCode(new byte[]{1});
+        accountOverride.setState(Map.of(DataWord.valueOf(1), DataWord.valueOf(2)));
+        accountOverride.setStateDiff(Map.of(DataWord.valueOf(3), DataWord.valueOf(4)));
+        accountOverride.setAddress(address);
+
+        assertEquals(accountOverride, other);
+        assertEquals(accountOverride.hashCode(), other.hashCode());
+    }
+}

--- a/rskj-core/src/test/java/org/ethereum/util/EthModuleTestUtils.java
+++ b/rskj-core/src/test/java/org/ethereum/util/EthModuleTestUtils.java
@@ -57,7 +57,7 @@ public class EthModuleTestUtils {
                 null,
                 new ReversibleTransactionExecutor(world.getRepositoryLocator(), executor),
                 new ExecutionBlockRetriever(world.getBlockChain(), null, null),
-                null,
+                world.getRepositoryLocator(),
                 null,
                 null,
                 world.getBridgeSupportFactory(),

--- a/rskj-core/src/test/resources/dsl/eth_module/check_balance.txt
+++ b/rskj-core/src/test/resources/dsl/eth_module/check_balance.txt
@@ -1,0 +1,36 @@
+comment
+
+Simple checkBalance contract
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract CheckSenderBalance {
+    function getMyBalance() public view returns (uint) {
+        return msg.sender.balance;
+    }
+}
+
+end
+
+account_new acc1 20000000
+
+transaction_build tx01
+    sender acc1
+    receiverAddress 00
+    value 0
+    data 608060405234801561000f575f80fd5b5060c58061001c5f395ff3fe6080604052348015600e575f80fd5b50600436106026575f3560e01c80634c73890914602a575b5f80fd5b60306044565b604051603b91906078565b60405180910390f35b5f3373ffffffffffffffffffffffffffffffffffffffff1631905090565b5f819050919050565b6072816062565b82525050565b5f60208201905060895f830184606b565b9291505056fea2646970667358221220c7d4fcf3078c2852b0165b9bde095a6b8e405c1cd68a1f19bd4bcdc33ec350d664736f6c63430008180033
+    gas 120468
+    build
+
+block_build b01
+    parent g00
+    transactions tx01
+    gasLimit 7500000
+    build
+
+block_connect b01
+
+
+# Assert best block
+assert_best b01

--- a/rskj-core/src/test/resources/dsl/eth_module/simple_contract.txt
+++ b/rskj-core/src/test/resources/dsl/eth_module/simple_contract.txt
@@ -1,0 +1,43 @@
+
+comment
+Simple contract created
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract SimpleStorage {
+    uint public storedData;
+
+    constructor() {
+        storedData = 10;
+    }
+
+    function get() public view returns (uint) {
+        return storedData;
+    }
+}
+
+end
+
+account_new acc1 20000000
+
+transaction_build tx01
+    sender acc1
+    receiverAddress 00
+    value 0
+    data 6080604052348015600e575f80fd5b50600a5f8190555060d8806100225f395ff3fe6080604052348015600e575f80fd5b50600436106030575f3560e01c80632a1afcd91460345780636d4ce63c14604e575b5f80fd5b603a6068565b60405160459190608b565b60405180910390f35b6054606d565b604051605f9190608b565b60405180910390f35b5f5481565b5f8054905090565b5f819050919050565b6085816075565b82525050565b5f602082019050609c5f830184607e565b9291505056fea2646970667358221220b4e997d985ec532ad9581a5a81d8812faea53a1735aab2d7ac8efcdc963d254664736f6c634300081a0033
+    gas 150742
+    build
+
+
+block_build b01
+    parent g00
+    transactions tx01
+    gasLimit 7500000
+    build
+
+block_connect b01
+
+# Assert best block
+assert_best b01
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Implements state override handling in EthModule to allow temporary account modifications during eth_call.

## Description
This PR introduces the necessary changes to support the state override feature in the EthModule. This allows modified account state (e.g., balance, nonce, code, or storage) to be temporarily applied when executing eth_call, without persisting those changes to the blockchain.

These changes are part of the effort to improve compatibility with Ethereum’s eth_call behavior and enable more advanced use cases such as contract testing and simulation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
