### PR TITLE
Add network check to `setUnionBridgeContractAddressForTestnet` BridgeMethod

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -1548,6 +1548,20 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         };
     }
 
+    public static BridgeMethods.BridgeMethodExecutor executeIfTestnetOrRegTest(BridgeMethods.BridgeMethodExecutor decoratee, String funcName) {
+        return (self, args) -> {
+            boolean isMainnet = self.constants.getChainId() == Constants.MAINNET_CHAIN_ID;
+            if (isMainnet) {
+                String errorMessage = String.format(
+                    "The %s function is disabled in Mainnet.",
+                    funcName
+                );
+                throw new VMException(errorMessage);
+            }
+            return decoratee.execute(self, args);
+        };
+    }
+
     public static BridgeMethods.BridgeMethodExecutor activeAndRetiringFederationOnly(BridgeMethods.BridgeMethodExecutor decoratee, String funcName) {
         return (self, args) -> {
             boolean isFromActiveFed = BridgeUtils.isFromFederateMember(self.rskTx, self.bridgeSupport.getActiveFederation(), self.signatureCache);

--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -1548,7 +1548,7 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         };
     }
 
-    public static BridgeMethods.BridgeMethodExecutor executeIfTestnetOrRegTest(BridgeMethods.BridgeMethodExecutor decoratee, String funcName) {
+    public static BridgeMethods.BridgeMethodExecutor executeIfEnabledEnvironment(BridgeMethods.BridgeMethodExecutor decoratee, String funcName) {
         return (self, args) -> {
             boolean isMainnet = self.constants.getChainId() == Constants.MAINNET_CHAIN_ID;
             if (isMainnet) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
@@ -833,7 +833,7 @@ public enum BridgeMethods {
             new String[]{"int"}
         ),
         fixedCost(24000L), // TODO: Define final cost
-        Bridge.executeIfTestnetOrRegTest(
+        Bridge.executeIfEnabledEnvironment(
             (BridgeMethodExecutorTyped<Integer>) Bridge::setUnionBridgeContractAddressForTestnet,
             "setUnionBridgeContractAddressForTestnet"
         ),

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeMethods.java
@@ -833,7 +833,10 @@ public enum BridgeMethods {
             new String[]{"int"}
         ),
         fixedCost(24000L), // TODO: Define final cost
-        (BridgeMethodExecutorTyped<Integer>) Bridge::setUnionBridgeContractAddressForTestnet,
+        Bridge.executeIfTestnetOrRegTest(
+            (BridgeMethodExecutorTyped<Integer>) Bridge::setUnionBridgeContractAddressForTestnet,
+            "setUnionBridgeContractAddressForTestnet"
+        ),
         activations -> activations.isActive(RSKIP502),
         fixedPermission(false)
     ),

--- a/rskj-core/src/test/java/co/rsk/peg/union/UnionBridgeIT.java
+++ b/rskj-core/src/test/java/co/rsk/peg/union/UnionBridgeIT.java
@@ -276,7 +276,7 @@ class UnionBridgeIT {
 
     @Test
     @Order(7)
-    void setUnionBridgeContractAddressForTestnet_whenAllActivations_shouldReturnEnvironmentDisabled()
+    void setUnionBridgeContractAddressForTestnet_whenAllActivations_shouldFail()
         throws VMException {
         // Setup for all activations
         setupForAllActivations();
@@ -289,10 +289,10 @@ class UnionBridgeIT {
         assertNoAddressIsStored();
 
         // Attempt to update union address when mainnet network. It should fail.
-        int actualUnionResponseCode = updateUnionAddress();
+        VMException actualException = assertThrows(VMException.class, this::updateUnionAddress);
 
         // Assert mainnet network does not allow updating union address
-        assertEquals(ENVIRONMENT_DISABLED.getCode(), actualUnionResponseCode);
+        assertTrue(actualException.getMessage().contains("The setUnionBridgeContractAddressForTestnet function is disabled in Mainnet."));
         assertNoAddressIsStored();
         assertNoEventWasEmitted();
 
@@ -504,14 +504,17 @@ class UnionBridgeIT {
 
     @Test
     @Order(25)
-    void setUnionBridgeContractAddressForTestnet_whenMainnetAndTransferIsDisabled_shouldReturnEnvironmentDisabled()
+    void setUnionBridgeContractAddressForTestnet_whenMainnetAndTransferIsDisabled_shouldFail()
         throws VMException {
         setupCaller(CURRENT_UNION_BRIDGE_ADDRESS);
         RskAddress actualUnionAddress = getUnionBridgeContractAddress();
         assertEquals(CURRENT_UNION_BRIDGE_ADDRESS, actualUnionAddress);
 
-        int actualUnionResponseCode = updateUnionAddress();
-        assertEquals(ENVIRONMENT_DISABLED.getCode(), actualUnionResponseCode);
+        // Attempt to update union address when mainnet network. It should fail.
+        VMException actualException = assertThrows(VMException.class, this::updateUnionAddress);
+
+        // Assert mainnet network does not allow updating union address
+        assertTrue(actualException.getMessage().contains("The setUnionBridgeContractAddressForTestnet function is disabled in Mainnet."));
 
         // Assert that the union address remains unchanged
         assertNoAddressIsStored();
@@ -798,13 +801,10 @@ class UnionBridgeIT {
         setupCaller(CURRENT_UNION_BRIDGE_ADDRESS);
     }
 
-    private int updateUnionAddress() throws VMException {
+    private void updateUnionAddress() throws VMException {
         CallTransaction.Function function = SET_UNION_BRIDGE_CONTRACT_ADDRESS_FOR_TESTNET.getFunction();
         byte[] setUnionBridgeContractAddressData = function.encode(NEW_UNION_BRIDGE_CONTRACT_ADDRESS.toHexString());
-        byte[] result = bridge.execute(setUnionBridgeContractAddressData);
-        BigInteger decodedResult = (BigInteger) Bridge.SET_UNION_BRIDGE_CONTRACT_ADDRESS_FOR_TESTNET.decodeResult(
-            result)[0];
-        return decodedResult.intValue();
+        bridge.execute(setUnionBridgeContractAddressData);
     }
 
     private void assertNoAddressIsStored() {


### PR DESCRIPTION
## Description
Added network check to the `setUnionBridgeContractAddressForTestnet` function to ensure it is disabled when the network is Mainnet.

## How Has This Been Tested?

Unit tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)