### PR TITLE
Refactor `getAddress` to remove activations parameter

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/union/UnionBridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/union/UnionBridgeStorageProvider.java
@@ -7,7 +7,7 @@ import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 
 public interface UnionBridgeStorageProvider {
     void setAddress(RskAddress address);
-    Optional<RskAddress> getAddress(ActivationConfig.ForBlock activations);
+    Optional<RskAddress> getAddress();
     void setLockingCap(Coin lockingCap);
     Optional<Coin> getLockingCap(ActivationConfig.ForBlock activations);
     Optional<co.rsk.core.Coin> getWeisTransferredToUnionBridge(ActivationConfig.ForBlock activations);

--- a/rskj-core/src/main/java/co/rsk/peg/union/UnionBridgeStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/union/UnionBridgeStorageProviderImpl.java
@@ -66,16 +66,14 @@ public class UnionBridgeStorageProviderImpl implements UnionBridgeStorageProvide
     }
 
     @Override
-    public Optional<RskAddress> getAddress(ActivationConfig.ForBlock activations) {
-        if (!activations.isActive(ConsensusRule.RSKIP502)) {
-            return Optional.empty();
-        }
-
+    public Optional<RskAddress> getAddress() {
         return Optional.ofNullable(unionBridgeAddress).or(
-            () -> Optional.ofNullable(bridgeStorageAccessor.getFromRepository(
-                UnionBridgeStorageIndexKey.UNION_BRIDGE_CONTRACT_ADDRESS.getKey(),
-                BridgeSerializationUtils::deserializeRskAddress
-            ))
+            () -> Optional.ofNullable(
+                bridgeStorageAccessor.getFromRepository(
+                    UnionBridgeStorageIndexKey.UNION_BRIDGE_CONTRACT_ADDRESS.getKey(),
+                    BridgeSerializationUtils::deserializeRskAddress
+                )
+            )
         );
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/union/UnionBridgeSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/union/UnionBridgeSupportImpl.java
@@ -44,7 +44,7 @@ public class UnionBridgeSupportImpl implements UnionBridgeSupport {
             return constants.getAddress();
         }
 
-        return storageProvider.getAddress(activations).orElse(constants.getAddress());
+        return storageProvider.getAddress().orElse(constants.getAddress());
     }
 
     private boolean isCurrentEnvironmentMainnet() {
@@ -71,7 +71,7 @@ public class UnionBridgeSupportImpl implements UnionBridgeSupport {
             return UnionResponseCode.INVALID_VALUE;
         }
 
-        RskAddress currentUnionBridgeAddress = storageProvider.getAddress(activations).orElse(constants.getAddress());
+        RskAddress currentUnionBridgeAddress = getUnionBridgeContractAddress();
         if (isAddressAlreadyStored(currentUnionBridgeAddress, unionBridgeContractAddress)) {
             return UnionResponseCode.INVALID_VALUE;
         }

--- a/rskj-core/src/test/java/co/rsk/peg/union/UnionBridgeStorageProviderImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/union/UnionBridgeStorageProviderImplTest.java
@@ -44,25 +44,9 @@ class UnionBridgeStorageProviderImplTest {
     }
 
     @Test
-    void getAddress_beforeRSKIP502_shouldReturnEmpty() {
-        // Arrange
-        // To simulate, there is an address already stored
-        storageAccessor.saveToRepository(
-            UnionBridgeStorageIndexKey.UNION_BRIDGE_CONTRACT_ADDRESS.getKey(),
-            storedUnionBridgeContractAddress, BridgeSerializationUtils::serializeRskAddress);
-
-        // Act
-        Optional<RskAddress> unionBridgeAddress = unionBridgeStorageProvider.getAddress(lovell700);
-
-        // Assert
-        assertTrue(unionBridgeAddress.isEmpty());
-    }
-
-    @Test
     void getAddress_whenNoAddressStoredOrSet_shouldReturnEmpty() {
         // Act
-        Optional<RskAddress> unionBridgeAddress = unionBridgeStorageProvider.getAddress(
-            allActivations);
+        Optional<RskAddress> unionBridgeAddress = unionBridgeStorageProvider.getAddress();
 
         // Assert
         assertTrue(unionBridgeAddress.isEmpty());
@@ -76,8 +60,7 @@ class UnionBridgeStorageProviderImplTest {
             storedUnionBridgeContractAddress, BridgeSerializationUtils::serializeRskAddress);
 
         // Act
-        Optional<RskAddress> unionBridgeAddress = unionBridgeStorageProvider.getAddress(
-            allActivations);
+        Optional<RskAddress> unionBridgeAddress = unionBridgeStorageProvider.getAddress();
 
         // Assert
         assertTrue(unionBridgeAddress.isPresent());
@@ -90,8 +73,7 @@ class UnionBridgeStorageProviderImplTest {
         unionBridgeStorageProvider.setAddress(storedUnionBridgeContractAddress);
 
         // Act
-        Optional<RskAddress> unionBridgeAddress = unionBridgeStorageProvider.getAddress(
-            allActivations);
+        Optional<RskAddress> unionBridgeAddress = unionBridgeStorageProvider.getAddress();
 
         // Assert
         assertTrue(unionBridgeAddress.isPresent());
@@ -108,8 +90,7 @@ class UnionBridgeStorageProviderImplTest {
         unionBridgeStorageProvider.save(allActivations);
 
         // Act
-        Optional<RskAddress> actualUnionBridgeContractAddress = unionBridgeStorageProvider.getAddress(
-            allActivations);
+        Optional<RskAddress> actualUnionBridgeContractAddress = unionBridgeStorageProvider.getAddress();
 
         // Assert
         assertTrue(actualUnionBridgeContractAddress.isPresent());
@@ -142,7 +123,7 @@ class UnionBridgeStorageProviderImplTest {
 
         // Assert
         // Check existing address is still stored
-        Optional<RskAddress> actualAddress = unionBridgeStorageProvider.getAddress(allActivations);
+        Optional<RskAddress> actualAddress = unionBridgeStorageProvider.getAddress();
         assertTrue(actualAddress.isPresent());
         // Check stored address is the same as the one before
         assertGivenAddressIsStored(storedUnionBridgeContractAddress);
@@ -166,14 +147,14 @@ class UnionBridgeStorageProviderImplTest {
     @Test
     void setAddress_withoutSaving_shouldCachedTheAddressButNotStore() {
         // Arrange
-        Optional<RskAddress> initialAddress = unionBridgeStorageProvider.getAddress(allActivations);
+        Optional<RskAddress> initialAddress = unionBridgeStorageProvider.getAddress();
         assertTrue(initialAddress.isEmpty());
 
         // Act
         unionBridgeStorageProvider.setAddress(newUnionBridgeContractAddress);
 
         // Assert
-        Optional<RskAddress> actualAddress = unionBridgeStorageProvider.getAddress(allActivations);
+        Optional<RskAddress> actualAddress = unionBridgeStorageProvider.getAddress();
         assertTrue(actualAddress.isPresent());
         assertNoAddressIsStored();
     }
@@ -196,7 +177,7 @@ class UnionBridgeStorageProviderImplTest {
         unionBridgeStorageProvider.save(allActivations);
 
         // Assert
-        Optional<RskAddress> actualAddress = unionBridgeStorageProvider.getAddress(allActivations);
+        Optional<RskAddress> actualAddress = unionBridgeStorageProvider.getAddress();
         assertTrue(actualAddress.isEmpty());
 
         assertNoAddressIsStored();
@@ -210,15 +191,14 @@ class UnionBridgeStorageProviderImplTest {
         // Check that the address is not present in the storage nor in the cache
         assertNoAddressIsStored();
 
-        Optional<RskAddress> unionBridgeAddress = unionBridgeStorageProvider.getAddress(
-            allActivations);
+        Optional<RskAddress> unionBridgeAddress = unionBridgeStorageProvider.getAddress();
         assertTrue(unionBridgeAddress.isEmpty());
 
         // Set address
         unionBridgeStorageProvider.setAddress(newUnionBridgeContractAddress);
 
         // Check that the address is now present in the cache
-        Optional<RskAddress> cachedAddress = unionBridgeStorageProvider.getAddress(allActivations);
+        Optional<RskAddress> cachedAddress = unionBridgeStorageProvider.getAddress();
         assertTrue(cachedAddress.isPresent());
         assertEquals(newUnionBridgeContractAddress, cachedAddress.get());
 
@@ -238,8 +218,7 @@ class UnionBridgeStorageProviderImplTest {
 
         // Act & Assert
         // Check that union address is present in the storage
-        Optional<RskAddress> unionBridgeAddress = unionBridgeStorageProvider.getAddress(
-            allActivations);
+        Optional<RskAddress> unionBridgeAddress = unionBridgeStorageProvider.getAddress();
         assertTrue(unionBridgeAddress.isPresent());
         assertEquals(storedUnionBridgeContractAddress, unionBridgeAddress.get());
 
@@ -253,7 +232,7 @@ class UnionBridgeStorageProviderImplTest {
         assertEquals(storedUnionBridgeContractAddress, originalAddress);
         assertNotEquals(newUnionBridgeContractAddress, originalAddress);
 
-        Optional<RskAddress> cachedAddress = unionBridgeStorageProvider.getAddress(allActivations);
+        Optional<RskAddress> cachedAddress = unionBridgeStorageProvider.getAddress();
         assertTrue(cachedAddress.isPresent());
         assertEquals(newUnionBridgeContractAddress, cachedAddress.get());
 

--- a/rskj-core/src/test/java/co/rsk/peg/union/UnionBridgeSupportImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/union/UnionBridgeSupportImplTest.java
@@ -87,23 +87,6 @@ class UnionBridgeSupportImplTest {
         );
     }
 
-    @Test
-    void getUnionBridgeContractAddress_beforeRSKIP502_shouldReturnConstantAddress() {
-        // arrange
-        unionBridgeSupport = unionBridgeSupportBuilder
-            .withConstants(unionBridgeConstants)
-            .withActivations(lovell700)
-            .build();
-
-        // act
-        RskAddress actualUnionBridgeContractAddress = unionBridgeSupport.getUnionBridgeContractAddress();
-
-        // assert
-        RskAddress expectedUnionBridgeContractAddress = unionBridgeConstants.getAddress();
-        Assertions.assertEquals(expectedUnionBridgeContractAddress, actualUnionBridgeContractAddress);
-        assertNoAddressIsStored();
-    }
-
     @ParameterizedTest
     @MethodSource("unionBridgeConstantsProvider")
     void getUnionBridgeContractAddress_whenNoStoredAddress_shouldReturnConstantAddress(
@@ -223,7 +206,7 @@ class UnionBridgeSupportImplTest {
     }
 
     private void assertAddressWasSet(RskAddress expectedAddress) {
-        Optional<RskAddress> actualAddress = unionBridgeStorageProvider.getAddress(allActivations);
+        Optional<RskAddress> actualAddress = unionBridgeStorageProvider.getAddress();
         Assertions.assertTrue(actualAddress.isPresent());
         Assertions.assertEquals(expectedAddress, actualAddress.get());
     }
@@ -252,7 +235,7 @@ class UnionBridgeSupportImplTest {
     }
 
     private void assertAddressWasNotSet(ActivationConfig.ForBlock activations) {
-        Optional<RskAddress> actualAddress = unionBridgeStorageProvider.getAddress(activations);
+        Optional<RskAddress> actualAddress = unionBridgeStorageProvider.getAddress();
         Assertions.assertTrue(actualAddress.isEmpty());
     }
 


### PR DESCRIPTION
Get rid of activations in union storage get address

## How Has This Been Tested?

Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)
