### PR TITLE
Refactor BTC_TX_VERSION constants and method for Java compliance

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -20,7 +20,7 @@ package co.rsk.peg;
 import static co.rsk.peg.BridgeUtils.calculatePegoutTxSize;
 import static co.rsk.peg.BridgeUtils.getRegularPegoutTxSize;
 import static co.rsk.peg.PegUtils.*;
-import static co.rsk.peg.ReleaseTransactionBuilder.BTC_TX_VERSION_2;
+import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
 import static co.rsk.peg.bitcoin.BitcoinUtils.*;
 import static co.rsk.peg.bitcoin.UtxoUtils.extractOutpointValues;
 import static java.util.Objects.isNull;

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
@@ -18,38 +18,42 @@
 
 package co.rsk.peg;
 
-import co.rsk.bitcoinj.core.*;
+import static co.rsk.peg.PegUtils.getFlyoverFederationAddress;
+import static co.rsk.peg.bitcoin.BitcoinUtils.addSpendingFederationBaseScript;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import co.rsk.bitcoinj.core.Address;
+import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.bitcoinj.core.InsufficientMoneyException;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.core.TransactionInput;
+import co.rsk.bitcoinj.core.UTXO;
+import co.rsk.bitcoinj.core.UTXOProviderException;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.wallet.RedeemData;
 import co.rsk.bitcoinj.wallet.SendRequest;
 import co.rsk.bitcoinj.wallet.Wallet;
 import co.rsk.crypto.Keccak256;
+import co.rsk.peg.bitcoin.BitcoinUtils;
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.FederationFormatVersion;
+import java.util.List;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
-
-import static co.rsk.peg.PegUtils.getFlyoverFederationAddress;
-import static co.rsk.peg.bitcoin.BitcoinUtils.addSpendingFederationBaseScript;
-import static com.google.common.base.Preconditions.checkNotNull;
-
 /**
  * Given a set of UTXOs, a ReleaseTransactionBuilder
  * knows how to build a release transaction
- * of a certain amount to a certain address,
+ * of a certain amount to a certain address
  * and how to signal the used UTXOs so they
  * can be invalidated.
  *
  * @author Ariel Mendelzon
  */
 public class ReleaseTransactionBuilder {
-
-    public static final int BTC_TX_VERSION_1 = 1;
-    public static final int BTC_TX_VERSION_2 = 2;
 
     public record BuildResult(BtcTransaction btcTx, List<UTXO> selectedUTXOs, Response responseCode) {}
 
@@ -132,7 +136,7 @@ public class ReleaseTransactionBuilder {
     public BuildResult buildMigrationTransaction(Coin migrationValue, Address destinationAddress) {
         return buildWithConfiguration((SendRequest sr) -> {
             if (!activations.isActive(ConsensusRule.RSKIP376)){
-                sr.tx.setVersion(BTC_TX_VERSION_1);
+                sr.tx.setVersion(BitcoinUtils.BTC_TX_VERSION_1);
             }
             sr.tx.addOutput(migrationValue, destinationAddress);
             sr.changeAddress = destinationAddress;
@@ -196,7 +200,7 @@ public class ReleaseTransactionBuilder {
         // Build a tx and send request and configure it
         BtcTransaction btcTx = new BtcTransaction(params);
         if (activations.isActive(ConsensusRule.RSKIP201)) {
-            btcTx.setVersion(BTC_TX_VERSION_2);
+            btcTx.setVersion(BitcoinUtils.BTC_TX_VERSION_2);
         }
 
         return btcTx;

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
@@ -19,6 +19,8 @@
 package co.rsk.peg;
 
 import static co.rsk.peg.PegUtils.getFlyoverFederationAddress;
+import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_1;
+import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
 import static co.rsk.peg.bitcoin.BitcoinUtils.addSpendingFederationBaseScript;
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -35,7 +37,6 @@ import co.rsk.bitcoinj.wallet.RedeemData;
 import co.rsk.bitcoinj.wallet.SendRequest;
 import co.rsk.bitcoinj.wallet.Wallet;
 import co.rsk.crypto.Keccak256;
-import co.rsk.peg.bitcoin.BitcoinUtils;
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.FederationFormatVersion;
 import java.util.List;
@@ -143,7 +144,7 @@ public class ReleaseTransactionBuilder {
     public BuildResult buildMigrationTransaction(Coin migrationValue, Address destinationAddress) {
         return buildWithConfiguration((SendRequest sr) -> {
             if (!activations.isActive(ConsensusRule.RSKIP376)){
-                sr.tx.setVersion(BitcoinUtils.BTC_TX_VERSION_1);
+                sr.tx.setVersion(BTC_TX_VERSION_1);
             }
             sr.tx.addOutput(migrationValue, destinationAddress);
             sr.changeAddress = destinationAddress;
@@ -207,7 +208,7 @@ public class ReleaseTransactionBuilder {
         // Build a tx and send request and configure it
         BtcTransaction btcTx = new BtcTransaction(params);
         if (activations.isActive(ConsensusRule.RSKIP201)) {
-            btcTx.setVersion(BitcoinUtils.BTC_TX_VERSION_2);
+            btcTx.setVersion(BTC_TX_VERSION_2);
         }
 
         return btcTx;

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
@@ -70,6 +70,13 @@ public class ReleaseTransactionBuilder {
     private final Coin feePerKb;
     private final ActivationConfig.ForBlock activations;
 
+    private final SendRequestConfigurator defaultSettingsConfigurator = (SendRequest sr) -> {
+        sr.missingSigsMode = Wallet.MissingSigsMode.USE_OP_ZERO;
+        sr.feePerKb = getFeePerKb();
+        sr.shuffleOutputs = false;
+        sr.recipientsPayFees = true;
+    };
+
     /**
      * Creates a release transaction builder.
      *
@@ -241,13 +248,6 @@ public class ReleaseTransactionBuilder {
             addSpendingFederationBaseScript(tx, i, redeemScript, federationFormatVersion);
         }
     }
-
-    private final SendRequestConfigurator defaultSettingsConfigurator = (SendRequest sr) -> {
-        sr.missingSigsMode = Wallet.MissingSigsMode.USE_OP_ZERO;
-        sr.feePerKb = getFeePerKb();
-        sr.shuffleOutputs = false;
-        sr.recipientsPayFees = true;
-    };
 
     public enum Response {
         SUCCESS,

--- a/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
@@ -17,8 +17,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class BitcoinUtils {
+    public static final int BTC_TX_VERSION_1 = 1;
+    public static final int BTC_TX_VERSION_2 = 2;
+
     protected static final byte[] WITNESS_COMMITMENT_HEADER = Hex.decode("aa21a9ed");
     protected static final int WITNESS_COMMITMENT_LENGTH = WITNESS_COMMITMENT_HEADER.length + Sha256Hash.LENGTH;
+
     private static final int MINIMUM_WITNESS_COMMITMENT_SIZE = WITNESS_COMMITMENT_LENGTH + 2; // 1 extra byte for OP_RETURN and another one for data length
     private static final Logger logger = LoggerFactory.getLogger(BitcoinUtils.class);
     private static final int FIRST_INPUT_INDEX = 0;
@@ -65,8 +69,7 @@ public class BitcoinUtils {
     }
 
     /**
-     * Extracts the redeem script from the input's scriptSig, if it's a P2SH input.
-     *
+     * Extracts the redeem script from the input's scriptSig if it's a P2SH input.
      * For some P2PKH inputs, the scriptSig contains a public key as the last chunk of the scriptSig that is parsed as a redeem script.
      * This is a known issue, pending review for a permanent solution. In the meantime, always call `isSentToMultiSig()` on the returned redeem script
      *

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportAddSignatureTest.java
@@ -5,7 +5,7 @@ import static co.rsk.RskTestUtils.createRskBlock;
 import static co.rsk.peg.BridgeStorageIndexKey.PEGOUTS_WAITING_FOR_SIGNATURES;
 import static co.rsk.peg.BridgeSupportTestUtil.*;
 import static co.rsk.peg.PegTestUtils.*;
-import static co.rsk.peg.ReleaseTransactionBuilder.BTC_TX_VERSION_2;
+import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.*;
 import static co.rsk.peg.federation.FederationTestUtils.REGTEST_FEDERATION_PRIVATE_KEYS;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportProcessFundsMigrationTest.java
@@ -38,7 +38,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static co.rsk.peg.PegTestUtils.BTC_TX_LEGACY_VERSION;
-import static co.rsk.peg.ReleaseTransactionBuilder.BTC_TX_VERSION_2;
+import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
@@ -8,7 +8,7 @@ import static co.rsk.peg.BridgeSupportTestUtil.*;
 import static co.rsk.peg.BridgeUtils.calculatePegoutTxSize;
 import static co.rsk.peg.PegUtils.getFlyoverFederationOutputScript;
 import static co.rsk.peg.PegUtils.getFlyoverFederationRedeemScript;
-import static co.rsk.peg.ReleaseTransactionBuilder.BTC_TX_VERSION_2;
+import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.*;
 import static co.rsk.peg.bitcoin.BitcoinUtils.*;
 import static co.rsk.peg.bitcoin.UtxoUtils.extractOutpointValues;

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -531,12 +531,12 @@ class BridgeUtilsTest {
         }, true); // we need the priv keys
 
         BtcTransaction prevTx = new BtcTransaction(bridgeConstantsMainnet.getBtcParams());
-        prevTx.setVersion(ReleaseTransactionBuilder.BTC_TX_VERSION_2);
+        prevTx.setVersion(BTC_TX_VERSION_2);
         Coin prevValue = Coin.COIN;
         prevTx.addOutput(prevValue, federation.getAddress());
 
         BtcTransaction tx = new BtcTransaction(networkParameters);
-        tx.setVersion(ReleaseTransactionBuilder.BTC_TX_VERSION_2);
+        tx.setVersion(BTC_TX_VERSION_2);
         tx.addInput(prevTx.getOutput(0));
 
         int inputIndex = 0;

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -19,8 +19,8 @@
 package co.rsk.peg;
 
 import static co.rsk.RskTestUtils.createRepository;
-import static co.rsk.peg.ReleaseTransactionBuilder.BTC_TX_VERSION_1;
-import static co.rsk.peg.ReleaseTransactionBuilder.BTC_TX_VERSION_2;
+import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_1;
+import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
 import static co.rsk.peg.ReleaseTransactionBuilder.Response.COULD_NOT_ADJUST_DOWNWARDS;
 import static co.rsk.peg.ReleaseTransactionBuilder.Response.DUSTY_SEND_REQUESTED;
 import static co.rsk.peg.ReleaseTransactionBuilder.Response.EXCEED_MAX_TRANSACTION_SIZE;

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinUtilsTest.java
@@ -16,7 +16,6 @@ import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.crypto.TransactionSignature;
 import co.rsk.bitcoinj.script.*;
 import co.rsk.peg.BridgeUtils;
-import co.rsk.peg.ReleaseTransactionBuilder;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.constants.BridgeMainNetConstants;
 import co.rsk.peg.constants.BridgeTestNetConstants;
@@ -582,12 +581,12 @@ class BitcoinUtilsTest {
 
         private void setUp(Federation federation) {
             BtcTransaction prevTx = new BtcTransaction(btcMainnetParams);
-            prevTx.setVersion(ReleaseTransactionBuilder.BTC_TX_VERSION_2);
+            prevTx.setVersion(BTC_TX_VERSION_2);
             Coin prevValue = Coin.COIN;
             prevTx.addOutput(prevValue, federation.getAddress());
 
             tx = new BtcTransaction(btcMainnetParams);
-            tx.setVersion(ReleaseTransactionBuilder.BTC_TX_VERSION_2);
+            tx.setVersion(BTC_TX_VERSION_2);
             tx.addInput(prevTx.getOutput(0));
 
             addSpendingFederationBaseScript(tx, inputIndex, federation.getRedeemScript(), federation.getFormatVersion());

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationTestUtils.java
@@ -19,7 +19,7 @@
 package co.rsk.peg.federation;
 
 import static co.rsk.peg.PegTestUtils.createBaseInputScriptThatSpendsFromTheFederation;
-import static co.rsk.peg.ReleaseTransactionBuilder.BTC_TX_VERSION_2;
+import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
 
 import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.crypto.TransactionSignature;

--- a/rskj-core/src/test/java/co/rsk/peg/federation/P2shP2wshErpFederationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/P2shP2wshErpFederationTest.java
@@ -1,6 +1,6 @@
 package co.rsk.peg.federation;
 
-import static co.rsk.peg.ReleaseTransactionBuilder.BTC_TX_VERSION_2;
+import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.signTxInputWithKey;
 import static co.rsk.peg.bitcoin.BitcoinUtils.*;
 import static co.rsk.peg.federation.ErpFederationCreationException.Reason.NULL_OR_EMPTY_EMERGENCY_KEYS;
@@ -12,7 +12,6 @@ import co.rsk.bitcoinj.crypto.TransactionSignature;
 import co.rsk.bitcoinj.script.*;
 import co.rsk.crypto.Keccak256;
 import co.rsk.peg.PegUtils;
-import co.rsk.peg.ReleaseTransactionBuilder;
 import co.rsk.peg.bitcoin.*;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.constants.BridgeMainNetConstants;
@@ -161,7 +160,7 @@ class P2shP2wshErpFederationTest {
             int outputIndex = 0;
             tx.addInput(prevTxHash, outputIndex, new Script(new byte[]{}));
             tx.addOutput(prevTxSentValue.minus(fee), receiver);
-            tx.setVersion(ReleaseTransactionBuilder.BTC_TX_VERSION_2);
+            tx.setVersion(BTC_TX_VERSION_2);
         }
 
         private void signTx() {


### PR DESCRIPTION
This pull request refactors how Bitcoin transaction version constants are defined and used throughout the codebase. The main change is moving the `BTC_TX_VERSION_1` and `BTC_TX_VERSION_2` constants from `ReleaseTransactionBuilder` to `BitcoinUtils`, making them more accessible and logically grouped with other Bitcoin utility functions. All usages in both production and test code have been updated accordingly. Additionally, some minor code cleanup and documentation improvements were made.

**Refactoring and Code Organization:**

* Moved `BTC_TX_VERSION_1` and `BTC_TX_VERSION_2` constants from `ReleaseTransactionBuilder` to `BitcoinUtils`, and updated all references in the codebase to use the new location. This improves code organization by grouping Bitcoin-specific constants with related utilities. [[1]](diffhunk://#diff-248b0253b5f1885806c559cf338f8d1b4202f8eb91e0757b92f2888a0d7bbc60L21-L53) [[2]](diffhunk://#diff-d2f7d48a230bf63b15d664979fed9c238a4e2abf5e281d00650b394d0eeaf3b8R20-R25)

* Updated import statements and usages in both main and test code to reference the transaction version constants from `BitcoinUtils` instead of `ReleaseTransactionBuilder`. [[1]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L23-R23) [[2]](diffhunk://#diff-aa013f6df11c8933018dedebcad0ca0beffef730bc60e0131f597e47d496a9e1L8-R8) [[3]](diffhunk://#diff-f25fddf0f0bed1223a863ea814b4b7c46d4897591afc78fe33078566397f4b3bL41-R41) [[4]](diffhunk://#diff-eac1f57884895b2183f2d0a57533776094b26a575c0da13d249096de00303d39L11-R11) [[5]](diffhunk://#diff-c2761df4b85b9eface15d5b96d9fb0519d27ac63d76ed9c64fcd39a0fbbbe044L22-R23) [[6]](diffhunk://#diff-f983ea43d54c2ca35d0e1ac572cc99ddbba5bcda419761e59e83e1c763381d13L22-R22) [[7]](diffhunk://#diff-cec60e24e36290393327576a945426d0d8f69861277d102c764189cab1a792efL3-R3) [[8]](diffhunk://#diff-cec60e24e36290393327576a945426d0d8f69861277d102c764189cab1a792efL15)

**Code Cleanup and Minor Improvements:**

* Removed now-unnecessary constant definitions from `ReleaseTransactionBuilder` and cleaned up related import statements.

* Improved JavaDoc comments for clarity in `BitcoinUtils`.

* Updated test code to use the new constant location, ensuring consistency and reducing coupling between test and production code. [[1]](diffhunk://#diff-78d8570042acbb682da726adaf857bdf828d2389842e4928ed5ffb89c017407cL534-R539) [[2]](diffhunk://#diff-a7df218cc85a955d453d0693359919da88fc6a8f1483b1ca5a63bba1460aa081L585-R589) [[3]](diffhunk://#diff-cec60e24e36290393327576a945426d0d8f69861277d102c764189cab1a792efL164-R163)

No behavior changes are introduced; these are organizational and maintainability improvements.