### PR TITLE
Add build svp fund transaction tests

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -203,9 +203,18 @@ class ReleaseTransactionBuilderTest {
      */
     @Nested
     class BuildSvpFundTransactionTest {
+        private static final int DEFAULT_UTXO_COUNT = 2;
+        private static final int MULTI_UTXO_COUNT = 4;
+
         private final Federation activeP2shErpFederation = P2shErpFederationBuilder.builder().build();
         private final Address activeP2shErpFederationAddress = activeP2shErpFederation.getAddress();
+        private final Federation activeP2shP2wshErpFederation = P2shP2wshErpFederationBuilder.builder().build();
+        private final Address activeP2shP2wshErpFederationAddress = activeP2shP2wshErpFederation.getAddress();
         private final Federation p2shP2wshErpProposedFederation = P2shP2wshErpFederationBuilder.builder().build();
+        private final Keccak256 proposedFlyoverPrefix = BRIDGE_MAINNET_CONSTANTS.getProposedFederationFlyoverPrefix();
+        private final Coin svpFundTxOutputsValue = BRIDGE_MAINNET_CONSTANTS.getSvpFundTxOutputsValue();
+        private final Coin totalSvpFundPaymentOutputsValue = svpFundTxOutputsValue.multiply(2);
+
         private BridgeStorageProvider bridgeStorageProviderMock;
 
         @BeforeEach
@@ -216,69 +225,37 @@ class ReleaseTransactionBuilderTest {
         @Test
         void buildSvpFundTransaction_withAFederationWithEnoughUTXOsForTheSvpFundTransaction_shouldReturnACorrectSvpFundTx() {
             // Arrange
-            int numberOfUtxos = 2;
-            List<UTXO> utxos = UTXOBuilder.builder()
-                .withScriptPubKey(activeP2shErpFederation.getP2SHScript())
-                .buildMany(numberOfUtxos, i -> createHash(i + 1));
-            ReleaseTransactionBuilder releaseTransactionBuilder = getReleaseTransactionBuilderForMainnet(utxos);
-            Keccak256 proposedFlyoverPrefix = BRIDGE_MAINNET_CONSTANTS.getProposedFederationFlyoverPrefix();
+            List<UTXO> utxos = buildUtxos(activeP2shErpFederation, DEFAULT_UTXO_COUNT);
 
             // Act
-            Coin svpFundTxOutputsValue = BRIDGE_MAINNET_CONSTANTS.getSvpFundTxOutputsValue();
-            ReleaseTransactionBuilder.BuildResult svpFundTransactionUnsignedBuildResult = releaseTransactionBuilder.buildSvpFundTransaction(
-                p2shP2wshErpProposedFederation,
-                proposedFlyoverPrefix,
-                svpFundTxOutputsValue
-            );
+            ReleaseTransactionBuilder.BuildResult buildResult = buildSvpFundTransaction(activeP2shErpFederation, utxos);
 
             // Assert
-            assertEquals(
-                SUCCESS,
-                svpFundTransactionUnsignedBuildResult.responseCode(),
+            assertBuildSvpFundTransactionSucceeded(
+                buildResult,
                 "SVP fund transaction build should succeed when active federation has enough UTXOs"
             );
-
             assertSuccessfulSvpFundTransaction(
-                svpFundTransactionUnsignedBuildResult.btcTx(),
-                svpFundTxOutputsValue,
-                p2shP2wshErpProposedFederation,
-                proposedFlyoverPrefix,
+                buildResult.btcTx(),
                 activeP2shErpFederationAddress,
                 List.of(utxos.get(0)),
-                svpFundTransactionUnsignedBuildResult.selectedUTXOs()
+                buildResult.selectedUTXOs()
             );
         }
 
         @Test
         void buildSvpFundTransaction_whenActiveFederationIsP2shP2wshErp_shouldSpendUtxosWithExpectedWitnessFormat() {
             // Arrange
-            Federation activeP2shP2wshErpFederation = P2shP2wshErpFederationBuilder.builder().build();
-            Address activeP2shP2wshErpFederationAddress = activeP2shP2wshErpFederation.getAddress();
-            int numberOfUtxos = 2;
-            List<UTXO> utxos = UTXOBuilder.builder()
-                .withScriptPubKey(activeP2shP2wshErpFederation.getP2SHScript())
-                .buildMany(numberOfUtxos, i -> createHash(i + 1));
-            ReleaseTransactionBuilder releaseTransactionBuilder = getReleaseTransactionBuilderForMainnet(
-                activeP2shP2wshErpFederation,
-                utxos
-            );
-            Keccak256 proposedFlyoverPrefix = BRIDGE_MAINNET_CONSTANTS.getProposedFederationFlyoverPrefix();
+            List<UTXO> utxos = buildUtxos(activeP2shP2wshErpFederation, DEFAULT_UTXO_COUNT);
 
             // Act
-            Coin svpFundTxOutputsValue = BRIDGE_MAINNET_CONSTANTS.getSvpFundTxOutputsValue();
-            ReleaseTransactionBuilder.BuildResult buildResult = releaseTransactionBuilder.buildSvpFundTransaction(
-                p2shP2wshErpProposedFederation,
-                proposedFlyoverPrefix,
-                svpFundTxOutputsValue
-            );
+            ReleaseTransactionBuilder.BuildResult buildResult = buildSvpFundTransaction(activeP2shP2wshErpFederation, utxos);
 
             // Assert
-            assertEquals(
-                SUCCESS,
-                buildResult.responseCode(),
+            assertBuildSvpFundTransactionSucceeded(
+                buildResult,
                 "SVP fund transaction build should succeed when active federation is P2shP2wshErp"
             );
-
             BtcTransaction svpFundTransaction = buildResult.btcTx();
             assertEquals(
                 BTC_TX_VERSION_2,
@@ -299,9 +276,6 @@ class ReleaseTransactionBuilderTest {
             );
             assertSuccessfulSvpFundTransaction(
                 svpFundTransaction,
-                svpFundTxOutputsValue,
-                p2shP2wshErpProposedFederation,
-                proposedFlyoverPrefix,
                 activeP2shP2wshErpFederationAddress,
                 List.of(utxos.get(0)),
                 buildResult.selectedUTXOs()
@@ -311,41 +285,20 @@ class ReleaseTransactionBuilderTest {
         @Test
         void buildSvpFundTransaction_whenNoSingleUtxoCoversTotalSpend_shouldCreateSvpFundTxSelectingMultipleInputs() {
             // Arrange
-            Federation activeP2shP2wshErpFederation = P2shP2wshErpFederationBuilder.builder().build();
-            Address activeP2shP2wshErpFederationAddress = activeP2shP2wshErpFederation.getAddress();
-            Coin svpFundTxOutputsValue = BRIDGE_MAINNET_CONSTANTS.getSvpFundTxOutputsValue();
-            Coin totalSvpFundPaymentOutputsValue = svpFundTxOutputsValue.multiply(2);
-            int numberOfUtxos = 4;
-            List<UTXO> utxos = UTXOBuilder.builder()
-                .withScriptPubKey(activeP2shP2wshErpFederation.getP2SHScript())
-                .withValue(svpFundTxOutputsValue)
-                .buildMany(numberOfUtxos, i -> createHash(i + 1));
-
+            List<UTXO> utxos = buildUtxos(activeP2shP2wshErpFederation, MULTI_UTXO_COUNT, svpFundTxOutputsValue);
             utxos.forEach(utxo -> assertTrue(
                 utxo.getValue().compareTo(totalSvpFundPaymentOutputsValue) < 0,
                 "Each UTXO should be insufficient on its own to fund both SVP payment outputs"
             ));
 
-            ReleaseTransactionBuilder releaseTransactionBuilder = getReleaseTransactionBuilderForMainnet(
-                activeP2shP2wshErpFederation,
-                utxos
-            );
-            Keccak256 proposedFlyoverPrefix = BRIDGE_MAINNET_CONSTANTS.getProposedFederationFlyoverPrefix();
-
             // Act
-            ReleaseTransactionBuilder.BuildResult buildResult = releaseTransactionBuilder.buildSvpFundTransaction(
-                p2shP2wshErpProposedFederation,
-                proposedFlyoverPrefix,
-                svpFundTxOutputsValue
-            );
+            ReleaseTransactionBuilder.BuildResult buildResult = buildSvpFundTransaction(activeP2shP2wshErpFederation, utxos);
 
             // Assert
-            assertEquals(
-                SUCCESS,
-                buildResult.responseCode(),
+            assertBuildSvpFundTransactionSucceeded(
+                buildResult,
                 "SVP fund transaction build should succeed when multiple UTXOs are required"
             );
-
             BtcTransaction svpFundTransaction = buildResult.btcTx();
             List<UTXO> selectedUtxos = buildResult.selectedUTXOs();
             assertTrue(
@@ -361,9 +314,6 @@ class ReleaseTransactionBuilderTest {
             );
             assertSuccessfulSvpFundTransaction(
                 svpFundTransaction,
-                svpFundTxOutputsValue,
-                p2shP2wshErpProposedFederation,
-                proposedFlyoverPrefix,
                 activeP2shP2wshErpFederationAddress,
                 selectedUtxos,
                 selectedUtxos
@@ -372,48 +322,33 @@ class ReleaseTransactionBuilderTest {
 
         @Test
         void buildSvpFundTransaction_withAFederationWithoutUTXOs_shouldThrowInsufficientMoneyResponseCode() {
-            // Arrange
-            List<UTXO> emptyUtxos = Collections.emptyList();
-            ReleaseTransactionBuilder releaseTransactionBuilder = getReleaseTransactionBuilderForMainnet(emptyUtxos);
-            Coin svpFundTxOutputsValue = BRIDGE_MAINNET_CONSTANTS.getSvpFundTxOutputsValue();
-            Keccak256 proposedFlyoverPrefix = BRIDGE_MAINNET_CONSTANTS.getProposedFederationFlyoverPrefix();
-
             // Act
-            ReleaseTransactionBuilder.BuildResult svpFundTransactionUnsignedBuildResult = releaseTransactionBuilder.buildSvpFundTransaction(
-                p2shP2wshErpProposedFederation,
-                proposedFlyoverPrefix,
-                svpFundTxOutputsValue
+            ReleaseTransactionBuilder.BuildResult buildResult = buildSvpFundTransaction(
+                activeP2shP2wshErpFederation,
+                Collections.emptyList()
             );
 
             // Assert
-            assertFailedBuildResult(INSUFFICIENT_MONEY, svpFundTransactionUnsignedBuildResult);
+            assertFailedBuildResult(INSUFFICIENT_MONEY, buildResult);
         }
 
         @Test
         void buildSvpFundTransaction_withAFederationWith1DustUTXO_shouldThrowInsufficientMoneyResponseCode() {
             // Arrange
-            Federation activeP2shP2wshErpFederation = P2shP2wshErpFederationBuilder.builder().build();
             Coin dustUtxoValue = MINIMUM_PEGIN_TX_VALUE_WITH_ALL_ACTIVATIONS.subtract(Coin.SATOSHI);
-
+            assertTrue(
+                dustUtxoValue.compareTo(MINIMUM_PEGIN_TX_VALUE_WITH_ALL_ACTIVATIONS) < 0,
+                "UTXO value should be below the minimum pegin threshold"
+            );
             List<UTXO> utxos = List.of(
                 UTXOBuilder.builder()
                     .withScriptPubKey(activeP2shP2wshErpFederation.getP2SHScript())
                     .withValue(dustUtxoValue)
                     .build()
             );
-            ReleaseTransactionBuilder releaseTransactionBuilder = getReleaseTransactionBuilderForMainnet(
-                activeP2shP2wshErpFederation,
-                utxos
-            );
-            Coin svpFundTxOutputsValue = BRIDGE_MAINNET_CONSTANTS.getSvpFundTxOutputsValue();
-            Keccak256 proposedFlyoverPrefix = BRIDGE_MAINNET_CONSTANTS.getProposedFederationFlyoverPrefix();
 
             // Act
-            ReleaseTransactionBuilder.BuildResult buildResult = releaseTransactionBuilder.buildSvpFundTransaction(
-                p2shP2wshErpProposedFederation,
-                proposedFlyoverPrefix,
-                svpFundTxOutputsValue
-            );
+            ReleaseTransactionBuilder.BuildResult buildResult = buildSvpFundTransaction(activeP2shP2wshErpFederation, utxos);
 
             // Assert
             assertFailedBuildResult(INSUFFICIENT_MONEY, buildResult);
@@ -422,91 +357,74 @@ class ReleaseTransactionBuilderTest {
         @Test
         void buildSvpFundTransaction_withDustValueAsSvpFundTxOutputsValue_shouldReturnDustySendRequestResponseCode() {
             // Arrange
-            int numberOfUtxos = 2;
-            List<UTXO> utxos = UTXOBuilder.builder()
-                .withScriptPubKey(activeP2shErpFederation.getP2SHScript())
-                .buildMany(numberOfUtxos, i -> createHash(i + 1));
-
-            ReleaseTransactionBuilder releaseTransactionBuilder = getReleaseTransactionBuilderForMainnet(utxos);
-            Keccak256 proposedFlyoverPrefix = BRIDGE_MAINNET_CONSTANTS.getProposedFederationFlyoverPrefix();
-            Coin svpFundTxOutputsValue = Coin.SATOSHI;
+            List<UTXO> utxos = buildUtxos(activeP2shP2wshErpFederation, DEFAULT_UTXO_COUNT);
 
             // Act
-            ReleaseTransactionBuilder.BuildResult svpFundTransactionUnsignedBuildResult = releaseTransactionBuilder.buildSvpFundTransaction(
-                p2shP2wshErpProposedFederation,
-                proposedFlyoverPrefix,
-                svpFundTxOutputsValue
+            ReleaseTransactionBuilder.BuildResult buildResult = buildSvpFundTransaction(
+                activeP2shP2wshErpFederation,
+                utxos,
+                Coin.SATOSHI
             );
 
             // Assert
-            assertFailedBuildResult(DUSTY_SEND_REQUESTED, svpFundTransactionUnsignedBuildResult);
+            assertFailedBuildResult(DUSTY_SEND_REQUESTED, buildResult);
         }
 
         @Test
         void buildSvpFundTransaction_withNullProposedFlyoverPrefix_shouldThrowRedeemScriptCreationException() {
             // Arrange
-            int numberOfUtxos = 2;
-            List<UTXO> utxos = UTXOBuilder.builder()
-                .withScriptPubKey(activeP2shErpFederation.getP2SHScript())
-                .buildMany(numberOfUtxos, i -> createHash(i + 1));
-            ReleaseTransactionBuilder releaseTransactionBuilder = getReleaseTransactionBuilderForMainnet(utxos);
-            Coin svpFundTxOutputsValue = Coin.SATOSHI;
+            ReleaseTransactionBuilder releaseTransactionBuilder = getReleaseTransactionBuilderForMainnet(
+                activeP2shP2wshErpFederation,
+                buildUtxos(activeP2shP2wshErpFederation, DEFAULT_UTXO_COUNT)
+            );
 
             // Act & Assert
             assertThrows(RedeemScriptCreationException.class, () -> releaseTransactionBuilder.buildSvpFundTransaction(
                 p2shP2wshErpProposedFederation,
                 null,
-                svpFundTxOutputsValue
+                Coin.SATOSHI
             ));
         }
 
         @Test
         void buildSvpFundTransaction_withInvalidProposedFlyoverPrefix_shouldThrowRedeemScriptCreationException() {
             // Arrange
-            int numberOfUtxos = 2;
-            List<UTXO> utxos = UTXOBuilder.builder()
-                .withScriptPubKey(activeP2shErpFederation.getP2SHScript())
-                .buildMany(numberOfUtxos, i -> createHash(i + 1));
-            ReleaseTransactionBuilder releaseTransactionBuilder = getReleaseTransactionBuilderForMainnet(utxos);
-            Keccak256 proposedFlyoverPrefix = Keccak256.ZERO_HASH;
-            Coin svpFundTxOutputsValue = Coin.SATOSHI;
+            ReleaseTransactionBuilder releaseTransactionBuilder = getReleaseTransactionBuilderForMainnet(
+                activeP2shP2wshErpFederation,
+                buildUtxos(activeP2shP2wshErpFederation, DEFAULT_UTXO_COUNT)
+            );
 
             // Act & Assert
             assertThrows(RedeemScriptCreationException.class, () -> releaseTransactionBuilder.buildSvpFundTransaction(
                 p2shP2wshErpProposedFederation,
-                proposedFlyoverPrefix,
-                svpFundTxOutputsValue
+                Keccak256.ZERO_HASH,
+                Coin.SATOSHI
             ));
         }
 
         @Test
         void buildSvpFundTransaction_withNullProposedFederation_shouldThrowNullPointerException() {
             // Arrange
-            int numberOfUtxos = 2;
-            List<UTXO> utxos = UTXOBuilder.builder()
-                .withScriptPubKey(activeP2shErpFederation.getP2SHScript())
-                .buildMany(numberOfUtxos, i -> createHash(i + 1));
-            ReleaseTransactionBuilder releaseTransactionBuilder = getReleaseTransactionBuilderForMainnet(utxos);
-            Keccak256 proposedFlyoverPrefix = BRIDGE_MAINNET_CONSTANTS.getProposedFederationFlyoverPrefix();
-            Coin svpFundTxOutputsValue = Coin.SATOSHI;
+            ReleaseTransactionBuilder releaseTransactionBuilder = getReleaseTransactionBuilderForMainnet(
+                activeP2shP2wshErpFederation,
+                buildUtxos(activeP2shP2wshErpFederation, DEFAULT_UTXO_COUNT)
+            );
 
             // Act & Assert
             assertThrows(NullPointerException.class, () -> releaseTransactionBuilder.buildSvpFundTransaction(
                 null,
                 proposedFlyoverPrefix,
-                svpFundTxOutputsValue
+                Coin.SATOSHI
             ));
         }
 
         @Test
         void buildSvpFundTransaction_withNullAsValueTransferred_shouldThrowNullPointerException() {
             // Arrange
-            int numberOfUtxos = 2;
-            List<UTXO> utxos = UTXOBuilder.builder()
-                .withScriptPubKey(activeP2shErpFederation.getP2SHScript())
-                .buildMany(numberOfUtxos, i -> createHash(i + 1));
-            ReleaseTransactionBuilder releaseTransactionBuilder = getReleaseTransactionBuilderForMainnet(utxos);
-            Keccak256 proposedFlyoverPrefix = BRIDGE_MAINNET_CONSTANTS.getProposedFederationFlyoverPrefix();
+            ReleaseTransactionBuilder releaseTransactionBuilder = getReleaseTransactionBuilderForMainnet(
+                activeP2shP2wshErpFederation,
+                buildUtxos(activeP2shP2wshErpFederation, DEFAULT_UTXO_COUNT)
+            );
 
             // Act & Assert
             assertThrows(NullPointerException.class, () -> releaseTransactionBuilder.buildSvpFundTransaction(
@@ -516,22 +434,41 @@ class ReleaseTransactionBuilderTest {
             ));
         }
 
-        private void assertSuccessfulSvpFundTransaction(
-            BtcTransaction svpFundTransaction,
-            Coin svpFundTxOutputsValue,
-            Federation proposedFederation,
-            Keccak256 proposedFlyoverPrefix,
-            Address activeFederationAddress,
-            List<UTXO> expectedSelectedUtxos,
-            List<UTXO> selectedUtxos
-        ) {
-            int numberOfOutputs = 3; // 1 for the federation, 1 for the flyover federation, and 1 for the change
-            assertEquals(
-                numberOfOutputs,
-                svpFundTransaction.getOutputs().size(),
-                "SVP fund transaction should have two payment outputs and one change output"
-            );
+        private List<UTXO> buildUtxos(Federation activeFederation, int numberOfUtxos) {
+            return buildUtxos(activeFederation, numberOfUtxos, Coin.COIN);
+        }
 
+        private List<UTXO> buildUtxos(Federation activeFederation, int numberOfUtxos, Coin value) {
+            return UTXOBuilder.builder()
+                .withScriptPubKey(activeFederation.getP2SHScript())
+                .withValue(value)
+                .buildMany(numberOfUtxos, i -> createHash(i + 1));
+        }
+
+        private ReleaseTransactionBuilder.BuildResult buildSvpFundTransaction(
+            Federation activeFederation,
+            List<UTXO> utxos
+        ) {
+            return buildSvpFundTransaction(activeFederation, utxos, svpFundTxOutputsValue);
+        }
+
+        private ReleaseTransactionBuilder.BuildResult buildSvpFundTransaction(
+            Federation activeFederation,
+            List<UTXO> utxos,
+            Coin outputsValue
+        ) {
+            return getReleaseTransactionBuilderForMainnet(activeFederation, utxos)
+                .buildSvpFundTransaction(p2shP2wshErpProposedFederation, proposedFlyoverPrefix, outputsValue);
+        }
+
+        private void assertBuildSvpFundTransactionSucceeded(
+            ReleaseTransactionBuilder.BuildResult buildResult,
+            String message
+        ) {
+            assertEquals(SUCCESS, buildResult.responseCode(), message);
+        }
+
+        private void assertSvpFundTransactionPaymentOutputs(BtcTransaction svpFundTransaction) {
             TransactionOutput outputToProposedFederation = svpFundTransaction.getOutput(0);
             assertEquals(
                 svpFundTxOutputsValue,
@@ -539,7 +476,7 @@ class ReleaseTransactionBuilderTest {
                 "SVP fund output to proposed federation should match configured value"
             );
             assertEquals(
-                proposedFederation.getAddress(),
+                p2shP2wshErpProposedFederation.getAddress(),
                 outputToProposedFederation.getAddressFromP2SH(BTC_MAINNET_PARAMS),
                 "SVP fund first output should be sent to the proposed federation address"
             );
@@ -553,27 +490,24 @@ class ReleaseTransactionBuilderTest {
             Address flyoverFederationAddress = PegUtils.getFlyoverFederationAddress(
                 BTC_MAINNET_PARAMS,
                 proposedFlyoverPrefix,
-                proposedFederation
+                p2shP2wshErpProposedFederation
             );
             assertEquals(
                 flyoverFederationAddress,
                 outputToFlyoverProposedFederation.getAddressFromP2SH(BTC_MAINNET_PARAMS),
                 "SVP fund second output should be sent to the flyover proposed federation address"
             );
-
-            assertEquals(
-                expectedSelectedUtxos,
-                selectedUtxos,
-                "SVP fund transaction should select the minimum sufficient UTXO set"
-            );
-
-            Coin totalSvpFundPaymentOutputsValue = svpFundTxOutputsValue.multiply(2);
             assertEquals(
                 totalSvpFundPaymentOutputsValue,
                 outputToProposedFederation.getValue().add(outputToFlyoverProposedFederation.getValue()),
                 "SVP fund payment outputs should keep their full value when recipientsPayFees is false"
             );
+        }
 
+        private void assertSvpFundTransactionChangeOutput(
+            BtcTransaction svpFundTransaction,
+            Address activeFederationAddress
+        ) {
             Coin inputTotal = svpFundTransaction.getInputSum();
             TransactionOutput changeOutput = svpFundTransaction.getOutput(2);
             assertEquals(
@@ -596,8 +530,24 @@ class ReleaseTransactionBuilderTest {
             );
         }
 
-        private ReleaseTransactionBuilder getReleaseTransactionBuilderForMainnet(List<UTXO> utxos) {
-            return getReleaseTransactionBuilderForMainnet(activeP2shErpFederation, utxos);
+        private void assertSuccessfulSvpFundTransaction(
+            BtcTransaction svpFundTransaction,
+            Address activeFederationAddress,
+            List<UTXO> expectedSelectedUtxos,
+            List<UTXO> selectedUtxos
+        ) {
+            assertEquals(
+                3,
+                svpFundTransaction.getOutputs().size(),
+                "SVP fund transaction should have two payment outputs and one change output"
+            );
+            assertSvpFundTransactionPaymentOutputs(svpFundTransaction);
+            assertEquals(
+                expectedSelectedUtxos,
+                selectedUtxos,
+                "SVP fund transaction should select the minimum sufficient UTXO set"
+            );
+            assertSvpFundTransactionChangeOutput(svpFundTransaction, activeFederationAddress);
         }
 
         private ReleaseTransactionBuilder getReleaseTransactionBuilderForMainnet(

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -390,6 +390,36 @@ class ReleaseTransactionBuilderTest {
         }
 
         @Test
+        void buildSvpFundTransaction_withAFederationWith1DustUTXO_shouldThrowInsufficientMoneyResponseCode() {
+            // Arrange
+            Federation activeP2shP2wshErpFederation = P2shP2wshErpFederationBuilder.builder().build();
+            Coin dustUtxoValue = MINIMUM_PEGIN_TX_VALUE_WITH_ALL_ACTIVATIONS.subtract(Coin.SATOSHI);
+
+            List<UTXO> utxos = List.of(
+                UTXOBuilder.builder()
+                    .withScriptPubKey(activeP2shP2wshErpFederation.getP2SHScript())
+                    .withValue(dustUtxoValue)
+                    .build()
+            );
+            ReleaseTransactionBuilder releaseTransactionBuilder = getReleaseTransactionBuilderForMainnet(
+                activeP2shP2wshErpFederation,
+                utxos
+            );
+            Coin svpFundTxOutputsValue = BRIDGE_MAINNET_CONSTANTS.getSvpFundTxOutputsValue();
+            Keccak256 proposedFlyoverPrefix = BRIDGE_MAINNET_CONSTANTS.getProposedFederationFlyoverPrefix();
+
+            // Act
+            ReleaseTransactionBuilder.BuildResult buildResult = releaseTransactionBuilder.buildSvpFundTransaction(
+                p2shP2wshErpProposedFederation,
+                proposedFlyoverPrefix,
+                svpFundTxOutputsValue
+            );
+
+            // Assert
+            assertFailedBuildResult(INSUFFICIENT_MONEY, buildResult);
+        }
+
+        @Test
         void buildSvpFundTransaction_withDustValueAsSvpFundTxOutputsValue_shouldReturnDustySendRequestResponseCode() {
             // Arrange
             int numberOfUtxos = 2;

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -309,6 +309,68 @@ class ReleaseTransactionBuilderTest {
         }
 
         @Test
+        void buildSvpFundTransaction_whenNoSingleUtxoCoversTotalSpend_shouldCreateSvpFundTxSelectingMultipleInputs() {
+            // Arrange
+            Federation activeP2shP2wshErpFederation = P2shP2wshErpFederationBuilder.builder().build();
+            Address activeP2shP2wshErpFederationAddress = activeP2shP2wshErpFederation.getAddress();
+            Coin svpFundTxOutputsValue = BRIDGE_MAINNET_CONSTANTS.getSvpFundTxOutputsValue();
+            Coin totalSvpFundPaymentOutputsValue = svpFundTxOutputsValue.multiply(2);
+            int numberOfUtxos = 4;
+            List<UTXO> utxos = UTXOBuilder.builder()
+                .withScriptPubKey(activeP2shP2wshErpFederation.getP2SHScript())
+                .withValue(svpFundTxOutputsValue)
+                .buildMany(numberOfUtxos, i -> createHash(i + 1));
+
+            utxos.forEach(utxo -> assertTrue(
+                utxo.getValue().compareTo(totalSvpFundPaymentOutputsValue) < 0,
+                "Each UTXO should be insufficient on its own to fund both SVP payment outputs"
+            ));
+
+            ReleaseTransactionBuilder releaseTransactionBuilder = getReleaseTransactionBuilderForMainnet(
+                activeP2shP2wshErpFederation,
+                utxos
+            );
+            Keccak256 proposedFlyoverPrefix = BRIDGE_MAINNET_CONSTANTS.getProposedFederationFlyoverPrefix();
+
+            // Act
+            ReleaseTransactionBuilder.BuildResult buildResult = releaseTransactionBuilder.buildSvpFundTransaction(
+                p2shP2wshErpProposedFederation,
+                proposedFlyoverPrefix,
+                svpFundTxOutputsValue
+            );
+
+            // Assert
+            assertEquals(
+                SUCCESS,
+                buildResult.responseCode(),
+                "SVP fund transaction build should succeed when multiple UTXOs are required"
+            );
+
+            BtcTransaction svpFundTransaction = buildResult.btcTx();
+            List<UTXO> selectedUtxos = buildResult.selectedUTXOs();
+            assertTrue(
+                selectedUtxos.size() >= 2,
+                "SVP fund transaction should select multiple UTXOs when no single UTXO covers the total spend"
+            );
+            assertReleaseTxInputsP2shP2wshErp(
+                svpFundTransaction,
+                selectedUtxos.size(),
+                activeP2shP2wshErpFederation.getRedeemScript(),
+                utxos,
+                selectedUtxos
+            );
+            assertSuccessfulSvpFundTransaction(
+                svpFundTransaction,
+                svpFundTxOutputsValue,
+                p2shP2wshErpProposedFederation,
+                proposedFlyoverPrefix,
+                activeP2shP2wshErpFederationAddress,
+                selectedUtxos,
+                selectedUtxos
+            );
+        }
+
+        @Test
         void buildSvpFundTransaction_withAFederationWithoutUTXOs_shouldThrowInsufficientMoneyResponseCode() {
             // Arrange
             List<UTXO> emptyUtxos = Collections.emptyList();

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -252,6 +252,34 @@ class ReleaseTransactionBuilderTest {
             List<UTXO> selectedUTXOs = svpFundTransactionUnsignedBuildResult.selectedUTXOs();
             List<UTXO> expectedSelectedUTXOs = List.of(utxos.get(0)); // First UTXO is enough to cover the svpFundTxOutputsValue
             assertEquals(expectedSelectedUTXOs, selectedUTXOs);
+
+            Coin totalSvpFundPaymentOutputsValue = svpFundTxOutputsValue.multiply(2);
+            assertEquals(
+                totalSvpFundPaymentOutputsValue,
+                actualFirstOutput.getValue().add(actualSecondOutput.getValue()),
+                "SVP fund payment outputs should keep their full value when recipientsPayFees is false"
+            );
+
+            Coin inputTotal = svpFundTransactionUnsigned.getInputSum();
+            TransactionOutput changeOutput = svpFundTransactionUnsigned.getOutput(2);
+            assertEquals(
+                activeP2shErpFederationAddress,
+                changeOutput.getAddressFromP2SH(BTC_MAINNET_PARAMS),
+                "SVP fund change output should be sent back to the active federation address"
+            );
+
+            Coin fee = svpFundTransactionUnsigned.getFee();
+            Coin expectedChangeValue = inputTotal.subtract(totalSvpFundPaymentOutputsValue).subtract(fee);
+            assertEquals(
+                expectedChangeValue,
+                changeOutput.getValue(),
+                "SVP fund change output value should equal inputs minus payment outputs minus fee"
+            );
+            assertEquals(
+                inputTotal,
+                totalSvpFundPaymentOutputsValue.add(changeOutput.getValue()).add(fee),
+                "SVP fund transaction inputs should equal payment outputs plus change plus fee"
+            );
         }
 
         @Test

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -215,13 +215,6 @@ class ReleaseTransactionBuilderTest {
         private final Coin svpFundTxOutputsValue = BRIDGE_MAINNET_CONSTANTS.getSvpFundTxOutputsValue();
         private final Coin totalSvpFundPaymentOutputsValue = svpFundTxOutputsValue.multiply(2);
 
-        private BridgeStorageProvider bridgeStorageProviderMock;
-
-        @BeforeEach
-        void setup() {
-            bridgeStorageProviderMock = mock(BridgeStorageProvider.class);
-        }
-
         @Test
         void buildSvpFundTransaction_withAFederationWithEnoughUTXOsForTheSvpFundTransaction_shouldReturnACorrectSvpFundTx() {
             // Arrange
@@ -231,15 +224,10 @@ class ReleaseTransactionBuilderTest {
             ReleaseTransactionBuilder.BuildResult buildResult = buildSvpFundTransaction(activeP2shErpFederation, utxos);
 
             // Assert
-            assertBuildSvpFundTransactionSucceeded(
-                buildResult,
-                "SVP fund transaction build should succeed when active federation has enough UTXOs"
-            );
             assertSuccessfulSvpFundTransaction(
-                buildResult.btcTx(),
+                buildResult,
                 activeP2shErpFederationAddress,
-                List.of(utxos.get(0)),
-                buildResult.selectedUTXOs()
+                List.of(utxos.get(0))
             );
         }
 
@@ -252,32 +240,19 @@ class ReleaseTransactionBuilderTest {
             ReleaseTransactionBuilder.BuildResult buildResult = buildSvpFundTransaction(activeP2shP2wshErpFederation, utxos);
 
             // Assert
-            assertBuildSvpFundTransactionSucceeded(
+            assertSuccessfulSvpFundTransaction(
                 buildResult,
-                "SVP fund transaction build should succeed when active federation is P2shP2wshErp"
+                activeP2shP2wshErpFederationAddress,
+                List.of(utxos.get(0))
             );
+
             BtcTransaction svpFundTransaction = buildResult.btcTx();
-            assertEquals(
-                BTC_TX_VERSION_2,
-                svpFundTransaction.getVersion(),
-                "SVP fund transaction should use BTC version 2"
-            );
-            assertEquals(
-                1,
-                svpFundTransaction.getInputs().size(),
-                "SVP fund transaction should select a single UTXO when one is sufficient"
-            );
+
             assertReleaseTxInputsP2shP2wshErp(
                 svpFundTransaction,
                 1,
                 activeP2shP2wshErpFederation.getRedeemScript(),
                 utxos,
-                buildResult.selectedUTXOs()
-            );
-            assertSuccessfulSvpFundTransaction(
-                svpFundTransaction,
-                activeP2shP2wshErpFederationAddress,
-                List.of(utxos.get(0)),
                 buildResult.selectedUTXOs()
             );
         }
@@ -295,27 +270,22 @@ class ReleaseTransactionBuilderTest {
             ReleaseTransactionBuilder.BuildResult buildResult = buildSvpFundTransaction(activeP2shP2wshErpFederation, utxos);
 
             // Assert
-            assertBuildSvpFundTransactionSucceeded(
+            List<UTXO> expectedSelectedUtxos = utxos.subList(0, 3);
+
+            assertSuccessfulSvpFundTransaction(
                 buildResult,
-                "SVP fund transaction build should succeed when multiple UTXOs are required"
+                activeP2shP2wshErpFederationAddress,
+                expectedSelectedUtxos
             );
-            BtcTransaction svpFundTransaction = buildResult.btcTx();
+
             List<UTXO> selectedUtxos = buildResult.selectedUTXOs();
-            assertTrue(
-                selectedUtxos.size() >= 2,
-                "SVP fund transaction should select multiple UTXOs when no single UTXO covers the total spend"
-            );
+
+            BtcTransaction svpFundTransaction = buildResult.btcTx();
             assertReleaseTxInputsP2shP2wshErp(
                 svpFundTransaction,
-                selectedUtxos.size(),
+                expectedSelectedUtxos.size(),
                 activeP2shP2wshErpFederation.getRedeemScript(),
                 utxos,
-                selectedUtxos
-            );
-            assertSuccessfulSvpFundTransaction(
-                svpFundTransaction,
-                activeP2shP2wshErpFederationAddress,
-                selectedUtxos,
                 selectedUtxos
             );
         }
@@ -461,13 +431,6 @@ class ReleaseTransactionBuilderTest {
                 .buildSvpFundTransaction(p2shP2wshErpProposedFederation, proposedFlyoverPrefix, outputsValue);
         }
 
-        private void assertBuildSvpFundTransactionSucceeded(
-            ReleaseTransactionBuilder.BuildResult buildResult,
-            String message
-        ) {
-            assertEquals(SUCCESS, buildResult.responseCode(), message);
-        }
-
         private void assertSvpFundTransactionPaymentOutputs(BtcTransaction svpFundTransaction) {
             TransactionOutput outputToProposedFederation = svpFundTransaction.getOutput(0);
             assertEquals(
@@ -531,17 +494,22 @@ class ReleaseTransactionBuilderTest {
         }
 
         private void assertSuccessfulSvpFundTransaction(
-            BtcTransaction svpFundTransaction,
+            BuildResult buildResult,
             Address activeFederationAddress,
-            List<UTXO> expectedSelectedUtxos,
-            List<UTXO> selectedUtxos
+            List<UTXO> expectedSelectedUtxos
         ) {
+            assertEquals(SUCCESS, buildResult.responseCode());
+
+            BtcTransaction svpFundTransaction = buildResult.btcTx();
+            assertBtcTxVersionIs2(svpFundTransaction);
             assertEquals(
                 3,
                 svpFundTransaction.getOutputs().size(),
                 "SVP fund transaction should have two payment outputs and one change output"
             );
             assertSvpFundTransactionPaymentOutputs(svpFundTransaction);
+
+            List<UTXO> selectedUtxos = buildResult.selectedUTXOs();
             assertEquals(
                 expectedSelectedUtxos,
                 selectedUtxos,
@@ -559,7 +527,7 @@ class ReleaseTransactionBuilderTest {
                 activeFederation,
                 utxos,
                 false,
-                bridgeStorageProviderMock
+                mock(BridgeStorageProvider.class)
             );
 
             return new ReleaseTransactionBuilder(

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -232,53 +232,79 @@ class ReleaseTransactionBuilderTest {
             );
 
             // Assert
-            ReleaseTransactionBuilder.Response actualResponseCode = svpFundTransactionUnsignedBuildResult.responseCode();
-            assertEquals(SUCCESS, actualResponseCode);
-
-            BtcTransaction svpFundTransactionUnsigned = svpFundTransactionUnsignedBuildResult.btcTx();
-            int numberOfOutputs = 3; // 1 for the federation, 1 for the flyover federation, and 1 for the change
-            assertEquals(numberOfOutputs, svpFundTransactionUnsigned.getOutputs().size());
-            TransactionOutput actualFirstOutput = svpFundTransactionUnsigned.getOutput(0);
-            assertEquals(svpFundTxOutputsValue, actualFirstOutput.getValue());
-            Address proposedFederationAddress = p2shP2wshErpProposedFederation.getAddress();
-            assertEquals(proposedFederationAddress, actualFirstOutput.getAddressFromP2SH(BTC_MAINNET_PARAMS));
-
-            TransactionOutput actualSecondOutput = svpFundTransactionUnsigned.getOutput(1);
-            assertEquals(svpFundTxOutputsValue, actualSecondOutput.getValue());
-
-            Address flyoverFederationAddress = PegUtils.getFlyoverFederationAddress(BTC_MAINNET_PARAMS, proposedFlyoverPrefix, p2shP2wshErpProposedFederation);
-            assertEquals(flyoverFederationAddress, actualSecondOutput.getAddressFromP2SH(BTC_MAINNET_PARAMS));
-
-            List<UTXO> selectedUTXOs = svpFundTransactionUnsignedBuildResult.selectedUTXOs();
-            List<UTXO> expectedSelectedUTXOs = List.of(utxos.get(0)); // First UTXO is enough to cover the svpFundTxOutputsValue
-            assertEquals(expectedSelectedUTXOs, selectedUTXOs);
-
-            Coin totalSvpFundPaymentOutputsValue = svpFundTxOutputsValue.multiply(2);
             assertEquals(
-                totalSvpFundPaymentOutputsValue,
-                actualFirstOutput.getValue().add(actualSecondOutput.getValue()),
-                "SVP fund payment outputs should keep their full value when recipientsPayFees is false"
+                SUCCESS,
+                svpFundTransactionUnsignedBuildResult.responseCode(),
+                "SVP fund transaction build should succeed when active federation has enough UTXOs"
             );
 
-            Coin inputTotal = svpFundTransactionUnsigned.getInputSum();
-            TransactionOutput changeOutput = svpFundTransactionUnsigned.getOutput(2);
-            assertEquals(
+            assertSuccessfulSvpFundTransaction(
+                svpFundTransactionUnsignedBuildResult.btcTx(),
+                svpFundTxOutputsValue,
+                p2shP2wshErpProposedFederation,
+                proposedFlyoverPrefix,
                 activeP2shErpFederationAddress,
-                changeOutput.getAddressFromP2SH(BTC_MAINNET_PARAMS),
-                "SVP fund change output should be sent back to the active federation address"
+                List.of(utxos.get(0)),
+                svpFundTransactionUnsignedBuildResult.selectedUTXOs()
+            );
+        }
+
+        @Test
+        void buildSvpFundTransaction_whenActiveFederationIsP2shP2wshErp_shouldSpendUtxosWithExpectedWitnessFormat() {
+            // Arrange
+            Federation activeP2shP2wshErpFederation = P2shP2wshErpFederationBuilder.builder().build();
+            Address activeP2shP2wshErpFederationAddress = activeP2shP2wshErpFederation.getAddress();
+            int numberOfUtxos = 2;
+            List<UTXO> utxos = UTXOBuilder.builder()
+                .withScriptPubKey(activeP2shP2wshErpFederation.getP2SHScript())
+                .buildMany(numberOfUtxos, i -> createHash(i + 1));
+            ReleaseTransactionBuilder releaseTransactionBuilder = getReleaseTransactionBuilderForMainnet(
+                activeP2shP2wshErpFederation,
+                utxos
+            );
+            Keccak256 proposedFlyoverPrefix = BRIDGE_MAINNET_CONSTANTS.getProposedFederationFlyoverPrefix();
+
+            // Act
+            Coin svpFundTxOutputsValue = BRIDGE_MAINNET_CONSTANTS.getSvpFundTxOutputsValue();
+            ReleaseTransactionBuilder.BuildResult buildResult = releaseTransactionBuilder.buildSvpFundTransaction(
+                p2shP2wshErpProposedFederation,
+                proposedFlyoverPrefix,
+                svpFundTxOutputsValue
             );
 
-            Coin fee = svpFundTransactionUnsigned.getFee();
-            Coin expectedChangeValue = inputTotal.subtract(totalSvpFundPaymentOutputsValue).subtract(fee);
+            // Assert
             assertEquals(
-                expectedChangeValue,
-                changeOutput.getValue(),
-                "SVP fund change output value should equal inputs minus payment outputs minus fee"
+                SUCCESS,
+                buildResult.responseCode(),
+                "SVP fund transaction build should succeed when active federation is P2shP2wshErp"
+            );
+
+            BtcTransaction svpFundTransaction = buildResult.btcTx();
+            assertEquals(
+                BTC_TX_VERSION_2,
+                svpFundTransaction.getVersion(),
+                "SVP fund transaction should use BTC version 2"
             );
             assertEquals(
-                inputTotal,
-                totalSvpFundPaymentOutputsValue.add(changeOutput.getValue()).add(fee),
-                "SVP fund transaction inputs should equal payment outputs plus change plus fee"
+                1,
+                svpFundTransaction.getInputs().size(),
+                "SVP fund transaction should select a single UTXO when one is sufficient"
+            );
+            assertReleaseTxInputsP2shP2wshErp(
+                svpFundTransaction,
+                1,
+                activeP2shP2wshErpFederation.getRedeemScript(),
+                utxos,
+                buildResult.selectedUTXOs()
+            );
+            assertSuccessfulSvpFundTransaction(
+                svpFundTransaction,
+                svpFundTxOutputsValue,
+                p2shP2wshErpProposedFederation,
+                proposedFlyoverPrefix,
+                activeP2shP2wshErpFederationAddress,
+                List.of(utxos.get(0)),
+                buildResult.selectedUTXOs()
             );
         }
 
@@ -398,10 +424,97 @@ class ReleaseTransactionBuilderTest {
             ));
         }
 
+        private void assertSuccessfulSvpFundTransaction(
+            BtcTransaction svpFundTransaction,
+            Coin svpFundTxOutputsValue,
+            Federation proposedFederation,
+            Keccak256 proposedFlyoverPrefix,
+            Address activeFederationAddress,
+            List<UTXO> expectedSelectedUtxos,
+            List<UTXO> selectedUtxos
+        ) {
+            int numberOfOutputs = 3; // 1 for the federation, 1 for the flyover federation, and 1 for the change
+            assertEquals(
+                numberOfOutputs,
+                svpFundTransaction.getOutputs().size(),
+                "SVP fund transaction should have two payment outputs and one change output"
+            );
+
+            TransactionOutput outputToProposedFederation = svpFundTransaction.getOutput(0);
+            assertEquals(
+                svpFundTxOutputsValue,
+                outputToProposedFederation.getValue(),
+                "SVP fund output to proposed federation should match configured value"
+            );
+            assertEquals(
+                proposedFederation.getAddress(),
+                outputToProposedFederation.getAddressFromP2SH(BTC_MAINNET_PARAMS),
+                "SVP fund first output should be sent to the proposed federation address"
+            );
+
+            TransactionOutput outputToFlyoverProposedFederation = svpFundTransaction.getOutput(1);
+            assertEquals(
+                svpFundTxOutputsValue,
+                outputToFlyoverProposedFederation.getValue(),
+                "SVP fund output to flyover proposed federation should match configured value"
+            );
+            Address flyoverFederationAddress = PegUtils.getFlyoverFederationAddress(
+                BTC_MAINNET_PARAMS,
+                proposedFlyoverPrefix,
+                proposedFederation
+            );
+            assertEquals(
+                flyoverFederationAddress,
+                outputToFlyoverProposedFederation.getAddressFromP2SH(BTC_MAINNET_PARAMS),
+                "SVP fund second output should be sent to the flyover proposed federation address"
+            );
+
+            assertEquals(
+                expectedSelectedUtxos,
+                selectedUtxos,
+                "SVP fund transaction should select the minimum sufficient UTXO set"
+            );
+
+            Coin totalSvpFundPaymentOutputsValue = svpFundTxOutputsValue.multiply(2);
+            assertEquals(
+                totalSvpFundPaymentOutputsValue,
+                outputToProposedFederation.getValue().add(outputToFlyoverProposedFederation.getValue()),
+                "SVP fund payment outputs should keep their full value when recipientsPayFees is false"
+            );
+
+            Coin inputTotal = svpFundTransaction.getInputSum();
+            TransactionOutput changeOutput = svpFundTransaction.getOutput(2);
+            assertEquals(
+                activeFederationAddress,
+                changeOutput.getAddressFromP2SH(BTC_MAINNET_PARAMS),
+                "SVP fund change output should be sent back to the active federation address"
+            );
+
+            Coin fee = svpFundTransaction.getFee();
+            Coin expectedChangeValue = inputTotal.subtract(totalSvpFundPaymentOutputsValue).subtract(fee);
+            assertEquals(
+                expectedChangeValue,
+                changeOutput.getValue(),
+                "SVP fund change output value should equal inputs minus payment outputs minus fee"
+            );
+            assertEquals(
+                inputTotal,
+                totalSvpFundPaymentOutputsValue.add(changeOutput.getValue()).add(fee),
+                "SVP fund transaction inputs should equal payment outputs plus change plus fee"
+            );
+        }
+
         private ReleaseTransactionBuilder getReleaseTransactionBuilderForMainnet(List<UTXO> utxos) {
+            return getReleaseTransactionBuilderForMainnet(activeP2shErpFederation, utxos);
+        }
+
+        private ReleaseTransactionBuilder getReleaseTransactionBuilderForMainnet(
+            Federation activeFederation,
+            List<UTXO> utxos
+        ) {
             Wallet thisWallet = BridgeUtils.getFederationSpendWallet(
                 new Context(BTC_MAINNET_PARAMS),
-                activeP2shErpFederation,
+                activeFederation,
                 utxos,
                 false,
                 bridgeStorageProviderMock
@@ -410,8 +523,8 @@ class ReleaseTransactionBuilderTest {
             return new ReleaseTransactionBuilder(
                 BTC_MAINNET_PARAMS,
                 thisWallet,
-                activeP2shErpFederation.getFormatVersion(),
-                activeP2shErpFederationAddress,
+                activeFederation.getFormatVersion(),
+                activeFederation.getAddress(),
                 MOCK_FEE_PER_KB,
                 ALL_ACTIVATIONS
             );


### PR DESCRIPTION
**Summary**

Adds and refactors unit tests for ReleaseTransactionBuilder.buildSvpFundTransaction in BuildSvpFundTransactionTest. Test-only change.

**Changes**

Strengthen happy-path checks: payment outputs, change address/value, fee paid from change (recipientsPayFees = false).
New tests: segwit active federation (witness inputs), multiple UTXOs when none alone is enough, dust UTXO → INSUFFICIENT_MONEY.
Keep legacy P2SH ERP active → segwit proposed happy path for regression.
Extract shared helpers (buildUtxos, buildSvpFundTransaction, assertion helpers).