### PR TITLE
Add missing log to getMultiSigTransactionWithoutSignatures

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
@@ -162,6 +162,8 @@ public class BitcoinUtils {
         NetworkParameters networkParameters = transaction.getParams();
         BtcTransaction transactionCopy = new BtcTransaction(networkParameters, transaction.bitcoinSerialize()); // this is needed to not remove signatures from the original tx
         removeSignaturesFromMultiSigTransaction(transactionCopy);
+
+        logger.trace("[getMultiSigTransactionWithoutSignatures] Btc tx hash without signatures {}", transactionCopy.getHash());
         return transactionCopy;
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
@@ -163,7 +163,11 @@ public class BitcoinUtils {
         BtcTransaction transactionCopy = new BtcTransaction(networkParameters, transaction.bitcoinSerialize()); // this is needed to not remove signatures from the original tx
         removeSignaturesFromMultiSigTransaction(transactionCopy);
 
-        logger.trace("[getMultiSigTransactionWithoutSignatures] Btc tx hash without signatures {}", transactionCopy.getHash());
+        logger.trace(
+            "[getMultiSigTransactionWithoutSignatures] Original btc tx hash: {}. Hash without signatures: {}",
+            transaction.getHash(),
+            transactionCopy.getHash()
+        );
         return transactionCopy;
     }
 


### PR DESCRIPTION
Some logs were removed from powpeg-node, including this one that logs the hash without signatures from a btc tx.
Since it is an important log, we should add it here. 