### PR TITLE
Removing mining group from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # mining
-/rskj-core/src/main/java/co/rsk/mine/                                       @rsksmart/rsk-mining
-/rskj-core/src/main/java/co/rsk/rpc/modules/mnr/                            @rsksmart/rsk-mining
-/rskj-core/src/main/java/co/rsk/validators/ProofOfWorkRule.java             @rsksmart/rsk-mining
-/rskj-core/src/main/java/co/rsk/validators/Rskip92MerkleProofValidator.java @rsksmart/rsk-mining
+/rskj-core/src/main/java/co/rsk/mine/                                       @rsksmart/rsk-core
+/rskj-core/src/main/java/co/rsk/rpc/modules/mnr/                            @rsksmart/rsk-core
+/rskj-core/src/main/java/co/rsk/validators/ProofOfWorkRule.java             @rsksmart/rsk-core
+/rskj-core/src/main/java/co/rsk/validators/Rskip92MerkleProofValidator.java @rsksmart/rsk-core
 
 # powpeg
 /rskj-core/src/main/java/co/rsk/peg/                                        @rsksmart/rsk-fed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We are removing the mining group and keeping only core group as responsible from the things we own.

## Motivation and Context
We want to remove the specific mining group, all members of core team are responsible for the mining part.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
