### PR TITLE
Adding consensus rules for rskip516 for ec secp256k1 curve

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -105,7 +105,8 @@ public enum ConsensusRule {
     RSKIP453("rskip453"),
     RSKIP454("rskip454"),
     RSKIP459("rskip459"),
-    RSKIP460("rskip460")
+    RSKIP460("rskip460"),
+    RSKIP516("rskip516"), //  Addition of precompiled contracts for add and mul operations on the secp256k1 curve
     ;
 
     private final String configKey;

--- a/rskj-core/src/main/resources/config/testnet2.conf
+++ b/rskj-core/src/main/resources/config/testnet2.conf
@@ -14,7 +14,8 @@ blockchain.config {
         fingerroot500 = 4015800,
         arrowhead600 = 4927100,
         arrowhead631 = -1,
-        lovell700 = -1
+        lovell700 = -1,
+        tbd800 = -1
     },
     consensusRules = {
         rskip97 = -1, # disable orchid difficulty drop

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -108,6 +108,7 @@ blockchain = {
             rskip454 = <hardforkName>
             rskip459 = <hardforkName>
             rskip460 = <hardforkName>
+            rskip516 = <hardforkName>
         }
     }
     gc = {

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -92,6 +92,7 @@ blockchain = {
             rskip454 = lovell700
             rskip459 = lovell700
             rskip460 = lovell700
+            rskip516 = tbd800
         }
     }
     gc = {

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -134,6 +134,7 @@ class ActivationConfigTest {
         "    rskip454: lovell700",
         "    rskip459: lovell700",
         "    rskip460: lovell700",
+        "    rskip516: tbd800",
         "}"
     ));
 


### PR DESCRIPTION
Adding consensus rules for RSKIP516, planned to be activated in the next RSKj hardfork.

## Motivation and Context
We need the consensus rule in order o implement the logic associated to it.

## How Has This Been Tested?
We added test classes for the new consensus rule

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
