### PR TITLE
fix: debug_traceTransaction failing with callTracer

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeFactoryImpl.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/invoke/ProgramInvokeFactoryImpl.java
@@ -164,7 +164,7 @@ public class ProgramInvokeFactoryImpl implements ProgramInvokeFactory {
         long agas = inGas;
         DataWord callValue = inValue;
 
-        BytesSlice data = dataIn;
+        BytesSlice data = dataIn != null ? dataIn.copyBytes() : null;
         DataWord lastHash = program.getPrevHash();
         DataWord coinbase = program.getCoinbase();
         DataWord timestamp = program.getTimestamp();

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/debug/trace/call/CallTracerTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/debug/trace/call/CallTracerTest.java
@@ -101,17 +101,14 @@ class CallTracerTest {
     }
 
     /**
-     * Reproduces RSKCORE-5466: debug_traceTransaction with callTracer fails with
-     * "Memory was changed during slice lifetime" on transactions with internal calls.
+     * Regression test for RSKCORE-5466: verifies that debug_traceTransaction with callTracer
+     * succeeds on transactions with internal calls.
      *
-     * The contract calls itself recursively via this.recurse(depth - 1). During execution,
-     * Program.callToAddress() creates a MemorySlice for the call data, which gets stored
-     * in the child ProgramInvokeImpl. After the child returns, memorySaveLimited() writes
-     * return data to parent Memory, incrementing its version and invalidating the slice.
-     * CallTraceTransformer.buildForCall() then tries to read the stale slice and throws.
-     *
-     * TODO: Once the fix is applied, this test should be changed to assert success
-     *       (remove assertThrows, uncomment the assertions below).
+     * The contract calls itself recursively via this.recurse(depth - 1). Previously,
+     * Program.callToAddress() created a MemorySlice for the call data which got stored
+     * in the child ProgramInvokeImpl. After the child returned, memorySaveLimited() wrote
+     * return data to parent Memory, invalidating the slice and causing an IllegalStateException
+     * when CallTraceTransformer.buildForCall() tried to read it.
      */
     @Test
     void traceTransactionWithInternalCalls() throws Exception {
@@ -126,24 +123,18 @@ class CallTracerTest {
 
         TransactionReceipt txReceipt = world.getTransactionReceiptByName("tx02");
         assertNotNull(txReceipt, "tx02 receipt should exist");
-        assertArrayEquals(new byte[]{0x01}, txReceipt.getStatus(), "tx02 should have succeeded");
+        assertTrue(txReceipt.isSuccessful(), "tx02 should have succeeded");
 
         CallTracer callTracer = new CallTracer(world.getBlockStore(), world.getBlockExecutor(), web3InformationRetriever, receiptStore, world.getBlockChain());
         String txHash = txReceipt.getTransaction().getHash().toJsonString();
 
-        // RSKCORE-5466: callTracer throws IllegalStateException due to stale MemorySlice
-        IllegalStateException exception = assertThrows(IllegalStateException.class,
-                () -> callTracer.traceTransaction(txHash, new TraceOptions()));
-        assertTrue(exception.getMessage().contains("Memory was changed during slice lifetime"));
-
-        // TODO: After fix, replace the assertThrows above with the following:
-        // JsonNode result = callTracer.traceTransaction(txHash, new TraceOptions());
-        // assertNotNull(result);
-        // TxTraceResult traceResult = objectMapper.treeToValue(result, TxTraceResult.class);
-        // assertNotNull(traceResult);
-        // assertEquals("CALL", traceResult.getType());
-        // assertNotNull(traceResult.getCalls(), "Should have internal calls");
-        // assertFalse(traceResult.getCalls().isEmpty(), "Should have at least one internal call");
+        JsonNode result = callTracer.traceTransaction(txHash, new TraceOptions());
+        assertNotNull(result);
+        TxTraceResult traceResult = objectMapper.treeToValue(result, TxTraceResult.class);
+        assertNotNull(traceResult);
+        assertEquals("CALL", traceResult.getType());
+        assertNotNull(traceResult.getCalls(), "Should have internal calls");
+        assertFalse(traceResult.getCalls().isEmpty(), "Should have at least one internal call");
     }
 
     private static void assertOOGError(TxTraceResult trace) {

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/debug/trace/call/CallTracerTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/debug/trace/call/CallTracerTest.java
@@ -100,6 +100,52 @@ class CallTracerTest {
         assertOOGError(traceResult.getCalls().get(0).getCalls().get(0));
     }
 
+    /**
+     * Reproduces RSKCORE-5466: debug_traceTransaction with callTracer fails with
+     * "Memory was changed during slice lifetime" on transactions with internal calls.
+     *
+     * The contract calls itself recursively via this.recurse(depth - 1). During execution,
+     * Program.callToAddress() creates a MemorySlice for the call data, which gets stored
+     * in the child ProgramInvokeImpl. After the child returns, memorySaveLimited() writes
+     * return data to parent Memory, incrementing its version and invalidating the slice.
+     * CallTraceTransformer.buildForCall() then tries to read the stale slice and throws.
+     *
+     * TODO: Once the fix is applied, this test should be changed to assert success
+     *       (remove assertThrows, uncomment the assertions below).
+     */
+    @Test
+    void traceTransactionWithInternalCalls() throws Exception {
+        DslParser parser = DslParser.fromResource("dsl/call_tracer_internal_call.txt");
+        ReceiptStore receiptStore = new ReceiptStoreImpl(new HashMapDB());
+        World world = new World(receiptStore);
+        ExecutionBlockRetriever executionBlockRetriever = Mockito.mock(ExecutionBlockRetriever.class);
+        Web3InformationRetriever web3InformationRetriever = new Web3InformationRetriever(world.getTransactionPool(), world.getBlockChain(), world.getRepositoryLocator(), executionBlockRetriever);
+
+        WorldDslProcessor processor = new WorldDslProcessor(world);
+        processor.processCommands(parser);
+
+        TransactionReceipt txReceipt = world.getTransactionReceiptByName("tx02");
+        assertNotNull(txReceipt, "tx02 receipt should exist");
+        assertArrayEquals(new byte[]{0x01}, txReceipt.getStatus(), "tx02 should have succeeded");
+
+        CallTracer callTracer = new CallTracer(world.getBlockStore(), world.getBlockExecutor(), web3InformationRetriever, receiptStore, world.getBlockChain());
+        String txHash = txReceipt.getTransaction().getHash().toJsonString();
+
+        // RSKCORE-5466: callTracer throws IllegalStateException due to stale MemorySlice
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> callTracer.traceTransaction(txHash, new TraceOptions()));
+        assertTrue(exception.getMessage().contains("Memory was changed during slice lifetime"));
+
+        // TODO: After fix, replace the assertThrows above with the following:
+        // JsonNode result = callTracer.traceTransaction(txHash, new TraceOptions());
+        // assertNotNull(result);
+        // TxTraceResult traceResult = objectMapper.treeToValue(result, TxTraceResult.class);
+        // assertNotNull(traceResult);
+        // assertEquals("CALL", traceResult.getType());
+        // assertNotNull(traceResult.getCalls(), "Should have internal calls");
+        // assertFalse(traceResult.getCalls().isEmpty(), "Should have at least one internal call");
+    }
+
     private static void assertOOGError(TxTraceResult trace) {
         String error = trace.getError();
         assertNotNull(error);

--- a/rskj-core/src/test/resources/dsl/call_tracer_internal_call.txt
+++ b/rskj-core/src/test/resources/dsl/call_tracer_internal_call.txt
@@ -1,0 +1,57 @@
+comment
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// Minimal contract with self-calling recursion to trigger internal CALL opcodes.
+// Used to reproduce RSKCORE-5466: MemorySlice becomes stale after child call
+// returns and parent memory is written to via memorySaveLimited().
+contract InternalCallTest {
+    function recurse(uint256 depth) public returns (uint256) {
+        if (depth == 0) return 1;
+        return this.recurse(depth - 1) + 1;
+    }
+}
+
+end
+
+account_new acc1 10000000
+
+# deploy InternalCallTest contract
+transaction_build tx01
+    sender acc1
+    receiverAddress 00
+    value 0
+    data 608060405234801561000f575f80fd5b506101808061001d5f395ff3fe608060405234801561000f575f80fd5b5060043610610029575f3560e01c8063b2041d211461002d575b5f80fd5b61004061003b3660046100e2565b610052565b60405190815260200160405180910390f35b5f815f0361006257506001919050565b3063b2041d2161007360018561010d565b6040518263ffffffff1660e01b815260040161009191815260200190565b6020604051808303815f875af11580156100ad573d5f803e3d5ffd5b505050506040513d601f19601f820116820180604052508101906100d19190610120565b6100dc906001610137565b92915050565b5f602082840312156100f2575f80fd5b5035919050565b634e487b7160e01b5f52601160045260245ffd5b818103818111156100dc576100dc6100f9565b5f60208284031215610130575f80fd5b5051919050565b808201808211156100dc576100dc6100f956fea2646970667358221220bed743d635a353cd168bcbfdd58a24170229dc6e0e1734ac5a805f0baade108464736f6c63430008140033
+    gas 1200000
+    build
+
+block_build b01
+    parent g00
+    gasLimit 7500000
+    transactions tx01
+    build
+
+block_connect b01
+assert_best b01
+
+# call recurse(2) - triggers 2 levels of internal self-calls
+# function selector: b2041d21
+# argument: 0000000000000000000000000000000000000000000000000000000000000002
+transaction_build tx02
+    sender acc1
+    nonce 1
+    contract tx01
+    value 0
+    data b2041d210000000000000000000000000000000000000000000000000000000000000002
+    gas 1000000
+    build
+
+block_build b02
+    parent b01
+    gasLimit 7500000
+    transactions tx02
+    build
+
+block_connect b02
+assert_best b02


### PR DESCRIPTION
## Description

Fix `debug_traceTransaction` crashing with `IllegalStateException: Memory was changed during slice lifetime` when using the `callTracer` on transactions that contain internal contract-to-contract calls.

The fix eagerly copies the call data `BytesSlice` into a stable `Bytes` object when constructing a `ProgramInvoke` for internal calls, preventing a stale `MemorySlice` reference from being read after the parent Memory has been modified.

**Changed files:**
- `ProgramInvokeFactoryImpl.java` — one-line fix: copy `dataIn` before storing in `ProgramInvokeImpl`
- `CallTracerTest.java` — regression test with a recursive self-calling contract
- `call_tracer_internal_call.txt` — DSL test fixture for the above

## Motivation and Context

Users reported that `debug_traceTransaction` with `{"tracer": "callTracer"}` fails on the Vetiver release for any transaction involving internal calls.

**Root cause:** The Memory versioning optimization (commit `8aa3ac2529`) introduced `MemorySlice` — a zero-copy view into VM Memory. For internal CALLs, `Program.callToAddress()` creates a `MemorySlice` for the call data and stores it in the child `ProgramInvokeImpl.msgData`. After the child returns, `memorySaveLimited()` writes return data to parent Memory, incrementing its version. When `CallTraceTransformer.buildForCall()` later reads that call data from the trace, the version check fails.

The fix makes the internal-call path consistent with the top-level transaction path, which already uses `Bytes.of(data)` (a safe copy). The `MemorySlice` optimization remains intact for KECCAK256 and CREATE2, where slices are consumed immediately.

## How Has This Been Tested?

- **Integration test:** Added `CallTracerTest.traceTransactionWithInternalCalls()` — deploys a contract with recursive self-calls (`this.recurse(depth - 1)`), executes a transaction with 2 levels of internal calls, and verifies that `callTracer.traceTransaction()` succeeds and returns the expected call hierarchy.
- **k6 test:** Created a test scenario in the k6 test suite to reproduce against a live regtest node (deploys CPUStress contract, calls `runRecursion(3)`, traces with both `callTracer` and `rskTracer`).
- **Local node verification:** Reproduced the original error on a local regtest node, confirmed the fix resolves it.
- All existing `CallTracerTest` tests continue to pass.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)

* **Other information**: The default tracer (`rskTracer`) was never affected — it does not access `ProgramInvoke.getDataCopy()` post-execution. Normal (non-tracing) execution is also unaffected because the child program reads the slice before the parent memory is modified.