### PR TITLE
Removing flag that fails when there is no cache

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -76,7 +76,6 @@ jobs:
           path: |
             gradle/wrapper/gradle-wrapper.jar
           key: gradle-wrapper-v1
-          fail-on-cache-miss: true
 
       - name: Download build artifacts
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 #v6.0.0
@@ -198,7 +197,6 @@ jobs:
           path: |
             gradle/wrapper/gradle-wrapper.jar
           key: gradle-wrapper-v1
-          fail-on-cache-miss: true
 
       - name: Download build artifacts
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 #v6.0.0
@@ -251,7 +249,6 @@ jobs:
           path: |
             gradle/wrapper/gradle-wrapper.jar
           key: gradle-wrapper-v1
-          fail-on-cache-miss: true
 
       - name: Run tests
         run: |
@@ -299,7 +296,6 @@ jobs:
           path: |
             gradle/wrapper/gradle-wrapper.jar
           key: gradle-wrapper-v1
-          fail-on-cache-miss: true
 
       - name: Run tests
         run: |

--- a/.github/workflows/fuzz-test.yml
+++ b/.github/workflows/fuzz-test.yml
@@ -47,7 +47,6 @@ jobs:
           path: |
             gradle/wrapper/gradle-wrapper.jar
           key: gradle-wrapper-v1
-          fail-on-cache-miss: true
 
       - name: Run fuzz tests
         run: |


### PR DESCRIPTION
Removing the enforcing from the cache in gradle wrapper action step to avoid errors for when there is no cache available.
