### PR TITLE
Add the abstractions for the math operations Secp256k1PrecompiledContract

### DIFF
--- a/rskj-core/src/main/java/co/rsk/pcc/secp256k1/Secp256k1PrecompiledContract.java
+++ b/rskj-core/src/main/java/co/rsk/pcc/secp256k1/Secp256k1PrecompiledContract.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2021 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.pcc.secp256k1;
+
+import org.ethereum.crypto.signature.Secp256k1Service;
+import org.ethereum.vm.PrecompiledContracts;
+import org.ethereum.vm.exception.VMException;
+
+import java.util.Optional;
+
+import static org.ethereum.util.ByteUtil.EMPTY_BYTE_ARRAY;
+
+public abstract class Secp256k1PrecompiledContract extends PrecompiledContracts.PrecompiledContract {
+    protected final Secp256k1Service secp256k1Service;
+
+    public Secp256k1PrecompiledContract(Secp256k1Service secp256k1Service) {
+        this.secp256k1Service = secp256k1Service;
+    }
+
+    @Override
+    public byte[] execute(byte[] data) throws VMException {
+        final var validatedData = Optional.ofNullable(data).orElse(EMPTY_BYTE_ARRAY);
+
+        return executeOperation(validatedData);
+    }
+
+    protected abstract byte[] executeOperation(byte[] data);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding the precompile contract abstract class that will be use to extend the `ADD` and `MUL` operations.

For more information see [**[RSKIP516](https://github.com/rsksmart/RSKIPs/blob/secp256k1/IPs/RSKIP516.md)**](https://github.com/rsksmart/RSKIPs/blob/secp256k1/IPs/RSKIP516.md)

## Motivation and Context

We want to introduce precompiles for point addition (ADD) and scalar multiplication (MUL) on the elliptic curve `secp256k1`. Having efficient operations on this curve is essential to enable musig2 functionality in contracts that need to coordinate the aggregation of signatures for Bitcoin transactions.

For more information see [**[RSKIP516](https://github.com/rsksmart/RSKIPs/blob/secp256k1/IPs/RSKIP516.md)**](https://github.com/rsksmart/RSKIPs/blob/secp256k1/IPs/RSKIP516.md)

## How Has This Been Tested?
N / A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
