### PR TITLE
Improve clarity on logic to handle block header compression

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/core/BlockFactory.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockFactory.java
@@ -185,7 +185,8 @@ public class BlockFactory {
         short[] txExecutionSublistsEdges = null;
         byte[] baseEvent = null;
 
-        if (!activationConfig.isActive(ConsensusRule.RSKIP351, blockNumber) || !compressed) {
+        // Compressed headers don't have the txExecutionSublistsEdges and baseEvent fields
+        if (!isCompressed(blockNumber, compressed)) {
             if (rlpHeader.size() > r && activationConfig.isActive(ConsensusRule.RSKIP144, blockNumber)) {
                 txExecutionSublistsEdges = ByteUtil.rlpToShorts(rlpHeader.get(r++).getRLPRawData());
             }
@@ -214,6 +215,17 @@ public class BlockFactory {
                 paidFees, minimumGasPriceBytes, minimumGasPrice, uncleCount, ummRoot, baseEvent, version, txExecutionSublistsEdges,
                 bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof, bitcoinMergedMiningCoinbaseTransaction,
                 useRskip92Encoding, includeForkDetectionData);
+    }
+
+    private boolean isCompressed(long blockNumber, boolean compressedFlag) {
+        // RSKIP-351 is what introduced the possibility of compressed headers
+        // before that, all headers were uncompressed
+        if (!activationConfig.isActive(ConsensusRule.RSKIP351, blockNumber)) {
+            return false;
+        }
+
+        // After RSKIP-351, we can trust the compressed flag
+        return compressedFlag;
     }
 
     private BlockHeader createBlockHeader(boolean compressed, boolean sealed, byte[] parentHash, byte[] unclesHash,


### PR DESCRIPTION
This keeps the same logic as the previous implementation, but extracts the logic that determines if a block header is compressed or not to a private function to improve clarity.


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
