### PR TITLE
Replace BitcoinJ Coin with RSK core Coin across UnionBridge impl

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -1496,20 +1496,15 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         return bridgeSupport.setUnionBridgeContractAddressForTestnet(rskTx, unionBridgeContractAddress).getCode();
     }
 
-    public long getUnionBridgeLockingCap(Object[] args) {
+    public BigInteger getUnionBridgeLockingCap(Object[] args) {
         logger.trace("getUnionBridgeLockingCap");
-        return bridgeSupport.getUnionBridgeLockingCap().getValue();
+        return bridgeSupport.getUnionBridgeLockingCap().asBigInteger();
     }
 
     public int increaseUnionBridgeLockingCap(Object[] args) {
         logger.trace("increaseUnionBridgeLockingCap");
-        try {
-            Coin newLockingCap = BridgeUtils.getCoinFromBigInteger((BigInteger) args[0]);
-            return bridgeSupport.increaseUnionBridgeLockingCap(rskTx, newLockingCap).getCode();
-        } catch (BridgeIllegalArgumentException e) {
-            logger.warn("Exception in increaseUnionBridgeLockingCap", e);
-            return UnionResponseCode.INVALID_VALUE.getCode();
-        }
+        co.rsk.core.Coin newLockingCap = new co.rsk.core.Coin((BigInteger) args[0]);
+        return bridgeSupport.increaseUnionBridgeLockingCap(rskTx, newLockingCap).getCode();
     }
 
     public int requestUnionRbtc(Object[] args) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
@@ -842,7 +842,7 @@ public enum BridgeMethods {
             new String[]{"int256"}
         ),
         fixedCost(3_000L), // TODO: Define final cost
-        (BridgeMethodExecutorTyped<Long>) Bridge::getUnionBridgeLockingCap,
+        (BridgeMethodExecutorTyped<BigInteger>) Bridge::getUnionBridgeLockingCap,
         activations -> activations.isActive(RSKIP502),
         fixedPermission(false)
     ),

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -2829,11 +2829,11 @@ public class BridgeSupport {
         return unionBridgeSupport.setUnionBridgeContractAddressForTestnet(tx, unionBridgeContractAddress);
     }
 
-    public Coin getUnionBridgeLockingCap() {
+    public co.rsk.core.Coin getUnionBridgeLockingCap() {
         return unionBridgeSupport.getLockingCap();
     }
 
-    public UnionResponseCode increaseUnionBridgeLockingCap(Transaction tx, Coin newLockingCap) {
+    public UnionResponseCode increaseUnionBridgeLockingCap(Transaction tx, co.rsk.core.Coin newLockingCap) {
         return unionBridgeSupport.increaseLockingCap(tx, newLockingCap);
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/union/UnionBridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/union/UnionBridgeStorageProvider.java
@@ -1,6 +1,6 @@
 package co.rsk.peg.union;
 
-import co.rsk.bitcoinj.core.Coin;
+import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import java.util.Optional;
 
@@ -9,7 +9,7 @@ public interface UnionBridgeStorageProvider {
     Optional<RskAddress> getAddress();
     void setLockingCap(Coin lockingCap);
     Optional<Coin> getLockingCap();
-    Optional<co.rsk.core.Coin> getWeisTransferredToUnionBridge();
-    void setWeisTransferredToUnionBridge(co.rsk.core.Coin weisTransferred);
+    Optional<Coin> getWeisTransferredToUnionBridge();
+    void setWeisTransferredToUnionBridge(Coin weisTransferred);
     void save();
 }

--- a/rskj-core/src/main/java/co/rsk/peg/union/UnionBridgeStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/union/UnionBridgeStorageProviderImpl.java
@@ -3,7 +3,7 @@ package co.rsk.peg.union;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
-import co.rsk.bitcoinj.core.Coin;
+import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.peg.BridgeSerializationUtils;
 import co.rsk.peg.storage.StorageAccessor;
@@ -16,7 +16,7 @@ public class UnionBridgeStorageProviderImpl implements UnionBridgeStorageProvide
 
     private RskAddress unionBridgeAddress;
     private Coin unionBridgeLockingCap;
-    private co.rsk.core.Coin weisTransferredToUnionBridge;
+    private Coin weisTransferredToUnionBridge;
 
     public UnionBridgeStorageProviderImpl(StorageAccessor bridgeStorageAccessor) {
         this.bridgeStorageAccessor = bridgeStorageAccessor;
@@ -36,7 +36,7 @@ public class UnionBridgeStorageProviderImpl implements UnionBridgeStorageProvide
             bridgeStorageAccessor.saveToRepository(
                 UnionBridgeStorageIndexKey.UNION_BRIDGE_LOCKING_CAP.getKey(),
                 unionBridgeLockingCap,
-                BridgeSerializationUtils::serializeCoin
+                BridgeSerializationUtils::serializeRskCoin
             );
         }
 
@@ -72,7 +72,7 @@ public class UnionBridgeStorageProviderImpl implements UnionBridgeStorageProvide
 
     @Override
     public void setLockingCap(Coin lockingCap) {
-        if (lockingCap != null && lockingCap.isZero()) {
+        if (lockingCap != null && lockingCap.equals(Coin.ZERO)) {
             throw new IllegalArgumentException("Union Bridge Locking Cap cannot be zero");
         }
 
@@ -84,21 +84,21 @@ public class UnionBridgeStorageProviderImpl implements UnionBridgeStorageProvide
         return Optional.ofNullable(unionBridgeLockingCap).or(
             () -> Optional.ofNullable(bridgeStorageAccessor.getFromRepository(
                 UnionBridgeStorageIndexKey.UNION_BRIDGE_LOCKING_CAP.getKey(),
-                BridgeSerializationUtils::deserializeCoin
+                BridgeSerializationUtils::deserializeRskCoin
             ))
         );
     }
 
     @Override
-    public void setWeisTransferredToUnionBridge(co.rsk.core.Coin weisTransferred) {
-        if (nonNull(weisTransferred) && weisTransferred.compareTo(co.rsk.core.Coin.ZERO) < 0) {
+    public void setWeisTransferredToUnionBridge(Coin weisTransferred) {
+        if (nonNull(weisTransferred) && weisTransferred.compareTo(Coin.ZERO) < 0) {
             throw new IllegalArgumentException("amount transferred to Union Bridge cannot be negative");
         }
         this.weisTransferredToUnionBridge = weisTransferred;
     }
 
     @Override
-    public Optional<co.rsk.core.Coin> getWeisTransferredToUnionBridge() {
+    public Optional<Coin> getWeisTransferredToUnionBridge() {
         return Optional.ofNullable(weisTransferredToUnionBridge).or(() -> Optional.ofNullable(
             bridgeStorageAccessor.getFromRepository(
                 UnionBridgeStorageIndexKey.WEIS_TRANSFERRED_TO_UNION_BRIDGE.getKey(),

--- a/rskj-core/src/main/java/co/rsk/peg/union/UnionBridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/union/UnionBridgeSupport.java
@@ -1,6 +1,6 @@
 package co.rsk.peg.union;
 
-import co.rsk.bitcoinj.core.Coin;
+import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 
 import org.ethereum.core.Transaction;
@@ -16,7 +16,7 @@ public interface UnionBridgeSupport {
 
     UnionResponseCode increaseLockingCap(Transaction tx, Coin newCap);
 
-    UnionResponseCode requestUnionRbtc(Transaction tx, co.rsk.core.Coin amount);
+    UnionResponseCode requestUnionRbtc(Transaction tx, Coin amount);
 
     void save();
 }

--- a/rskj-core/src/main/java/co/rsk/peg/union/UnionBridgeSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/union/UnionBridgeSupportImpl.java
@@ -1,10 +1,11 @@
 package co.rsk.peg.union;
 
-import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.peg.union.constants.UnionBridgeConstants;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
+import java.math.BigInteger;
 import javax.annotation.Nonnull;
 import org.ethereum.core.SignatureCache;
 import org.ethereum.core.Transaction;
@@ -134,16 +135,16 @@ public class UnionBridgeSupportImpl implements UnionBridgeSupport {
 
         storageProvider.setLockingCap(newCap);
         logger.info("[{}] Union Locking Cap has been increased. New value: {}",
-            INCREASE_LOCKING_CAP_TAG, newCap.value);
+            INCREASE_LOCKING_CAP_TAG, newCap);
         return UnionResponseCode.SUCCESS;
     }
 
-    private co.rsk.core.Coin getWeisTransferredToUnionBridge() {
-        return storageProvider.getWeisTransferredToUnionBridge().orElse(co.rsk.core.Coin.ZERO);
+    private Coin getWeisTransferredToUnionBridge() {
+        return storageProvider.getWeisTransferredToUnionBridge().orElse(Coin.ZERO);
     }
 
     @Override
-    public UnionResponseCode requestUnionRbtc(Transaction tx, co.rsk.core.Coin amount) {
+    public UnionResponseCode requestUnionRbtc(Transaction tx, Coin amount) {
         final String REQUEST_UNION_RBTC_TAG = "requestUnionRbtc";
 
         if (!isCallerUnionBridgeContractAddress(tx)) {
@@ -169,19 +170,19 @@ public class UnionBridgeSupportImpl implements UnionBridgeSupport {
         return isCallerUnionBridgeContractAddress;
     }
 
-    private boolean isValidAmount(co.rsk.core.Coin amountRequested) {
-        boolean isAmountNullOrLessThanOne = amountRequested == null || amountRequested.compareTo(co.rsk.core.Coin.ZERO) < 1;
+    private boolean isValidAmount(Coin amountRequested) {
+        boolean isAmountNullOrLessThanOne = amountRequested == null || amountRequested.compareTo(Coin.ZERO) < 1;
         if (isAmountNullOrLessThanOne) {
             logger.warn(
                 "[isValidAmount] Amount requested cannot be negative or zero. Amount requested: {}", amountRequested);
             return false;
         }
 
-        co.rsk.core.Coin lockingCap = co.rsk.core.Coin.fromBitcoin(getLockingCap());
+        Coin lockingCap = getLockingCap();
 
-        co.rsk.core.Coin previousAmountRequested = getWeisTransferredToUnionBridge();
+        Coin previousAmountRequested = getWeisTransferredToUnionBridge();
 
-        co.rsk.core.Coin newAmountRequested = previousAmountRequested.add(amountRequested);
+        Coin newAmountRequested = previousAmountRequested.add(amountRequested);
         boolean doesNewAmountAndPreviousAmountRequestedSurpassLockingCap =
             newAmountRequested.compareTo(lockingCap) > 0;
         if (doesNewAmountAndPreviousAmountRequestedSurpassLockingCap) {
@@ -200,16 +201,16 @@ public class UnionBridgeSupportImpl implements UnionBridgeSupport {
         if (newCap.compareTo(currentLockingCap) < 1) {
             logger.warn(
                 "[isValidLockingCap] Attempted value doesn't increase Union Locking Cap. Value attempted: {} . currentLockingCap: {}",
-                newCap.value, currentLockingCap.value);
+                newCap, currentLockingCap);
             return false;
         }
 
         Coin maxLockingCapIncreaseAllowed = currentLockingCap.multiply(
-            constants.getLockingCapIncrementsMultiplier());
+            BigInteger.valueOf(constants.getLockingCapIncrementsMultiplier()));
         if (newCap.compareTo(maxLockingCapIncreaseAllowed) > 0) {
             logger.warn(
                 "[isValidLockingCap] Attempted value tries to increase Union Locking Cap above its limit. Value attempted: {} . maxLockingCapIncreasedAllowed: {}",
-                newCap.value, maxLockingCapIncreaseAllowed.value);
+                newCap, maxLockingCapIncreaseAllowed);
             return false;
         }
 

--- a/rskj-core/src/main/java/co/rsk/peg/union/constants/UnionBridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/union/constants/UnionBridgeConstants.java
@@ -1,7 +1,7 @@
 package co.rsk.peg.union.constants;
 
-import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
 

--- a/rskj-core/src/main/java/co/rsk/peg/union/constants/UnionBridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/union/constants/UnionBridgeMainNetConstants.java
@@ -1,9 +1,10 @@
 package co.rsk.peg.union.constants;
 
-import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
+import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
 import org.bouncycastle.util.encoders.Hex;
@@ -22,7 +23,8 @@ public class UnionBridgeMainNetConstants extends UnionBridgeConstants {
         unionBridgeAddress = new RskAddress("5988645d30cd01e4b3bc2c02cb3909dec991ae31");
 
         // TODO: Replace with actual initial locking cap value and increments multiplier
-        initialLockingCap = Coin.COIN.multiply(300L); // 300 BTC
+        BigInteger oneRbtc = BigInteger.TEN.pow(18); // 1 RBTC = 1000000000000000000 wei
+        initialLockingCap = new Coin(oneRbtc).multiply(BigInteger.valueOf(300)); // 300 rbtc
         lockingCapIncrementsMultiplier = 2;
 
         // TODO: Replace with actual authorizers

--- a/rskj-core/src/main/java/co/rsk/peg/union/constants/UnionBridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/union/constants/UnionBridgeRegTestConstants.java
@@ -1,9 +1,10 @@
 package co.rsk.peg.union.constants;
 
-import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
+import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
 import org.bouncycastle.util.encoders.Hex;
@@ -21,7 +22,8 @@ public class UnionBridgeRegTestConstants extends UnionBridgeConstants {
         unionBridgeAddress = new RskAddress("5988645d30cd01e4b3bc2c02cb3909dec991ae31");
 
         // TODO: Replace with actual initial value and increments multiplier
-        initialLockingCap = Coin.COIN.multiply(500L); // 500 BTC
+        BigInteger oneRbtc = BigInteger.TEN.pow(18); // 1 RBTC = 1000000000000000000 wei
+        initialLockingCap = new Coin(oneRbtc).multiply(BigInteger.valueOf(500)); // 500 rbtc
         lockingCapIncrementsMultiplier = 4;
 
         // TODO: Replace with actual authorizers

--- a/rskj-core/src/main/java/co/rsk/peg/union/constants/UnionBridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/union/constants/UnionBridgeTestNetConstants.java
@@ -1,9 +1,10 @@
 package co.rsk.peg.union.constants;
 
-import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
+import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
 import org.bouncycastle.util.encoders.Hex;
@@ -21,7 +22,8 @@ public class UnionBridgeTestNetConstants extends UnionBridgeConstants {
         unionBridgeAddress = new RskAddress("5988645d30cd01e4b3bc2c02cb3909dec991ae31");
 
         // TODO: Replace with actual initial value and increments multiplier
-        initialLockingCap = Coin.COIN.multiply(400L); // 400 BTC
+        BigInteger oneRbtc = BigInteger.TEN.pow(18); // 1 RBTC = 1000000000000000000 wei
+        initialLockingCap = new Coin(oneRbtc).multiply(BigInteger.valueOf(400)); // 400 rbtc
         lockingCapIncrementsMultiplier = 3;
 
         // TODO: Replace with actual authorizers

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -875,10 +875,10 @@ class BridgeSupportTest {
         @Test
         void getUnionBridgeLockingCap_whenNoLockingCapIsStored_shouldReturnInitialConstantLockingCapValue() {
             // act
-            Coin actualUnionBridgeLockingCap = bridgeSupport.getUnionBridgeLockingCap();
+            co.rsk.core.Coin actualUnionBridgeLockingCap = bridgeSupport.getUnionBridgeLockingCap();
 
             // assert
-            Coin expectedLockingCap = unionBridgeConstants.getInitialLockingCap();
+            co.rsk.core.Coin expectedLockingCap = unionBridgeConstants.getInitialLockingCap();
             assertEquals(expectedLockingCap, actualUnionBridgeLockingCap);
         }
 
@@ -886,7 +886,8 @@ class BridgeSupportTest {
         void getUnionBridgeLockingCap_whenStoredLockingCap_shouldReturnStoredLockingCap() {
             // arrange
             UnionBridgeStorageProvider unionBridgeStorageProvider = mock(UnionBridgeStorageProvider.class);
-            Coin storedLockingCap = Coin.COIN.multiply(10);
+            BigInteger oneEth = BigInteger.TEN.pow(18); // 1 ETH = 1000000000000000000 wei
+            co.rsk.core.Coin storedLockingCap = new co.rsk.core.Coin(oneEth.multiply(BigInteger.valueOf(500))); // 500 RBTC
             when(unionBridgeStorageProvider.getLockingCap()).thenReturn(Optional.of(storedLockingCap));
 
             bridgeSupport = bridgeSupportBuilder
@@ -900,7 +901,7 @@ class BridgeSupportTest {
                 .build();
 
             // act
-            Coin actualUnionBridgeLockingCap = bridgeSupport.getUnionBridgeLockingCap();
+            co.rsk.core.Coin actualUnionBridgeLockingCap = bridgeSupport.getUnionBridgeLockingCap();
 
             // assert
             assertEquals(storedLockingCap, actualUnionBridgeLockingCap);
@@ -919,8 +920,9 @@ class BridgeSupportTest {
                 .withUnionBridgeSupport(unionBridgeSupport)
                 .build();
 
-            Coin initialLockingCap = unionBridgeConstants.getInitialLockingCap();
-            Coin newLockingCap = initialLockingCap.multiply(unionBridgeConstants.getLockingCapIncrementsMultiplier());
+            co.rsk.core.Coin initialLockingCap = unionBridgeConstants.getInitialLockingCap();
+            co.rsk.core.Coin newLockingCap = initialLockingCap.multiply(
+                BigInteger.valueOf(unionBridgeConstants.getLockingCapIncrementsMultiplier()));
 
             // act
             UnionResponseCode actualResult = bridgeSupport.increaseUnionBridgeLockingCap(

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -3404,9 +3404,10 @@ class BridgeTest {
 
         private static final UnionBridgeConstants unionBridgeMainNetConstants = mainNetConstants.getBridgeConstants()
             .getUnionBridgeConstants();
-        private static final Coin initialLockingCap = unionBridgeMainNetConstants.getInitialLockingCap();
+        private static final co.rsk.core.Coin initialLockingCap = unionBridgeMainNetConstants.getInitialLockingCap();
 
-        private static final Coin newLockingCap = initialLockingCap.multiply(unionBridgeMainNetConstants.getLockingCapIncrementsMultiplier());
+        private static final co.rsk.core.Coin newLockingCap = initialLockingCap.multiply(
+            BigInteger.valueOf(unionBridgeMainNetConstants.getLockingCapIncrementsMultiplier()));
         private UnionBridgeSupport unionBridgeSupport;
         private Repository repository;
         private BridgeEventLogger eventLogger;
@@ -3524,7 +3525,7 @@ class BridgeTest {
         void getUnionBridgeLockingCap_afterRSKIP502_shouldReturnLockingCap(Constants constants)
             throws VMException {
             // Arrange
-            Coin expectedLockingCap = constants.getBridgeConstants().getUnionBridgeConstants()
+            co.rsk.core.Coin expectedLockingCap = constants.getBridgeConstants().getUnionBridgeConstants()
                 .getInitialLockingCap();
             when(unionBridgeSupport.getLockingCap()).thenReturn(expectedLockingCap);
 
@@ -3535,7 +3536,7 @@ class BridgeTest {
 
             // Assert
             BigInteger decodedResult = (BigInteger)Bridge.GET_UNION_BRIDGE_LOCKING_CAP.decodeResult(result)[0];
-            Coin actualLockingCap = Coin.valueOf(decodedResult.longValue());
+            co.rsk.core.Coin actualLockingCap = new co.rsk.core.Coin(decodedResult);
             assertEquals(expectedLockingCap, actualLockingCap);
         }
 
@@ -3546,7 +3547,7 @@ class BridgeTest {
                 .build();
 
 
-            byte[] data = Bridge.INCREASE_UNION_BRIDGE_LOCKING_CAP.encode(newLockingCap.getValue());
+            byte[] data = Bridge.INCREASE_UNION_BRIDGE_LOCKING_CAP.encode(newLockingCap.asBigInteger());
 
             assertThrows(VMException.class, () -> bridge.execute(data));
         }
@@ -3558,7 +3559,7 @@ class BridgeTest {
             UnionResponseCode expectedResponseCode = UnionResponseCode.SUCCESS;
             when(bridgeSupport.increaseUnionBridgeLockingCap(any(), any())).thenReturn(expectedResponseCode);
 
-            byte[] data = Bridge.INCREASE_UNION_BRIDGE_LOCKING_CAP.encode(newLockingCap.getValue());
+            byte[] data = Bridge.INCREASE_UNION_BRIDGE_LOCKING_CAP.encode(newLockingCap.asBigInteger());
 
             // Act
             byte[] result = bridge.execute(data);
@@ -3571,15 +3572,15 @@ class BridgeTest {
         }
 
         @Test
-        void increaseUnionBridgeLockingCap_afterRSKIP502_whenNewLockingCapSurpassingMaxIcrement_shouldReturnInvalidLockingCapCode()
+        void increaseUnionBridgeLockingCap_afterRSKIP502_whenNewLockingCapSurpassingMaxIncrement_shouldReturnInvalidLockingCapCode()
             throws VMException {
             // Arrange
             UnionResponseCode expectedResponseCode = UnionResponseCode.INVALID_VALUE;
             when(bridgeSupport.increaseUnionBridgeLockingCap(any(), any())).thenReturn(
                 expectedResponseCode);
 
-            Coin lockingCapAboveMaxIncrementAllowed = newLockingCap.add(Coin.COIN);
-            byte[] data = Bridge.INCREASE_UNION_BRIDGE_LOCKING_CAP.encode(lockingCapAboveMaxIncrementAllowed.getValue());
+            co.rsk.core.Coin lockingCapAboveMaxIncrementAllowed = newLockingCap.add(co.rsk.core.Coin.valueOf(1));
+            byte[] data = Bridge.INCREASE_UNION_BRIDGE_LOCKING_CAP.encode(lockingCapAboveMaxIncrementAllowed.asBigInteger());
 
             // Act
             byte[] result = bridge.execute(data);
@@ -3621,7 +3622,7 @@ class BridgeTest {
             when(bridgeSupport.increaseUnionBridgeLockingCap(any(), eq(newLockingCap))).thenReturn(
                 expectedResponseCode);
 
-            byte[] data = Bridge.INCREASE_UNION_BRIDGE_LOCKING_CAP.encode(newLockingCap.getValue());
+            byte[] data = Bridge.INCREASE_UNION_BRIDGE_LOCKING_CAP.encode(newLockingCap.asBigInteger());
 
             // Act
             byte[] result = bridge.execute(data);
@@ -3639,7 +3640,7 @@ class BridgeTest {
             UnionResponseCode expectedResponseCode = UnionResponseCode.INVALID_VALUE;
 
             // when no argument is passed, the default value assigned to the arg is a big integer of zero
-            when(bridgeSupport.increaseUnionBridgeLockingCap(any(), eq(Coin.ZERO))).thenReturn(expectedResponseCode);
+            when(bridgeSupport.increaseUnionBridgeLockingCap(any(), eq(co.rsk.core.Coin.ZERO))).thenReturn(expectedResponseCode);
 
             CallTransaction.Function function = BridgeMethods.INCREASE_UNION_BRIDGE_LOCKING_CAP.getFunction();
             byte[] data = function.encode();

--- a/rskj-core/src/test/java/co/rsk/peg/union/UnionBridgeStorageProviderImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/union/UnionBridgeStorageProviderImplTest.java
@@ -2,12 +2,13 @@ package co.rsk.peg.union;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import co.rsk.bitcoinj.core.Coin;
+import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.peg.BridgeSerializationUtils;
 import co.rsk.peg.storage.InMemoryStorage;
 import co.rsk.peg.storage.StorageAccessor;
 import co.rsk.peg.union.constants.UnionBridgeMainNetConstants;
+import java.math.BigInteger;
 import java.util.Optional;
 import org.ethereum.TestUtils;
 import org.junit.jupiter.api.Assertions;
@@ -21,10 +22,10 @@ class UnionBridgeStorageProviderImplTest {
         "newUnionBridgeContractAddress");
 
     private static final Coin unionBridgeLockingCap = UnionBridgeMainNetConstants.getInstance().getInitialLockingCap();
-    private static final Coin newUnionBridgeLockingCap = unionBridgeLockingCap.times(2);
+    private static final Coin newUnionBridgeLockingCap = unionBridgeLockingCap.multiply(BigInteger.TWO);
 
-    private static final co.rsk.core.Coin amountTransferredToUnionBridge = co.rsk.core.Coin.fromBitcoin(unionBridgeLockingCap.divide(2));
-    private static final co.rsk.core.Coin newAmountTransferredToUnionBridge = co.rsk.core.Coin.fromBitcoin(newUnionBridgeLockingCap.divide(2));
+    private static final Coin amountTransferredToUnionBridge = unionBridgeLockingCap.divide(BigInteger.TWO);
+    private static final Coin newAmountTransferredToUnionBridge = newUnionBridgeLockingCap.divide(BigInteger.TWO);
 
     private StorageAccessor storageAccessor;
     private UnionBridgeStorageProviderImpl unionBridgeStorageProvider;
@@ -235,7 +236,7 @@ class UnionBridgeStorageProviderImplTest {
         // Arrange
         storageAccessor.saveToRepository(
             UnionBridgeStorageIndexKey.UNION_BRIDGE_LOCKING_CAP.getKey(),
-            unionBridgeLockingCap, BridgeSerializationUtils::serializeCoin);
+            unionBridgeLockingCap, BridgeSerializationUtils::serializeRskCoin);
 
         // Act
         Optional<Coin> actualLockingCap = unionBridgeStorageProvider.getLockingCap();
@@ -262,7 +263,7 @@ class UnionBridgeStorageProviderImplTest {
     private void assertNoLockingCapIsStored() {
         Coin retrievedLockingCap = storageAccessor.getFromRepository(
             UnionBridgeStorageIndexKey.UNION_BRIDGE_LOCKING_CAP.getKey(),
-            BridgeSerializationUtils::deserializeCoin);
+            BridgeSerializationUtils::deserializeRskCoin);
         assertNull(retrievedLockingCap);
     }
 
@@ -294,7 +295,7 @@ class UnionBridgeStorageProviderImplTest {
         // To simulate, there is a locking cap already stored
         storageAccessor.saveToRepository(
             UnionBridgeStorageIndexKey.UNION_BRIDGE_LOCKING_CAP.getKey(),
-            unionBridgeLockingCap, BridgeSerializationUtils::serializeCoin
+            unionBridgeLockingCap, BridgeSerializationUtils::serializeRskCoin
         );
 
         // Act
@@ -311,7 +312,7 @@ class UnionBridgeStorageProviderImplTest {
     private void assertGivenLockingCapIsStored(Coin newUnionBridgeLockingCap) {
         Coin savedLockingCap = storageAccessor.getFromRepository(
             UnionBridgeStorageIndexKey.UNION_BRIDGE_LOCKING_CAP.getKey(),
-            BridgeSerializationUtils::deserializeCoin);
+            BridgeSerializationUtils::deserializeRskCoin);
         assertNotNull(savedLockingCap);
         assertEquals(newUnionBridgeLockingCap, savedLockingCap);
     }
@@ -359,7 +360,7 @@ class UnionBridgeStorageProviderImplTest {
         // Arrange
         storageAccessor.saveToRepository(
             UnionBridgeStorageIndexKey.UNION_BRIDGE_LOCKING_CAP.getKey(),
-            unionBridgeLockingCap, BridgeSerializationUtils::serializeCoin);
+            unionBridgeLockingCap, BridgeSerializationUtils::serializeRskCoin);
 
         // Act & Assert
         // Check that locking cap is stored
@@ -373,7 +374,7 @@ class UnionBridgeStorageProviderImplTest {
         // Check the new locking cap is not stored yet but is present in the cache
         Coin originalLockingCap = storageAccessor.getFromRepository(
             UnionBridgeStorageIndexKey.UNION_BRIDGE_LOCKING_CAP.getKey(),
-            BridgeSerializationUtils::deserializeCoin);
+            BridgeSerializationUtils::deserializeRskCoin);
         assertEquals(unionBridgeLockingCap, originalLockingCap);
         assertNotEquals(newUnionBridgeLockingCap, originalLockingCap);
 
@@ -389,7 +390,7 @@ class UnionBridgeStorageProviderImplTest {
     @Test
     void getWeisTransferredToUnionBridge_whenNoValueIsStoredOrSet_shouldReturnEmpty() {
         // Act
-        Optional<co.rsk.core.Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge();
+        Optional<Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge();
 
         // Assert
         assertTrue(actualWeisTransferredToUnionBridge.isEmpty());
@@ -403,7 +404,7 @@ class UnionBridgeStorageProviderImplTest {
             amountTransferredToUnionBridge, BridgeSerializationUtils::serializeRskCoin);
 
         // Act
-        Optional<co.rsk.core.Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge();
+        Optional<Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge();
 
         // Assert
         assertTrue(actualWeisTransferredToUnionBridge.isPresent());
@@ -416,7 +417,7 @@ class UnionBridgeStorageProviderImplTest {
         unionBridgeStorageProvider.setWeisTransferredToUnionBridge(amountTransferredToUnionBridge);
 
         // Act
-        Optional<co.rsk.core.Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge();
+        Optional<Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge();
 
         // Assert
         assertTrue(actualWeisTransferredToUnionBridge.isPresent());
@@ -427,7 +428,7 @@ class UnionBridgeStorageProviderImplTest {
     @Test
     void setWeisTransferredToUnionBridge_whenNegative_shouldThrowIllegalArgumentException() {
         // Arrange
-        co.rsk.core.Coin negativeAmount = co.rsk.core.Coin.valueOf(-1);
+        Coin negativeAmount = Coin.valueOf(-1);
 
         // Act
         Assertions.assertThrows(IllegalArgumentException.class,
@@ -438,13 +439,13 @@ class UnionBridgeStorageProviderImplTest {
     @Test
     void setWeisTransferredToUnionBridge_whenZero_shouldSetZero() {
         // Arrange
-        co.rsk.core.Coin zeroAmount = co.rsk.core.Coin.ZERO;
+        Coin zeroAmount = Coin.ZERO;
 
         // Act
         unionBridgeStorageProvider.setWeisTransferredToUnionBridge(zeroAmount);
 
         // Assert
-        Optional<co.rsk.core.Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge();
+        Optional<Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge();
         assertTrue(actualWeisTransferredToUnionBridge.isPresent());
         assertEquals(zeroAmount, actualWeisTransferredToUnionBridge.get());
 
@@ -453,7 +454,7 @@ class UnionBridgeStorageProviderImplTest {
 
         // Create a new instance of the storage provider to retrieve the value from the storage
         unionBridgeStorageProvider = new UnionBridgeStorageProviderImpl(storageAccessor);
-        Optional<co.rsk.core.Coin> savedWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge();
+        Optional<Coin> savedWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge();
 
         assertTrue(savedWeisTransferredToUnionBridge.isPresent());
         assertEquals(zeroAmount, savedWeisTransferredToUnionBridge.get());
@@ -466,7 +467,7 @@ class UnionBridgeStorageProviderImplTest {
 
         // Assert
         assertNoWeisTransferredToUnionBridgeIsStored();
-        Optional<co.rsk.core.Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge();
+        Optional<Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge();
         assertTrue(actualWeisTransferredToUnionBridge.isPresent());
     }
 
@@ -485,13 +486,13 @@ class UnionBridgeStorageProviderImplTest {
 
         // Assert
         // Check existing wei transferred to union bridge is still stored
-        Optional<co.rsk.core.Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge();
+        Optional<Coin> actualWeisTransferredToUnionBridge = unionBridgeStorageProvider.getWeisTransferredToUnionBridge();
         assertTrue(actualWeisTransferredToUnionBridge.isPresent());
         assertGivenWeisTransferredToUnionBridgeIsStored(amountTransferredToUnionBridge);
     }
 
     private void assertNoWeisTransferredToUnionBridgeIsStored() {
-        co.rsk.core.Coin retrievedWeisTransferredToUnionBridge = storageAccessor.getFromRepository(
+        Coin retrievedWeisTransferredToUnionBridge = storageAccessor.getFromRepository(
             UnionBridgeStorageIndexKey.WEIS_TRANSFERRED_TO_UNION_BRIDGE.getKey(),
             BridgeSerializationUtils::deserializeRskCoin);
         assertNull(retrievedWeisTransferredToUnionBridge);
@@ -508,7 +509,7 @@ class UnionBridgeStorageProviderImplTest {
         // To simulate, there is a locking cap already stored
         storageAccessor.saveToRepository(
             UnionBridgeStorageIndexKey.UNION_BRIDGE_LOCKING_CAP.getKey(),
-            unionBridgeLockingCap, BridgeSerializationUtils::serializeCoin
+            unionBridgeLockingCap, BridgeSerializationUtils::serializeRskCoin
         );
         // To simulate, there is WEIS_TRANSFERRED_TO_UNION_BRIDGE's value already stored
         storageAccessor.saveToRepository(
@@ -541,8 +542,8 @@ class UnionBridgeStorageProviderImplTest {
     }
 
     private void assertGivenWeisTransferredToUnionBridgeIsStored(
-        co.rsk.core.Coin expectedTransferredToUnionBridge) {
-        co.rsk.core.Coin savedWeisTransferredToUnionBridge = storageAccessor.getFromRepository(
+        Coin expectedTransferredToUnionBridge) {
+        Coin savedWeisTransferredToUnionBridge = storageAccessor.getFromRepository(
             UnionBridgeStorageIndexKey.WEIS_TRANSFERRED_TO_UNION_BRIDGE.getKey(),
             BridgeSerializationUtils::deserializeRskCoin);
         assertNotNull(savedWeisTransferredToUnionBridge);

--- a/rskj-core/src/test/java/co/rsk/peg/union/constants/UnionBridgeConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/union/constants/UnionBridgeConstantsTest.java
@@ -3,10 +3,11 @@ package co.rsk.peg.union.constants;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.samePropertyValuesAs;
 
-import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
+import java.math.BigInteger;
 import java.util.Collections;
 import java.util.stream.Stream;
 
@@ -84,10 +85,11 @@ class UnionBridgeConstantsTest {
     }
 
     public static Stream<Arguments> unionLockingCapInitialValueProvider() {
+        Coin oneEth = new Coin(BigInteger.TEN.pow(18)); // 1 ETH = 1000000000000000000 wei
         return Stream.of(
-            Arguments.of(UnionBridgeMainNetConstants.getInstance(), Coin.COIN.multiply(300L)),
-            Arguments.of(UnionBridgeTestNetConstants.getInstance(), Coin.COIN.multiply(400L)),
-            Arguments.of(UnionBridgeRegTestConstants.getInstance(), Coin.COIN.multiply(500L))
+            Arguments.of(UnionBridgeMainNetConstants.getInstance(), oneEth.multiply(BigInteger.valueOf(300L))),
+            Arguments.of(UnionBridgeTestNetConstants.getInstance(), oneEth.multiply(BigInteger.valueOf(400L))),
+            Arguments.of(UnionBridgeRegTestConstants.getInstance(), oneEth.multiply(BigInteger.valueOf(500L)))
         );
     }
 


### PR DESCRIPTION
Replace BitcoinJ Coin with RSK core Coin across UnionBridge impl to get rid of conversions when doing operations with locking cap and weisTransferred together

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)