### PR TITLE
Consider P2shP2wsh federation in PegUtilsLegacy::isPegoutTx

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
@@ -49,7 +49,7 @@ class PegUtilsLegacyTest {
         // Peg-in is for the genesis federation ATM
         Context btcContext = new Context(networkParameters);
         Federation federation = getErpFederationWithPrivKeys(networkParameters, REGTEST_FEDERATION_PRIVATE_KEYS);
-        Wallet wallet = new BridgeBtcWallet(btcContext, Collections.singletonList(federation));
+        Wallet wallet = new BridgeBtcWallet(btcContext, List.of(federation));
         Address federationAddress = federation.getAddress();
         wallet.addWatchedAddress(federationAddress, federation.getCreationTime().toEpochMilli());
         when(activations.isActive(any(ConsensusRule.class))).thenReturn(false);
@@ -102,7 +102,7 @@ class PegUtilsLegacyTest {
         tx.addOutput(minimumPegInValueAfterIris.subtract(Coin.CENT), federation.getAddress());
         tx.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(federation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(federation));
         assertFalse(isValidPegInTx(tx, federation, federationWallet, bridgeConstantsRegtest, activations));
     }
 
@@ -126,7 +126,7 @@ class PegUtilsLegacyTest {
         tx.addInput(txIn);
         signWithNecessaryKeys(federation, REGTEST_FEDERATION_PRIVATE_KEYS, txIn, tx);
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(federation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(federation));
         assertFalse(isValidPegInTx(tx, federation, federationWallet, bridgeConstantsRegtest, activations));
     }
 
@@ -142,7 +142,7 @@ class PegUtilsLegacyTest {
         tx.addOutput(Coin.FIFTY_COINS, federation.getAddress());
         tx.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(federation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(federation));
         assertTrue(isValidPegInTx(tx, federation, federationWallet, bridgeConstantsMainnet, activations));
     }
 
@@ -166,7 +166,7 @@ class PegUtilsLegacyTest {
         tx.addOutput(valueLock, federation.getAddress());
         tx.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(federation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(federation));
         assertFalse(isValidPegInTx(tx, federation, federationWallet, bridgeConstantsMainnet, activations));
     }
 
@@ -189,7 +189,7 @@ class PegUtilsLegacyTest {
         tx.addOutput(valueLock, federation.getAddress());
         tx.addInput(Sha256Hash.ZERO_HASH, 0, new Script(new byte[]{}));
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(federation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(federation));
         assertTrue(isValidPegInTx(tx, federation, federationWallet, bridgeConstantsMainnet, activations));
     }
 
@@ -386,7 +386,7 @@ class PegUtilsLegacyTest {
         signWithNecessaryKeys(federation1, federation1Keys, txIn, tx2);
         assertFalse(isValidPegInTx(
             tx2,
-            Collections.singletonList(federation2),
+            List.of(federation2),
             federation1.getP2SHScript(),
             federationsWallet,
             minimumPeginTxValue,
@@ -493,7 +493,7 @@ class PegUtilsLegacyTest {
         tx.addOutput(Coin.COIN, activeFederation.getAddress());
         tx.addInput(Sha256Hash.ZERO_HASH, 0, flyoverRedeemScript);
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(activeFederation));
 
         Assertions.assertTrue(isValidPegInTx(tx, activeFederation, federationWallet,
             bridgeConstantsMainnet, activations));
@@ -519,7 +519,7 @@ class PegUtilsLegacyTest {
         Script flyoverInputScriptSig = ScriptBuilder.createP2SHMultiSigInputScript(null, flyoverRedeemScript);
         tx.addInput(Sha256Hash.ZERO_HASH, 0, flyoverInputScriptSig);
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(activeFederation));
         Assertions.assertFalse(isValidPegInTx(tx, activeFederation, federationWallet,
             bridgeConstantsMainnet, activations));
     }
@@ -554,7 +554,7 @@ class PegUtilsLegacyTest {
         tx.addOutput(Coin.COIN, activeFederation.getAddress());
         tx.addInput(Sha256Hash.ZERO_HASH, 0, flyoverNonStandardRedeemScript);
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(activeFederation));
 
         Assertions.assertTrue(isValidPegInTx(
             tx,
@@ -606,7 +606,7 @@ class PegUtilsLegacyTest {
         Script flyoverInputScriptSig = ScriptBuilder.createP2SHMultiSigInputScript(null, flyoverNonStandardRedeemScript);
         tx.addInput(Sha256Hash.ZERO_HASH, 0, flyoverInputScriptSig);
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(activeFederation));
 
         Assertions.assertFalse(isValidPegInTx(
             tx,
@@ -656,7 +656,7 @@ class PegUtilsLegacyTest {
         tx.addOutput(Coin.COIN, activeFederation.getAddress());
         tx.addInput(Sha256Hash.ZERO_HASH, 0, erpRedeemScript);
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(activeFederation));
 
         Assertions.assertTrue(isValidPegInTx(tx, activeFederation, federationWallet,
             bridgeConstantsRegtest, activations));
@@ -703,7 +703,7 @@ class PegUtilsLegacyTest {
         Script flyoverInputScriptSig = ScriptBuilder.createP2SHMultiSigInputScript(null, erpRedeemScript);
         tx.addInput(Sha256Hash.ZERO_HASH, 0, flyoverInputScriptSig);
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(activeFederation));
 
         Assertions.assertFalse(isValidPegInTx(tx, activeFederation, federationWallet,
             bridgeConstantsRegtest, activations));
@@ -749,11 +749,11 @@ class PegUtilsLegacyTest {
 
         signWithNecessaryKeys(retiredFederation, flyoverRedeemScript, retiredFederationKeys, txInput, tx);
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(activeFederation));
 
         assertTrue(isValidPegInTx(
             tx,
-            Collections.singletonList(activeFederation),
+            List.of(activeFederation),
             retiredFederation.getP2SHScript(),
             federationWallet,
             bridgeConstantsRegtest.getMinimumPeginTxValue(activations),
@@ -801,11 +801,11 @@ class PegUtilsLegacyTest {
 
         signWithNecessaryKeys(retiredFederation, flyoverRedeemScript, retiredFederationKeys, txInput, tx);
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(activeFederation));
 
         assertFalse(isValidPegInTx(
             tx,
-            Collections.singletonList(activeFederation),
+            List.of(activeFederation),
             retiredFederation.getP2SHScript(),
             federationWallet,
             bridgeConstantsRegtest.getMinimumPeginTxValue(activations),
@@ -856,11 +856,11 @@ class PegUtilsLegacyTest {
 
         signWithNecessaryKeys(nonStandardErpFederation, flyoverNonStandardRedeemScript, retiredFederationKeys, txInput, tx);
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(activeFederation));
 
         assertTrue(isValidPegInTx(
             tx,
-            Collections.singletonList(activeFederation),
+            List.of(activeFederation),
             retiredFederation.getP2SHScript(),
             federationWallet,
             bridgeConstantsRegtest.getMinimumPeginTxValue(activations),
@@ -911,11 +911,11 @@ class PegUtilsLegacyTest {
 
         signWithNecessaryKeys(nonStandardErpFederation, flyoverNonStandardRedeemScript, retiredFederationKeys, txInput, tx);
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(activeFederation));
 
         assertFalse(isValidPegInTx(
             tx,
-            Collections.singletonList(activeFederation),
+            List.of(activeFederation),
             retiredFederation.getP2SHScript(),
             federationWallet,
             bridgeConstantsRegtest.getMinimumPeginTxValue(activations),
@@ -959,11 +959,11 @@ class PegUtilsLegacyTest {
         tx.addInput(txInput);
         signWithErpFederation(nonStandardErpFederation, retiredFederationKeys, txInput, tx);
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(activeFederation));
 
         assertTrue(isValidPegInTx(
             tx,
-            Collections.singletonList(activeFederation),
+            List.of(activeFederation),
             retiredFederation.getP2SHScript(),
             federationWallet,
             bridgeConstantsRegtest.getMinimumPeginTxValue(activations),
@@ -1008,11 +1008,11 @@ class PegUtilsLegacyTest {
         tx.addInput(txInput);
         signWithErpFederation(nonStandardErpFederation, retiredFederationKeys, txInput, tx);
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(activeFederation));
 
         assertFalse(isValidPegInTx(
             tx,
-            Collections.singletonList(activeFederation),
+            List.of(activeFederation),
             retiredFederation.getP2SHScript(),
             federationWallet,
             bridgeConstantsRegtest.getMinimumPeginTxValue(activations),
@@ -1035,11 +1035,11 @@ class PegUtilsLegacyTest {
         tx.addOutput(minimumPeginValue.div(4), activeFederation.getAddress());
         tx.addOutput(minimumPeginValue.div(4), activeFederation.getAddress());
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(activeFederation));
 
         assertTrue(isValidPegInTx(
             tx,
-            Collections.singletonList(activeFederation),
+            List.of(activeFederation),
             null,
             federationWallet,
             minimumPeginValue,
@@ -1062,11 +1062,11 @@ class PegUtilsLegacyTest {
         tx.addOutput(minimumPeginValue.div(4), activeFederation.getAddress());
         tx.addOutput(minimumPeginValue.div(5), activeFederation.getAddress());
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(activeFederation));
 
         assertFalse(isValidPegInTx(
             tx,
-            Collections.singletonList(activeFederation),
+            List.of(activeFederation),
             null,
             federationWallet,
             bridgeConstantsMainnet.getMinimumPeginTxValue(activations),
@@ -1093,11 +1093,11 @@ class PegUtilsLegacyTest {
         tx.addOutput(minimumPeginValue, activeFederation.getAddress());
         tx.addOutput(aboveMinimumPeginValue, activeFederation.getAddress());
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(activeFederation));
 
         assertFalse(isValidPegInTx(
             tx,
-            Collections.singletonList(activeFederation),
+            List.of(activeFederation),
             null,
             federationWallet,
             minimumPeginValue,
@@ -1117,11 +1117,11 @@ class PegUtilsLegacyTest {
         BtcTransaction tx = new BtcTransaction(bridgeConstantsMainnet.getBtcParams());
         tx.addOutput(minimumPeginValue, activeFederation.getAddress());
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(activeFederation));
 
         assertTrue(isValidPegInTx(
             tx,
-            Collections.singletonList(activeFederation),
+            List.of(activeFederation),
             null,
             federationWallet,
             minimumPeginValue,
@@ -1212,7 +1212,7 @@ class PegUtilsLegacyTest {
             inputScriptSig
         );
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(activeFederation));
 
         assertEquals(expectedResult, isValidPegInTx(
             tx,
@@ -1284,7 +1284,7 @@ class PegUtilsLegacyTest {
         migrationTx.addInput(migrationTxInput);
         signWithNecessaryKeys(retiredFederation, retiredFederationKeys, migrationTxInput, migrationTx);
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(activeFederation));
 
         FederationContext federationContext = FederationContext.builder()
             .withActiveFederation(activeFederation)
@@ -1338,7 +1338,7 @@ class PegUtilsLegacyTest {
         List<FederationMember> activeFedMembers = getFederationMembersWithBtcKeys(activeFederationKeys);
         FederationArgs activeFedArgs =
             new FederationArgs(activeFedMembers, creationTime, 1L, btcParams);
-        
+
         Federation activeFederation = FederationFactory.buildP2shErpFederation(activeFedArgs, erpPubKeys, activationDelay);
 
         Address activeFederationAddress = activeFederation.getAddress();
@@ -1478,7 +1478,7 @@ class PegUtilsLegacyTest {
         migrationTx.addInput(migrationTxInput);
         signWithNecessaryKeys(retiringFederation, retiringFederationKeys, migrationTxInput, migrationTx);
 
-        Wallet federationWallet = new BridgeBtcWallet(btcContext, Collections.singletonList(activeFederation));
+        Wallet federationWallet = new BridgeBtcWallet(btcContext, List.of(activeFederation));
 
         FederationContext federationContext = FederationContext.builder()
             .withActiveFederation(activeFederation)
@@ -1800,7 +1800,7 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fa01")),
             BtcECKey.fromPrivate(Hex.decode("fa02")),
             BtcECKey.fromPrivate(Hex.decode("fa03"))
-        ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
+        ).sorted(BtcECKey.PUBKEY_COMPARATOR).toList();
         FederationArgs args = new FederationArgs(getFederationMembersWithBtcKeys(activeFederationKeys),
             Instant.ofEpochMilli(2000L),
             2L,
@@ -1809,7 +1809,7 @@ class PegUtilsLegacyTest {
         Federation federation2 = FederationFactory.buildStandardMultiSigFederation(
             args
         );
-        Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(bridgeConstantsRegtest.getBtcParams());
+        Address randomAddress = BitcoinTestUtils.createP2PKHAddress(bridgeConstantsRegtest.getBtcParams(), "randomAddress");
 
         BtcTransaction pegOutTx1 = new BtcTransaction(networkParameters);
         pegOutTx1.addOutput(Coin.COIN, randomAddress);
@@ -1822,13 +1822,13 @@ class PegUtilsLegacyTest {
         pegOutTx1.addInput(pegOutInput1);
         signWithNecessaryKeys(federation, REGTEST_FEDERATION_PRIVATE_KEYS, pegOutInput1, pegOutTx1);
 
-        assertTrue(isPegOutTx(pegOutTx1, Collections.singletonList(federation), activations));
+        assertTrue(isPegOutTx(pegOutTx1, List.of(federation), activations));
         assertTrue(isPegOutTx(pegOutTx1, Arrays.asList(federation, federation2), activations));
-        assertFalse(isPegOutTx(pegOutTx1, Collections.singletonList(federation2), activations));
+        assertFalse(isPegOutTx(pegOutTx1, List.of(federation2), activations));
 
-        assertTrue(isPegOutTx(pegOutTx1, activations, federation.getP2SHScript()));
-        assertTrue(isPegOutTx(pegOutTx1, activations, federation.getP2SHScript(), federation2.getP2SHScript()));
-        assertFalse(isPegOutTx(pegOutTx1, activations, federation2.getP2SHScript()));
+        assertTrue(isPegOutTx(pegOutTx1, activations, List.of(federation.getP2SHScript())));
+        assertTrue(isPegOutTx(pegOutTx1, activations, Arrays.asList(federation.getP2SHScript(), federation2.getP2SHScript())));
+        assertFalse(isPegOutTx(pegOutTx1, activations, List.of(federation2.getP2SHScript())));
     }
 
     @Test
@@ -1873,24 +1873,24 @@ class PegUtilsLegacyTest {
         // Before RSKIP 201 activation
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(false);
 
-        assertFalse(isPegOutTx(pegOutTx1, Collections.singletonList(standardMultisigFederation), activations));
+        assertFalse(isPegOutTx(pegOutTx1, List.of(standardMultisigFederation), activations));
         assertFalse(isPegOutTx(pegOutTx1, Arrays.asList(standardMultisigFederation, standardFederation), activations));
-        assertFalse(isPegOutTx(pegOutTx1, Collections.singletonList(standardFederation), activations));
+        assertFalse(isPegOutTx(pegOutTx1, List.of(standardFederation), activations));
 
-        assertFalse(isPegOutTx(pegOutTx1, activations, standardMultisigFederation.getP2SHScript()));
-        assertFalse(isPegOutTx(pegOutTx1, activations, standardMultisigFederation.getP2SHScript(), standardFederation.getP2SHScript()));
-        assertFalse(isPegOutTx(pegOutTx1, activations, standardFederation.getP2SHScript()));
+        assertFalse(isPegOutTx(pegOutTx1, activations, List.of(standardMultisigFederation.getP2SHScript())));
+        assertFalse(isPegOutTx(pegOutTx1, activations, Arrays.asList(standardMultisigFederation.getP2SHScript(), standardFederation.getP2SHScript())));
+        assertFalse(isPegOutTx(pegOutTx1, activations, List.of(standardFederation.getP2SHScript())));
 
         // After RSKIP 201 activation
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
 
-        assertTrue(isPegOutTx(pegOutTx1, Collections.singletonList(standardMultisigFederation), activations));
+        assertTrue(isPegOutTx(pegOutTx1, List.of(standardMultisigFederation), activations));
         assertTrue(isPegOutTx(pegOutTx1, Arrays.asList(standardMultisigFederation, standardFederation), activations));
-        assertFalse(isPegOutTx(pegOutTx1, Collections.singletonList(standardFederation), activations));
+        assertFalse(isPegOutTx(pegOutTx1, List.of(standardFederation), activations));
 
-        assertTrue(isPegOutTx(pegOutTx1, activations, standardMultisigFederation.getP2SHScript()));
-        assertTrue(isPegOutTx(pegOutTx1, activations, standardMultisigFederation.getP2SHScript(), standardFederation.getP2SHScript()));
-        assertFalse(isPegOutTx(pegOutTx1, activations, standardFederation.getP2SHScript()));
+        assertTrue(isPegOutTx(pegOutTx1, activations, List.of(standardMultisigFederation.getP2SHScript())));
+        assertTrue(isPegOutTx(pegOutTx1, activations, Arrays.asList(standardMultisigFederation.getP2SHScript(), standardFederation.getP2SHScript())));
+        assertFalse(isPegOutTx(pegOutTx1, activations, List.of(standardFederation.getP2SHScript())));
     }
 
     @Test
@@ -1932,30 +1932,30 @@ class PegUtilsLegacyTest {
         // Before RSKIP 201 activation
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(false);
 
-        assertFalse(isPegOutTx(pegOutTx1, Collections.singletonList(defaultFederation), activations));
+        assertFalse(isPegOutTx(pegOutTx1, List.of(defaultFederation), activations));
         assertFalse(isPegOutTx(pegOutTx1, Arrays.asList(defaultFederation, standardFederation), activations));
-        assertFalse(isPegOutTx(pegOutTx1, Collections.singletonList(standardFederation), activations));
+        assertFalse(isPegOutTx(pegOutTx1, List.of(standardFederation), activations));
 
-        assertFalse(isPegOutTx(pegOutTx1, activations, defaultFederation.getP2SHScript()));
-        assertFalse(isPegOutTx(pegOutTx1, activations, defaultFederation.getP2SHScript(), standardFederation.getP2SHScript()));
-        assertFalse(isPegOutTx(pegOutTx1, activations, standardFederation.getP2SHScript()));
+        assertFalse(isPegOutTx(pegOutTx1, activations, List.of(defaultFederation.getP2SHScript())));
+        assertFalse(isPegOutTx(pegOutTx1, activations, Arrays.asList(defaultFederation.getP2SHScript(), standardFederation.getP2SHScript())));
+        assertFalse(isPegOutTx(pegOutTx1, activations, List.of(standardFederation.getP2SHScript())));
 
-        assertFalse(isPegOutTx(pegOutTx1, Collections.singletonList(nonStandardErpFederation), activations));
-        assertFalse(isPegOutTx(pegOutTx1, activations, nonStandardErpFederation.getDefaultP2SHScript()));
+        assertFalse(isPegOutTx(pegOutTx1, List.of(nonStandardErpFederation), activations));
+        assertFalse(isPegOutTx(pegOutTx1, activations, List.of(nonStandardErpFederation.getDefaultP2SHScript())));
 
         // After RSKIP 201 activation
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
 
-        assertTrue(isPegOutTx(pegOutTx1, Collections.singletonList(defaultFederation), activations));
+        assertTrue(isPegOutTx(pegOutTx1, List.of(defaultFederation), activations));
         assertTrue(isPegOutTx(pegOutTx1, Arrays.asList(defaultFederation, standardFederation), activations));
-        assertFalse(isPegOutTx(pegOutTx1, Collections.singletonList(standardFederation), activations));
+        assertFalse(isPegOutTx(pegOutTx1, List.of(standardFederation), activations));
 
-        assertTrue(isPegOutTx(pegOutTx1, activations, defaultFederation.getP2SHScript()));
-        assertTrue(isPegOutTx(pegOutTx1, activations, defaultFederation.getP2SHScript(), standardFederation.getP2SHScript()));
-        assertFalse(isPegOutTx(pegOutTx1, activations, standardFederation.getP2SHScript()));
+        assertTrue(isPegOutTx(pegOutTx1, activations, List.of(defaultFederation.getP2SHScript())));
+        assertTrue(isPegOutTx(pegOutTx1, activations, Arrays.asList(defaultFederation.getP2SHScript(), standardFederation.getP2SHScript())));
+        assertFalse(isPegOutTx(pegOutTx1, activations, List.of(standardFederation.getP2SHScript())));
 
-        assertTrue(isPegOutTx(pegOutTx1, Collections.singletonList(nonStandardErpFederation), activations));
-        assertTrue(isPegOutTx(pegOutTx1, activations, nonStandardErpFederation.getDefaultP2SHScript()));
+        assertTrue(isPegOutTx(pegOutTx1, List.of(nonStandardErpFederation), activations));
+        assertTrue(isPegOutTx(pegOutTx1, activations, List.of(nonStandardErpFederation.getDefaultP2SHScript())));
     }
 
     @Test
@@ -2004,24 +2004,24 @@ class PegUtilsLegacyTest {
         // Before RSKIP 201 activation
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(false);
 
-        assertFalse(isPegOutTx(pegOutTx1, Collections.singletonList(defaultFederation), activations));
-        assertFalse(isPegOutTx(pegOutTx1, Arrays.asList(defaultFederation, standardFederation), activations));
-        assertFalse(isPegOutTx(pegOutTx1, Collections.singletonList(standardFederation), activations));
+        assertFalse(isPegOutTx(pegOutTx1, List.of(defaultFederation), activations));
+        assertFalse(isPegOutTx(pegOutTx1, List.of(defaultFederation, standardFederation), activations));
+        assertFalse(isPegOutTx(pegOutTx1, List.of(standardFederation), activations));
 
-        assertFalse(isPegOutTx(pegOutTx1, activations, defaultFederation.getP2SHScript()));
-        assertFalse(isPegOutTx(pegOutTx1, activations, defaultFederation.getP2SHScript(), standardFederation.getP2SHScript()));
-        assertFalse(isPegOutTx(pegOutTx1, activations, standardFederation.getP2SHScript()));
+        assertFalse(isPegOutTx(pegOutTx1, activations, List.of(defaultFederation.getP2SHScript())));
+        assertFalse(isPegOutTx(pegOutTx1, activations, List.of(defaultFederation.getP2SHScript(), standardFederation.getP2SHScript())));
+        assertFalse(isPegOutTx(pegOutTx1, activations, List.of(standardFederation.getP2SHScript())));
 
         // After RSKIP 201 activation
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
 
-        assertTrue(isPegOutTx(pegOutTx1, Collections.singletonList(defaultFederation), activations));
-        assertTrue(isPegOutTx(pegOutTx1, Arrays.asList(defaultFederation, standardFederation), activations));
-        assertFalse(isPegOutTx(pegOutTx1, Collections.singletonList(standardFederation), activations));
+        assertTrue(isPegOutTx(pegOutTx1, List.of(defaultFederation), activations));
+        assertTrue(isPegOutTx(pegOutTx1, List.of(defaultFederation, standardFederation), activations));
+        assertFalse(isPegOutTx(pegOutTx1, List.of(standardFederation), activations));
 
-        assertTrue(isPegOutTx(pegOutTx1, activations, defaultFederation.getP2SHScript()));
-        assertTrue(isPegOutTx(pegOutTx1, activations, defaultFederation.getP2SHScript(), standardFederation.getP2SHScript()));
-        assertFalse(isPegOutTx(pegOutTx1, activations, standardFederation.getP2SHScript()));
+        assertTrue(isPegOutTx(pegOutTx1, activations, List.of(defaultFederation.getP2SHScript())));
+        assertTrue(isPegOutTx(pegOutTx1, activations, List.of(defaultFederation.getP2SHScript(), standardFederation.getP2SHScript())));
+        assertFalse(isPegOutTx(pegOutTx1, activations, List.of(standardFederation.getP2SHScript())));
     }
 
     @Test
@@ -2039,7 +2039,7 @@ class PegUtilsLegacyTest {
         );
         pegOutTx1.addInput(pegOutInput1);
 
-        assertFalse(isPegOutTx(pegOutTx1, Collections.singletonList(federation), activations));
+        assertFalse(isPegOutTx(pegOutTx1, List.of(federation), activations));
     }
 
     @Test
@@ -2058,7 +2058,7 @@ class PegUtilsLegacyTest {
         );
         pegOutTx1.addInput(pegOutInput1);
 
-        assertFalse(isPegOutTx(pegOutTx1, Collections.singletonList(federation), activations));
+        assertFalse(isPegOutTx(pegOutTx1, List.of(federation), activations));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsLegacyTest.java
@@ -45,7 +45,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx() {
+    void isValidPegInTx_withGenesisFederation() {
         // Peg-in is for the genesis federation ATM
         Context btcContext = new Context(networkParameters);
         Federation federation = getErpFederationWithPrivKeys(networkParameters, REGTEST_FEDERATION_PRIVATE_KEYS);
@@ -89,7 +89,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_less_than_minimum_not_pegin_after_iris() {
+    void isValidPegInTx_less_than_minimum_not_pegin_after_iris() {
         // Tx sending less than the minimum allowed, not a peg-in tx
         Context btcContext = new Context(networkParameters);
         Federation federation = getErpFederationWithPrivKeys(networkParameters, REGTEST_FEDERATION_PRIVATE_KEYS);
@@ -107,7 +107,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_spending_from_federation_is_pegout_after_iris() {
+    void isValidPegInTx_spending_from_federation_is_pegout_after_iris() {
         // Tx sending 1 btc to the federation, but also spending from the federation address,
         // the typical peg-out tx, not a peg-in tx.
         Context btcContext = new Context(networkParameters);
@@ -131,7 +131,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_sending_50_btc_after_iris() {
+    void isValidPegInTx_sending_50_btc_after_iris() {
         // Tx sending 50 btc to the federation, is a peg-in tx
         Context btcContext = new Context(bridgeConstantsMainnet.getBtcParams());
         Federation federation = getErpFederationWithPrivKeys(networkParameters, REGTEST_FEDERATION_PRIVATE_KEYS);
@@ -147,7 +147,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_value_between_old_and_new_before_iris() {
+    void isValidPegInTx_value_between_old_and_new_before_iris() {
         // Tx sending btc between old and new value, it is not a peg-in before iris
         Context btcContext = new Context(bridgeConstantsMainnet.getBtcParams());
         Federation federation = getErpFederationWithPrivKeys(networkParameters, REGTEST_FEDERATION_PRIVATE_KEYS);
@@ -171,7 +171,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_value_between_old_and_new_after_iris() {
+    void isValidPegInTx_value_between_old_and_new_after_iris() {
         // Tx sending btc between old and new value, it is a peg-in after iris
         Context btcContext = new Context(bridgeConstantsMainnet.getBtcParams());
         Federation federation = getErpFederationWithPrivKeys(networkParameters, REGTEST_FEDERATION_PRIVATE_KEYS);
@@ -194,7 +194,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTxForTwoFederations() {
+    void isValidPegInTxForTwoFederations() {
         when(activations.isActive(any(ConsensusRule.class))).thenReturn(false);
 
         Context btcContext = new Context(networkParameters);
@@ -476,7 +476,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_hasChangeUtxoFromFlyoverFederation_beforeRskip201_isPegin() {
+    void isValidPegInTx_hasChangeUtxoFromFlyoverFederation_beforeRskip201_isPegin() {
         Context btcContext = new Context(bridgeConstantsMainnet.getBtcParams());
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(false);
 
@@ -500,7 +500,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_hasChangeUtxoFromFlyoverFederation_afterRskip201_notPegin() {
+    void isValidPegInTx_hasChangeUtxoFromFlyoverFederation_afterRskip201_notPegin() {
         Context btcContext = new Context(bridgeConstantsMainnet.getBtcParams());
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
 
@@ -525,7 +525,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_hasChangeUtxoFromFlyoverErpFederation_beforeRskip201_isPegin() {
+    void isValidPegInTx_hasChangeUtxoFromFlyoverErpFederation_beforeRskip201_isPegin() {
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(false);
 
         Context btcContext = new Context(networkParameters);
@@ -566,7 +566,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_hasChangeUtxoFromFlyoverErpFederation_afterRskip201_notPegin() {
+    void isValidPegInTx_hasChangeUtxoFromFlyoverErpFederation_afterRskip201_notPegin() {
         Context btcContext = new Context(networkParameters);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
 
@@ -618,7 +618,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_hasChangeUtxoFromErpFederation_beforeRskip201_isPegin() {
+    void isValidPegInTx_hasChangeUtxoFromErpFederation_beforeRskip201_isPegin() {
         Context btcContext = new Context(networkParameters);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(false);
 
@@ -663,7 +663,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_hasChangeUtxoFromErpFederation_afterRskip201_notPegin() {
+    void isValidPegInTx_hasChangeUtxoFromErpFederation_afterRskip201_notPegin() {
         Context btcContext = new Context(networkParameters);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
 
@@ -710,7 +710,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_hasChangeUtxoFromFlyoverRetiredFederation_beforeRskip201_isPegin() {
+    void isValidPegInTx_hasChangeUtxoFromFlyoverRetiredFederation_beforeRskip201_isPegin() {
         Context btcContext = new Context(networkParameters);
         Federation activeFederation = getErpFederationWithPrivKeys(networkParameters, REGTEST_FEDERATION_PRIVATE_KEYS);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(false);
@@ -762,7 +762,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_hasChangeUtxoFromFlyoverRetiredFederation_afterRskip201_notPegin() {
+    void isValidPegInTx_hasChangeUtxoFromFlyoverRetiredFederation_afterRskip201_notPegin() {
         Context btcContext = new Context(networkParameters);
         Federation activeFederation = getErpFederationWithPrivKeys(networkParameters, REGTEST_FEDERATION_PRIVATE_KEYS);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
@@ -814,7 +814,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_hasChangeUtxoFromFlyoverErpRetiredFederation_beforeRskip201_isPegin() {
+    void isValidPegInTx_hasChangeUtxoFromFlyoverErpRetiredFederation_beforeRskip201_isPegin() {
         Context btcContext = new Context(networkParameters);
         Federation activeFederation = getErpFederationWithPrivKeys(networkParameters, REGTEST_FEDERATION_PRIVATE_KEYS);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(false);
@@ -869,7 +869,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_hasChangeUtxoFromFlyoverErpRetiredFederation_afterRskip201_notPegin() {
+    void isValidPegInTx_hasChangeUtxoFromFlyoverErpRetiredFederation_afterRskip201_notPegin() {
         Context btcContext = new Context(networkParameters);
         Federation activeFederation = getErpFederationWithPrivKeys(networkParameters, REGTEST_FEDERATION_PRIVATE_KEYS);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
@@ -924,7 +924,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_hasChangeUtxoFromErpRetiredFederation_beforeRskip201_isPegin() {
+    void isValidPegInTx_hasChangeUtxoFromErpRetiredFederation_beforeRskip201_isPegin() {
         Context btcContext = new Context(networkParameters);
         Federation activeFederation = getErpFederationWithPrivKeys(networkParameters, REGTEST_FEDERATION_PRIVATE_KEYS);
 
@@ -972,7 +972,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_hasChangeUtxoFromErpRetiredFederation_afterRskip201_notPegin() {
+    void isValidPegInTx_hasChangeUtxoFromErpRetiredFederation_afterRskip201_notPegin() {
         Context btcContext = new Context(networkParameters);
         Federation activeFederation = getErpFederationWithPrivKeys(networkParameters, REGTEST_FEDERATION_PRIVATE_KEYS);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
@@ -1021,7 +1021,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_has_multiple_utxos_below_minimum_but_total_amount_is_ok_before_RSKIP293() {
+    void isValidPegInTx_has_multiple_utxos_below_minimum_but_total_amount_is_ok_before_RSKIP293() {
         Context btcContext = new Context(bridgeConstantsMainnet.getBtcParams());
         Federation activeFederation = getErpFederationWithPrivKeys(networkParameters, REGTEST_FEDERATION_PRIVATE_KEYS);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
@@ -1048,7 +1048,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_has_utxos_below_minimum_and_total_amount_as_well_before_RSKIP293() {
+    void isValidPegInTx_has_utxos_below_minimum_and_total_amount_as_well_before_RSKIP293() {
         Context btcContext = new Context(bridgeConstantsMainnet.getBtcParams());
         Federation activeFederation = getErpFederationWithPrivKeys(networkParameters, REGTEST_FEDERATION_PRIVATE_KEYS);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
@@ -1075,7 +1075,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_has_utxos_below_minimum_after_RSKIP293() {
+    void isValidPegInTx_has_utxos_below_minimum_after_RSKIP293() {
         Context btcContext = new Context(bridgeConstantsMainnet.getBtcParams());
         Federation activeFederation = getErpFederationWithPrivKeys(networkParameters, REGTEST_FEDERATION_PRIVATE_KEYS);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
@@ -1106,7 +1106,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_utxo_equal_to_minimum_after_RSKIP293() {
+    void isValidPegInTx_utxo_equal_to_minimum_after_RSKIP293() {
         Context btcContext = new Context(bridgeConstantsMainnet.getBtcParams());
         Federation activeFederation = getErpFederationWithPrivKeys(networkParameters, REGTEST_FEDERATION_PRIVATE_KEYS);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
@@ -1130,7 +1130,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_p2shErpScript_sends_funds_to_federation_address_after_RSKIP353() {
+    void isValidPegInTx_p2shErpScript_sends_funds_to_federation_address_after_RSKIP353() {
         Federation federation = getErpFederationWithPrivKeys(networkParameters, REGTEST_FEDERATION_PRIVATE_KEYS);
         Address activeFederationAddress = federation.getAddress();
         testIsValidPegInTx_fromP2shErpScriptSender(
@@ -1142,8 +1142,8 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_p2shErpScript_sends_funds_to_random_address_after_RSKIP353() {
-        Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
+    void isValidPegInTx_p2shErpScript_sends_funds_to_random_address_after_RSKIP353() {
+        Address randomAddress = BitcoinTestUtils.createP2PKHAddress(networkParameters, "random");
         testIsValidPegInTx_fromP2shErpScriptSender(
             true,
             false,
@@ -1153,7 +1153,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_flyoverpP2shErpScript_sends_funds_to_federation_address_after_RSKIP353() {
+    void isValidPegInTx_flyoverpP2shErpScript_sends_funds_to_federation_address_after_RSKIP353() {
         Federation activeFederation = getErpFederationWithPrivKeys(networkParameters, REGTEST_FEDERATION_PRIVATE_KEYS);
         Address activeFederationAddress = activeFederation.getAddress();
         testIsValidPegInTx_fromP2shErpScriptSender(
@@ -1165,8 +1165,8 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsValidPegInTx_flyoverP2shErpScript_sends_funds_to_random_address_after_RSKIP353() {
-        Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
+    void isValidPegInTx_flyoverP2shErpScript_sends_funds_to_random_address_after_RSKIP353() {
+        Address randomAddress = BitcoinTestUtils.createP2PKHAddress(networkParameters, "random");
         testIsValidPegInTx_fromP2shErpScriptSender(
             true,
             true,
@@ -1245,7 +1245,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsMigrationTx_sending_funds_from_retired_p2sh_fed_to_active_p2sh_fed() {
+    void isMigrationTx_sending_funds_from_retired_p2sh_fed_to_active_p2sh_fed() {
         NetworkParameters networkParameters = bridgeConstantsMainnet.getBtcParams();
         Context btcContext = new Context(networkParameters);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
@@ -1253,7 +1253,7 @@ class PegUtilsLegacyTest {
         List<BtcECKey> retiredFederationKeys = Stream.of(
             BtcECKey.fromPrivate(Hex.decode("fc01")),
             BtcECKey.fromPrivate(Hex.decode("fc02"))
-        ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
+        ).sorted(BtcECKey.PUBKEY_COMPARATOR).toList();
         List<FederationMember> retiredFedMembers = getFederationMembersWithBtcKeys(retiredFederationKeys);
         NetworkParameters btcParams = bridgeConstantsMainnet.getBtcParams();
         FederationArgs retiredFedArgs = new FederationArgs(retiredFedMembers, creationTime, 1L, btcParams);
@@ -1261,7 +1261,7 @@ class PegUtilsLegacyTest {
         List<BtcECKey> activeFederationKeys = Stream.of(
             BtcECKey.fromPrivate(Hex.decode("fa01")),
             BtcECKey.fromPrivate(Hex.decode("fa02"))
-        ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
+        ).sorted(BtcECKey.PUBKEY_COMPARATOR).toList();
         List<FederationMember> activeFedMembers = getFederationMembersWithBtcKeys(activeFederationKeys);
         FederationArgs activeFedArgs = new FederationArgs(activeFedMembers, creationTime, 1L, btcParams);
 
@@ -1313,7 +1313,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsMigrationTx_sending_funds_from_retiring_p2sh_fed_to_active_p2sh_fed() {
+    void isMigrationTx_sending_funds_from_retiring_p2sh_fed_to_active_p2sh_fed() {
         NetworkParameters networkParameters = bridgeConstantsMainnet.getBtcParams();
         Context btcContext = new Context(networkParameters);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
@@ -1371,7 +1371,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsMigrationTx_sending_funds_from_retired_standard_fed_to_active_p2sh_fed() {
+    void isMigrationTx_sending_funds_from_retired_standard_fed_to_active_p2sh_fed() {
         NetworkParameters networkParameters = bridgeConstantsMainnet.getBtcParams();
         Context btcContext = new Context(networkParameters);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
@@ -1438,7 +1438,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsMigrationTx_sending_funds_from_retiring_standard_fed_to_active_p2sh_fed() {
+    void isMigrationTx_sending_funds_from_retiring_standard_fed_to_active_p2sh_fed() {
         NetworkParameters networkParameters = bridgeConstantsMainnet.getBtcParams();
         Context btcContext = new Context(networkParameters);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
@@ -1495,7 +1495,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsMigrationTx_sending_funds_from_retired_standard_fed_to_active_standard_fed() {
+    void isMigrationTx_sending_funds_from_retired_standard_fed_to_active_standard_fed() {
         NetworkParameters networkParameters = bridgeConstantsMainnet.getBtcParams();
         Context btcContext = new Context(networkParameters);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
@@ -1503,7 +1503,7 @@ class PegUtilsLegacyTest {
         List<BtcECKey> retiredFederationKeys = Stream.of(
             BtcECKey.fromPrivate(Hex.decode("fc01")),
             BtcECKey.fromPrivate(Hex.decode("fc02"))
-        ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
+        ).sorted(BtcECKey.PUBKEY_COMPARATOR).toList();
 
         FederationArgs retiredFedArgs = new FederationArgs(getFederationMembersWithBtcKeys(retiredFederationKeys),
             creationTime,
@@ -1517,7 +1517,7 @@ class PegUtilsLegacyTest {
         List<BtcECKey> activeFederationKeys = Stream.of(
             BtcECKey.fromPrivate(Hex.decode("fa01")),
             BtcECKey.fromPrivate(Hex.decode("fa02"))
-        ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
+        ).sorted(BtcECKey.PUBKEY_COMPARATOR).toList();
 
         FederationArgs activeFedArgs = new FederationArgs(getFederationMembersWithBtcKeys(activeFederationKeys),
             creationTime,
@@ -1558,7 +1558,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsMigrationTx_sending_funds_from_retiring_standard_fed_to_active_standard_fed() {
+    void isMigrationTx_sending_funds_from_retiring_standard_fed_to_active_standard_fed() {
         NetworkParameters networkParameters = bridgeConstantsMainnet.getBtcParams();
         Context btcContext = new Context(networkParameters);
         when(activations.isActive(ConsensusRule.RSKIP201)).thenReturn(true);
@@ -1566,7 +1566,7 @@ class PegUtilsLegacyTest {
         List<BtcECKey> retiringFederationKeys = Stream.of(
             BtcECKey.fromPrivate(Hex.decode("fc01")),
             BtcECKey.fromPrivate(Hex.decode("fc02"))
-        ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
+        ).sorted(BtcECKey.PUBKEY_COMPARATOR).toList();
 
         FederationArgs retiringFedArgs = new FederationArgs(
             getFederationMembersWithBtcKeys(retiringFederationKeys),
@@ -1581,7 +1581,7 @@ class PegUtilsLegacyTest {
         List<BtcECKey> activeFederationKeys = Stream.of(
             BtcECKey.fromPrivate(Hex.decode("fa01")),
             BtcECKey.fromPrivate(Hex.decode("fa02"))
-        ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
+        ).sorted(BtcECKey.PUBKEY_COMPARATOR).toList();
 
         FederationArgs activeFedArgs = new FederationArgs(getFederationMembersWithBtcKeys(activeFederationKeys),
             creationTime,
@@ -1622,13 +1622,13 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsMigrationTx() {
+    void isMigrationTx_fromStandardFederation_toStandardFederation() {
         Context btcContext = new Context(networkParameters);
 
         List<BtcECKey> activeFederationKeys = Stream.of(
             BtcECKey.fromPrivate(Hex.decode("fa01")),
             BtcECKey.fromPrivate(Hex.decode("fa02"))
-        ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
+        ).sorted(BtcECKey.PUBKEY_COMPARATOR).toList();
 
         FederationArgs activeFedArgs = new FederationArgs(getFederationMembersWithBtcKeys(activeFederationKeys),
             Instant.ofEpochMilli(2000L),
@@ -1643,7 +1643,7 @@ class PegUtilsLegacyTest {
             BtcECKey.fromPrivate(Hex.decode("fb01")),
             BtcECKey.fromPrivate(Hex.decode("fb02")),
             BtcECKey.fromPrivate(Hex.decode("fb03"))
-        ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
+        ).sorted(BtcECKey.PUBKEY_COMPARATOR).toList();
 
         FederationArgs retiringFedArgs = new FederationArgs(getFederationMembersWithBtcKeys(retiringFederationKeys),
             creationTime,
@@ -1657,7 +1657,7 @@ class PegUtilsLegacyTest {
         List<BtcECKey> retiredFederationKeys = Stream.of(
             BtcECKey.fromPrivate(Hex.decode("fc01")),
             BtcECKey.fromPrivate(Hex.decode("fc02"))
-        ).sorted(BtcECKey.PUBKEY_COMPARATOR).collect(Collectors.toList());
+        ).sorted(BtcECKey.PUBKEY_COMPARATOR).toList();
         FederationArgs retiredFedArgs = new FederationArgs(getFederationMembersWithBtcKeys(retiredFederationKeys),
             creationTime,
             1L,
@@ -1793,7 +1793,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsPegOutTx() {
+    void isPegOutTx_withStandardFederation() {
         Federation federation = getFederationWithPrivateKeys(REGTEST_FEDERATION_PRIVATE_KEYS);
 
         List<BtcECKey> activeFederationKeys = Stream.of(
@@ -1823,16 +1823,16 @@ class PegUtilsLegacyTest {
         signWithNecessaryKeys(federation, REGTEST_FEDERATION_PRIVATE_KEYS, pegOutInput1, pegOutTx1);
 
         assertTrue(isPegOutTx(pegOutTx1, List.of(federation), activations));
-        assertTrue(isPegOutTx(pegOutTx1, Arrays.asList(federation, federation2), activations));
+        assertTrue(isPegOutTx(pegOutTx1, List.of(federation, federation2), activations));
         assertFalse(isPegOutTx(pegOutTx1, List.of(federation2), activations));
 
         assertTrue(isPegOutTx(pegOutTx1, activations, List.of(federation.getP2SHScript())));
-        assertTrue(isPegOutTx(pegOutTx1, activations, Arrays.asList(federation.getP2SHScript(), federation2.getP2SHScript())));
+        assertTrue(isPegOutTx(pegOutTx1, activations, List.of(federation.getP2SHScript(), federation2.getP2SHScript())));
         assertFalse(isPegOutTx(pegOutTx1, activations, List.of(federation2.getP2SHScript())));
     }
 
     @Test
-    void testIsPegOutTx_fromFlyoverFederation() {
+    void isPegOutTx_fromFlyoverFederation() {
         List<BtcECKey> flyoverFederationKeys = Arrays.asList(
             BtcECKey.fromPrivate(Hex.decode("fa01")),
             BtcECKey.fromPrivate(Hex.decode("fa02")),
@@ -1894,7 +1894,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsPegOutTx_fromErpFederation() {
+    void isPegOutTx_fromErpFederation() {
         List<BtcECKey> defaultFederationKeys = Arrays.asList(
             BtcECKey.fromPrivate(Hex.decode("fa01")),
             BtcECKey.fromPrivate(Hex.decode("fa02")),
@@ -1959,7 +1959,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsPegOutTx_fromFlyoverErpFederation() {
+    void isPegOutTx_fromFlyoverErpFederation() {
         List<BtcECKey> defaultFederationKeys = Arrays.asList(
             BtcECKey.fromPrivate(Hex.decode("fa01")),
             BtcECKey.fromPrivate(Hex.decode("fa02")),
@@ -2025,7 +2025,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsPegOutTx_noRedeemScript() {
+    void isPegOutTx_noRedeemScript() {
         Federation federation = getErpFederationWithPrivKeys(networkParameters, REGTEST_FEDERATION_PRIVATE_KEYS);
         Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(bridgeConstantsMainnet.getBtcParams());
 
@@ -2043,7 +2043,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsPegOutTx_invalidRedeemScript() {
+    void isPegOutTx_invalidRedeemScript() {
         Federation federation = getErpFederationWithPrivKeys(networkParameters, REGTEST_FEDERATION_PRIVATE_KEYS);
         Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(bridgeConstantsMainnet.getBtcParams());
         Script invalidRedeemScript = ScriptBuilder.createRedeemScript(2, Arrays.asList(new BtcECKey(), new BtcECKey()));
@@ -2126,7 +2126,7 @@ class PegUtilsLegacyTest {
     }
 
     @Test
-    void testIsAnyUTXOAmountBelowMinimum_has_utxos_below_minimum() {
+    void isAnyUTXOAmountBelowMinimum_has_utxos_below_minimum() {
         Coin minimumPegInTxValue = bridgeConstantsRegtest.getMinimumPeginTxValue(activations);
         Coin valueBelowMinimum = minimumPegInTxValue.minus(Coin.SATOSHI);
         Coin valueAboveMinimum = minimumPegInTxValue.plus(Coin.SATOSHI);

--- a/rskj-core/src/test/java/co/rsk/peg/federation/P2shP2wshErpFederationBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/P2shP2wshErpFederationBuilder.java
@@ -23,18 +23,19 @@ public class P2shP2wshErpFederationBuilder {
     private NetworkParameters networkParameters;
 
     private P2shP2wshErpFederationBuilder() {
+        FederationConstants federationMainnetConstants = FederationMainNetConstants.getInstance();
+
         this.membersBtcPublicKeys = BitcoinTestUtils.getBtcEcKeysFromSeeds(new String[]{
             "member01", "member02", "member03", "member04", "member05", "member06", "member07", "member08", "member09", "member10",
             "member11", "member12", "member13", "member14", "member15", "member16", "member17", "member18", "member19", "member20"
         }, true);
         this.membersRskPublicKeys = new ArrayList<>();
         this.membersMstPublicKeys = new ArrayList<>();
-        FederationConstants federationMainnetConstants = FederationMainNetConstants.getInstance();
         this.erpPublicKeys = federationMainnetConstants.getErpFedPubKeysList();
         this.erpActivationDelay = federationMainnetConstants.getErpFedActivationDelay();
         this.creationTime = Instant.ofEpochSecond(100_000_000L);
         this.creationBlockNumber = 1L;
-        this.networkParameters = NetworkParameters.fromID(NetworkParameters.ID_MAINNET);
+        this.networkParameters = federationMainnetConstants.getBtcParams();
     }
 
     public static P2shP2wshErpFederationBuilder builder() {

--- a/rskj-core/src/test/java/co/rsk/test/builders/MigrationTransactionBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/MigrationTransactionBuilder.java
@@ -1,0 +1,100 @@
+package co.rsk.test.builders;
+
+import co.rsk.bitcoinj.core.*;
+import co.rsk.bitcoinj.script.Script;
+import co.rsk.peg.bitcoin.BitcoinTestUtils;
+import co.rsk.peg.bitcoin.BitcoinUtils;
+import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.P2shP2wshErpFederationBuilder;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MigrationTransactionBuilder {
+    private NetworkParameters networkParameters;
+    private Federation activeFederation;
+    private Federation retiringFederation;
+    private final List<UTXO> utxos;
+
+    private MigrationTransactionBuilder() {
+        this.networkParameters = NetworkParameters.fromID(NetworkParameters.ID_MAINNET);
+        this.activeFederation = P2shP2wshErpFederationBuilder.builder().build();
+        this.retiringFederation = P2shP2wshErpFederationBuilder.builder().build();
+        this.utxos = new ArrayList<>();
+    }
+
+    public static MigrationTransactionBuilder builder() {
+        return new MigrationTransactionBuilder();
+    }
+
+    public MigrationTransactionBuilder withNetworkParameters(NetworkParameters networkParameters) {
+        this.networkParameters = networkParameters;
+        return this;
+    }
+
+    public MigrationTransactionBuilder withActiveFederation(Federation activeFederation) {
+        this.activeFederation = activeFederation;
+        return this;
+    }
+
+    public MigrationTransactionBuilder withRetiringFederation(Federation retiringFederation) {
+        this.retiringFederation = retiringFederation;
+        return this;
+    }
+
+    public MigrationTransactionBuilder withUTXO(UTXO utxo) {
+        this.utxos.add(utxo);
+        return this;
+    }
+
+    public BtcTransaction build() {
+        BtcTransaction migrationTx = new BtcTransaction(networkParameters);
+
+        addInputsToTransaction(migrationTx);
+        addOutputsToTransaction(migrationTx);
+
+        return migrationTx;
+    }
+
+    private void addInputsToTransaction(BtcTransaction transaction) {
+        if (utxos.isEmpty()) {
+            UTXO defaultUtxo = new UTXO(
+                BitcoinTestUtils.createHash(11),
+                0,
+                Coin.COIN,
+                0,
+                false,
+                retiringFederation.getP2SHScript()
+            );
+            utxos.add(defaultUtxo);
+        }
+
+        for (UTXO utxo : utxos) {
+            TransactionInput input = new TransactionInput(
+                networkParameters,
+                null,
+                new byte[]{},
+                new TransactionOutPoint(networkParameters, utxo.getIndex(), utxo.getHash())
+            );
+
+            Script baseScriptSig = BitcoinUtils.createBaseInputScriptThatSpendsFromRedeemScript(retiringFederation.getRedeemScript());
+            input.setScriptSig(baseScriptSig);
+
+            transaction.addInput(input);
+        }
+    }
+
+    private void addOutputsToTransaction(BtcTransaction transaction) {
+        Coin totalAmount = utxos.stream().reduce(
+            Coin.ZERO,
+            (sum, utxo) -> sum.add(utxo.getValue()),
+            Coin::add
+        );
+        TransactionOutput output = new TransactionOutput(
+            networkParameters,
+            null,
+            totalAmount,
+            activeFederation.getAddress()
+        );
+        transaction.addOutput(output);
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/test/builders/MigrationTransactionBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/MigrationTransactionBuilder.java
@@ -1,7 +1,6 @@
 package co.rsk.test.builders;
 
 import co.rsk.bitcoinj.core.*;
-import co.rsk.bitcoinj.script.Script;
 import co.rsk.peg.bitcoin.BitcoinTestUtils;
 import co.rsk.peg.bitcoin.BitcoinUtils;
 import co.rsk.peg.federation.Federation;
@@ -68,6 +67,7 @@ public class MigrationTransactionBuilder {
             utxos.add(defaultUtxo);
         }
 
+        int inputIndex = 0;
         for (UTXO utxo : utxos) {
             TransactionInput input = new TransactionInput(
                 networkParameters,
@@ -76,10 +76,15 @@ public class MigrationTransactionBuilder {
                 new TransactionOutPoint(networkParameters, utxo.getIndex(), utxo.getHash())
             );
 
-            Script baseScriptSig = BitcoinUtils.createBaseInputScriptThatSpendsFromRedeemScript(retiringFederation.getRedeemScript());
-            input.setScriptSig(baseScriptSig);
-
             transaction.addInput(input);
+            BitcoinUtils.addSpendingFederationBaseScript(
+                transaction,
+                inputIndex,
+                retiringFederation.getRedeemScript(),
+                retiringFederation.getFormatVersion()
+            );
+
+            inputIndex++;
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/test/builders/PegoutTransactionBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/PegoutTransactionBuilder.java
@@ -80,11 +80,17 @@ public class PegoutTransactionBuilder {
             inputs.add(defaultInput);
         }
 
+        int inputIndex = 0;
         for (TransactionInput input : inputs) {
-            Script baseScriptSig = BitcoinUtils.createBaseInputScriptThatSpendsFromRedeemScript(activeFederation.getRedeemScript());
-            input.setScriptSig(baseScriptSig);
-
             transaction.addInput(input);
+            BitcoinUtils.addSpendingFederationBaseScript(
+                transaction,
+                inputIndex,
+                activeFederation.getRedeemScript(),
+                activeFederation.getFormatVersion()
+            );
+
+            inputIndex++;
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/test/builders/PegoutTransactionBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/PegoutTransactionBuilder.java
@@ -41,11 +41,10 @@ public class PegoutTransactionBuilder {
     }
 
     public PegoutTransactionBuilder withInput(Sha256Hash spendTxHash, int outputIndex) {
-        Script activeFederationRedeemScript = activeFederation.getRedeemScript();
         TransactionInput input = new TransactionInput(
             networkParameters,
             null,
-            activeFederationRedeemScript.getProgram(),
+            new byte[]{},
             new TransactionOutPoint(networkParameters, outputIndex, spendTxHash)
         );
 

--- a/rskj-core/src/test/java/co/rsk/test/builders/PegoutTransactionBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/PegoutTransactionBuilder.java
@@ -1,0 +1,126 @@
+package co.rsk.test.builders;
+
+import co.rsk.bitcoinj.core.*;
+import co.rsk.bitcoinj.script.Script;
+import co.rsk.peg.bitcoin.BitcoinTestUtils;
+import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.P2shP2wshErpFederationBuilder;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PegoutTransactionBuilder {
+    private NetworkParameters networkParameters;
+    private Federation activeFederation;
+
+    private final List<TransactionInput> inputs;
+    private final List<TransactionOutput> outputs;
+
+    private Coin changeAmount;
+
+    private PegoutTransactionBuilder() {
+        this.networkParameters = NetworkParameters.fromID(NetworkParameters.ID_MAINNET);
+        this.activeFederation = P2shP2wshErpFederationBuilder.builder().build();
+        this.changeAmount = Coin.COIN.div(2);
+
+        this.inputs = new ArrayList<>();
+        this.outputs = new ArrayList<>();
+    }
+
+    public static PegoutTransactionBuilder builder() {
+        return new PegoutTransactionBuilder();
+    }
+
+    public PegoutTransactionBuilder withNetworkParameters(NetworkParameters networkParameters) {
+        this.networkParameters = networkParameters;
+        return this;
+    }
+
+    public PegoutTransactionBuilder withActiveFederation(Federation activeFederation) {
+        this.activeFederation = activeFederation;
+        return this;
+    }
+
+    public PegoutTransactionBuilder withInput(Sha256Hash spendTxHash, int outputIndex) {
+        Script activeFederationRedeemScript = activeFederation.getRedeemScript();
+        TransactionInput input = new TransactionInput(
+            networkParameters,
+            null,
+            activeFederationRedeemScript.getProgram(),
+            new TransactionOutPoint(networkParameters, outputIndex, spendTxHash)
+        );
+
+        inputs.add(input);
+        return this;
+    }
+
+    public PegoutTransactionBuilder withOutput(Coin amount, Address address) {
+        TransactionOutput output = new TransactionOutput(networkParameters, null, amount, address);
+        outputs.add(output);
+        return this;
+    }
+
+    public PegoutTransactionBuilder withChangeAmount(Coin changeAmount) {
+        this.changeAmount = changeAmount;
+        return this;
+    }
+
+    public BtcTransaction build() {
+        BtcTransaction pegoutTransaction = new BtcTransaction(networkParameters);
+
+        addInputsToTransaction(pegoutTransaction);
+        addOutputsToTransaction(pegoutTransaction);
+        addChangeOutput(pegoutTransaction);
+
+        return pegoutTransaction;
+    }
+
+    private void addInputsToTransaction(BtcTransaction transaction) {
+        if (inputs.isEmpty()) {
+            // Add a default input if no inputs are specified
+            TransactionInput defaultInput = getDefaultInput();
+            inputs.add(defaultInput);
+        }
+
+        for (TransactionInput input : inputs) {
+            transaction.addInput(input);
+        }
+    }
+
+    private TransactionInput getDefaultInput() {
+        Script activeFederationRedeemScript = activeFederation.getRedeemScript();
+        int outputIndex = 0;
+        Sha256Hash spendTxHash = BitcoinTestUtils.createHash(10);
+
+        return new TransactionInput(
+            networkParameters,
+            null,
+            activeFederationRedeemScript.getProgram(),
+            new TransactionOutPoint(networkParameters, outputIndex, spendTxHash)
+        );
+    }
+
+    private void addOutputsToTransaction(BtcTransaction transaction) {
+        if (outputs.isEmpty()) {
+            // Add default user output if no outputs are specified
+            TransactionOutput defaultOutput = getDefaultUserOutput();
+            outputs.add(defaultOutput);
+        }
+
+        for (TransactionOutput output : outputs) {
+            transaction.addOutput(output);
+        }
+    }
+
+    private TransactionOutput getDefaultUserOutput() {
+        Address receiverAddress = BitcoinTestUtils.createP2PKHAddress(networkParameters, "receiver");
+        Coin amount = Coin.COIN;
+
+        return new TransactionOutput(networkParameters, null, amount, receiverAddress);
+    }
+
+    private void addChangeOutput(BtcTransaction transaction) {
+        Address changeAddress = activeFederation.getAddress();
+        TransactionOutput changeOutput = new TransactionOutput(networkParameters, null, changeAmount, changeAddress);
+        transaction.addOutput(changeOutput);
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/test/builders/PegoutTransactionBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/PegoutTransactionBuilder.java
@@ -2,7 +2,7 @@ package co.rsk.test.builders;
 
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.script.Script;
-import co.rsk.peg.bitcoin.BitcoinTestUtils;
+import co.rsk.peg.bitcoin.*;
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.P2shP2wshErpFederationBuilder;
 import java.util.ArrayList;
@@ -82,6 +82,9 @@ public class PegoutTransactionBuilder {
         }
 
         for (TransactionInput input : inputs) {
+            Script baseScriptSig = BitcoinUtils.createBaseInputScriptThatSpendsFromRedeemScript(activeFederation.getRedeemScript());
+            input.setScriptSig(baseScriptSig);
+
             transaction.addInput(input);
         }
     }


### PR DESCRIPTION
PegUtilsLegacy::isPegoutTx method is still used from the powpeg-node. It needs to be updated to consider for P2shP2wsh federation 

## Description
- Create PegoutTransactionBuilder class 
- Create MigrationTransactionBuilder class
- Add new tests for isPegoutTx, pegouts created from a P2shP2wsh federation 
- Add new tests for isMigrationTx, migration to P2shP2wsh federation 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
