### PR TITLE
Default properties for eth_getLogs

### DIFF
--- a/rskj-core/src/main/resources/config/devnet.conf
+++ b/rskj-core/src/main/resources/config/devnet.conf
@@ -50,3 +50,16 @@ wallet {
 }
 
 targetgaslimit = 6800000
+
+
+rpc {
+    logs {
+	# Reasonable limit to do not overload your node
+	# You could lower it down to 1k as a precaution
+        maxBlocksToQuery = 5000
+	# Ballpark size esitmation for 20k logs is about 10Mb
+	# With gzip compression it could be less than 1Mb
+        maxLogsToReturn = 20000
+    }
+}
+

--- a/rskj-core/src/main/resources/config/devnet.conf
+++ b/rskj-core/src/main/resources/config/devnet.conf
@@ -51,15 +51,3 @@ wallet {
 
 targetgaslimit = 6800000
 
-
-rpc {
-    logs {
-	# Reasonable limit to do not overload your node
-	# You could lower it down to 1k as a precaution
-        maxBlocksToQuery = 5000
-	# Ballpark size esitmation for 20k logs is about 10Mb
-	# With gzip compression it could be less than 1Mb
-        maxLogsToReturn = 20000
-    }
-}
-

--- a/rskj-core/src/main/resources/config/main.conf
+++ b/rskj-core/src/main/resources/config/main.conf
@@ -102,15 +102,3 @@ wallet {
     accounts = []
 }
 
-
-rpc {
-    logs {
-	# Reasonable limit to do not overload your node
-	# You could lower it down to 1k as a precaution
-        maxBlocksToQuery = 5000
-	# Ballpark size esitmation for 20k logs is about 10Mb
-	# With gzip compression it could be less than 1Mb
-        maxLogsToReturn = 20000
-    }
-}
-

--- a/rskj-core/src/main/resources/config/main.conf
+++ b/rskj-core/src/main/resources/config/main.conf
@@ -101,3 +101,16 @@ wallet {
     enabled = false
     accounts = []
 }
+
+
+rpc {
+    logs {
+	# Reasonable limit to do not overload your node
+	# You could lower it down to 1k as a precaution
+        maxBlocksToQuery = 5000
+	# Ballpark size esitmation for 20k logs is about 10Mb
+	# With gzip compression it could be less than 1Mb
+        maxLogsToReturn = 20000
+    }
+}
+

--- a/rskj-core/src/main/resources/config/regtest.conf
+++ b/rskj-core/src/main/resources/config/regtest.conf
@@ -80,3 +80,16 @@ wallet {
 }
 
 targetgaslimit = 7500000
+
+
+rpc {
+    logs {
+	# Reasonable limit to do not overload your node
+	# You could lower it down to 1k as a precaution
+        maxBlocksToQuery = 5000
+	# Ballpark size esitmation for 20k logs is about 10Mb
+	# With gzip compression it could be less than 1Mb
+        maxLogsToReturn = 20000
+    }
+}
+

--- a/rskj-core/src/main/resources/config/regtest.conf
+++ b/rskj-core/src/main/resources/config/regtest.conf
@@ -81,15 +81,3 @@ wallet {
 
 targetgaslimit = 7500000
 
-
-rpc {
-    logs {
-	# Reasonable limit to do not overload your node
-	# You could lower it down to 1k as a precaution
-        maxBlocksToQuery = 5000
-	# Ballpark size esitmation for 20k logs is about 10Mb
-	# With gzip compression it could be less than 1Mb
-        maxLogsToReturn = 20000
-    }
-}
-

--- a/rskj-core/src/main/resources/config/testnet.conf
+++ b/rskj-core/src/main/resources/config/testnet.conf
@@ -98,15 +98,3 @@ wallet {
 #    }
 #}
 
-
-rpc {
-    logs {
-	# Reasonable limit to do not overload your node
-	# You could lower it down to 1k as a precaution
-        maxBlocksToQuery = 5000
-	# Ballpark size esitmation for 20k logs is about 10Mb
-	# With gzip compression it could be less than 1Mb
-        maxLogsToReturn = 20000
-    }
-}
-

--- a/rskj-core/src/main/resources/config/testnet.conf
+++ b/rskj-core/src/main/resources/config/testnet.conf
@@ -97,3 +97,16 @@ wallet {
 #        size: 20000
 #    }
 #}
+
+
+rpc {
+    logs {
+	# Reasonable limit to do not overload your node
+	# You could lower it down to 1k as a precaution
+        maxBlocksToQuery = 5000
+	# Ballpark size esitmation for 20k logs is about 10Mb
+	# With gzip compression it could be less than 1Mb
+        maxLogsToReturn = 20000
+    }
+}
+

--- a/rskj-core/src/main/resources/config/testnet2.conf
+++ b/rskj-core/src/main/resources/config/testnet2.conf
@@ -89,3 +89,15 @@ wallet {
     accounts = []
 }
 
+
+rpc {
+    logs {
+	# Reasonable limit to do not overload your node
+	# You could lower it down to 1k as a precaution
+        maxBlocksToQuery = 5000
+	# Ballpark size esitmation for 20k logs is about 10Mb
+	# With gzip compression it could be less than 1Mb
+        maxLogsToReturn = 20000
+    }
+}
+

--- a/rskj-core/src/main/resources/config/testnet2.conf
+++ b/rskj-core/src/main/resources/config/testnet2.conf
@@ -89,15 +89,3 @@ wallet {
     accounts = []
 }
 
-
-rpc {
-    logs {
-	# Reasonable limit to do not overload your node
-	# You could lower it down to 1k as a precaution
-        maxBlocksToQuery = 5000
-	# Ballpark size esitmation for 20k logs is about 10Mb
-	# With gzip compression it could be less than 1Mb
-        maxLogsToReturn = 20000
-    }
-}
-

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -533,12 +533,19 @@ rpc {
     # set signature to zero (instead of null) for Remasc transaction on RPC DTOs
     zeroSignatureIfRemasc = true
     gasEstimationCap = 6800000 # block gasLimit, rpc DoS protection for gas estimation
+    
     logs {
-        # maximum number of blocks to query
-        maxBlocksToQuery = 0
-        # maximum number of logs to return
-        maxLogsToReturn = 0
+	# Reasonable limit to not to overload your node
+	# You could lower it down to 1k as a precaution
+	# Set to 0 to disable limit (unlimited)
+        maxBlocksToQuery = 5000
+	
+	# Ballpark size estimation for 20k logs is about 10Mb
+	# With gzip compression it could be less than 1Mb
+	# Set to 0 to disable limit (unlimited)
+        maxLogsToReturn = 20000
     }
+
     trace {
         # maximum number of traces per request for trace_filter method
         maxTracesPerRequest = 10000


### PR DESCRIPTION
This PR added default safeguard limiters for RPC `eth_getLogs` function.