### PR TITLE
Rename AddressBasedAuthorizer methods for clarity and consistency

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/vote/ABICallElection.java
+++ b/rskj-core/src/main/java/co/rsk/peg/vote/ABICallElection.java
@@ -110,7 +110,7 @@ public class ABICallElection {
     }
 
     private boolean areEnoughVotes(int votesSize) {
-        return votesSize >= authorizer.getRequiredAuthorizedKeys();
+        return votesSize >= authorizer.getRequiredAuthorizedAddresses();
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/peg/vote/AddressBasedAuthorizer.java
+++ b/rskj-core/src/main/java/co/rsk/peg/vote/AddressBasedAuthorizer.java
@@ -73,15 +73,15 @@ public class AddressBasedAuthorizer {
         return isAuthorized(tx.getSender(signatureCache));
     }
 
-    public int getNumberOfAuthorizedKeys() {
+    public int getNumberOfAuthorizedAddresses() {
         return authorizedAddresses.size();
     }
 
-    public int getRequiredAuthorizedKeys() {
+    public int getRequiredAuthorizedAddresses() {
         return switch (requiredCalculation) {
             case ONE -> 1;
-            case MAJORITY -> getNumberOfAuthorizedKeys() / 2 + 1;
-            default -> getNumberOfAuthorizedKeys();
+            case MAJORITY -> getNumberOfAuthorizedAddresses() / 2 + 1;
+            default -> getNumberOfAuthorizedAddresses();
         };
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/vote/AddressBasedAuthorizerFactoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/vote/AddressBasedAuthorizerFactoryTest.java
@@ -108,8 +108,8 @@ class AddressBasedAuthorizerFactoryTest {
     }
 
     private void assertSingleAuthorizer(AddressBasedAuthorizer addressBasedAuthorizer, RskAddress authorizedAddress) {
-        Assertions.assertEquals(1, addressBasedAuthorizer.getNumberOfAuthorizedKeys());
-        Assertions.assertEquals(1, addressBasedAuthorizer.getRequiredAuthorizedKeys());
+        Assertions.assertEquals(1, addressBasedAuthorizer.getNumberOfAuthorizedAddresses());
+        Assertions.assertEquals(1, addressBasedAuthorizer.getNumberOfAuthorizedAddresses());
 
         // should be authorized
         Assertions.assertTrue(addressBasedAuthorizer.isAuthorized(authorizedAddress));
@@ -119,8 +119,8 @@ class AddressBasedAuthorizerFactoryTest {
     }
 
     private void assertMajorityAuthorizer(AddressBasedAuthorizer majorityAuthorizer, Set<RskAddress> authorizedAddresses) {
-        Assertions.assertEquals(authorizedAddresses.size(), majorityAuthorizer.getNumberOfAuthorizedKeys());
-        Assertions.assertEquals(authorizedAddresses.size() / 2 + 1, majorityAuthorizer.getRequiredAuthorizedKeys());
+        Assertions.assertEquals(authorizedAddresses.size(), majorityAuthorizer.getNumberOfAuthorizedAddresses());
+        Assertions.assertEquals(authorizedAddresses.size() / 2 + 1, majorityAuthorizer.getRequiredAuthorizedAddresses());
 
         authorizedAddresses.stream().map(majorityAuthorizer::isAuthorized).forEach(Assertions::assertTrue);
         authorizedAddresses.forEach(address -> {

--- a/rskj-core/src/test/java/co/rsk/peg/vote/AddressBasedAuthorizerTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/vote/AddressBasedAuthorizerTest.java
@@ -44,8 +44,8 @@ class AddressBasedAuthorizerTest {
             mock(ECKey.class)
         ), AddressBasedAuthorizer.MinimumRequiredCalculation.ONE);
 
-        Assertions.assertEquals(4, auth.getNumberOfAuthorizedKeys());
-        Assertions.assertEquals(1, auth.getRequiredAuthorizedKeys());
+        Assertions.assertEquals(4, auth.getNumberOfAuthorizedAddresses());
+        Assertions.assertEquals(1, auth.getRequiredAuthorizedAddresses());
     }
 
     @Test
@@ -57,8 +57,8 @@ class AddressBasedAuthorizerTest {
             mock(ECKey.class)
         ), AddressBasedAuthorizer.MinimumRequiredCalculation.MAJORITY);
 
-        Assertions.assertEquals(4, auth.getNumberOfAuthorizedKeys());
-        Assertions.assertEquals(3, auth.getRequiredAuthorizedKeys());
+        Assertions.assertEquals(4, auth.getNumberOfAuthorizedAddresses());
+        Assertions.assertEquals(3, auth.getRequiredAuthorizedAddresses());
     }
 
     @Test
@@ -70,8 +70,8 @@ class AddressBasedAuthorizerTest {
             mock(ECKey.class)
         ), AddressBasedAuthorizer.MinimumRequiredCalculation.ALL);
 
-        Assertions.assertEquals(4, auth.getNumberOfAuthorizedKeys());
-        Assertions.assertEquals(4, auth.getRequiredAuthorizedKeys());
+        Assertions.assertEquals(4, auth.getNumberOfAuthorizedAddresses());
+        Assertions.assertEquals(4, auth.getRequiredAuthorizedAddresses());
     }
 
     @Test


### PR DESCRIPTION
## Description
Renamed methods:
- `getNumberOfAuthorizedKeys` to `getNumberOfAuthorizedAddresses`
- `getRequiredAuthorizedKeys` to `getRequiredAuthorizedAddresses`


## How Has This Been Tested?

Unit tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)