### PR TITLE
Changing the pipeline to release it also on master

### DIFF
--- a/.github/workflows/docker-release-master-to-edge.yml
+++ b/.github/workflows/docker-release-master-to-edge.yml
@@ -1,4 +1,4 @@
-name: Docker image release for edge from master
+name: Docker image release for edge and master tags from master
 
 on:
   push:
@@ -23,6 +23,7 @@ jobs:
           images: rsksmart/rskj
           tags: |
             type=edge
+            type=ref,event=branch
 
       - name: DockerHub login
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0


### PR DESCRIPTION
Fixing the docker release pipeline to update also `master` tag when there is a push on master.


## Motivation and Context
It solves the issue of generate master docker tag when we push to master.

## How Has This Been Tested?
It will be tested once we merge to master.

Testing locally it worked: https://github.com/rmoreliovlabs/rskj/actions/runs/14897575674/job/41842968609

<img width="1421" alt="Screenshot 2025-05-07 at 10 58 43 PM" src="https://github.com/user-attachments/assets/e3a4831f-a056-4339-a0b1-788d3a89a532" />

You can see that only `edge` and `master` have recent pushes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
