### PR TITLE
Remove  redundant network check for setUnionBridgeContractAddressForTestnet in UnionBridgeSupportImpl

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/union/UnionBridgeSupportImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/union/UnionBridgeSupportImpl.java
@@ -50,16 +50,6 @@ public class UnionBridgeSupportImpl implements UnionBridgeSupport {
         final String SET_UNION_BRIDGE_ADDRESS_TAG = "setUnionBridgeContractAddressForTestnet";
         logger.info("[{}] Setting new union bridge contract address: {}", SET_UNION_BRIDGE_ADDRESS_TAG, unionBridgeContractAddress);
 
-        // Check if the network is MAINNET as the contract address can only be set in testnet or regtest
-        if (isCurrentEnvironmentMainnet()) {
-            logger.warn(
-                "[{}] Union Bridge Contract Address can only be set in Testnet and RegTest environments. Current network: {}",
-                SET_UNION_BRIDGE_ADDRESS_TAG,
-                constants.getBtcParams().getId()
-            );
-            return UnionResponseCode.ENVIRONMENT_DISABLED;
-        }
-
         AddressBasedAuthorizer authorizer = constants.getChangeUnionBridgeContractAddressAuthorizer();
         if (!isAuthorized(tx, authorizer)) {
             return UnionResponseCode.UNAUTHORIZED_CALLER;

--- a/rskj-core/src/main/java/co/rsk/peg/union/UnionResponseCode.java
+++ b/rskj-core/src/main/java/co/rsk/peg/union/UnionResponseCode.java
@@ -11,8 +11,6 @@ public enum UnionResponseCode {
     // Response codes when request or release is disabled:
     REQUEST_DISABLED(-3),
     RELEASE_DISABLED(-3),
-    // Environment restriction for preventing union bridge address being updated on production
-    ENVIRONMENT_DISABLED(-3),
     GENERIC_ERROR(-10)
     ;
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTest.java
@@ -884,7 +884,6 @@ class BridgeSupportTest {
         private static Stream<Arguments> unionResponseCodeProvider() {
             return Stream.of(
                 Arguments.of(UnionResponseCode.SUCCESS),
-                Arguments.of(UnionResponseCode.ENVIRONMENT_DISABLED),
                 Arguments.of(UnionResponseCode.UNAUTHORIZED_CALLER),
                 Arguments.of(UnionResponseCode.GENERIC_ERROR)
             );
@@ -1011,8 +1010,7 @@ class BridgeSupportTest {
             return Stream.of(
                 Arguments.of(UnionResponseCode.SUCCESS),
                 Arguments.of(UnionResponseCode.GENERIC_ERROR),
-                Arguments.of(UnionResponseCode.INVALID_VALUE),
-                Arguments.of(UnionResponseCode.UNAUTHORIZED_CALLER)
+                Arguments.of(UnionResponseCode.INVALID_VALUE)
             );
         }
 
@@ -1155,22 +1153,6 @@ class BridgeSupportTest {
             );
 
             assertEquals(UnionResponseCode.SUCCESS, actualResponseCode);
-        }
-
-        @Test
-        void setTransferPermissions_whenUnauthorizedCaller_shouldReturnUnauthorizedResponseCode() {
-            // arrange
-            unionBridgeSupport = mock(UnionBridgeSupport.class);
-            when(unionBridgeSupport.setTransferPermissions(any(), anyBoolean(), anyBoolean()))
-                .thenReturn(UnionResponseCode.UNAUTHORIZED_CALLER);
-            bridgeSupport = bridgeSupportBuilder.withUnionBridgeSupport(unionBridgeSupport).build();
-
-            // act
-            UnionResponseCode responseCode = bridgeSupport.setUnionBridgeTransferPermissions(transaction, true, false);
-
-            // assert
-            assertEquals(UnionResponseCode.UNAUTHORIZED_CALLER, responseCode);
-            verify(unionBridgeSupport, times(1)).setTransferPermissions(transaction, true, false);
         }
 
         @Test

--- a/rskj-core/src/test/java/co/rsk/peg/union/UnionBridgeSupportImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/union/UnionBridgeSupportImplTest.java
@@ -265,25 +265,6 @@ class UnionBridgeSupportImplTest {
     }
 
     @Test
-    void setUnionBridgeContractAddressForTestnet_whenMainnet_shouldReturnEnvironmentDisabledCode() {
-        // arrange
-        when(rskTx.getSender(signatureCache)).thenReturn(
-            changeUnionAddressAuthorizer);
-        // act
-        UnionResponseCode actualResponseCode = unionBridgeSupport.setUnionBridgeContractAddressForTestnet(rskTx,
-            unionBridgeContractAddress);
-
-        // assert
-        UnionResponseCode expectedResponseCode = UnionResponseCode.ENVIRONMENT_DISABLED;
-        Assertions.assertEquals(
-            expectedResponseCode,
-            actualResponseCode
-        );
-        assertAddressWasNotSet();
-        assertNoAddressIsStored();
-    }
-
-    @Test
     void setUnionBridgeContractAddressForTestnet_whenCallerIsNotAuthorized_shouldReturnUnauthorizedCode() {
         // arrange
         unionBridgeSupport = unionBridgeSupportBuilder
@@ -1265,12 +1246,6 @@ class UnionBridgeSupportImplTest {
         // arrange
         unionBridgeSupport = unionBridgeSupportBuilder
             .withConstants(mainnetUnionBridgeConstants).build();
-
-        // Attempt to set union bridge contract address for mainnet should fail
-        when(rskTx.getSender(signatureCache)).thenReturn(changeUnionAddressAuthorizer);
-        UnionResponseCode setAddressResponseCode = unionBridgeSupport.setUnionBridgeContractAddressForTestnet(rskTx,
-            mainnetUnionBridgeContractAddress);
-        Assertions.assertEquals(UnionResponseCode.ENVIRONMENT_DISABLED, setAddressResponseCode);
 
         // increase locking cap
         Coin initialLockingCap = mainnetUnionBridgeConstants.getInitialLockingCap();

--- a/rskj-core/src/test/java/co/rsk/peg/union/UnionResponseCodeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/union/UnionResponseCodeTest.java
@@ -40,10 +40,4 @@ class UnionResponseCodeTest {
         // Arrange
         Assertions.assertEquals(-3, UnionResponseCode.RELEASE_DISABLED.getCode());
     }
-
-    @Test
-    void getCode_whenEnvironmentDisabled_shouldReturnCode() {
-        // Arrange
-        Assertions.assertEquals(-3, UnionResponseCode.ENVIRONMENT_DISABLED.getCode());
-    }
 }


### PR DESCRIPTION
## Description
Removed redundant network check for the `setUnionBridgeContractAddressForTestnet` method from `UnionBridgeSupportImpl` and updated related tests accordingly.

## How Has This Been Tested?

Unit tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)