### PR TITLE
Get rid of activations checks of `weisTransferredToUnionBridge` logic

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/union/UnionBridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/union/UnionBridgeStorageProvider.java
@@ -10,7 +10,7 @@ public interface UnionBridgeStorageProvider {
     Optional<RskAddress> getAddress();
     void setLockingCap(Coin lockingCap);
     Optional<Coin> getLockingCap();
-    Optional<co.rsk.core.Coin> getWeisTransferredToUnionBridge(ActivationConfig.ForBlock activations);
+    Optional<co.rsk.core.Coin> getWeisTransferredToUnionBridge();
     void setWeisTransferredToUnionBridge(co.rsk.core.Coin weisTransferred);
     void save(ActivationConfig.ForBlock activations);
 }

--- a/rskj-core/src/main/java/co/rsk/peg/union/UnionBridgeStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/union/UnionBridgeStorageProviderImpl.java
@@ -9,7 +9,7 @@ import co.rsk.peg.BridgeSerializationUtils;
 import co.rsk.peg.storage.StorageAccessor;
 import java.util.Optional;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
-import org.ethereum.config.blockchain.upgrades.ActivationConfig.ForBlock;
+
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 
 public class UnionBridgeStorageProviderImpl implements UnionBridgeStorageProvider {
@@ -105,16 +105,12 @@ public class UnionBridgeStorageProviderImpl implements UnionBridgeStorageProvide
     }
 
     @Override
-    public Optional<co.rsk.core.Coin> getWeisTransferredToUnionBridge(ForBlock activations) {
-        if (!activations.isActive(ConsensusRule.RSKIP502)) {
-            return Optional.empty();
-        }
-
-        return Optional.ofNullable(weisTransferredToUnionBridge).or(
-            () -> Optional.ofNullable(bridgeStorageAccessor.getFromRepository(
+    public Optional<co.rsk.core.Coin> getWeisTransferredToUnionBridge() {
+        return Optional.ofNullable(weisTransferredToUnionBridge).or(() -> Optional.ofNullable(
+            bridgeStorageAccessor.getFromRepository(
                 UnionBridgeStorageIndexKey.WEIS_TRANSFERRED_TO_UNION_BRIDGE.getKey(),
                 BridgeSerializationUtils::deserializeRskCoin
-            ))
-        );
+            )
+        ));
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/union/UnionBridgeSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/union/UnionBridgeSupportImpl.java
@@ -147,6 +147,10 @@ public class UnionBridgeSupportImpl implements UnionBridgeSupport {
         return UnionResponseCode.SUCCESS;
     }
 
+    private co.rsk.core.Coin getWeisTransferredToUnionBridge() {
+        return storageProvider.getWeisTransferredToUnionBridge().orElse(co.rsk.core.Coin.ZERO);
+    }
+
     @Override
     public UnionResponseCode requestUnionRbtc(Transaction tx, co.rsk.core.Coin amount) {
         final String REQUEST_UNION_RBTC_TAG = "requestUnionRbtc";
@@ -184,8 +188,7 @@ public class UnionBridgeSupportImpl implements UnionBridgeSupport {
 
         co.rsk.core.Coin lockingCap = co.rsk.core.Coin.fromBitcoin(getLockingCap());
 
-        co.rsk.core.Coin previousAmountRequested = storageProvider.getWeisTransferredToUnionBridge(activations)
-            .orElse(co.rsk.core.Coin.ZERO);
+        co.rsk.core.Coin previousAmountRequested = getWeisTransferredToUnionBridge();
 
         co.rsk.core.Coin newAmountRequested = previousAmountRequested.add(amountRequested);
         boolean doesNewAmountAndPreviousAmountRequestedSurpassLockingCap =

--- a/rskj-core/src/test/java/co/rsk/peg/union/UnionBridgeStorageProviderImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/union/UnionBridgeStorageProviderImplTest.java
@@ -407,24 +407,9 @@ class UnionBridgeStorageProviderImplTest {
     }
 
     @Test
-    void getWeisTransferredToUnionBridge_beforeRSKIP502_shouldReturnEmpty() {
-        // Arrange
-        // To simulate WEIS_TRANSFERRED_TO_UNION_BRIDGE's value already stored
-        storageAccessor.saveToRepository(
-            UnionBridgeStorageIndexKey.WEIS_TRANSFERRED_TO_UNION_BRIDGE.getKey(),
-            amountTransferredToUnionBridge, BridgeSerializationUtils::serializeRskCoin);
-
-        // Act
-        Optional<co.rsk.core.Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge(lovell700);
-
-        // Assert
-        assertTrue(actualWeisTransferredToUnionBridge.isEmpty());
-    }
-
-    @Test
     void getWeisTransferredToUnionBridge_whenNoValueIsStoredOrSet_shouldReturnEmpty() {
         // Act
-        Optional<co.rsk.core.Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge(allActivations);
+        Optional<co.rsk.core.Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge();
 
         // Assert
         assertTrue(actualWeisTransferredToUnionBridge.isEmpty());
@@ -438,7 +423,7 @@ class UnionBridgeStorageProviderImplTest {
             amountTransferredToUnionBridge, BridgeSerializationUtils::serializeRskCoin);
 
         // Act
-        Optional<co.rsk.core.Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge(allActivations);
+        Optional<co.rsk.core.Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge();
 
         // Assert
         assertTrue(actualWeisTransferredToUnionBridge.isPresent());
@@ -451,7 +436,7 @@ class UnionBridgeStorageProviderImplTest {
         unionBridgeStorageProvider.setWeisTransferredToUnionBridge(amountTransferredToUnionBridge);
 
         // Act
-        Optional<co.rsk.core.Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge(allActivations);
+        Optional<co.rsk.core.Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge();
 
         // Assert
         assertTrue(actualWeisTransferredToUnionBridge.isPresent());
@@ -460,7 +445,7 @@ class UnionBridgeStorageProviderImplTest {
     }
 
     @Test
-    void setWeisTransferredToUnionBridge_whenNegative_shouldNotSetNegative() {
+    void setWeisTransferredToUnionBridge_whenNegative_shouldThrowIllegalArgumentException() {
         // Arrange
         co.rsk.core.Coin negativeAmount = co.rsk.core.Coin.valueOf(-1);
 
@@ -473,15 +458,25 @@ class UnionBridgeStorageProviderImplTest {
     @Test
     void setWeisTransferredToUnionBridge_whenZero_shouldSetZero() {
         // Arrange
-        co.rsk.core.Coin zeronAmount = co.rsk.core.Coin.ZERO;
+        co.rsk.core.Coin zeroAmount = co.rsk.core.Coin.ZERO;
 
         // Act
-        unionBridgeStorageProvider.setWeisTransferredToUnionBridge(zeronAmount);
+        unionBridgeStorageProvider.setWeisTransferredToUnionBridge(zeroAmount);
 
         // Assert
-        Optional<co.rsk.core.Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge(allActivations);
+        Optional<co.rsk.core.Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge();
         assertTrue(actualWeisTransferredToUnionBridge.isPresent());
-        assertEquals(zeronAmount, actualWeisTransferredToUnionBridge.get());
+        assertEquals(zeroAmount, actualWeisTransferredToUnionBridge.get());
+
+        // save the value
+        unionBridgeStorageProvider.save(allActivations);
+
+        // Create a new instance of the storage provider to retrieve the value from the storage
+        unionBridgeStorageProvider = new UnionBridgeStorageProviderImpl(storageAccessor);
+        Optional<co.rsk.core.Coin> savedWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge();
+
+        assertTrue(savedWeisTransferredToUnionBridge.isPresent());
+        assertEquals(zeroAmount, savedWeisTransferredToUnionBridge.get());
     }
 
     @Test
@@ -491,7 +486,7 @@ class UnionBridgeStorageProviderImplTest {
 
         // Assert
         assertNoWeisTransferredToUnionBridgeIsStored();
-        Optional<co.rsk.core.Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge(allActivations);
+        Optional<co.rsk.core.Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge();
         assertTrue(actualWeisTransferredToUnionBridge.isPresent());
     }
 
@@ -510,7 +505,7 @@ class UnionBridgeStorageProviderImplTest {
 
         // Assert
         // Check existing wei transferred to union bridge is still stored
-        Optional<co.rsk.core.Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge(allActivations);
+        Optional<co.rsk.core.Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge();
         assertTrue(actualWeisTransferredToUnionBridge.isPresent());
         assertGivenWeisTransferredToUnionBridgeIsStored(amountTransferredToUnionBridge);
     }


### PR DESCRIPTION
Get rid of activations checks of `weisTransferredToUnionBridge` logic

## How Has This Been Tested?

Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
