### PR TITLE
Remove standard federation size validation

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/federation/StandardMultisigFederation.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/StandardMultisigFederation.java
@@ -35,8 +35,6 @@ public class StandardMultisigFederation extends Federation {
         int formatVersion) {
 
         super(federationArgs, formatVersion);
-
-        validateRedeemScriptSize();
     }
 
     @Override
@@ -44,12 +42,8 @@ public class StandardMultisigFederation extends Federation {
         if (redeemScript == null) {
             redeemScript = ScriptBuilder.createRedeemScript(getNumberOfSignaturesRequired(), getBtcPublicKeys());
         }
+        ScriptValidations.validateSizeOfRedeemScriptForScriptSig(redeemScript);
 
         return redeemScript;
-    }
-
-    private void validateRedeemScriptSize() {
-        Script redeemScript = this.getRedeemScript();
-        ScriptValidations.validateSizeOfRedeemScriptForScriptSig(redeemScript);
     }
 }


### PR DESCRIPTION
Remove standard federation script size validation on creation

## Description
Federations are always serialized and deserialized as standard multisig federations. Because the standard multisig information is the important data to keep in storage. ERP related information is obtained from the Bridge constants.

This is also true for P2WSH-P2SH federations, but these federation can now have up to 20 members. So the script size validation done in the creation of standard multisig federations needs to be moved to `getRedeemScript` method. Basically, no validation is done when creating the federation, only whn getting the redeem script

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
