### PR TITLE
Powpeg refactors integration

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeConstants.java
@@ -39,7 +39,6 @@ public abstract class BridgeConstants {
     protected UnionBridgeConstants unionBridgeConstants;
 
     protected int btc2RskMinimumAcceptableConfirmations;
-    protected int btc2RskMinimumAcceptableConfirmationsOnRsk;
     protected int rsk2BtcMinimumAcceptableConfirmations;
 
     protected int updateBridgeExecutionPeriod;
@@ -85,11 +84,6 @@ public abstract class BridgeConstants {
 
     public String getBtcParamsString() {
         return btcParamsString;
-    }
-
-    // Used by powpeg-node
-    public int getBtc2RskMinimumAcceptableConfirmationsOnRsk() {
-        return btc2RskMinimumAcceptableConfirmationsOnRsk;
     }
 
     public int getBtc2RskMinimumAcceptableConfirmations() {

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeMainNetConstants.java
@@ -20,7 +20,6 @@ public class BridgeMainNetConstants extends BridgeConstants {
         unionBridgeConstants = UnionBridgeMainNetConstants.getInstance();
 
         btc2RskMinimumAcceptableConfirmations = 100;
-        btc2RskMinimumAcceptableConfirmationsOnRsk = 1000;
         rsk2BtcMinimumAcceptableConfirmations = 4000;
 
         updateBridgeExecutionPeriod = 3 * 60 * 1000; // 3 minutes

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
@@ -53,7 +53,6 @@ public class BridgeRegTestConstants extends BridgeConstants {
         unionBridgeConstants = UnionBridgeRegTestConstants.getInstance();
 
         btc2RskMinimumAcceptableConfirmations = 3;
-        btc2RskMinimumAcceptableConfirmationsOnRsk = 5;
         rsk2BtcMinimumAcceptableConfirmations = 3;
 
         updateBridgeExecutionPeriod = 15_000; //15 seconds in millis

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeTestNetConstants.java
@@ -38,7 +38,6 @@ public class BridgeTestNetConstants extends BridgeConstants {
         unionBridgeConstants = UnionBridgeTestNetConstants.getInstance();
 
         btc2RskMinimumAcceptableConfirmations = 10;
-        btc2RskMinimumAcceptableConfirmationsOnRsk = 10;
         rsk2BtcMinimumAcceptableConfirmations = 10;
 
         updateBridgeExecutionPeriod = 3 * 60 * 1000; // 3 minutes


### PR DESCRIPTION
Remove constants only being used by powpeg-node 
(they are defined in powpeg-node now)

`rit:powpeg-refactors-integration`