### PR TITLE
Decode always-present extension fields as non-null byte arrays

### DIFF
--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -377,7 +377,9 @@ public class RskContext implements NodeContext, NodeBootstrapper {
         checkIfNotClosed();
 
         if (blockFactory == null) {
-            blockFactory = new BlockFactory(getRskSystemProperties().getActivationConfig());
+            blockFactory = new BlockFactory(
+                    getRskSystemProperties().getActivationConfig(),
+                    getRskSystemProperties().getNetworkConstants().getChainId());
         }
 
         return blockFactory;

--- a/rskj-core/src/main/java/org/ethereum/core/BlockFactory.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockFactory.java
@@ -25,6 +25,7 @@ import co.rsk.core.RskAddress;
 import co.rsk.remasc.RemascTransaction;
 import co.rsk.validators.BtcHeaderSizeRule;
 import org.bouncycastle.util.BigIntegers;
+import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.util.ByteUtil;
@@ -62,10 +63,19 @@ public final class BlockFactory implements BtcHeaderSizeRule {
     private static final int MAX_RLP_HEADER_SIZE_WITH_MINING = 23;
     private static final int NUMBER_OF_ELEMENTS_IN_BLOCK_RLP = 3;
 
+    // Upper block-height bound for the testnet baseEvent size-tolerance branch in canBeDecoded.
+    private static final long BASE_EVENT_RECOVERY_UPPER_BOUND = 7_800_000L;
+
     private final ActivationConfig activationConfig;
+    private final byte chainId;
 
     public BlockFactory(ActivationConfig activationConfig) {
+        this(activationConfig, Constants.MAINNET_CHAIN_ID);
+    }
+
+    public BlockFactory(ActivationConfig activationConfig, byte chainId) {
         this.activationConfig = activationConfig;
+        this.chainId = chainId;
     }
 
     private static BigInteger parseBigInteger(byte[] bytes) {
@@ -217,8 +227,20 @@ public final class BlockFactory implements BtcHeaderSizeRule {
             }
 
 
-        if (rlpHeader.size() > r && isBaseEventEnabled(blockNumber) && !compressed) {
-            baseEvent = rlpHeader.get(r++).getRLPRawData();
+        if (isBaseEventEnabled(blockNumber) && !compressed) {
+            int miningFieldCount = MAX_RLP_HEADER_SIZE_WITH_MINING - MAX_RLP_HEADER_SIZE_WITHOUT_MINING;
+            // How many more fields are present starting from the baseEvent index?
+            int remaining = rlpHeader.size() - r;
+            // We are exactly at the offset where the baseEvent is expected to be present.
+            // If there are no more fields to process OR there are exactly miningFieldCount
+            // fields left, this means the baseEvent is not present and this is represented
+            // as an EMPTY_BYTE_ARRAY.
+            boolean isBaseEventAbsent = remaining == 0 || remaining == miningFieldCount;
+            if (isBaseEventAbsent) {
+                baseEvent = ByteUtil.EMPTY_BYTE_ARRAY;
+            } else {
+                baseEvent = rlpHeader.get(r++).getRLPRawData();
+            }
         }
 
         byte[] bitcoinMergedMiningHeader = null;
@@ -335,8 +357,26 @@ public final class BlockFactory implements BtcHeaderSizeRule {
         int expectedSizeWithoutMining = calculateExpectedHeaderSize(blockNumber, compressed, false);
         int expectedSizeWithMining = calculateExpectedHeaderSize(blockNumber, compressed, true);
 
-        return rlpHeader.size() == expectedSizeWithoutMining ||
-                rlpHeader.size() == expectedSizeWithMining;
+        if (rlpHeader.size() == expectedSizeWithoutMining
+                || rlpHeader.size() == expectedSizeWithMining) {
+            return true;
+        }
+
+        // Testnet-only tolerance: accept a header that is one RLP element short of the
+        // expected layout and have the decoder supply an empty baseEvent for it.
+        if (isInBaseEventRecoveryWindow(blockNumber, compressed)) {
+            return rlpHeader.size() == expectedSizeWithoutMining - 1
+                    || rlpHeader.size() == expectedSizeWithMining - 1;
+        }
+
+        return false;
+    }
+
+    private boolean isInBaseEventRecoveryWindow(long blockNumber, boolean compressed) {
+        return !compressed
+                && chainId == Constants.TESTNET_CHAIN_ID
+                && isBaseEventEnabled(blockNumber)
+                && blockNumber < BASE_EVENT_RECOVERY_UPPER_BOUND;
     }
 
     /**

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderExtensionV1.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderExtensionV1.java
@@ -39,7 +39,7 @@ public class BlockHeaderExtensionV1 implements BlockHeaderExtension {
     public static BlockHeaderExtensionV1 fromEncoded(byte[] encoded) {
         RLPList rlpExtension = RLP.decodeList(encoded);
         return new BlockHeaderExtensionV1(
-                rlpExtension.get(0).getRLPData(),
+                rlpExtension.get(0).getRLPRawData(),
                 rlpExtension.size() == 2 ? ByteUtil.rlpToShorts(rlpExtension.get(1).getRLPRawData()) : null
         );
     }

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderExtensionV2.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderExtensionV2.java
@@ -42,7 +42,9 @@ public class BlockHeaderExtensionV2 extends BlockHeaderExtensionV1 {
     public static BlockHeaderExtensionV2 fromEncoded(byte[] encoded) {
         RLPList rlpExtension = RLP.decodeList(encoded);
         byte[] logsBloom = rlpExtension.get(0).getRLPData();
-        byte[] baseEvent = rlpExtension.get(1).getRLPData();
+        // getRLPRawData() (not getRLPData()) so an empty baseEvent decodes to byte[0]
+        // rather than null. This is consistent with how edges (below) and BlockFactory decode it.
+        byte[] baseEvent = rlpExtension.get(1).getRLPRawData();
 
         return new BlockHeaderExtensionV2(
                 logsBloom,

--- a/rskj-core/src/main/java/org/ethereum/core/BlockHeaderExtensionV2.java
+++ b/rskj-core/src/main/java/org/ethereum/core/BlockHeaderExtensionV2.java
@@ -41,9 +41,10 @@ public class BlockHeaderExtensionV2 extends BlockHeaderExtensionV1 {
 
     public static BlockHeaderExtensionV2 fromEncoded(byte[] encoded) {
         RLPList rlpExtension = RLP.decodeList(encoded);
-        byte[] logsBloom = rlpExtension.get(0).getRLPData();
-        // getRLPRawData() (not getRLPData()) so an empty baseEvent decodes to byte[0]
-        // rather than null. This is consistent with how edges (below) and BlockFactory decode it.
+        // Always-present extension fields use getRLPRawData() so an empty element decodes
+        // to byte[0] rather than null, consistent with the edges slot (when present) and
+        // with how BlockFactory.decodeHeader reads the same fields.
+        byte[] logsBloom = rlpExtension.get(0).getRLPRawData();
         byte[] baseEvent = rlpExtension.get(1).getRLPRawData();
 
         return new BlockHeaderExtensionV2(

--- a/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
@@ -22,11 +22,14 @@ import co.rsk.config.RskMiningConstants;
 import co.rsk.crypto.Keccak256;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.TestUtils;
+import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.BlockHeader;
 import org.ethereum.core.BlockHeaderBuilder;
+import org.ethereum.core.BlockHeaderExtension;
+import org.ethereum.core.BlockHeaderExtensionV2;
 import org.ethereum.core.BlockHeaderV1;
 import org.ethereum.core.Bloom;
 import org.ethereum.crypto.HashUtil;
@@ -926,6 +929,285 @@ class BlockFactoryTest {
         assertArrayEquals(logsBloom, decodedHeader.getLogsBloom());
         assertArrayEquals(edges, decodedHeader.getTxExecutionSublistsEdges());
         assertArrayEquals(baseEvent, decodedHeader.getBaseEvent());
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // baseEvent encoding and size-tolerance coverage.
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * An empty baseEvent on a header with merged-mining fields round-trips through the
+     * extension wire encoding and the outer header re-encode, keeping the full 23-element
+     * RLP layout intact and the hash stable.
+     */
+    @Test
+    void emptyBaseEventPreservedAcrossExtensionRoundTripWithMining() {
+        long number = 500L;
+        setupRskip535Test(number, RSKIPUMM, RSKIP144);
+
+        byte[] ummRoot = TestUtils.generateBytes("ummRoot", 20);
+        short[] edges = TestUtils.randomShortArray("edges", 4);
+
+        BlockHeader header = new TestBlockHeaderBuilder(number)
+                .withMergedMining()
+                .withUmmRoot(ummRoot)
+                .withEdges(edges)
+                .build();
+        assertArrayEquals(new byte[0], header.getBaseEvent());
+
+        // Round-trip the extension through its wire encoding so an empty baseEvent
+        // is read back via fromEncoded.
+        BlockHeaderExtension wireExtension = BlockHeaderExtension.fromEncoded(
+                BlockHeaderExtension.toEncoded(header.getExtension()));
+        header.setExtension(wireExtension);
+
+        // Re-encode the header: the empty baseEvent slot is preserved in the layout.
+        byte[] stored = header.getFullEncoded();
+        assertThat(RLP.decodeList(stored).size(), is(23));
+
+        BlockHeader reloaded = factory.decodeHeader(stored, false);
+
+        assertArrayEquals(new byte[0], reloaded.getBaseEvent());
+        assertThat(reloaded.getHash(), is(header.getHash()));
+    }
+
+    /**
+     * Same round-trip property as above, for a header without merged-mining fields.
+     */
+    @Test
+    void emptyBaseEventPreservedAcrossExtensionRoundTripNoMining() {
+        long number = 500L;
+        setupRskip535Test(number, RSKIP144);
+
+        short[] edges = TestUtils.randomShortArray("edges", 4);
+        BlockHeader header = new TestBlockHeaderBuilder(number)
+                .withEdges(edges)
+                .build();
+        assertArrayEquals(new byte[0], header.getBaseEvent());
+
+        BlockHeaderExtension wireExtension = BlockHeaderExtension.fromEncoded(
+                BlockHeaderExtension.toEncoded(header.getExtension()));
+        header.setExtension(wireExtension);
+
+        byte[] stored = header.getFullEncoded();
+        BlockHeader reloaded = factory.decodeHeader(stored, false);
+
+        assertArrayEquals(new byte[0], reloaded.getBaseEvent());
+        assertThat(reloaded.getHash(), is(header.getHash()));
+    }
+
+    /**
+     * A header whose RLP layout is one element shy of the expected with-mining shape
+     * decodes on a testnet factory within the bounded height range; the absent baseEvent
+     * slot is supplied as an empty byte array. Exercises the decoder's
+     * "remaining == miningFieldCount" disambiguation branch.
+     */
+    @Test
+    void headerOneElementShortDecodableOnTestnetWithinBoundWithMining() {
+        long number = 500L;
+        setupRskip535Test(number, RSKIPUMM, RSKIP144);
+
+        byte[] ummRoot = TestUtils.generateBytes("ummRoot", 20);
+        short[] edges = TestUtils.randomShortArray("edges", 4);
+        BlockHeader header = new TestBlockHeaderBuilder(number)
+                .withMergedMining()
+                .withUmmRoot(ummRoot)
+                .withEdges(edges)
+                .build();
+
+        // Build a 22-element layout by attaching a V2 extension with a null baseEvent so
+        // the outer encode omits the baseEvent slot.
+        header.setExtension(new BlockHeaderExtensionV2(
+                header.getLogsBloom(),
+                header.getTxExecutionSublistsEdges(),
+                null));
+        byte[] stored = header.getFullEncoded();
+        assertThat(RLP.decodeList(stored).size(), is(22));
+
+        BlockFactory testnetFactory = new BlockFactory(activationConfig, Constants.TESTNET_CHAIN_ID);
+        BlockHeader reloaded = testnetFactory.decodeHeader(stored, false);
+
+        assertArrayEquals(new byte[0], reloaded.getBaseEvent());
+        assertArrayEquals(edges, reloaded.getTxExecutionSublistsEdges());
+    }
+
+    /**
+     * Same as the with-mining case above, for a header without merged-mining fields.
+     * Exercises the decoder's "remaining == 0" disambiguation branch.
+     */
+    @Test
+    void headerOneElementShortDecodableOnTestnetWithinBoundNoMining() {
+        long number = 500L;
+        setupRskip535Test(number, RSKIP144);
+
+        short[] edges = TestUtils.randomShortArray("edges", 4);
+        BlockHeader header = new TestBlockHeaderBuilder(number)
+                .withEdges(edges)
+                .build();
+
+        header.setExtension(new BlockHeaderExtensionV2(
+                header.getLogsBloom(),
+                header.getTxExecutionSublistsEdges(),
+                null));
+        byte[] stored = header.getFullEncoded();
+
+        BlockFactory testnetFactory = new BlockFactory(activationConfig, Constants.TESTNET_CHAIN_ID);
+        BlockHeader reloaded = testnetFactory.decodeHeader(stored, false);
+
+        assertArrayEquals(new byte[0], reloaded.getBaseEvent());
+        assertArrayEquals(edges, reloaded.getTxExecutionSublistsEdges());
+    }
+
+    /**
+     * The one-element-short tolerance is testnet-scoped: a mainnet factory rejects the
+     * same payload.
+     */
+    @Test
+    void headerOneElementShortRejectedOnMainnetFactory() {
+        long number = 500L;
+        setupRskip535Test(number, RSKIPUMM, RSKIP144);
+
+        byte[] ummRoot = TestUtils.generateBytes("ummRoot", 20);
+        short[] edges = TestUtils.randomShortArray("edges", 4);
+        BlockHeader header = new TestBlockHeaderBuilder(number)
+                .withMergedMining()
+                .withUmmRoot(ummRoot)
+                .withEdges(edges)
+                .build();
+        header.setExtension(new BlockHeaderExtensionV2(
+                header.getLogsBloom(),
+                header.getTxExecutionSublistsEdges(),
+                null));
+        byte[] stored = header.getFullEncoded();
+        assertThat(RLP.decodeList(stored).size(), is(22));
+
+        // The default `factory` field uses the single-arg constructor and so defaults the
+        // chain ID to mainnet.
+        assertThrows(IllegalArgumentException.class, () -> factory.decodeHeader(stored, false));
+    }
+
+    /**
+     * The tolerance applies only below BASE_EVENT_RECOVERY_UPPER_BOUND. A payload at the
+     * bound itself is rejected even on testnet.
+     */
+    @Test
+    void headerOneElementShortRejectedAboveUpperBound() {
+        long number = 7_800_000L;
+        setupRskip535Test(number, RSKIPUMM, RSKIP144);
+
+        byte[] ummRoot = TestUtils.generateBytes("ummRoot", 20);
+        short[] edges = TestUtils.randomShortArray("edges", 4);
+        BlockHeader header = new TestBlockHeaderBuilder(number)
+                .withMergedMining()
+                .withUmmRoot(ummRoot)
+                .withEdges(edges)
+                .build();
+        header.setExtension(new BlockHeaderExtensionV2(
+                header.getLogsBloom(),
+                header.getTxExecutionSublistsEdges(),
+                null));
+        byte[] stored = header.getFullEncoded();
+        assertThat(RLP.decodeList(stored).size(), is(22));
+
+        BlockFactory testnetFactory = new BlockFactory(activationConfig, Constants.TESTNET_CHAIN_ID);
+        assertThrows(IllegalArgumentException.class, () -> testnetFactory.decodeHeader(stored, false));
+    }
+
+    /**
+     * The tolerance does not extend to other chain IDs. Regtest stands in for any
+     * non-testnet network.
+     */
+    @Test
+    void headerOneElementShortRejectedOnNonTestnetChainId() {
+        long number = 500L;
+        setupRskip535Test(number, RSKIPUMM, RSKIP144);
+
+        byte[] ummRoot = TestUtils.generateBytes("ummRoot", 20);
+        short[] edges = TestUtils.randomShortArray("edges", 4);
+        BlockHeader header = new TestBlockHeaderBuilder(number)
+                .withMergedMining()
+                .withUmmRoot(ummRoot)
+                .withEdges(edges)
+                .build();
+        header.setExtension(new BlockHeaderExtensionV2(
+                header.getLogsBloom(),
+                header.getTxExecutionSublistsEdges(),
+                null));
+        byte[] stored = header.getFullEncoded();
+
+        BlockFactory regtestFactory = new BlockFactory(activationConfig, Constants.REGTEST_CHAIN_ID);
+        assertThrows(IllegalArgumentException.class, () -> regtestFactory.decodeHeader(stored, false));
+    }
+
+    /**
+     * The one-element-short tolerance only covers headers where the absent element is
+     * the baseEvent slot. A layout that keeps baseEvent but drops one merged-mining
+     * element lands on the same size; the decoder then reads the baseEvent slot as the
+     * BTC merged-mining header and the downstream size guard rejects it because the
+     * slot is not 80 bytes.
+     */
+    @Test
+    void headerOneElementShortWithBaseEventPresentRejectedOnTestnet() {
+        long number = 500L;
+        setupRskip535Test(number, RSKIPUMM, RSKIP144, RSKIP98);
+
+        byte[] baseEvent = TestUtils.generateBytes("baseEvent", 32);
+        byte[] ummRoot = TestUtils.generateBytes("ummRoot", 20);
+        short[] edges = TestUtils.randomShortArray("edges", 4);
+        BlockHeader header = new TestBlockHeaderBuilder(number)
+                .withMergedMining()
+                .withUmmRoot(ummRoot)
+                .withEdges(edges)
+                .withBaseEvent(baseEvent)
+                .build();
+
+        byte[] fullEncoded = header.getFullEncoded();
+        RLPList parsed = RLP.decodeList(fullEncoded);
+        assertThat(parsed.size(), is(23));
+
+        // Drop the last RLP element so the resulting header has baseEvent present but
+        // only two of the three merged-mining elements (a one-element-short layout
+        // whose missing element is not the baseEvent slot). All header fields are
+        // byte-string elements, so re-wrapping each payload with RLP.encodeElement
+        // reconstructs the original on-wire form.
+        byte[][] reencodedElements = new byte[parsed.size() - 1][];
+        for (int i = 0; i < reencodedElements.length; i++) {
+            reencodedElements[i] = RLP.encodeElement(parsed.get(i).getRLPRawData());
+        }
+        byte[] truncated = RLP.encodeList(reencodedElements);
+        assertThat(RLP.decodeList(truncated).size(), is(22));
+
+        BlockFactory testnetFactory = new BlockFactory(activationConfig, Constants.TESTNET_CHAIN_ID);
+        assertThrows(IllegalArgumentException.class, () -> testnetFactory.decodeHeader(truncated, false));
+    }
+
+    /**
+     * Smoke coverage that a 22-element uncompressed payload does not accidentally decode
+     * through the compressed code path. The compressed expected sizes for this block
+     * (20 with mining, 17 without) do not align with the recovery targets either, so
+     * this only verifies the rejection path stays rejecting when compressed=true is
+     * requested.
+     */
+    @Test
+    void compressedHeaderRejectedWhenSizeDoesNotMatch() {
+        long number = 500L;
+        setupRskip535Test(number, RSKIPUMM, RSKIP144);
+
+        byte[] ummRoot = TestUtils.generateBytes("ummRoot", 20);
+        short[] edges = TestUtils.randomShortArray("edges", 4);
+        BlockHeader header = new TestBlockHeaderBuilder(number)
+                .withMergedMining()
+                .withUmmRoot(ummRoot)
+                .withEdges(edges)
+                .build();
+        header.setExtension(new BlockHeaderExtensionV2(
+                header.getLogsBloom(),
+                header.getTxExecutionSublistsEdges(),
+                null));
+        byte[] stored = header.getFullEncoded();
+
+        BlockFactory testnetFactory = new BlockFactory(activationConfig, Constants.TESTNET_CHAIN_ID);
+        assertThrows(IllegalArgumentException.class, () -> testnetFactory.decodeHeader(stored, true));
     }
 
     @ParameterizedTest(name = "btcHeaderSize={0}, shouldSucceed={1} — {2}")

--- a/rskj-core/src/test/java/org/ethereum/core/BlockHeaderExtensionV2Test.java
+++ b/rskj-core/src/test/java/org/ethereum/core/BlockHeaderExtensionV2Test.java
@@ -91,7 +91,9 @@ class BlockHeaderExtensionV2Test {
         byte[] encoded = ext.getEncoded();
         BlockHeaderExtensionV2 decoded = BlockHeaderExtensionV2.fromEncoded(encoded);
 
-        assertNull(decoded.getLogsBloom());
+        // Always-present fields (logsBloom, baseEvent) decode to byte[0] when empty; the
+        // optional edges slot remains null when absent from the encoded list.
+        assertArrayEquals(new byte[0], decoded.getLogsBloom());
         assertNull(decoded.getTxExecutionSublistsEdges());
         assertArrayEquals(new byte[0], decoded.getBaseEvent());
     }

--- a/rskj-core/src/test/java/org/ethereum/core/BlockHeaderExtensionV2Test.java
+++ b/rskj-core/src/test/java/org/ethereum/core/BlockHeaderExtensionV2Test.java
@@ -93,7 +93,7 @@ class BlockHeaderExtensionV2Test {
 
         assertNull(decoded.getLogsBloom());
         assertNull(decoded.getTxExecutionSublistsEdges());
-        assertNull(decoded.getBaseEvent());
+        assertArrayEquals(new byte[0], decoded.getBaseEvent());
     }
 
     @Test
@@ -111,7 +111,7 @@ class BlockHeaderExtensionV2Test {
 
         assertArrayEquals(logsBloom, decoded.getLogsBloom());
         assertNull(decoded.getTxExecutionSublistsEdges());
-        assertNull(decoded.getBaseEvent());
+        assertArrayEquals(new byte[0], decoded.getBaseEvent());
     }
 
     @Test
@@ -125,7 +125,7 @@ class BlockHeaderExtensionV2Test {
 
         assertArrayEquals(logsBloom, decoded.getLogsBloom());
         assertArrayEquals(edges, decoded.getTxExecutionSublistsEdges());
-        assertNull(decoded.getBaseEvent());
+        assertArrayEquals(new byte[0], decoded.getBaseEvent());
     }
 
     @Test
@@ -154,7 +154,9 @@ class BlockHeaderExtensionV2Test {
 
         assertArrayEquals(logsBloom, decoded.getLogsBloom());
         assertArrayEquals(edges, decoded.getTxExecutionSublistsEdges());
-        assertNull(decoded.getBaseEvent());
+        // An empty baseEvent is encoded as the RLP byte 0x80 and fromEncoded() reads it
+        // back as byte[0] (via getRLPRawData()) -- it must not be lost as null.
+        assertArrayEquals(new byte[0], decoded.getBaseEvent());
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This branch contains two commits aligned around how the V2 block header extension reads its always-present fields, plus a narrow, height-bounded testnet decode tolerance for one specific RLP layout.

1. **`Decode an empty baseEvent as a non-null byte array`** — `BlockHeaderExtensionV2.fromEncoded()` now reads the `baseEvent` slot with `getRLPRawData()` so an empty element decodes to `byte[0]`, matching how the edges field and `BlockFactory.decodeHeader` already read it. The `baseEvent` decoding inside `decodeHeader` follows the same inline cursor pattern used for the other optional header fields and treats an absent field as an empty event.

   `BlockFactory.canBeDecoded` additionally accepts an uncompressed testnet header that is one RLP element short of its expected layout, provided `baseEvent` is active at that block and the height is below a bounded threshold; the decoder reconstructs the absent element as an empty event. Outside this height range the strict size check applies as before.

   `BlockFactory` now takes a chain ID; the existing single-arg constructor delegates with `MAINNET_CHAIN_ID` so the additional tolerance is off by default. `RskContext` passes the real chain ID at the single production instantiation site.

2. **`Decode an empty extension logsBloom as a non-null byte array`** — `BlockHeaderExtensionV1` and `BlockHeaderExtensionV2` now read the `logsBloom` slot with `getRLPRawData()` for the same reason as `baseEvent`. After this commit, every always-present extension field decodes empty as `byte[0]` and only the optional `edges` slot remains nullable when absent from the encoded list.

Encoding and hashing are unchanged across both commits, so no hardfork is required.

## Motivation and Context

The V2 extension and the outer header decoder used `RLPItem.getRLPData()` for the always-present extension fields, which returns `null` for an empty element rather than `byte[0]`. That asymmetry — empty round-trips as `null` but the encoder accepts both — can cause an always-present field to disappear from the re-encoded layout when an extension makes a wire round-trip, and the strict size check then rejects the re-encoded payload on disk reload. Switching the always-present fields to `getRLPRawData()` removes the asymmetry; the encoder side was already `null`-safe.

The bounded testnet decode tolerance recovers nodes that already persisted such one-element-short layouts. The combination of testnet-only chain ID, RSKIP-535 + RSKIP-351 active, height below an arbitrary upper bound, and uncompressed restricts the recovery surface to the specific layout the tolerance targets. Misshapen one-element-short payloads whose absent element is a merged-mining field rather than `baseEvent` are caught by the existing BTC merged-mining header size validation immediately downstream of the recovery branch.

## How Has This Been Tested?

**Unit / module tests**
- `./gradlew :rskj-core:test --tests "co.rsk.core.BlockFactoryTest" --tests "org.ethereum.core.BlockHeaderExtensionV2Test" --tests "co.rsk.core.BlockHeaderExtensionV1Test" --tests "co.rsk.core.BlockHeaderV1Test" --tests "co.rsk.core.BlockHeaderV2Test"` — all green.
- `./gradlew :rskj-core:test` — full module suite, BUILD SUCCESSFUL.
- `./gradlew spotlessJavaCheck -PratchetFrom=origin/master` — green.

New tests added in `BlockFactoryTest`:
- `emptyBaseEventPreservedAcrossExtensionRoundTrip{WithMining,NoMining}` — encoder/decoder symmetry for an empty `baseEvent`.
- `headerOneElementShortDecodableOnTestnetWithinBound{WithMining,NoMining}` — decode of a one-element-short header on a testnet factory within the bounded height range.
- `headerOneElementShortRejectedOnMainnetFactory`, `headerOneElementShortRejectedAboveUpperBound`, `headerOneElementShortRejectedOnNonTestnetChainId`, `compressedHeaderRejectedWhenSizeDoesNotMatch` — strict-rejection paths for every combination outside the tolerance.
- `headerOneElementShortWithBaseEventPresentRejectedOnTestnet` — a one-element-short layout whose absent element is a merged-mining field rather than `baseEvent` is rejected at decode time by the BTC merged-mining header size validation immediately downstream of the recovery branch.

`BlockHeaderExtensionV2Test.encodingWithNullFields` was updated to assert the new symmetric shape; the other extension tests use 256-byte logsBloom values and are unaffected by the change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**: The testnet decode tolerance in `BlockFactory.canBeDecoded` is intentionally height-bounded by an arbitrary constant (`BASE_EVENT_RECOVERY_UPPER_BOUND = 7_800_000L`). A follow-up will replace the bounded tolerance with a non-sunset solution once the deployment window is past.
