### PR TITLE
Update BitcoinUtils to also remove signatures from witness transactions

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
@@ -117,7 +117,6 @@ public class BitcoinUtils {
     public static void removeSignaturesFromMultiSigTransaction(BtcTransaction transaction) {
         List<TransactionInput> inputs = transaction.getInputs();
         for (int inputIndex = 0; inputIndex < inputs.size(); inputIndex++) {
-            TransactionInput input = inputs.get(inputIndex);
             Script inputRedeemScript = extractRedeemScriptFromInput(transaction, inputIndex)
                 .orElseThrow(
                     () -> {
@@ -127,13 +126,10 @@ public class BitcoinUtils {
                     }
                 );
             boolean inputHasWitness = inputHasWitness(transaction, inputIndex);
-            if (inputHasWitness) {
-                TransactionWitness witnessScript = createBaseWitnessThatSpendsFromErpRedeemScript(inputRedeemScript);
-                transaction.setWitness(inputIndex, witnessScript);
-            } else {
-                Script inputScript = createBaseInputScriptThatSpendsFromRedeemScript(inputRedeemScript);
-                input.setScriptSig(inputScript);
-            }
+            int federationFormatVersion = inputHasWitness ?
+                FederationFormatVersion.P2SH_P2WSH_ERP_FEDERATION.getFormatVersion() :
+                FederationFormatVersion.P2SH_ERP_FEDERATION.getFormatVersion();
+            addSpendingFederationBaseScript(transaction, inputIndex, inputRedeemScript, federationFormatVersion);
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
@@ -41,6 +41,7 @@ import co.rsk.peg.utils.BridgeEventLoggerImpl;
 import co.rsk.peg.utils.NonRefundablePeginReason;
 import co.rsk.test.builders.BridgeSupportBuilder;
 import co.rsk.test.builders.FederationSupportBuilder;
+import co.rsk.test.builders.PegoutTransactionBuilder;
 import java.io.IOException;
 import java.util.*;
 import java.util.stream.IntStream;
@@ -77,7 +78,8 @@ class BridgeSupportSvpTest {
 
     private final BridgeSupportBuilder bridgeSupportBuilder = BridgeSupportBuilder.builder();
 
-    private final List<BtcECKey> membersBtcPublicKeys = BitcoinTestUtils.getBtcEcKeysFromSeeds(new String[]{
+    private final List<BtcECKey> activeFederationKeys = BitcoinTestUtils.getBtcEcKeys(9);
+    private final List<BtcECKey> proposedFederationKeys = BitcoinTestUtils.getBtcEcKeysFromSeeds(new String[]{
         "member01", "member02", "member03", "member04", "member05", "member06", "member07", "member08", "member09", "member10",
         "member11", "member12", "member13", "member14", "member15", "member16", "member17", "member18", "member19", "member20"
     }, true);
@@ -128,7 +130,9 @@ class BridgeSupportSvpTest {
         bridgeStorageAccessor = new InMemoryStorage();
         federationStorageProvider = new FederationStorageProviderImpl(bridgeStorageAccessor);
 
-        activeFederation = FederationTestUtils.getErpFederation(federationMainNetConstants.getBtcParams());
+        activeFederation = P2shErpFederationBuilder.builder()
+            .withMembersBtcPublicKeys(activeFederationKeys)
+            .build();
         federationStorageProvider.setNewFederation(activeFederation);
 
         List<UTXO> activeFederationUTXOs = Arrays.asList(
@@ -139,7 +143,7 @@ class BridgeSupportSvpTest {
         bridgeStorageAccessor.saveToRepository(NEW_FEDERATION_BTC_UTXOS_KEY.getKey(), activeFederationUTXOs, BridgeSerializationUtils::serializeUTXOList);
 
         proposedFederation = P2shP2wshErpFederationBuilder.builder()
-            .withMembersBtcPublicKeys(membersBtcPublicKeys)
+            .withMembersBtcPublicKeys(proposedFederationKeys)
             .build();
         federationStorageProvider.setProposedFederation(proposedFederation);
 
@@ -497,7 +501,7 @@ class BridgeSupportSvpTest {
             TransactionWitness witness = createBaseWitnessThatSpendsFromErpRedeemScript(activeFederation.getRedeemScript());
 
             for (int i = 0; i < svpFundTransaction.getInputs().size(); i++) {
-                assertTrue(witness.equals(svpFundTransaction.getWitness(i)));
+                assertEquals(witness, svpFundTransaction.getWitness(i));
             }
         }
 
@@ -644,9 +648,14 @@ class BridgeSupportSvpTest {
             // Arrange
             arrangeSvpFundTransactionUnsigned();
 
-            BtcTransaction pegout = createPegout(proposedFederation);
+            BtcTransaction pegout = PegoutTransactionBuilder.builder()
+                .withActiveFederation(activeFederation)
+                .withInput(BitcoinTestUtils.createHash(2), 0, Coin.COIN)
+                .withChangeAmount(Coin.COIN.multiply(10))
+                .withSignatures(activeFederationKeys)
+                .build();
+
             savePegoutIndex(pegout);
-            signInputs(pegout); // a transaction trying to be registered should be signed
             setUpForTransactionRegistration(pegout);
 
             // Act
@@ -826,8 +835,8 @@ class BridgeSupportSvpTest {
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     @Tag("Spend transaction signing tests")
     class SpendTxSigning {
-        private final int threshold = membersBtcPublicKeys.size() / 2 + 1;
-        private final List<BtcECKey> proposedFederationSignersKeys = membersBtcPublicKeys.subList(0, threshold);
+        private final int threshold = proposedFederationKeys.size() / 2 + 1;
+        private final List<BtcECKey> proposedFederationSignersKeys = proposedFederationKeys.subList(0, threshold);
         private List<Sha256Hash> svpSpendTxSigHashes;
 
         @BeforeEach
@@ -968,12 +977,13 @@ class BridgeSupportSvpTest {
         void addSignature_forNormalPegout_whenSvpIsOngoing_shouldAddJustActiveFederatorsSignaturesToPegout() throws Exception {
             Keccak256 rskTxHash = RskTestUtils.createHash(2);
 
-            BtcTransaction pegout = createPegout(activeFederation);
+            BtcTransaction pegout = PegoutTransactionBuilder.builder()
+                .withActiveFederation(activeFederation)
+                .build();
             SortedMap<Keccak256, BtcTransaction> pegoutsWFS = bridgeStorageProvider.getPegoutsWaitingForSignatures();
             pegoutsWFS.put(rskTxHash, pegout);
 
-            List<BtcECKey> activeFedSignersKeys =
-                BitcoinTestUtils.getBtcEcKeysFromSeeds(new String[]{"fa01", "fa02", "fa03", "fa04", "fa05"}, true);
+            List<BtcECKey> activeFedSignersKeys = activeFederationKeys.subList(0, activeFederation.getNumberOfSignaturesRequired());
 
             List<Sha256Hash> pegoutTxSigHashes = generateTransactionInputsSigHashes(pegout);
 
@@ -1019,9 +1029,14 @@ class BridgeSupportSvpTest {
             arrangeSvpSpendTransaction();
             setUpForTransactionRegistration(svpSpendTransaction);
 
-            BtcTransaction pegout = createPegout(proposedFederation);
+            BtcTransaction pegout = PegoutTransactionBuilder.builder()
+                .withActiveFederation(activeFederation)
+                .withInput(BitcoinTestUtils.createHash(2), 0, Coin.COIN)
+                .withChangeAmount(Coin.COIN.multiply(10))
+                .withSignatures(activeFederationKeys)
+                .build();
+
             savePegoutIndex(pegout);
-            signInputs(pegout);
             setUpForTransactionRegistration(pegout);
 
             int activeFederationUtxosSizeBeforeRegisteringTx = federationSupport.getActiveFederationBtcUTXOs().size();
@@ -1627,14 +1642,6 @@ class BridgeSupportSvpTest {
             proposedFederation
         );
         svpFundTransaction.addOutput(svpFundTxOutputsValue, flyoverProposedFederationAddress);
-    }
-
-    private BtcTransaction createPegout(Federation federation) {
-        BtcTransaction pegout = new BtcTransaction(btcMainnetParams);
-        addInput(pegout, federation);
-        addOutputChange(pegout);
-
-        return pegout;
     }
 
     private void addInput(BtcTransaction transaction, Federation federation) {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
@@ -1659,7 +1659,7 @@ class BridgeSupportSvpTest {
             BitcoinTestUtils.getBtcEcKeysFromSeeds(new String[]{"member01", "member02", "member03", "member04", "member05"}, true);
         List<TransactionInput> inputs = transaction.getInputs();
         IntStream.range(0, inputs.size()).forEach(i ->
-            BitcoinTestUtils.signTransactionInputFromP2shMultiSig(transaction, i, keysToSign)
+            BitcoinTestUtils.signLegacyTransactionInputFromP2shMultiSig(transaction, i, keysToSign)
         );
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinTestUtils.java
@@ -155,7 +155,8 @@ public class BitcoinTestUtils {
             false
         );
 
-        for (BtcECKey key : keys) {
+        List<BtcECKey> requiredKeys = getRequiredKeysToSign(keys, inputRedeemScript);
+        for (BtcECKey key : requiredKeys) {
             signTxInputWithKey(transaction, inputIndex, sigHash, key, outputScript);
         }
     }
@@ -178,11 +179,17 @@ public class BitcoinTestUtils {
             false
         );
 
-        int requiredSignatures = inputRedeemScript.getNumberOfSignaturesRequiredToSpend();
-        List<BtcECKey> requiredKeys = new ArrayList<>(keys.subList(0, requiredSignatures));
+        List<BtcECKey> requiredKeys = getRequiredKeysToSign(keys, inputRedeemScript);
         for (BtcECKey key : requiredKeys) {
             signTxInputWithKey(transaction, inputIndex, sigHash, key, outputScript);
         }
+    }
+
+    private static List<BtcECKey> getRequiredKeysToSign(List<BtcECKey> allKeys, Script redeemScript) {
+        int requiredSignatures = redeemScript.getNumberOfSignaturesRequiredToSpend();
+        int keysToSign = Math.min(requiredSignatures, allKeys.size());
+
+        return new ArrayList<>(allKeys.subList(0, keysToSign));
     }
 
     public static void signTxInputWithKey(

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinTestUtils.java
@@ -34,6 +34,17 @@ public class BitcoinTestUtils {
         return keys;
     }
 
+    public static List<BtcECKey> getBtcEcKeys(int amount) {
+        List<BtcECKey> keys = new ArrayList<>();
+        for (int i = 0; i < amount; i++) {
+            String seed = "seed" + i;
+            BtcECKey key = getBtcEcKeyFromSeed(seed);
+            keys.add(key);
+        }
+
+        return keys;
+    }
+
     public static Address createP2PKHAddress(NetworkParameters networkParameters, String seed) {
         BtcECKey key = BtcECKey.fromPrivate(
             HashUtil.keccak256(seed.getBytes(StandardCharsets.UTF_8)));
@@ -142,7 +153,12 @@ public class BitcoinTestUtils {
             .orElseThrow(() -> new IllegalArgumentException("Cannot sign inputs that are not from a p2sh multisig"));
 
         Script outputScript = createP2SHOutputScript(inputRedeemScript);
-        Sha256Hash sigHash = transaction.hashForSignature(inputIndex, inputRedeemScript, BtcTransaction.SigHash.ALL, false);
+        Sha256Hash sigHash = transaction.hashForSignature(
+            inputIndex,
+            inputRedeemScript,
+            BtcTransaction.SigHash.ALL,
+            false
+        );
 
         for (BtcECKey key : keys) {
             signTxInputWithKey(transaction, inputIndex, sigHash, key, outputScript);

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
@@ -1072,6 +1072,9 @@ class BitcoinUtilsTest {
             );
         }
 
+        // Make sure the transaction has signatures
+        assertNotEquals(transactionBeforeSigning, transaction);
+
         // act
         BitcoinUtils.removeSignaturesFromMultiSigTransaction(transaction);
 
@@ -1079,8 +1082,9 @@ class BitcoinUtilsTest {
         assertEquals(transactionBeforeSigning, transaction);
 
         Script federationRedeemScript = federation.getRedeemScript();
-        for (TransactionInput input : transaction.getInputs()) {
-            int inputIndex = transaction.getInputs().indexOf(input);
+        List<TransactionInput> transactionInputs = transaction.getInputs();
+        for (TransactionInput input : transactionInputs) {
+            int inputIndex = transactionInputs.indexOf(input);
             TransactionWitness witness = transaction.getWitness(inputIndex);
 
             assertWitnessScriptWithoutSignaturesHasProperFormat(witness, federationRedeemScript);
@@ -1158,6 +1162,9 @@ class BitcoinUtilsTest {
             inputValue,
             p2wshFederationBtcKeys
         );
+
+        // Make sure the transaction has signatures
+        assertNotEquals(transactionBeforeSigning, transaction);
 
         // act
         BitcoinUtils.removeSignaturesFromMultiSigTransaction(transaction);

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationChangeIT.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationChangeIT.java
@@ -836,7 +836,7 @@ class FederationChangeIT {
     private void signInputs(BtcTransaction transaction, List<BtcECKey> keysToSign) {
         List<TransactionInput> inputs = transaction.getInputs();
         IntStream.range(0, inputs.size()).forEach(i ->
-            BitcoinTestUtils.signTransactionInputFromP2shMultiSig(transaction, i, keysToSign)
+            BitcoinTestUtils.signLegacyTransactionInputFromP2shMultiSig(transaction, i, keysToSign)
         );
     }
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
BitcoinUtils::removeSignaturesFromMultiSigTransaction method can now remove signatures from both legacy and witness transactions.

Unit tests added.

Improvements in other utils methods and PegoutTransactionBuilder

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
