### PR TITLE
Improves baseEvent handling

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/core/BlockFactory.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockFactory.java
@@ -217,9 +217,9 @@ public final class BlockFactory implements BtcHeaderSizeRule {
             }
 
 
-        if (rlpHeader.size() > r && isBaseEventEnabled(blockNumber) && !compressed) {
-            baseEvent = rlpHeader.get(r++).getRLPRawData();
-        }
+        BaseEventDecodeResult baseEventResult = decodeBaseEvent(rlpHeader, r, blockNumber, compressed);
+        baseEvent = baseEventResult.baseEvent;
+        r = baseEventResult.nextIndex;
 
         byte[] bitcoinMergedMiningHeader = null;
         byte[] bitcoinMergedMiningMerkleProof = null;
@@ -242,6 +242,41 @@ public final class BlockFactory implements BtcHeaderSizeRule {
                 txExecutionSublistsEdges,
                 bitcoinMergedMiningHeader, bitcoinMergedMiningMerkleProof, bitcoinMergedMiningCoinbaseTransaction,
                 useRskip92Encoding, includeForkDetectionData);
+    }
+
+    /**
+     * Decodes the optional baseEvent field (RSKIP-535) and reports the index past it.
+     *
+     * <p>A header persisted before the baseEvent encoding fix is missing the element, so an
+     * absent field is decoded as an empty event -- this keeps a reloaded legacy header equal
+     * to a freshly built one.
+     */
+    private BaseEventDecodeResult decodeBaseEvent(RLPList rlpHeader, int baseEventIndex, long blockNumber, boolean compressed) {
+        if (!isBaseEventEnabled(blockNumber) || compressed) {
+            return new BaseEventDecodeResult(null, baseEventIndex);
+        }
+
+        // baseEvent is followed only by the optional merged-mining fields, so the remaining
+        // element count is 0, 1, miningFieldCount, or 1 + miningFieldCount. A remaining count
+        // of 0 or miningFieldCount means the baseEvent field is absent -- a header persisted
+        // before the baseEvent encoding fix.
+        int remaining = rlpHeader.size() - baseEventIndex;
+        int miningFieldCount = MAX_RLP_HEADER_SIZE_WITH_MINING - MAX_RLP_HEADER_SIZE_WITHOUT_MINING;
+        if (remaining == 0 || remaining == miningFieldCount) {
+            return new BaseEventDecodeResult(ByteUtil.EMPTY_BYTE_ARRAY, baseEventIndex);
+        }
+
+        return new BaseEventDecodeResult(rlpHeader.get(baseEventIndex).getRLPRawData(), baseEventIndex + 1);
+    }
+
+    private static final class BaseEventDecodeResult {
+        private final byte[] baseEvent;
+        private final int nextIndex;
+
+        private BaseEventDecodeResult(byte[] baseEvent, int nextIndex) {
+            this.baseEvent = baseEvent;
+            this.nextIndex = nextIndex;
+        }
     }
 
     private void validateBitcoinMergedMiningHeader(byte[] bitcoinMergedMiningHeader, long blockNumber) {
@@ -334,9 +369,20 @@ public final class BlockFactory implements BtcHeaderSizeRule {
     private boolean canBeDecoded(RLPList rlpHeader, long blockNumber, boolean compressed) {
         int expectedSizeWithoutMining = calculateExpectedHeaderSize(blockNumber, compressed, false);
         int expectedSizeWithMining = calculateExpectedHeaderSize(blockNumber, compressed, true);
+        int actualSize = rlpHeader.size();
 
-        return rlpHeader.size() == expectedSizeWithoutMining ||
-                rlpHeader.size() == expectedSizeWithMining;
+        if (actualSize == expectedSizeWithoutMining || actualSize == expectedSizeWithMining) {
+            return true;
+        }
+
+        // Backward compatibility: a header persisted before the baseEvent encoding fix is
+        // missing the baseEvent element, so it is exactly one RLP element short.
+        if (isBaseEventEnabled(blockNumber) && !compressed) {
+            return actualSize == expectedSizeWithoutMining - 1 ||
+                    actualSize == expectedSizeWithMining - 1;
+        }
+
+        return false;
     }
 
     /**

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderExtensionV2.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderExtensionV2.java
@@ -42,7 +42,9 @@ public class BlockHeaderExtensionV2 extends BlockHeaderExtensionV1 {
     public static BlockHeaderExtensionV2 fromEncoded(byte[] encoded) {
         RLPList rlpExtension = RLP.decodeList(encoded);
         byte[] logsBloom = rlpExtension.get(0).getRLPData();
-        byte[] baseEvent = rlpExtension.get(1).getRLPData();
+        // getRLPRawData() (not getRLPData()) so an empty baseEvent decodes to byte[0]
+        // rather than null. This is consistent with how edges (below) and BlockFactory decode it.
+        byte[] baseEvent = rlpExtension.get(1).getRLPRawData();
 
         return new BlockHeaderExtensionV2(
                 logsBloom,

--- a/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
@@ -931,24 +931,22 @@ class BlockFactoryTest {
     }
 
     // ---------------------------------------------------------------------------------------
-    // BUGFIX-REPORT: baseEvent encoding bug
+    // baseEvent encoding bug — regression tests
     //
-    // The three tests below reproduce the testnet crash
+    // VETIVER-9.0.x nodes (RSKIP535 active) crashed during sync with
     //   "java.lang.IllegalArgumentException: Invalid block header size: 22"
-    // reported for VETIVER-9.0.x nodes (RSKIP535 active). They pin the CURRENT (buggy)
-    // behavior with assertThrows so this commit stays green; a follow-up commit fixes the
-    // root cause and must flip each assertThrows back to a successful decode (see FIXMEs).
+    // because BlockHeaderExtensionV2.fromEncoded() decoded an empty baseEvent as null
+    // (instead of byte[0]); BlockHeader.addBaseEvent() then dropped the null field on
+    // re-encode, so the header was persisted one RLP element short.
     //
-    // Root cause: BlockHeaderExtensionV2.fromEncoded() reads baseEvent with getRLPData(),
-    // which returns null for an empty (0x80) RLP element. A null baseEvent is then silently
-    // skipped by BlockHeader.addBaseEvent() when the block is re-encoded for storage, so the
-    // header is persisted one RLP element short and BlockFactory.canBeDecoded() rejects it
-    // when the block is later read back from disk.
+    // The tests below verify the fix: the backward body-sync store-and-reload path no
+    // longer corrupts the header, and a header already persisted in the short form is
+    // still decodable (backward compatibility).
     // ---------------------------------------------------------------------------------------
 
     /**
-     * Reproduces the exact testnet error ("Invalid block header size: 22") through the
-     * backward body-sync store-and-reload path, for a block with merged-mining fields.
+     * Verifies the backward body-sync store-and-reload path for a block with merged-mining
+     * fields: an empty baseEvent must survive the wire round-trip and be persisted in full.
      */
     @Test
     void blockWithEmptyBaseEventSurvivesBackwardSyncStoreAndReloadWithMining() {
@@ -969,31 +967,25 @@ class BlockFactoryTest {
         // Backward body sync: the extension travels over the wire and is parsed via
         // BlockHeaderExtension.fromEncoded (MessageType.BODY_RESPONSE_MESSAGE.createMessage),
         // then attached to the header (DownloadingBackwardsBodiesSyncState.newBody -> setExtension).
-        // fromEncoded turns the empty baseEvent into null.
         BlockHeaderExtension wireExtension = BlockHeaderExtension.fromEncoded(
                 BlockHeaderExtension.toEncoded(header.getExtension()));
         header.setExtension(wireExtension);
 
         // IndexedBlockStore.saveBlock stores block.getEncoded() -> header.getFullEncoded().
-        // addBaseEvent() skips the now-null baseEvent -> header stored with only 22 RLP elements.
+        // The empty baseEvent is preserved, so the header keeps all 23 RLP elements.
         byte[] stored = header.getFullEncoded();
-        assertThat(RLP.decodeList(stored).size(), is(22));
+        assertThat(RLP.decodeList(stored).size(), is(23));
 
         // IndexedBlockStore.getBlock reloads via blockFactory.decodeBlock -> decodeHeader.
-        // FIXME(baseEvent encoding bug): the header was stored one RLP element short, so the
-        // reload throws. This assertThrows pins the buggy behavior to keep the commit green.
-        // The follow-up fix makes the decoder tolerant; when it lands, flip this to:
-        //   BlockHeader reloaded = factory.decodeHeader(stored, false);
-        //   assertArrayEquals(new byte[0], reloaded.getBaseEvent());
-        //   assertThat(reloaded.getHash(), is(header.getHash()));
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> factory.decodeHeader(stored, false));
-        assertThat(ex.getMessage(), is("Invalid block header size: 22"));
+        BlockHeader reloaded = factory.decodeHeader(stored, false);
+
+        assertArrayEquals(new byte[0], reloaded.getBaseEvent());
+        assertThat(reloaded.getHash(), is(header.getHash()));
     }
 
     /**
-     * Same backward body-sync store-and-reload path as above, but for a block without
-     * merged-mining fields (exercises the no-mining branch of the size validator).
+     * Same backward body-sync store-and-reload path as above, for a block without
+     * merged-mining fields.
      */
     @Test
     void blockWithEmptyBaseEventSurvivesBackwardSyncStoreAndReloadNoMining() {
@@ -1010,24 +1002,17 @@ class BlockFactoryTest {
                 BlockHeaderExtension.toEncoded(header.getExtension()));
         header.setExtension(wireExtension);
 
-        // 18-element header: 16 base + version + edges, baseEvent dropped.
         byte[] stored = header.getFullEncoded();
+        BlockHeader reloaded = factory.decodeHeader(stored, false);
 
-        // FIXME(baseEvent encoding bug): pins the buggy behavior; the reload throws because
-        // the short header is rejected. The follow-up fix makes the decoder tolerant; when
-        // it lands, flip this to:
-        //   BlockHeader reloaded = factory.decodeHeader(stored, false);
-        //   assertArrayEquals(new byte[0], reloaded.getBaseEvent());
-        //   assertThat(reloaded.getHash(), is(header.getHash()));
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> factory.decodeHeader(stored, false));
-        assertThat(ex.getMessage(), is("Invalid block header size: 18"));
+        assertArrayEquals(new byte[0], reloaded.getBaseEvent());
+        assertThat(reloaded.getHash(), is(header.getHash()));
     }
 
     /**
-     * Simulates a block already persisted with a missing baseEvent (an existing corrupted
-     * database entry). This isolates the decoder's intolerance to a 22-element header,
-     * independently of the BlockHeaderExtensionV2.fromEncoded null bug.
+     * Backward compatibility: a block already persisted with a missing baseEvent (an
+     * existing corrupted database entry, with merged-mining fields) must still decode.
+     * Exercises the decoder's "remaining == miningFieldCount" disambiguation branch.
      */
     @Test
     void blockStoredWithMissingBaseEventCanBeDecoded() {
@@ -1051,14 +1036,38 @@ class BlockFactoryTest {
         byte[] corrupted = header.getFullEncoded();
         assertThat(RLP.decodeList(corrupted).size(), is(22));
 
-        // FIXME(baseEvent encoding bug): pins the buggy behavior; the decoder cannot tolerate
-        // a 22-element header already on disk. The follow-up fix makes it tolerant; when it
-        // lands, flip this to:
-        //   BlockHeader reloaded = factory.decodeHeader(corrupted, false);
-        //   assertArrayEquals(new byte[0], reloaded.getBaseEvent());
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> factory.decodeHeader(corrupted, false));
-        assertThat(ex.getMessage(), is("Invalid block header size: 22"));
+        // The tolerant decoder reads the short header and treats the absent field as empty.
+        BlockHeader reloaded = factory.decodeHeader(corrupted, false);
+
+        assertArrayEquals(new byte[0], reloaded.getBaseEvent());
+        assertArrayEquals(edges, reloaded.getTxExecutionSublistsEdges());
+    }
+
+    /**
+     * Backward compatibility for a corrupted entry without merged-mining fields. Exercises
+     * the decoder's "remaining == 0" disambiguation branch.
+     */
+    @Test
+    void blockStoredWithMissingBaseEventCanBeDecodedNoMining() {
+        long number = 500L;
+        setupRskip535Test(number, RSKIP144);
+
+        short[] edges = TestUtils.randomShortArray("edges", 4);
+        BlockHeader header = new TestBlockHeaderBuilder(number)
+                .withEdges(edges)
+                .build();
+
+        // Corrupted entry: a V2 extension with a null baseEvent, encoded without the field.
+        header.setExtension(new BlockHeaderExtensionV2(
+                header.getLogsBloom(),
+                header.getTxExecutionSublistsEdges(),
+                null));
+        byte[] corrupted = header.getFullEncoded();
+
+        BlockHeader reloaded = factory.decodeHeader(corrupted, false);
+
+        assertArrayEquals(new byte[0], reloaded.getBaseEvent());
+        assertArrayEquals(edges, reloaded.getTxExecutionSublistsEdges());
     }
 
     @ParameterizedTest(name = "btcHeaderSize={0}, shouldSucceed={1} — {2}")

--- a/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
@@ -27,6 +27,8 @@ import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.BlockHeaderBuilder;
+import org.ethereum.core.BlockHeaderExtension;
+import org.ethereum.core.BlockHeaderExtensionV2;
 import org.ethereum.core.BlockHeaderV1;
 import org.ethereum.core.Bloom;
 import org.ethereum.crypto.HashUtil;
@@ -926,6 +928,137 @@ class BlockFactoryTest {
         assertArrayEquals(logsBloom, decodedHeader.getLogsBloom());
         assertArrayEquals(edges, decodedHeader.getTxExecutionSublistsEdges());
         assertArrayEquals(baseEvent, decodedHeader.getBaseEvent());
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // BUGFIX-REPORT: baseEvent encoding bug
+    //
+    // The three tests below reproduce the testnet crash
+    //   "java.lang.IllegalArgumentException: Invalid block header size: 22"
+    // reported for VETIVER-9.0.x nodes (RSKIP535 active). They pin the CURRENT (buggy)
+    // behavior with assertThrows so this commit stays green; a follow-up commit fixes the
+    // root cause and must flip each assertThrows back to a successful decode (see FIXMEs).
+    //
+    // Root cause: BlockHeaderExtensionV2.fromEncoded() reads baseEvent with getRLPData(),
+    // which returns null for an empty (0x80) RLP element. A null baseEvent is then silently
+    // skipped by BlockHeader.addBaseEvent() when the block is re-encoded for storage, so the
+    // header is persisted one RLP element short and BlockFactory.canBeDecoded() rejects it
+    // when the block is later read back from disk.
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Reproduces the exact testnet error ("Invalid block header size: 22") through the
+     * backward body-sync store-and-reload path, for a block with merged-mining fields.
+     */
+    @Test
+    void blockWithEmptyBaseEventSurvivesBackwardSyncStoreAndReloadWithMining() {
+        long number = 500L;
+        setupRskip535Test(number, RSKIPUMM, RSKIP144);
+
+        byte[] ummRoot = TestUtils.generateBytes("ummRoot", 20);
+        short[] edges = TestUtils.randomShortArray("edges", 4);
+
+        // A block with no Union Bridge event -> empty baseEvent (BlockHeaderBuilder fills byte[0]).
+        BlockHeader header = new TestBlockHeaderBuilder(number)
+                .withMergedMining()
+                .withUmmRoot(ummRoot)
+                .withEdges(edges)
+                .build();
+        assertArrayEquals(new byte[0], header.getBaseEvent());
+
+        // Backward body sync: the extension travels over the wire and is parsed via
+        // BlockHeaderExtension.fromEncoded (MessageType.BODY_RESPONSE_MESSAGE.createMessage),
+        // then attached to the header (DownloadingBackwardsBodiesSyncState.newBody -> setExtension).
+        // fromEncoded turns the empty baseEvent into null.
+        BlockHeaderExtension wireExtension = BlockHeaderExtension.fromEncoded(
+                BlockHeaderExtension.toEncoded(header.getExtension()));
+        header.setExtension(wireExtension);
+
+        // IndexedBlockStore.saveBlock stores block.getEncoded() -> header.getFullEncoded().
+        // addBaseEvent() skips the now-null baseEvent -> header stored with only 22 RLP elements.
+        byte[] stored = header.getFullEncoded();
+        assertThat(RLP.decodeList(stored).size(), is(22));
+
+        // IndexedBlockStore.getBlock reloads via blockFactory.decodeBlock -> decodeHeader.
+        // FIXME(baseEvent encoding bug): the header was stored one RLP element short, so the
+        // reload throws. This assertThrows pins the buggy behavior to keep the commit green.
+        // The follow-up fix makes the decoder tolerant; when it lands, flip this to:
+        //   BlockHeader reloaded = factory.decodeHeader(stored, false);
+        //   assertArrayEquals(new byte[0], reloaded.getBaseEvent());
+        //   assertThat(reloaded.getHash(), is(header.getHash()));
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> factory.decodeHeader(stored, false));
+        assertThat(ex.getMessage(), is("Invalid block header size: 22"));
+    }
+
+    /**
+     * Same backward body-sync store-and-reload path as above, but for a block without
+     * merged-mining fields (exercises the no-mining branch of the size validator).
+     */
+    @Test
+    void blockWithEmptyBaseEventSurvivesBackwardSyncStoreAndReloadNoMining() {
+        long number = 500L;
+        setupRskip535Test(number, RSKIP144);
+
+        short[] edges = TestUtils.randomShortArray("edges", 4);
+        BlockHeader header = new TestBlockHeaderBuilder(number)
+                .withEdges(edges)
+                .build();
+        assertArrayEquals(new byte[0], header.getBaseEvent());
+
+        BlockHeaderExtension wireExtension = BlockHeaderExtension.fromEncoded(
+                BlockHeaderExtension.toEncoded(header.getExtension()));
+        header.setExtension(wireExtension);
+
+        // 18-element header: 16 base + version + edges, baseEvent dropped.
+        byte[] stored = header.getFullEncoded();
+
+        // FIXME(baseEvent encoding bug): pins the buggy behavior; the reload throws because
+        // the short header is rejected. The follow-up fix makes the decoder tolerant; when
+        // it lands, flip this to:
+        //   BlockHeader reloaded = factory.decodeHeader(stored, false);
+        //   assertArrayEquals(new byte[0], reloaded.getBaseEvent());
+        //   assertThat(reloaded.getHash(), is(header.getHash()));
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> factory.decodeHeader(stored, false));
+        assertThat(ex.getMessage(), is("Invalid block header size: 18"));
+    }
+
+    /**
+     * Simulates a block already persisted with a missing baseEvent (an existing corrupted
+     * database entry). This isolates the decoder's intolerance to a 22-element header,
+     * independently of the BlockHeaderExtensionV2.fromEncoded null bug.
+     */
+    @Test
+    void blockStoredWithMissingBaseEventCanBeDecoded() {
+        long number = 500L;
+        setupRskip535Test(number, RSKIPUMM, RSKIP144);
+
+        byte[] ummRoot = TestUtils.generateBytes("ummRoot", 20);
+        short[] edges = TestUtils.randomShortArray("edges", 4);
+        BlockHeader header = new TestBlockHeaderBuilder(number)
+                .withMergedMining()
+                .withUmmRoot(ummRoot)
+                .withEdges(edges)
+                .build();
+
+        // Attach a V2 extension whose baseEvent is null directly, then encode: addBaseEvent()
+        // drops the field, yielding the 22-element layout of an already-corrupted DB entry.
+        header.setExtension(new BlockHeaderExtensionV2(
+                header.getLogsBloom(),
+                header.getTxExecutionSublistsEdges(),
+                null));
+        byte[] corrupted = header.getFullEncoded();
+        assertThat(RLP.decodeList(corrupted).size(), is(22));
+
+        // FIXME(baseEvent encoding bug): pins the buggy behavior; the decoder cannot tolerate
+        // a 22-element header already on disk. The follow-up fix makes it tolerant; when it
+        // lands, flip this to:
+        //   BlockHeader reloaded = factory.decodeHeader(corrupted, false);
+        //   assertArrayEquals(new byte[0], reloaded.getBaseEvent());
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> factory.decodeHeader(corrupted, false));
+        assertThat(ex.getMessage(), is("Invalid block header size: 22"));
     }
 
     @ParameterizedTest(name = "btcHeaderSize={0}, shouldSucceed={1} — {2}")

--- a/rskj-core/src/test/java/org/ethereum/core/BlockHeaderExtensionV2Test.java
+++ b/rskj-core/src/test/java/org/ethereum/core/BlockHeaderExtensionV2Test.java
@@ -154,6 +154,11 @@ class BlockHeaderExtensionV2Test {
 
         assertArrayEquals(logsBloom, decoded.getLogsBloom());
         assertArrayEquals(edges, decoded.getTxExecutionSublistsEdges());
+        // FIXME(baseEvent encoding bug): this pins the CURRENT (buggy) behavior. An empty
+        // baseEvent is encoded as the RLP byte 0x80, but fromEncoded() reads it with
+        // RLPItem.getRLPData(), which returns null for a zero-length element. A follow-up
+        // commit fixes fromEncoded() to use getRLPRawData() and must flip this assertion to:
+        //   assertArrayEquals(new byte[0], decoded.getBaseEvent());
         assertNull(decoded.getBaseEvent());
     }
 

--- a/rskj-core/src/test/java/org/ethereum/core/BlockHeaderExtensionV2Test.java
+++ b/rskj-core/src/test/java/org/ethereum/core/BlockHeaderExtensionV2Test.java
@@ -93,7 +93,7 @@ class BlockHeaderExtensionV2Test {
 
         assertNull(decoded.getLogsBloom());
         assertNull(decoded.getTxExecutionSublistsEdges());
-        assertNull(decoded.getBaseEvent());
+        assertArrayEquals(new byte[0], decoded.getBaseEvent());
     }
 
     @Test
@@ -111,7 +111,7 @@ class BlockHeaderExtensionV2Test {
 
         assertArrayEquals(logsBloom, decoded.getLogsBloom());
         assertNull(decoded.getTxExecutionSublistsEdges());
-        assertNull(decoded.getBaseEvent());
+        assertArrayEquals(new byte[0], decoded.getBaseEvent());
     }
 
     @Test
@@ -125,7 +125,7 @@ class BlockHeaderExtensionV2Test {
 
         assertArrayEquals(logsBloom, decoded.getLogsBloom());
         assertArrayEquals(edges, decoded.getTxExecutionSublistsEdges());
-        assertNull(decoded.getBaseEvent());
+        assertArrayEquals(new byte[0], decoded.getBaseEvent());
     }
 
     @Test
@@ -154,12 +154,9 @@ class BlockHeaderExtensionV2Test {
 
         assertArrayEquals(logsBloom, decoded.getLogsBloom());
         assertArrayEquals(edges, decoded.getTxExecutionSublistsEdges());
-        // FIXME(baseEvent encoding bug): this pins the CURRENT (buggy) behavior. An empty
-        // baseEvent is encoded as the RLP byte 0x80, but fromEncoded() reads it with
-        // RLPItem.getRLPData(), which returns null for a zero-length element. A follow-up
-        // commit fixes fromEncoded() to use getRLPRawData() and must flip this assertion to:
-        //   assertArrayEquals(new byte[0], decoded.getBaseEvent());
-        assertNull(decoded.getBaseEvent());
+        // An empty baseEvent is encoded as the RLP byte 0x80 and fromEncoded() reads it
+        // back as byte[0] (via getRLPRawData()) -- it must not be lost as null.
+        assertArrayEquals(new byte[0], decoded.getBaseEvent());
     }
 
     @Test


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
`BlockHeaderExtensionV2.fromEncoded()` decoded an empty `baseEvent` field with
`getRLPData()`, which returns `null` for the empty RLP element `0x80` (it should
be `byte[0]`). `BlockHeader.addBaseEvent()` then silently drops a `null`
`baseEvent` on re-encode, so any header that travels the **backward body-sync**
path is persisted one RLP element short. On reload, `BlockFactory.canBeDecoded()`
rejects the truncated header and the node crashes with
`IllegalArgumentException: Invalid block header size: 22`.

This PR fixes the root cause **and** makes the decoder tolerant of headers that
were already persisted in the corrupted (short) form, so an affected node can
upgrade by dropping in the new jar — no resync or DB migration required.

**Root-cause fix**
- `BlockHeaderExtensionV2.fromEncoded()` now reads `baseEvent` with
  `getRLPRawData()`, so an empty `baseEvent` decodes to `byte[0]` instead of
  `null` — consistent with how the `edges` field on the next line and
  `BlockFactory.decodeHeader()` already decode it. This alone stops all *new*
  corruption.

**Backward compatibility (headers already persisted short)**
- `BlockFactory.canBeDecoded()` accepts a header that is exactly one RLP element
  short, gated to the only case it can legitimately occur in (`baseEvent`
  enabled, uncompressed header).
- `BlockFactory.decodeHeader()` disambiguates an absent `baseEvent` from the
  optional merged-mining fields using the remaining element count, and treats an
  absent field as an empty event (`byte[0]`), so a reloaded legacy header is
  equal to a freshly built one.

This changes neither block encoding nor hashing — `addElementsEncoded()` already
encodes an empty and a `null` `baseEvent` identically as `0x80`, so the extension
hash and block hash are unchanged.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Some VETIVER-9.0.x testnet nodes crash during sync with
`IllegalArgumentException: Invalid block header size: 22`. The bug corrupts
header persistence on the backward body-sync path whenever a block carries an
empty `baseEvent` (i.e. no Union Bridge event), which is the common case. Without
this fix, affected nodes cannot complete sync; with it, they recover on a simple
jar swap because the tolerant decoder reads the already-corrupted entries in
place.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
The first commit adds tests that pin the buggy behavior with `assertThrows`; the
second (fix) commit flips them to successful-decode assertions, so CI moves from
asserting the bug to asserting the fix.

- `BlockHeaderExtensionV2Test` (22 tests, 0 failures) — four decode tests now
  assert an empty/absent `baseEvent` decodes to `byte[0]` rather than `null`.
- `BlockFactoryTest` (47 tests, 0 failures) — regression tests covering the
  backward body-sync store-and-reload path (with and without merged-mining
  fields) and the tolerant decoder reading a header persisted with the
  `baseEvent` element missing (`remaining == 0` and `remaining == miningFieldCount`
  branches).
- Broader regression sweep over `BlockHeader*`, `Block*` and `co.rsk.core.*`
  test classes — the compressed-path and pre-RSKIP351 tests are unaffected, as
  the fix does not touch those paths.
- `spotlessJavaCheck` / `checkstyle` pass on the changed files.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)

**Requires Activation Code (Hard Fork): No.** The fix changes neither block
encoding nor hashing. `BlockHeaderExtensionV2.addElementsEncoded()` already
encodes an empty and a `null` `baseEvent` identically as the RLP byte `0x80`, so
the extension hash and the block hash are unchanged. `canBeDecoded()` /
`decodeHeader()` only change which headers are *accepted* and how an absent field
is *read* — a correctly sized header decodes exactly as before. This is a
storage/decoding-tolerance fix for an already-active feature, not a consensus
change.

* **Other information**:
Legacy 22-element header entries are read in place by the tolerant decoder and
left as-is on disk; they are never rewritten by `IndexedBlockStore.saveBlock`, so
no DB migration is needed.
