### PR TITLE
Added ProcessFundsMigrationTest as a new class of tests

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestUtil.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestUtil.java
@@ -1,13 +1,32 @@
 package co.rsk.peg;
 
 import static co.rsk.bitcoinj.script.ScriptOpCodes.OP_0;
-import static co.rsk.peg.BridgeEventsTestUtils.*;
+import static co.rsk.peg.BridgeEventsTestUtils.getEncodedData;
+import static co.rsk.peg.BridgeEventsTestUtils.getEncodedTopics;
 import static co.rsk.peg.BridgeEventsTestUtils.getLogsData;
+import static co.rsk.peg.BridgeEventsTestUtils.getLogsTopics;
 import static co.rsk.peg.BridgeStorageIndexKey.RELEASES_OUTPOINTS_VALUES;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import co.rsk.bitcoinj.core.*;
+import co.rsk.RskTestUtils;
+import co.rsk.bitcoinj.core.BtcBlock;
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.core.PartialMerkleTree;
+import co.rsk.bitcoinj.core.Sha256Hash;
+import co.rsk.bitcoinj.core.StoredBlock;
+import co.rsk.bitcoinj.core.TransactionInput;
+import co.rsk.bitcoinj.core.TransactionWitness;
+import co.rsk.bitcoinj.core.Utils;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
 import co.rsk.bitcoinj.script.ScriptChunk;
@@ -24,12 +43,18 @@ import co.rsk.peg.pegin.RejectedPeginReason;
 import co.rsk.peg.utils.NonRefundablePeginReason;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.core.CallTransaction;
 import org.ethereum.core.Repository;
+import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
@@ -37,6 +62,9 @@ import org.ethereum.vm.LogInfo;
 import org.ethereum.vm.PrecompiledContracts;
 
 public final class BridgeSupportTestUtil {
+
+    private BridgeSupportTestUtil() {}
+
     public static PartialMerkleTree createValidPmtForTransactions(List<BtcTransaction> btcTransactions, NetworkParameters networkParameters) {
         List<Sha256Hash> hashesToAdd = new ArrayList<>();
         for (BtcTransaction transaction : btcTransactions) {
@@ -132,6 +160,23 @@ public final class BridgeSupportTestUtil {
         bridgeStorageProvider.save();
 
         return pmtWithTransactions;
+    }
+
+    public static Transaction buildUpdateCollectionsTransaction() {
+        return buildUpdateCollectionsTransaction(0);
+    }
+
+    public static Transaction buildUpdateCollectionsTransaction(long nonce) {
+        Transaction tx = Transaction
+            .builder()
+            .nonce(BigInteger.valueOf(nonce))
+            .destination(PrecompiledContracts.BRIDGE_ADDR)
+            .data(Bridge.UPDATE_COLLECTIONS.encode())
+            .chainId(Constants.MAINNET_CHAIN_ID)
+            .build();
+
+        tx.sign(RskTestUtils.getEcKeyFromSeed("sender").getPrivKeyBytes());
+        return tx;
     }
 
     public static DataWord getStorageKeyForReleaseOutpointsValues(Sha256Hash releaseTxHash) {

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -97,7 +97,7 @@ class ProcessFundsMigrationTest {
                 .withScriptPubKey(retiringFederation.getP2SHScript())
                 .build()
             );
-            long executionBlockNumber = blockNumberBeforeMigrationBegins(ALL_ACTIVATIONS);
+            long executionBlockNumber = blockNumberBeforeMigrationBegins();
 
             setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
@@ -121,7 +121,7 @@ class ProcessFundsMigrationTest {
                 .build()
             );
 
-            long executionBlockNumber = duringMigrationBlockNumber(ALL_ACTIVATIONS);
+            long executionBlockNumber = duringMigrationBlockNumber();
             setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
@@ -143,7 +143,7 @@ class ProcessFundsMigrationTest {
                 .withScriptPubKey(retiringFederation.getP2SHScript())
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
-            long executionBlockNumber = duringMigrationBlockNumber(ALL_ACTIVATIONS);
+            long executionBlockNumber = duringMigrationBlockNumber();
             setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
@@ -166,7 +166,7 @@ class ProcessFundsMigrationTest {
                 .withScriptPubKey(retiringFederation.getP2SHScript())
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
-            long executionBlockNumber = duringMigrationBlockNumber(ALL_ACTIVATIONS);
+            long executionBlockNumber = duringMigrationBlockNumber();
             setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
@@ -189,7 +189,7 @@ class ProcessFundsMigrationTest {
                 .build()
             );
 
-            long executionBlockNumber = duringMigrationBlockNumber(ALL_ACTIVATIONS);
+            long executionBlockNumber = duringMigrationBlockNumber();
             setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
@@ -212,7 +212,7 @@ class ProcessFundsMigrationTest {
                 .withScriptPubKey(retiringFederation.getP2SHScript())
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
-            long executionBlockNumber = duringMigrationBlockNumber(ALL_ACTIVATIONS);
+            long executionBlockNumber = duringMigrationBlockNumber();
             setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
@@ -245,7 +245,7 @@ class ProcessFundsMigrationTest {
                 .build()
             );
 
-            long executionBlockNumber = pastMigrationBlockNumber(ALL_ACTIVATIONS);
+            long executionBlockNumber = pastMigrationBlockNumber();
             setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
@@ -267,7 +267,7 @@ class ProcessFundsMigrationTest {
                 .withScriptPubKey(retiringFederation.getP2SHScript())
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
-            long executionBlockNumber = pastMigrationBlockNumber(ALL_ACTIVATIONS);
+            long executionBlockNumber = pastMigrationBlockNumber();
             setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
@@ -290,7 +290,7 @@ class ProcessFundsMigrationTest {
                 .withScriptPubKey(retiringFederation.getP2SHScript())
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
-            long executionBlockNumber = pastMigrationBlockNumber(ALL_ACTIVATIONS);
+            long executionBlockNumber = pastMigrationBlockNumber();
             setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
@@ -306,7 +306,7 @@ class ProcessFundsMigrationTest {
         @Test
         void updateCollections_pastMigrationAge_withZeroBalance_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
             // Arrange
-            long executionBlockNumber = pastMigrationBlockNumber(ALL_ACTIVATIONS);
+            long executionBlockNumber = pastMigrationBlockNumber();
             setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, List.of());
 
@@ -329,7 +329,7 @@ class ProcessFundsMigrationTest {
                 .build()
             );
 
-            long executionBlockNumber = pastMigrationBlockNumber(ALL_ACTIVATIONS);
+            long executionBlockNumber = pastMigrationBlockNumber();
             setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
@@ -353,7 +353,7 @@ class ProcessFundsMigrationTest {
                 .build()
             );
 
-            long executionBlockNumber = pastMigrationBlockNumber(ALL_ACTIVATIONS);
+            long executionBlockNumber = pastMigrationBlockNumber();
             setUpBridgeAndFederationSupport(highFeePerKb, executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
@@ -372,7 +372,7 @@ class ProcessFundsMigrationTest {
         long executionBlockNumber
     ) {
         Repository repository = createRepository();
-        bridgeStorageProvider = new BridgeStorageProvider(repository, NETWORK_PARAMETERS, ProcessFundsMigrationTest.ALL_ACTIVATIONS);
+        bridgeStorageProvider = new BridgeStorageProvider(repository, NETWORK_PARAMETERS, ALL_ACTIVATIONS);
         bridgeStorageAccessor = new InMemoryStorage();
         setUpFeePerKb(feePerKb);
         federationStorageProvider = new FederationStorageProviderImpl(bridgeStorageAccessor);
@@ -383,14 +383,14 @@ class ProcessFundsMigrationTest {
             .withFederationConstants(BRIDGE_CONSTANTS.getFederationConstants())
             .withFederationStorageProvider(federationStorageProvider)
             .withRskExecutionBlock(executionBlock)
-            .withActivations(ProcessFundsMigrationTest.ALL_ACTIVATIONS)
+            .withActivations(ALL_ACTIVATIONS)
             .build();
 
         bridgeSupport = BridgeSupportBuilder.builder()
             .withBridgeConstants(BRIDGE_CONSTANTS)
             .withProvider(bridgeStorageProvider)
             .withExecutionBlock(executionBlock)
-            .withActivations(ProcessFundsMigrationTest.ALL_ACTIVATIONS)
+            .withActivations(ALL_ACTIVATIONS)
             .withFederationSupport(federationSupport)
             .withFeePerKbSupport(feePerKbSupport)
             .build();
@@ -421,21 +421,21 @@ class ProcessFundsMigrationTest {
         );
     }
 
-    private long blockNumberBeforeMigrationBegins(ActivationConfig.ForBlock activations) {
-        long activationAge = BRIDGE_CONSTANTS.getFederationConstants().getFederationActivationAge(activations);
+    private long blockNumberBeforeMigrationBegins() {
+        long activationAge = BRIDGE_CONSTANTS.getFederationConstants().getFederationActivationAge(ALL_ACTIVATIONS);
         return ACTIVE_FEDERATION_CREATION_BLOCK +
             activationAge +
             BRIDGE_CONSTANTS.getFederationConstants().getFundsMigrationAgeSinceActivationBegin();
     }
 
-    private long duringMigrationBlockNumber(ActivationConfig.ForBlock activations) {
-        return blockNumberBeforeMigrationBegins(activations) + 1;
+    private long duringMigrationBlockNumber() {
+        return blockNumberBeforeMigrationBegins() + 1;
     }
 
-    private long pastMigrationBlockNumber(ActivationConfig.ForBlock activations) {
-        long migrationPeriodDuration = BRIDGE_CONSTANTS.getFederationConstants().getFundsMigrationAgeSinceActivationEnd(activations) -
+    private long pastMigrationBlockNumber() {
+        long migrationPeriodDuration = BRIDGE_CONSTANTS.getFederationConstants().getFundsMigrationAgeSinceActivationEnd(ALL_ACTIVATIONS) -
             BRIDGE_CONSTANTS.getFederationConstants().getFundsMigrationAgeSinceActivationBegin();
-        return blockNumberBeforeMigrationBegins(activations) + migrationPeriodDuration;
+        return blockNumberBeforeMigrationBegins() + migrationPeriodDuration;
     }
 
     private void assertNoMigrationTxCreated() throws IOException {

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -152,7 +152,7 @@ class ProcessFundsMigrationTest {
         }
 
         @Test
-        void updateCollections_duringMigration_withManyMinNonDustRetiringUtxos_shouldThrowIllegalStateException() throws IOException {
+        void updateCollections_duringMigration_withManyMinNonDustRetiringUtxos_whenMigrationBuildFails_shouldThrowIllegalStateException() throws IOException {
             // Arrange
             int numberOfUtxos = 5;
             List<UTXO> retiringUtxos = UTXOBuilder.builder()

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -234,6 +234,8 @@ class ProcessFundsMigrationTest {
             assertRetiringUtxosCount(remainingUtxos);
 
             // Act
+            long secondExecutionBlockNumber = executionBlockNumber + 1;
+            setUpBridgeAndFederationSupportForExecutionBlock(secondExecutionBlockNumber);
             Transaction secondUpdateCollectionsTransaction = buildUpdateCollectionsTransaction(1);
             bridgeSupport.updateCollections(secondUpdateCollectionsTransaction);
 
@@ -391,6 +393,10 @@ class ProcessFundsMigrationTest {
         setUpFeePerKb(feePerKb);
         federationStorageProvider = new FederationStorageProviderImpl(bridgeStorageAccessor);
 
+        setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
+    }
+
+    private void setUpBridgeAndFederationSupportForExecutionBlock(long executionBlockNumber) {
         org.ethereum.core.Block executionBlock = new BlockGenerator().createBlock(executionBlockNumber, 1);
 
         federationSupport = FederationSupportBuilder.builder()

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -50,6 +50,7 @@ import static co.rsk.peg.bitcoin.BitcoinTestUtils.MIN_NON_DUST_VALUE_FOR_P2SH_OU
 import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
 import static co.rsk.peg.federation.FederationStorageIndexKey.OLD_FEDERATION_BTC_UTXOS_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ProcessFundsMigrationTest {
@@ -160,26 +161,24 @@ class ProcessFundsMigrationTest {
         }
 
         @Test
-        void updateCollections_duringMigration_withManyMinNonDustRetiringUtxos_shouldCreateMigrationTx() throws IOException {
+        void updateCollections_duringMigration_withManyMinNonDustRetiringUtxos_shouldThrowIllegalStateException() throws IOException {
             // Arrange
-            Coin lowSpendableValue = MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT.add(FEE_PER_KB);
             int numberOfUtxos = 5;
             List<UTXO> retiringUtxos = UTXOBuilder.builder()
-                .withValue(lowSpendableValue)
+                .withValue(MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT)
                 .withScriptPubKey(retiringFederation.getP2SHScript())
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(Coin.valueOf(1_000L), executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
-            // Act
-            bridgeSupport.updateCollections(updateCollectionsTransaction);
-
-            // Assert
-            assertOneMigrationTransactionWasBuiltAsExpected(retiringFederation, retiringUtxos, retiringUtxos.size());
+            // Act & Assert
+            assertThrows(IllegalStateException.class,
+                () -> bridgeSupport.updateCollections(updateCollectionsTransaction));
+            assertNoMigrationTxCreated();
             assertRetiringFederationStillPresent();
-            assertNoRemainingRetiringUtxos();
+            assertRetiringUtxosCount(numberOfUtxos);
         }
 
         @Test

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -1,82 +1,599 @@
 package co.rsk.peg;
 
 import co.rsk.RskTestUtils;
+import co.rsk.bitcoinj.core.Address;
+import co.rsk.bitcoinj.core.BtcTransaction;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.core.TransactionInput;
+import co.rsk.bitcoinj.core.TransactionOutput;
+import co.rsk.bitcoinj.core.TransactionWitness;
+import co.rsk.bitcoinj.core.UTXO;
+import co.rsk.bitcoinj.script.Script;
+import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.constants.BridgeMainNetConstants;
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.FederationStorageProviderImpl;
 import co.rsk.peg.federation.FederationSupport;
 import co.rsk.peg.federation.P2shP2wshErpFederationBuilder;
-import co.rsk.peg.feeperkb.*;
+import co.rsk.peg.feeperkb.FeePerKbStorageIndexKey;
+import co.rsk.peg.feeperkb.FeePerKbStorageProvider;
+import co.rsk.peg.feeperkb.FeePerKbStorageProviderImpl;
+import co.rsk.peg.feeperkb.FeePerKbSupport;
+import co.rsk.peg.feeperkb.FeePerKbSupportImpl;
 import co.rsk.peg.feeperkb.constants.FeePerKbConstants;
 import co.rsk.peg.storage.InMemoryStorage;
 import co.rsk.peg.storage.StorageAccessor;
 import co.rsk.test.builders.BridgeSupportBuilder;
 import co.rsk.test.builders.FederationSupportBuilder;
+import co.rsk.test.builders.UTXOBuilder;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
 import org.ethereum.vm.PrecompiledContracts;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Comparator;
+import java.util.List;
 
 import static co.rsk.RskTestUtils.createRepository;
+import static co.rsk.peg.bitcoin.BitcoinTestAssertions.assertP2shP2wshWitnessWithoutSignaturesHasProperFormat;
+import static co.rsk.peg.bitcoin.BitcoinTestUtils.MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT;
+import static co.rsk.peg.bitcoin.BitcoinTestUtils.createHash;
+import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
+import static co.rsk.peg.federation.FederationStorageIndexKey.OLD_FEDERATION_BTC_UTXOS_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ProcessFundsMigrationTest {
 
-    @Test
-    void updateCollections_withP2shP2wshActiveFed_withNoRetiringFederation_shouldNotCreateAMigrationTx() throws IOException {
-        // Arrange
-        BridgeConstants bridgeConstants = BridgeMainNetConstants.getInstance();
-        ActivationConfig.ForBlock activationConfig = ActivationConfigsForTest.all().forBlock(0L);
-        NetworkParameters networkParameters = bridgeConstants.getBtcParams();
+    private static final BridgeConstants BRIDGE_CONSTANTS = BridgeMainNetConstants.getInstance();
+    private static final NetworkParameters NETWORK_PARAMETERS = BRIDGE_CONSTANTS.getBtcParams();
+    private static final ActivationConfig.ForBlock ALL_ACTIVATIONS = ActivationConfigsForTest.all().forBlock(0L);
+    private static final Coin FEE_PER_KB = Coin.valueOf(8_000L);
+    private static final long ACTIVE_FEDERATION_CREATION_BLOCK = 100L;
+
+    private StorageAccessor bridgeStorageAccessor;
+    private BridgeStorageProvider bridgeStorageProvider;
+    private FederationStorageProviderImpl federationStorageProvider;
+    private FederationSupport federationSupport;
+    private BridgeSupport bridgeSupport;
+    private FeePerKbSupport feePerKbSupport;
+
+    @Nested
+    class P2shP2wshErpFederationTest {
+
+        private final Federation activeFederation = buildP2shP2wshFederation();
+        private final Transaction updateCollectionsTransaction = buildUpdateCollectionsTransaction();
+
+        @Test
+        void updateCollections_withNoRetiringFederation_shouldNotCreateMigrationTx() throws IOException {
+            // Arrange
+            setUpBridgeAndFederationSupport(FEE_PER_KB, ACTIVE_FEDERATION_CREATION_BLOCK + 1);
+            setUpActiveFederation(activeFederation);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertNoMigrationTxCreated();
+        }
+
+        @Test
+        void updateCollections_withNewFederationAgeBeforeMigrationBegins_shouldNotCreateMigrationTx() throws IOException {
+            // Arrange
+            Federation retiringFederation = buildP2shP2wshFederation();
+            List<UTXO> retiringUtxos = buildUtxos(retiringFederation, 1, Coin.COIN);
+            long executionBlockNumber = blockNumberBeforeMigrationBegins(ALL_ACTIVATIONS);
+
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertNoMigrationTxCreated();
+            assertRetiringFederationStillPresent();
+            assertRetiringUtxosCount(1);
+        }
+
+        @Test
+        void updateCollections_duringMigration_withOneSpendableRetiringUtxo_shouldCreateMigrationTx() throws IOException {
+            // Arrange
+            Federation retiringFederation = buildP2shP2wshFederation();
+            List<UTXO> retiringUtxos = buildUtxos(retiringFederation, 1, Coin.COIN);
+
+            long executionBlockNumber = duringMigrationBlockNumber(ALL_ACTIVATIONS);
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertOneMigrationTransactionWasBuiltAsExpected(retiringFederation, retiringUtxos, retiringUtxos.size());
+            assertRetiringFederationStillPresent();
+            assertRetiringUtxosCount(0);
+        }
+
+        @Test
+        void updateCollections_duringMigration_withMultipleSpendableRetiringUtxos_shouldCreateMigrationTx() throws IOException {
+            // Arrange
+            Federation retiringFederation = buildP2shP2wshFederation();
+            List<UTXO> retiringUtxos = buildUtxos(retiringFederation, 3, Coin.COIN);
+
+            long executionBlockNumber = duringMigrationBlockNumber(ALL_ACTIVATIONS);
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertOneMigrationTransactionWasBuiltAsExpected(retiringFederation, retiringUtxos, retiringUtxos.size());
+            assertRetiringFederationStillPresent();
+            assertRetiringUtxosCount(0);
+        }
+
+        @Test
+        void updateCollections_duringMigration_withManyMinNonDustRetiringUtxos_shouldCreateMigrationTx() throws IOException {
+            // Arrange
+            Federation retiringFederation = buildP2shP2wshFederation();
+            Coin lowSpendableValue = MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT.add(FEE_PER_KB);
+            List<UTXO> retiringUtxos = buildUtxos(retiringFederation, 5, lowSpendableValue);
+
+            long executionBlockNumber = duringMigrationBlockNumber(ALL_ACTIVATIONS);
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertOneMigrationTransactionWasBuiltAsExpected(retiringFederation, retiringUtxos, retiringUtxos.size());
+            assertRetiringFederationStillPresent();
+            assertRetiringUtxosCount(0);
+        }
+
+        @Test
+        void updateCollections_duringMigration_withBalanceBelowThreshold_shouldNotCreateMigrationTx() throws IOException {
+            // Arrange
+            Federation retiringFederation = buildP2shP2wshFederation();
+            List<UTXO> retiringUtxos = buildUtxos(retiringFederation, 1, FEE_PER_KB.divide(2));
+
+            long executionBlockNumber = duringMigrationBlockNumber(ALL_ACTIVATIONS);
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertNoMigrationTxCreated();
+            assertRetiringFederationStillPresent();
+            assertRetiringUtxosCount(1);
+        }
+
+        @Test
+        void updateCollections_duringMigration_withMoreUtxosThanMaxInputs_whenCalledRepeatedly_shouldCreateAMigrationTxEachTime() throws IOException {
+            // Arrange
+            Federation retiringFederation = buildP2shP2wshFederation();
+            int maxInputs = BRIDGE_CONSTANTS.getMaxInputsPerPegoutTransaction();
+            List<UTXO> retiringUtxos = buildUtxos(retiringFederation, maxInputs + 2, Coin.COIN);
+            Transaction secondUpdateCollectionsTransaction = buildUpdateCollectionsTransaction(1);
+
+            long executionBlockNumber = duringMigrationBlockNumber(ALL_ACTIVATIONS);
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+            bridgeSupport.updateCollections(secondUpdateCollectionsTransaction);
+
+            // Assert
+            assertMultipleMigrationTransactionsWereBuiltAsExpected(retiringFederation, retiringUtxos, 2);
+            assertRetiringFederationStillPresent();
+            assertRetiringUtxosCount(0);
+        }
+
+        @Test
+        void updateCollections_pastMigrationAge_withOneSpendableRetiringUtxo_shouldCreateMigrationTxAndClearRetiringFed() throws IOException {
+            // Arrange
+            Federation retiringFederation = buildP2shP2wshFederation();
+            List<UTXO> retiringUtxos = buildUtxos(retiringFederation, 1, Coin.COIN);
+
+            long executionBlockNumber = pastMigrationBlockNumber(ALL_ACTIVATIONS);
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertOneMigrationTransactionWasBuiltAsExpected(retiringFederation, retiringUtxos, retiringUtxos.size());
+            assertRetiringFederationCleared();
+            assertRetiringUtxosCount(0);
+        }
+
+        @Test
+        void updateCollections_pastMigrationAge_withManySpendableRetiringUtxos_shouldCreateMigrationTxAndClearRetiringFed() throws IOException {
+            // Arrange
+            Federation retiringFederation = buildP2shP2wshFederation();
+            List<UTXO> retiringUtxos = buildUtxos(retiringFederation, 3, Coin.COIN);
+
+            long executionBlockNumber = pastMigrationBlockNumber(ALL_ACTIVATIONS);
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertOneMigrationTransactionWasBuiltAsExpected(retiringFederation, retiringUtxos, retiringUtxos.size());
+            assertRetiringFederationCleared();
+            assertRetiringUtxosCount(0);
+        }
+
+        @Test
+        void updateCollections_pastMigrationAge_withMoreUtxosThanMaxInputs_shouldClearRetiringFedEvenIfUtxosRemain() throws IOException {
+            // Arrange
+            Federation retiringFederation = buildP2shP2wshFederation();
+            int maxInputs = BRIDGE_CONSTANTS.getMaxInputsPerPegoutTransaction();
+            List<UTXO> retiringUtxos = buildUtxos(retiringFederation, maxInputs + 2, Coin.COIN);
+
+            long executionBlockNumber = pastMigrationBlockNumber(ALL_ACTIVATIONS);
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertOneMigrationTransactionWasBuiltAsExpected(retiringFederation, retiringUtxos, maxInputs);
+            assertRetiringFederationCleared();
+            assertRetiringUtxosCount(2);
+        }
+
+        @Test
+        void updateCollections_pastMigrationAge_withZeroBalance_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
+            // Arrange
+            Federation retiringFederation = buildP2shP2wshFederation();
+
+            long executionBlockNumber = pastMigrationBlockNumber(ALL_ACTIVATIONS);
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, List.of());
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertNoMigrationTxCreated();
+            assertRetiringFederationCleared();
+            assertRetiringUtxosCount(0);
+        }
+
+        @Test
+        void updateCollections_pastMigrationAge_withMinNonDustRetiringUtxo_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
+            // Arrange
+            Federation retiringFederation = buildP2shP2wshFederation();
+            List<UTXO> retiringUtxos = buildUtxos(retiringFederation, 1, MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT);
+
+            long executionBlockNumber = pastMigrationBlockNumber(ALL_ACTIVATIONS);
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertNoMigrationTxCreated();
+            assertRetiringFederationCleared();
+            assertRetiringUtxosCount(1);
+        }
+
+        @Test
+        void updateCollections_pastMigrationAge_withHighFees_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
+            // Arrange
+            Federation retiringFederation = buildP2shP2wshFederation();
+            Coin highFeePerKb = Coin.COIN.multiply(2).subtract(Coin.SATOSHI);
+            List<UTXO> retiringUtxos = buildUtxos(retiringFederation, 1, Coin.COIN);
+
+            long executionBlockNumber = pastMigrationBlockNumber(ALL_ACTIVATIONS);
+            setUpBridgeAndFederationSupport(highFeePerKb, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertNoMigrationTxCreated();
+            assertRetiringFederationCleared();
+            assertRetiringUtxosCount(1);
+        }
+    }
+
+    private void setUpBridgeAndFederationSupport(
+        Coin feePerKb,
+        long executionBlockNumber
+    ) {
         Repository repository = createRepository();
+        bridgeStorageProvider = new BridgeStorageProvider(repository, NETWORK_PARAMETERS, ProcessFundsMigrationTest.ALL_ACTIVATIONS);
+        bridgeStorageAccessor = new InMemoryStorage();
+        setUpFeePerKb(feePerKb);
+        federationStorageProvider = new FederationStorageProviderImpl(bridgeStorageAccessor);
 
-        BridgeStorageProvider bridgeStorageProvider = new BridgeStorageProvider(repository, networkParameters, activationConfig);
-        StorageAccessor bridgeStorageAccessor = new InMemoryStorage();
-        Coin feePerKb = Coin.valueOf(8_000L);
-        bridgeStorageAccessor.saveToRepository(FeePerKbStorageIndexKey.FEE_PER_KB.getKey(), feePerKb, BridgeSerializationUtils::serializeCoin);
-        FeePerKbConstants feePerKbConstants = bridgeConstants.getFeePerKbConstants();
-        FeePerKbStorageProvider feePerKbStorageProvider = new FeePerKbStorageProviderImpl(bridgeStorageAccessor);
-        FeePerKbSupport feePerKbSupport = new FeePerKbSupportImpl(feePerKbConstants, feePerKbStorageProvider);
-        FederationStorageProviderImpl federationStorageProvider = new FederationStorageProviderImpl(bridgeStorageAccessor);
+        org.ethereum.core.Block executionBlock = new BlockGenerator().createBlock(executionBlockNumber, 1);
 
-        FederationSupport federationSupport = FederationSupportBuilder.builder()
-            .withFederationConstants(bridgeConstants.getFederationConstants())
+        federationSupport = FederationSupportBuilder.builder()
+            .withFederationConstants(BRIDGE_CONSTANTS.getFederationConstants())
             .withFederationStorageProvider(federationStorageProvider)
-            .withActivations(activationConfig)
+            .withRskExecutionBlock(executionBlock)
+            .withActivations(ProcessFundsMigrationTest.ALL_ACTIVATIONS)
             .build();
 
-        BridgeSupport bridgeSupport = BridgeSupportBuilder.builder()
-            .withBridgeConstants(bridgeConstants)
+        bridgeSupport = BridgeSupportBuilder.builder()
+            .withBridgeConstants(BRIDGE_CONSTANTS)
             .withProvider(bridgeStorageProvider)
-            .withActivations(activationConfig)
+            .withExecutionBlock(executionBlock)
+            .withActivations(ProcessFundsMigrationTest.ALL_ACTIVATIONS)
             .withFederationSupport(federationSupport)
             .withFeePerKbSupport(feePerKbSupport)
             .build();
+    }
 
-        Federation activeFederation = P2shP2wshErpFederationBuilder.builder().build();
+    private void setUpFeePerKb(Coin feePerKb) {
+        bridgeStorageAccessor.saveToRepository(FeePerKbStorageIndexKey.FEE_PER_KB.getKey(), feePerKb, BridgeSerializationUtils::serializeCoin);
+        FeePerKbConstants feePerKbConstants = BRIDGE_CONSTANTS.getFeePerKbConstants();
+        FeePerKbStorageProvider feePerKbStorageProvider = new FeePerKbStorageProviderImpl(bridgeStorageAccessor);
+        feePerKbSupport = new FeePerKbSupportImpl(feePerKbConstants, feePerKbStorageProvider);
+    }
+
+    private void setUpActiveFederation(Federation activeFederation) {
         federationStorageProvider.setNewFederation(activeFederation);
+    }
 
-        Transaction updateCollectionsTx = buildUpdateCollectionsTransaction();
+    private void setUpActiveAndRetiringFederations(
+        Federation activeFederation,
+        Federation retiringFederation,
+        List<UTXO> retiringUtxos
+    ) {
+        federationStorageProvider.setNewFederation(activeFederation);
+        federationStorageProvider.setOldFederation(retiringFederation);
+        bridgeStorageAccessor.saveToRepository(
+            OLD_FEDERATION_BTC_UTXOS_KEY.getKey(),
+            retiringUtxos,
+            BridgeSerializationUtils::serializeUTXOList
+        );
+    }
 
-        // Act
-        bridgeSupport.updateCollections(updateCollectionsTx);
+    private Federation buildP2shP2wshFederation() {
+        return P2shP2wshErpFederationBuilder.builder()
+            .withNetworkParameters(NETWORK_PARAMETERS)
+            .withCreationBlockNumber(ACTIVE_FEDERATION_CREATION_BLOCK)
+            .build();
+    }
 
-        // Assert
+    private List<UTXO> buildUtxos(Federation federation, int count, Coin value) {
+        return UTXOBuilder.builder()
+            .withValue(value)
+            .withScriptPubKey(federation.getP2SHScript())
+            .buildMany(count, i -> createHash(i + 1));
+    }
+
+    private long blockNumberBeforeMigrationBegins(ActivationConfig.ForBlock activations) {
+        long activationAge = BRIDGE_CONSTANTS.getFederationConstants().getFederationActivationAge(activations);
+        return ACTIVE_FEDERATION_CREATION_BLOCK +
+            activationAge +
+            BRIDGE_CONSTANTS.getFederationConstants().getFundsMigrationAgeSinceActivationBegin();
+    }
+
+    private long duringMigrationBlockNumber(ActivationConfig.ForBlock activations) {
+        return blockNumberBeforeMigrationBegins(activations) + 1;
+    }
+
+    private long pastMigrationBlockNumber(ActivationConfig.ForBlock activations) {
+        long migrationPeriodDuration = BRIDGE_CONSTANTS.getFederationConstants().getFundsMigrationAgeSinceActivationEnd(activations) -
+            BRIDGE_CONSTANTS.getFederationConstants().getFundsMigrationAgeSinceActivationBegin();
+        return blockNumberBeforeMigrationBegins(activations) + migrationPeriodDuration;
+    }
+
+    private void assertNoMigrationTxCreated() throws IOException {
+        assertMigrationTxCount(0);
+    }
+
+    private void assertOneMigrationTransactionWasBuiltAsExpected(
+        Federation retiringFederation,
+        List<UTXO> retiringFederationUtxos,
+        int expectedInputCount
+    ) throws IOException {
+        assertMigrationTxCount(1);
+        BtcTransaction migrationTransaction = bridgeStorageProvider.getPegoutsWaitingForConfirmations()
+            .getEntries()
+            .iterator()
+            .next()
+            .getBtcTransaction();
+
+        assertMigrationTransactionWasBuiltAsExpected(
+            migrationTransaction,
+            retiringFederation,
+            retiringFederationUtxos,
+            expectedInputCount
+        );
+    }
+
+    private void assertMultipleMigrationTransactionsWereBuiltAsExpected(
+        Federation retiringFederation,
+        List<UTXO> retiringFederationUtxos,
+        int expectedTransactionCount
+    ) throws IOException {
+        List<BtcTransaction> migrationTransactions = bridgeStorageProvider.getPegoutsWaitingForConfirmations()
+            .getEntries()
+            .stream()
+            .map(PegoutsWaitingForConfirmations.Entry::getBtcTransaction)
+            .sorted(Comparator.comparingInt(tx -> tx.getInputs().size()))
+            .toList();
+        assertEquals(expectedTransactionCount, migrationTransactions.size());
+
+        List<UTXO> selectedUtxos = migrationTransactions.stream()
+            .flatMap(tx -> getSelectedUtxos(tx, retiringFederationUtxos).stream())
+            .toList();
+        assertEquals(retiringFederationUtxos.size(), selectedUtxos.size());
+        assertTrue(selectedUtxos.containsAll(retiringFederationUtxos));
+
+        for (BtcTransaction migrationTransaction : migrationTransactions) {
+            assertMigrationTransactionWasBuiltAsExpected(
+                migrationTransaction,
+                retiringFederation,
+                retiringFederationUtxos,
+                migrationTransaction.getInputs().size()
+            );
+        }
+    }
+
+    private void assertMigrationTransactionWasBuiltAsExpected(
+        BtcTransaction migrationTransaction,
+        Federation retiringFederation,
+        List<UTXO> retiringFederationUtxos,
+        int expectedInputCount
+    ) {
+        List<UTXO> selectedUtxos = getSelectedUtxos(migrationTransaction, retiringFederationUtxos);
+
+        assertBtcTxVersionIs2(migrationTransaction);
+        assertMigrationReleaseTxInputsP2shP2wshErp(
+            migrationTransaction,
+            retiringFederation.getRedeemScript(),
+            retiringFederationUtxos,
+            selectedUtxos,
+            expectedInputCount
+        );
+
+        Coin migrationValue = selectedUtxos.stream()
+            .map(UTXO::getValue)
+            .reduce(Coin.ZERO, Coin::add);
+        assertMigrationTxWithOnlyMigrationOutputs(migrationTransaction, migrationValue);
+    }
+
+    private void assertBtcTxVersionIs2(BtcTransaction migrationTransaction) {
+        assertEquals(BTC_TX_VERSION_2, migrationTransaction.getVersion());
+    }
+
+    private void assertMigrationReleaseTxInputsP2shP2wshErp(
+        BtcTransaction migrationTransaction,
+        Script retiringFederationRedeemScript,
+        List<UTXO> retiringFederationUtxos,
+        List<UTXO> selectedUtxos,
+        int expectedInputCount
+    ) {
+        List<TransactionInput> inputs = migrationTransaction.getInputs();
+        assertEquals(expectedInputCount, inputs.size());
+        assertEquals(expectedInputCount, selectedUtxos.size());
+        assertReleaseTxInputsHasProperFormatAndBelongsToP2shP2wshErpFederation(
+            migrationTransaction,
+            retiringFederationRedeemScript,
+            retiringFederationUtxos
+        );
+        assertSelectedUtxosBelongToTheInputs(selectedUtxos, inputs);
+    }
+
+    private void assertReleaseTxInputsHasProperFormatAndBelongsToP2shP2wshErpFederation(
+        BtcTransaction migrationTransaction,
+        Script retiringFederationRedeemScript,
+        List<UTXO> retiringFederationUtxos
+    ) {
+        List<TransactionInput> inputs = migrationTransaction.getInputs();
+        for (int inputIndex = 0; inputIndex < inputs.size(); inputIndex++) {
+            TransactionWitness witness = migrationTransaction.getWitness(inputIndex);
+            assertP2shP2wshWitnessWithoutSignaturesHasProperFormat(witness, retiringFederationRedeemScript);
+            assertInputIsFromFederationUtxosWallet(inputs.get(inputIndex), retiringFederationUtxos);
+        }
+    }
+
+    private void assertInputIsFromFederationUtxosWallet(TransactionInput input, List<UTXO> federationUtxos) {
+        long matchingUtxos = federationUtxos.stream()
+            .filter(utxo -> utxo.getHash().equals(input.getOutpoint().getHash()) &&
+                utxo.getIndex() == input.getOutpoint().getIndex())
+            .count();
+        assertEquals(1, matchingUtxos);
+    }
+
+    private void assertSelectedUtxosBelongToTheInputs(List<UTXO> selectedUtxos, List<TransactionInput> inputs) {
+        for (UTXO selectedUtxo : selectedUtxos) {
+            long matchingInputs = inputs.stream()
+                .filter(input -> input.getOutpoint().getHash().equals(selectedUtxo.getHash()) &&
+                    input.getOutpoint().getIndex() == selectedUtxo.getIndex())
+                .count();
+            assertEquals(1, matchingInputs);
+        }
+    }
+
+    private void assertMigrationTxWithOnlyMigrationOutputs(
+        BtcTransaction migrationTransaction,
+        Coin migrationValue
+    ) {
+        int expectedNumberOfOutputs = 1;
+        List<TransactionOutput> migrationTransactionOutputs = migrationTransaction.getOutputs();
+        assertEquals(expectedNumberOfOutputs, migrationTransactionOutputs.size());
+        assertDestinationAddress(migrationTransactionOutputs, federationSupport.getActiveFederationAddress());
+        assertOutputsWithNoChange(migrationTransaction, migrationValue);
+    }
+
+    private void assertDestinationAddress(List<TransactionOutput> outputs, Address expectedDestinationAddress) {
+        for (TransactionOutput output : outputs) {
+            Address destinationAddress = output.getScriptPubKey().getToAddress(NETWORK_PARAMETERS);
+            assertEquals(expectedDestinationAddress, destinationAddress);
+        }
+    }
+
+    private void assertOutputsWithNoChange(BtcTransaction migrationTransaction, Coin expectedSentAmount) {
+        Coin outputsAmount = migrationTransaction.getOutputSum();
+        Coin fees = migrationTransaction.getFee();
+        Coin totalAmountSent = fees.add(outputsAmount);
+        assertEquals(expectedSentAmount, totalAmountSent);
+        assertEquals(migrationTransaction.getInputSum(), totalAmountSent);
+    }
+
+    private List<UTXO> getSelectedUtxos(BtcTransaction migrationTransaction, List<UTXO> federationUtxos) {
+        return migrationTransaction.getInputs()
+            .stream()
+            .map(input -> federationUtxos.stream()
+                .filter(utxo -> utxo.getHash().equals(input.getOutpoint().getHash()) &&
+                    utxo.getIndex() == input.getOutpoint().getIndex())
+                .findFirst()
+                .orElseThrow())
+            .toList();
+    }
+
+    private void assertMigrationTxCount(int expectedCount) throws IOException {
+        assertEquals(expectedCount, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries().size());
+    }
+
+    private void assertRetiringFederationStillPresent() {
+        assertTrue(federationSupport.getRetiringFederation().isPresent());
+    }
+
+    private void assertRetiringFederationCleared() {
         assertTrue(federationSupport.getRetiringFederation().isEmpty());
-        assertTrue(bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries().isEmpty());
+    }
+
+    private void assertRetiringUtxosCount(int expectedCount) {
+        assertEquals(expectedCount, federationStorageProvider.getOldFederationBtcUTXOs().size());
     }
 
     private Transaction buildUpdateCollectionsTransaction() {
+        return buildUpdateCollectionsTransaction(0);
+    }
+
+    private Transaction buildUpdateCollectionsTransaction(long nonce) {
         Transaction tx = Transaction
             .builder()
+            .nonce(BigInteger.valueOf(nonce))
             .destination(PrecompiledContracts.BRIDGE_ADDR)
             .data(Bridge.UPDATE_COLLECTIONS.encode())
             .chainId(Constants.MAINNET_CHAIN_ID)

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -646,7 +646,7 @@ class ProcessFundsMigrationTest {
     private List<BtcECKey> getActiveMemberKeys() {
         String[] memberSeeds = new String[20];
         for (int i = 0; i < 20; i++) {
-            memberSeeds[i] = "newActiveMember-" + i;
+            memberSeeds[i] = String.format("newActiveMember-%s", i);
         }
         return getBtcEcKeysFromSeeds(memberSeeds, true);
     }

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -486,11 +486,14 @@ class ProcessFundsMigrationTest {
         Federation retiringFederation,
         List<UTXO> retiringFederationUtxos
     ) throws IOException {
-        List<BtcTransaction> migrationTransactions = bridgeStorageProvider.getPegoutsWaitingForConfirmations()
+        List<PegoutsWaitingForConfirmations.Entry> migrationTransactionEntries = bridgeStorageProvider.getPegoutsWaitingForConfirmations()
             .getEntries()
             .stream()
+            .sorted(Comparator.comparing(PegoutsWaitingForConfirmations.Entry::getPegoutCreationRskBlockNumber))
+            .toList();
+
+        List<BtcTransaction> migrationTransactions = migrationTransactionEntries.stream()
             .map(PegoutsWaitingForConfirmations.Entry::getBtcTransaction)
-            .sorted(Comparator.comparingInt(tx -> tx.getInputs().size()))
             .toList();
         assertEquals(EXPECTED_MULTIPLE_MIGRATION_TX_COUNT, migrationTransactions.size());
 
@@ -500,13 +503,17 @@ class ProcessFundsMigrationTest {
         assertEquals(retiringFederationUtxos.size(), selectedUtxos.size());
         assertTrue(selectedUtxos.containsAll(retiringFederationUtxos));
 
+        int maxInputCount = BRIDGE_CONSTANTS.getMaxInputsPerPegoutTransaction();
+        int remainingRetiringFederationUtxos = retiringFederationUtxos.size();
         for (BtcTransaction migrationTransaction : migrationTransactions) {
+            int expectedInputCount = Math.min(maxInputCount, remainingRetiringFederationUtxos);
             assertMigrationTransactionWasBuiltAsExpected(
                 migrationTransaction,
                 retiringFederation,
                 retiringFederationUtxos,
-                migrationTransaction.getInputs().size()
+                expectedInputCount
             );
+            remainingRetiringFederationUtxos -= expectedInputCount;
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -58,6 +58,7 @@ class ProcessFundsMigrationTest {
     private static final ActivationConfig.ForBlock ALL_ACTIVATIONS = ActivationConfigsForTest.all().forBlock(0L);
     private static final Coin FEE_PER_KB = Coin.valueOf(8_000L);
     private static final long ACTIVE_FEDERATION_CREATION_BLOCK = 100L;
+    private static final int EXPECTED_MULTIPLE_MIGRATION_TX_COUNT = 2;
 
     private StorageAccessor bridgeStorageAccessor;
     private BridgeStorageProvider bridgeStorageProvider;
@@ -230,7 +231,7 @@ class ProcessFundsMigrationTest {
             bridgeSupport.updateCollections(secondUpdateCollectionsTransaction);
 
             // Assert
-            assertMultipleMigrationTransactionsWereBuiltAsExpected(retiringFederation, retiringUtxos, 2);
+            assertMultipleMigrationTransactionsWereBuiltAsExpected(retiringFederation, retiringUtxos);
             assertRetiringFederationStillPresent();
             assertNoRemainingRetiringUtxos();
         }
@@ -464,8 +465,7 @@ class ProcessFundsMigrationTest {
 
     private void assertMultipleMigrationTransactionsWereBuiltAsExpected(
         Federation retiringFederation,
-        List<UTXO> retiringFederationUtxos,
-        int expectedTransactionCount
+        List<UTXO> retiringFederationUtxos
     ) throws IOException {
         List<BtcTransaction> migrationTransactions = bridgeStorageProvider.getPegoutsWaitingForConfirmations()
             .getEntries()
@@ -473,7 +473,7 @@ class ProcessFundsMigrationTest {
             .map(PegoutsWaitingForConfirmations.Entry::getBtcTransaction)
             .sorted(Comparator.comparingInt(tx -> tx.getInputs().size()))
             .toList();
-        assertEquals(expectedTransactionCount, migrationTransactions.size());
+        assertEquals(EXPECTED_MULTIPLE_MIGRATION_TX_COUNT, migrationTransactions.size());
 
         List<UTXO> selectedUtxos = migrationTransactions.stream()
             .flatMap(tx -> getSelectedUtxos(tx, retiringFederationUtxos).stream())

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -161,7 +161,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(Coin.valueOf(1_000L), executionBlockNumber);
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act & Assert

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -527,18 +527,12 @@ class ProcessFundsMigrationTest {
         Coin migrationValue = selectedUtxos.stream()
             .map(UTXO::getValue)
             .reduce(Coin.ZERO, Coin::add);
-        assertMigrationTxWithOnlyMigrationOutputs(migrationTransaction, migrationValue);
-    }
-
-    private void assertMigrationTxWithOnlyMigrationOutputs(
-        BtcTransaction migrationTransaction,
-        Coin migrationValue
-    ) {
-        int expectedNumberOfOutputs = 1;
-        List<TransactionOutput> migrationTransactionOutputs = migrationTransaction.getOutputs();
-        assertEquals(expectedNumberOfOutputs, migrationTransactionOutputs.size());
-        assertDestinationAddress(migrationTransactionOutputs, federationSupport.getActiveFederationAddress(), NETWORK_PARAMETERS);
-        assertOutputsWithNoChange(migrationTransaction, migrationValue);
+        assertMigrationTxWithOnlyMigrationOutputs(
+            migrationTransaction,
+            migrationValue,
+            federationSupport.getActiveFederationAddress(),
+            NETWORK_PARAMETERS
+        );
     }
 
     private List<UTXO> getSelectedUtxos(BtcTransaction migrationTransaction, List<UTXO> federationUtxos) {

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -112,7 +112,9 @@ class ProcessFundsMigrationTest {
             // Assert
             assertNoMigrationTxCreated();
             assertRetiringFederationStillPresent();
-            assertRetiringUtxosCount(1);
+
+            int expectedRemainingUtxos = retiringUtxos.size();
+            assertRetiringUtxosCount(expectedRemainingUtxos);
         }
 
         @Test
@@ -178,7 +180,9 @@ class ProcessFundsMigrationTest {
                 () -> bridgeSupport.updateCollections(updateCollectionsTransaction));
             assertNoMigrationTxCreated();
             assertRetiringFederationStillPresent();
-            assertRetiringUtxosCount(numberOfUtxos);
+
+            int expectedRemainingUtxos = retiringUtxos.size();
+            assertRetiringUtxosCount(expectedRemainingUtxos);
         }
 
         @Test
@@ -201,7 +205,9 @@ class ProcessFundsMigrationTest {
             // Assert
             assertNoMigrationTxCreated();
             assertRetiringFederationStillPresent();
-            assertRetiringUtxosCount(1);
+
+            int expectedRemainingUtxos = retiringUtxos.size();
+            assertRetiringUtxosCount(expectedRemainingUtxos);
         }
 
         @Test
@@ -224,7 +230,8 @@ class ProcessFundsMigrationTest {
             // Assert
             assertOneMigrationTransactionWasBuiltAsExpected(retiringFederation, retiringUtxos, maxInputs);
             assertRetiringFederationStillPresent();
-            int remainingUtxos = numberOfUtxos - maxInputs;
+
+            int remainingUtxos = retiringUtxos.size() - maxInputs;
             assertRetiringUtxosCount(remainingUtxos);
 
             // Act
@@ -302,7 +309,9 @@ class ProcessFundsMigrationTest {
             // Assert
             assertOneMigrationTransactionWasBuiltAsExpected(retiringFederation, retiringUtxos, maxInputs);
             assertRetiringFederationCleared();
-            assertRetiringUtxosCount(2);
+
+            int expectedRemainingUtxos = retiringUtxos.size() - maxInputs;
+            assertRetiringUtxosCount(expectedRemainingUtxos);
         }
 
         @Test
@@ -341,13 +350,15 @@ class ProcessFundsMigrationTest {
             // Assert
             assertNoMigrationTxCreated();
             assertRetiringFederationCleared();
-            assertRetiringUtxosCount(1);
+
+            int expectedRemainingUtxos = retiringUtxos.size();
+            assertRetiringUtxosCount(expectedRemainingUtxos);
         }
 
         @Test
         void updateCollections_pastMigrationAge_withHighFees_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
             // Arrange
-            Coin highFeePerKb = Coin.COIN.multiply(2).subtract(Coin.SATOSHI);
+            Coin highFeePerKb = Coin.COIN.multiply(2);
             List<UTXO> retiringUtxos = List.of(
                 UTXOBuilder.builder()
                 .withValue(Coin.COIN)
@@ -365,7 +376,9 @@ class ProcessFundsMigrationTest {
             // Assert
             assertNoMigrationTxCreated();
             assertRetiringFederationCleared();
-            assertRetiringUtxosCount(1);
+
+            int expectedRemainingUtxos = retiringUtxos.size();
+            assertRetiringUtxosCount(expectedRemainingUtxos);
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -130,7 +130,7 @@ class ProcessFundsMigrationTest {
             // Assert
             assertOneMigrationTransactionWasBuiltAsExpected(retiringFederation, retiringUtxos, retiringUtxos.size());
             assertRetiringFederationStillPresent();
-            assertRetiringUtxosCount(0);
+            assertNoRemainingRetiringUtxos();
         }
 
         @Test
@@ -153,7 +153,7 @@ class ProcessFundsMigrationTest {
             // Assert
             assertOneMigrationTransactionWasBuiltAsExpected(retiringFederation, retiringUtxos, retiringUtxos.size());
             assertRetiringFederationStillPresent();
-            assertRetiringUtxosCount(0);
+            assertNoRemainingRetiringUtxos();
         }
 
         @Test
@@ -177,7 +177,7 @@ class ProcessFundsMigrationTest {
             // Assert
             assertOneMigrationTransactionWasBuiltAsExpected(retiringFederation, retiringUtxos, retiringUtxos.size());
             assertRetiringFederationStillPresent();
-            assertRetiringUtxosCount(0);
+            assertNoRemainingRetiringUtxos();
         }
 
         @Test
@@ -227,7 +227,7 @@ class ProcessFundsMigrationTest {
             // Assert
             assertMultipleMigrationTransactionsWereBuiltAsExpected(retiringFederation, retiringUtxos, 2);
             assertRetiringFederationStillPresent();
-            assertRetiringUtxosCount(0);
+            assertNoRemainingRetiringUtxos();
         }
 
         @Test
@@ -251,7 +251,7 @@ class ProcessFundsMigrationTest {
             // Assert
             assertOneMigrationTransactionWasBuiltAsExpected(retiringFederation, retiringUtxos, retiringUtxos.size());
             assertRetiringFederationCleared();
-            assertRetiringUtxosCount(0);
+            assertNoRemainingRetiringUtxos();
         }
 
         @Test
@@ -274,7 +274,7 @@ class ProcessFundsMigrationTest {
             // Assert
             assertOneMigrationTransactionWasBuiltAsExpected(retiringFederation, retiringUtxos, retiringUtxos.size());
             assertRetiringFederationCleared();
-            assertRetiringUtxosCount(0);
+            assertNoRemainingRetiringUtxos();
         }
 
         @Test
@@ -316,7 +316,7 @@ class ProcessFundsMigrationTest {
             // Assert
             assertNoMigrationTxCreated();
             assertRetiringFederationCleared();
-            assertRetiringUtxosCount(0);
+            assertNoRemainingRetiringUtxos();
         }
 
         @Test
@@ -627,6 +627,10 @@ class ProcessFundsMigrationTest {
 
     private void assertRetiringUtxosCount(int expectedCount) {
         assertEquals(expectedCount, federationStorageProvider.getOldFederationBtcUTXOs().size());
+    }
+
+    private void assertNoRemainingRetiringUtxos() {
+        assertEquals(0, federationStorageProvider.getOldFederationBtcUTXOs().size());
     }
 
     private Transaction buildUpdateCollectionsTransaction() {

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -3,6 +3,7 @@ package co.rsk.peg;
 import co.rsk.RskTestUtils;
 import co.rsk.bitcoinj.core.Address;
 import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.Coin;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.core.TransactionInput;
@@ -73,6 +74,7 @@ class ProcessFundsMigrationTest {
         private final Federation retiringFederation = P2shP2wshErpFederationBuilder.builder().build();
         private final Federation activeFederation = P2shP2wshErpFederationBuilder.builder()
             .withCreationBlockNumber(ACTIVE_FEDERATION_CREATION_BLOCK)
+            .withMembersBtcPublicKeys(getActiveMemberKeys())
             .build();
         private final Transaction updateCollectionsTransaction = buildUpdateCollectionsTransaction();
 
@@ -639,5 +641,13 @@ class ProcessFundsMigrationTest {
 
         tx.sign(RskTestUtils.getEcKeyFromSeed("sender").getPrivKeyBytes());
         return tx;
+    }
+
+    private List<BtcECKey> getActiveMemberKeys() {
+        String[] memberSeeds = new String[20];
+        for (int i = 0; i < 20; i++) {
+            memberSeeds[i] = String.format("newActiveMember-" + i + 1);
+        }
+        return getBtcEcKeysFromSeeds(memberSeeds, true);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -1,7 +1,23 @@
 package co.rsk.peg;
 
-import co.rsk.RskTestUtils;
-import co.rsk.bitcoinj.core.*;
+import static co.rsk.RskTestUtils.createRepository;
+import static co.rsk.peg.BridgeSupportTestUtil.buildUpdateCollectionsTransaction;
+import static co.rsk.peg.ReleaseTransactionAssertions.assertBtcTxVersionIs2;
+import static co.rsk.peg.ReleaseTransactionAssertions.assertMigrationTxWithOnlyMigrationOutputs;
+import static co.rsk.peg.ReleaseTransactionAssertions.assertReleaseTxInputsP2shP2wshErp;
+import static co.rsk.peg.bitcoin.BitcoinTestUtils.MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT;
+import static co.rsk.peg.bitcoin.BitcoinTestUtils.createHash;
+import static co.rsk.peg.bitcoin.BitcoinTestUtils.getBtcEcKeysFromSeeds;
+import static co.rsk.peg.federation.FederationStorageIndexKey.OLD_FEDERATION_BTC_UTXOS_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.core.UTXO;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.constants.BridgeMainNetConstants;
@@ -20,27 +36,15 @@ import co.rsk.peg.storage.StorageAccessor;
 import co.rsk.test.builders.BridgeSupportBuilder;
 import co.rsk.test.builders.FederationSupportBuilder;
 import co.rsk.test.builders.UTXOBuilder;
-import org.ethereum.config.Constants;
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
-import org.ethereum.vm.PrecompiledContracts;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.math.BigInteger;
-import java.util.Comparator;
-import java.util.List;
-
-import static co.rsk.RskTestUtils.createRepository;
-import static co.rsk.peg.ReleaseTransactionAssertions.*;
-import static co.rsk.peg.bitcoin.BitcoinTestUtils.*;
-import static co.rsk.peg.federation.FederationStorageIndexKey.OLD_FEDERATION_BTC_UTXOS_KEY;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ProcessFundsMigrationTest {
 
@@ -564,23 +568,6 @@ class ProcessFundsMigrationTest {
 
     private void assertNoRemainingRetiringUtxos() {
         assertEquals(0, federationStorageProvider.getOldFederationBtcUTXOs().size());
-    }
-
-    private Transaction buildUpdateCollectionsTransaction() {
-        return buildUpdateCollectionsTransaction(0);
-    }
-
-    private Transaction buildUpdateCollectionsTransaction(long nonce) {
-        Transaction tx = Transaction
-            .builder()
-            .nonce(BigInteger.valueOf(nonce))
-            .destination(PrecompiledContracts.BRIDGE_ADDR)
-            .data(Bridge.UPDATE_COLLECTIONS.encode())
-            .chainId(Constants.MAINNET_CHAIN_ID)
-            .build();
-
-        tx.sign(RskTestUtils.getEcKeyFromSeed("sender").getPrivKeyBytes());
-        return tx;
     }
 
     private List<BtcECKey> getActiveMemberKeys() {

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -646,7 +646,7 @@ class ProcessFundsMigrationTest {
     private List<BtcECKey> getActiveMemberKeys() {
         String[] memberSeeds = new String[20];
         for (int i = 0; i < 20; i++) {
-            memberSeeds[i] = String.format("newActiveMember-" + i + 1);
+            memberSeeds[i] = "newActiveMember-" + i;
         }
         return getBtcEcKeysFromSeeds(memberSeeds, true);
     }

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -214,7 +214,6 @@ class ProcessFundsMigrationTest {
                 .withValue(Coin.COIN)
                 .withScriptPubKey(retiringFederation.getP2SHScript())
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
-            Transaction secondUpdateCollectionsTransaction = buildUpdateCollectionsTransaction(1);
 
             long executionBlockNumber = duringMigrationBlockNumber(ALL_ACTIVATIONS);
             setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
@@ -222,6 +221,15 @@ class ProcessFundsMigrationTest {
 
             // Act
             bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertOneMigrationTransactionWasBuiltAsExpected(retiringFederation, retiringUtxos, maxInputs);
+            assertRetiringFederationStillPresent();
+            int remainingUtxos = numberOfUtxos - maxInputs;
+            assertRetiringUtxosCount(remainingUtxos);
+
+            // Act
+            Transaction secondUpdateCollectionsTransaction = buildUpdateCollectionsTransaction(1);
             bridgeSupport.updateCollections(secondUpdateCollectionsTransaction);
 
             // Assert

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -1,0 +1,88 @@
+package co.rsk.peg;
+
+import co.rsk.RskTestUtils;
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.peg.constants.BridgeConstants;
+import co.rsk.peg.constants.BridgeMainNetConstants;
+import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationStorageProviderImpl;
+import co.rsk.peg.federation.FederationSupport;
+import co.rsk.peg.federation.P2shP2wshErpFederationBuilder;
+import co.rsk.peg.feeperkb.*;
+import co.rsk.peg.feeperkb.constants.FeePerKbConstants;
+import co.rsk.peg.storage.InMemoryStorage;
+import co.rsk.peg.storage.StorageAccessor;
+import co.rsk.test.builders.BridgeSupportBuilder;
+import co.rsk.test.builders.FederationSupportBuilder;
+import org.ethereum.config.Constants;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
+import org.ethereum.core.Repository;
+import org.ethereum.core.Transaction;
+import org.ethereum.vm.PrecompiledContracts;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static co.rsk.RskTestUtils.createRepository;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ProcessFundsMigrationTest {
+
+    @Test
+    void updateCollections_withP2shP2wshActiveFed_withNoRetiringFederation_shouldNotCreateAMigrationTx() throws IOException {
+        // Arrange
+        BridgeConstants bridgeConstants = BridgeMainNetConstants.getInstance();
+        ActivationConfig.ForBlock activationConfig = ActivationConfigsForTest.all().forBlock(0L);
+        NetworkParameters networkParameters = bridgeConstants.getBtcParams();
+        Repository repository = createRepository();
+
+        BridgeStorageProvider bridgeStorageProvider = new BridgeStorageProvider(repository, networkParameters, activationConfig);
+        StorageAccessor bridgeStorageAccessor = new InMemoryStorage();
+        Coin feePerKb = Coin.valueOf(8_000L);
+        bridgeStorageAccessor.saveToRepository(FeePerKbStorageIndexKey.FEE_PER_KB.getKey(), feePerKb, BridgeSerializationUtils::serializeCoin);
+        FeePerKbConstants feePerKbConstants = bridgeConstants.getFeePerKbConstants();
+        FeePerKbStorageProvider feePerKbStorageProvider = new FeePerKbStorageProviderImpl(bridgeStorageAccessor);
+        FeePerKbSupport feePerKbSupport = new FeePerKbSupportImpl(feePerKbConstants, feePerKbStorageProvider);
+        FederationStorageProviderImpl federationStorageProvider = new FederationStorageProviderImpl(bridgeStorageAccessor);
+
+        FederationSupport federationSupport = FederationSupportBuilder.builder()
+            .withFederationConstants(bridgeConstants.getFederationConstants())
+            .withFederationStorageProvider(federationStorageProvider)
+            .withActivations(activationConfig)
+            .build();
+
+        BridgeSupport bridgeSupport = BridgeSupportBuilder.builder()
+            .withBridgeConstants(bridgeConstants)
+            .withProvider(bridgeStorageProvider)
+            .withActivations(activationConfig)
+            .withFederationSupport(federationSupport)
+            .withFeePerKbSupport(feePerKbSupport)
+            .build();
+
+        Federation activeFederation = P2shP2wshErpFederationBuilder.builder().build();
+        federationStorageProvider.setNewFederation(activeFederation);
+
+        Transaction updateCollectionsTx = buildUpdateCollectionsTransaction();
+
+        // Act
+        bridgeSupport.updateCollections(updateCollectionsTx);
+
+        // Assert
+        assertTrue(federationSupport.getRetiringFederation().isEmpty());
+        assertTrue(bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries().isEmpty());
+    }
+
+    private Transaction buildUpdateCollectionsTransaction() {
+        Transaction tx = Transaction
+            .builder()
+            .destination(PrecompiledContracts.BRIDGE_ADDR)
+            .data(Bridge.UPDATE_COLLECTIONS.encode())
+            .chainId(Constants.MAINNET_CHAIN_ID)
+            .build();
+
+        tx.sign(RskTestUtils.getEcKeyFromSeed("sender").getPrivKeyBytes());
+        return tx;
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -358,7 +358,6 @@ class ProcessFundsMigrationTest {
         @Test
         void updateCollections_pastMigrationAge_withHighFees_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
             // Arrange
-            Coin highFeePerKb = Coin.COIN.multiply(2);
             List<UTXO> retiringUtxos = List.of(
                 UTXOBuilder.builder()
                 .withValue(Coin.COIN)
@@ -366,6 +365,7 @@ class ProcessFundsMigrationTest {
                 .build()
             );
 
+            Coin highFeePerKb = Coin.COIN.multiply(2);
             long executionBlockNumber = pastMigrationBlockNumber();
             setUpBridgeAndFederationSupport(highFeePerKb, executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -46,7 +46,6 @@ import java.util.List;
 import static co.rsk.RskTestUtils.createRepository;
 import static co.rsk.peg.bitcoin.BitcoinTestAssertions.assertP2shP2wshWitnessWithoutSignaturesHasProperFormat;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.*;
-import static co.rsk.peg.bitcoin.BitcoinTestUtils.MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT;
 import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
 import static co.rsk.peg.federation.FederationStorageIndexKey.OLD_FEDERATION_BTC_UTXOS_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -1,16 +1,7 @@
 package co.rsk.peg;
 
 import co.rsk.RskTestUtils;
-import co.rsk.bitcoinj.core.Address;
-import co.rsk.bitcoinj.core.BtcTransaction;
-import co.rsk.bitcoinj.core.BtcECKey;
-import co.rsk.bitcoinj.core.Coin;
-import co.rsk.bitcoinj.core.NetworkParameters;
-import co.rsk.bitcoinj.core.TransactionInput;
-import co.rsk.bitcoinj.core.TransactionOutput;
-import co.rsk.bitcoinj.core.TransactionWitness;
-import co.rsk.bitcoinj.core.UTXO;
-import co.rsk.bitcoinj.script.Script;
+import co.rsk.bitcoinj.core.*;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.constants.BridgeMainNetConstants;
@@ -44,9 +35,8 @@ import java.util.Comparator;
 import java.util.List;
 
 import static co.rsk.RskTestUtils.createRepository;
-import static co.rsk.peg.bitcoin.BitcoinTestAssertions.assertP2shP2wshWitnessWithoutSignaturesHasProperFormat;
+import static co.rsk.peg.ReleaseTransactionAssertions.*;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.*;
-import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
 import static co.rsk.peg.federation.FederationStorageIndexKey.OLD_FEDERATION_BTC_UTXOS_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -526,7 +516,7 @@ class ProcessFundsMigrationTest {
         List<UTXO> selectedUtxos = getSelectedUtxos(migrationTransaction, retiringFederationUtxos);
 
         assertBtcTxVersionIs2(migrationTransaction);
-        assertMigrationReleaseTxInputsP2shP2wshErp(
+        assertReleaseTxInputsP2shP2wshErp(
             migrationTransaction,
             retiringFederation.getRedeemScript(),
             retiringFederationUtxos,
@@ -540,59 +530,6 @@ class ProcessFundsMigrationTest {
         assertMigrationTxWithOnlyMigrationOutputs(migrationTransaction, migrationValue);
     }
 
-    private void assertBtcTxVersionIs2(BtcTransaction migrationTransaction) {
-        assertEquals(BTC_TX_VERSION_2, migrationTransaction.getVersion());
-    }
-
-    private void assertMigrationReleaseTxInputsP2shP2wshErp(
-        BtcTransaction migrationTransaction,
-        Script retiringFederationRedeemScript,
-        List<UTXO> retiringFederationUtxos,
-        List<UTXO> selectedUtxos,
-        int expectedInputCount
-    ) {
-        List<TransactionInput> inputs = migrationTransaction.getInputs();
-        assertEquals(expectedInputCount, inputs.size());
-        assertEquals(expectedInputCount, selectedUtxos.size());
-        assertReleaseTxInputsHasProperFormatAndBelongsToP2shP2wshErpFederation(
-            migrationTransaction,
-            retiringFederationRedeemScript,
-            retiringFederationUtxos
-        );
-        assertSelectedUtxosBelongToTheInputs(selectedUtxos, inputs);
-    }
-
-    private void assertReleaseTxInputsHasProperFormatAndBelongsToP2shP2wshErpFederation(
-        BtcTransaction migrationTransaction,
-        Script retiringFederationRedeemScript,
-        List<UTXO> retiringFederationUtxos
-    ) {
-        List<TransactionInput> inputs = migrationTransaction.getInputs();
-        for (int inputIndex = 0; inputIndex < inputs.size(); inputIndex++) {
-            TransactionWitness witness = migrationTransaction.getWitness(inputIndex);
-            assertP2shP2wshWitnessWithoutSignaturesHasProperFormat(witness, retiringFederationRedeemScript);
-            assertInputIsFromFederationUtxosWallet(inputs.get(inputIndex), retiringFederationUtxos);
-        }
-    }
-
-    private void assertInputIsFromFederationUtxosWallet(TransactionInput input, List<UTXO> federationUtxos) {
-        long matchingUtxos = federationUtxos.stream()
-            .filter(utxo -> utxo.getHash().equals(input.getOutpoint().getHash()) &&
-                utxo.getIndex() == input.getOutpoint().getIndex())
-            .count();
-        assertEquals(1, matchingUtxos);
-    }
-
-    private void assertSelectedUtxosBelongToTheInputs(List<UTXO> selectedUtxos, List<TransactionInput> inputs) {
-        for (UTXO selectedUtxo : selectedUtxos) {
-            long matchingInputs = inputs.stream()
-                .filter(input -> input.getOutpoint().getHash().equals(selectedUtxo.getHash()) &&
-                    input.getOutpoint().getIndex() == selectedUtxo.getIndex())
-                .count();
-            assertEquals(1, matchingInputs);
-        }
-    }
-
     private void assertMigrationTxWithOnlyMigrationOutputs(
         BtcTransaction migrationTransaction,
         Coin migrationValue
@@ -600,23 +537,8 @@ class ProcessFundsMigrationTest {
         int expectedNumberOfOutputs = 1;
         List<TransactionOutput> migrationTransactionOutputs = migrationTransaction.getOutputs();
         assertEquals(expectedNumberOfOutputs, migrationTransactionOutputs.size());
-        assertDestinationAddress(migrationTransactionOutputs, federationSupport.getActiveFederationAddress());
+        assertDestinationAddress(migrationTransactionOutputs, federationSupport.getActiveFederationAddress(), NETWORK_PARAMETERS);
         assertOutputsWithNoChange(migrationTransaction, migrationValue);
-    }
-
-    private void assertDestinationAddress(List<TransactionOutput> outputs, Address expectedDestinationAddress) {
-        for (TransactionOutput output : outputs) {
-            Address destinationAddress = output.getScriptPubKey().getToAddress(NETWORK_PARAMETERS);
-            assertEquals(expectedDestinationAddress, destinationAddress);
-        }
-    }
-
-    private void assertOutputsWithNoChange(BtcTransaction migrationTransaction, Coin expectedSentAmount) {
-        Coin outputsAmount = migrationTransaction.getOutputSum();
-        Coin fees = migrationTransaction.getFee();
-        Coin totalAmountSent = fees.add(outputsAmount);
-        assertEquals(expectedSentAmount, totalAmountSent);
-        assertEquals(migrationTransaction.getInputSum(), totalAmountSent);
     }
 
     private List<UTXO> getSelectedUtxos(BtcTransaction migrationTransaction, List<UTXO> federationUtxos) {

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -44,8 +44,8 @@ import java.util.List;
 
 import static co.rsk.RskTestUtils.createRepository;
 import static co.rsk.peg.bitcoin.BitcoinTestAssertions.assertP2shP2wshWitnessWithoutSignaturesHasProperFormat;
+import static co.rsk.peg.bitcoin.BitcoinTestUtils.*;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT;
-import static co.rsk.peg.bitcoin.BitcoinTestUtils.createHash;
 import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
 import static co.rsk.peg.federation.FederationStorageIndexKey.OLD_FEDERATION_BTC_UTXOS_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -89,7 +89,12 @@ class ProcessFundsMigrationTest {
         void updateCollections_withNewFederationAgeBeforeMigrationBegins_shouldNotCreateMigrationTx() throws IOException {
             // Arrange
             Federation retiringFederation = buildP2shP2wshFederation();
-            List<UTXO> retiringUtxos = buildUtxos(retiringFederation, 1, Coin.COIN);
+            List<UTXO> retiringUtxos = List.of(
+                UTXOBuilder.builder()
+                .withValue(Coin.COIN)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .build()
+            );
             long executionBlockNumber = blockNumberBeforeMigrationBegins(ALL_ACTIVATIONS);
 
             setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
@@ -108,7 +113,12 @@ class ProcessFundsMigrationTest {
         void updateCollections_duringMigration_withOneSpendableRetiringUtxo_shouldCreateMigrationTx() throws IOException {
             // Arrange
             Federation retiringFederation = buildP2shP2wshFederation();
-            List<UTXO> retiringUtxos = buildUtxos(retiringFederation, 1, Coin.COIN);
+            List<UTXO> retiringUtxos = List.of(
+                UTXOBuilder.builder()
+                .withValue(Coin.COIN)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .build()
+            );
 
             long executionBlockNumber = duringMigrationBlockNumber(ALL_ACTIVATIONS);
             setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
@@ -127,7 +137,11 @@ class ProcessFundsMigrationTest {
         void updateCollections_duringMigration_withMultipleSpendableRetiringUtxos_shouldCreateMigrationTx() throws IOException {
             // Arrange
             Federation retiringFederation = buildP2shP2wshFederation();
-            List<UTXO> retiringUtxos = buildUtxos(retiringFederation, 3, Coin.COIN);
+            int numberOfUtxos = 3;
+            List<UTXO> retiringUtxos = UTXOBuilder.builder()
+                .withValue(Coin.COIN)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumber(ALL_ACTIVATIONS);
             setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
@@ -147,7 +161,11 @@ class ProcessFundsMigrationTest {
             // Arrange
             Federation retiringFederation = buildP2shP2wshFederation();
             Coin lowSpendableValue = MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT.add(FEE_PER_KB);
-            List<UTXO> retiringUtxos = buildUtxos(retiringFederation, 5, lowSpendableValue);
+            int numberOfUtxos = 5;
+            List<UTXO> retiringUtxos = UTXOBuilder.builder()
+                .withValue(lowSpendableValue)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumber(ALL_ACTIVATIONS);
             setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
@@ -166,7 +184,12 @@ class ProcessFundsMigrationTest {
         void updateCollections_duringMigration_withBalanceBelowThreshold_shouldNotCreateMigrationTx() throws IOException {
             // Arrange
             Federation retiringFederation = buildP2shP2wshFederation();
-            List<UTXO> retiringUtxos = buildUtxos(retiringFederation, 1, FEE_PER_KB.divide(2));
+            List<UTXO> retiringUtxos = List.of(
+                UTXOBuilder.builder()
+                .withValue(FEE_PER_KB.divide(2))
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .build()
+            );
 
             long executionBlockNumber = duringMigrationBlockNumber(ALL_ACTIVATIONS);
             setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
@@ -186,7 +209,11 @@ class ProcessFundsMigrationTest {
             // Arrange
             Federation retiringFederation = buildP2shP2wshFederation();
             int maxInputs = BRIDGE_CONSTANTS.getMaxInputsPerPegoutTransaction();
-            List<UTXO> retiringUtxos = buildUtxos(retiringFederation, maxInputs + 2, Coin.COIN);
+            int numberOfUtxos = maxInputs + 2;
+            List<UTXO> retiringUtxos = UTXOBuilder.builder()
+                .withValue(Coin.COIN)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .buildMany(numberOfUtxos, i -> createHash(i + 1));
             Transaction secondUpdateCollectionsTransaction = buildUpdateCollectionsTransaction(1);
 
             long executionBlockNumber = duringMigrationBlockNumber(ALL_ACTIVATIONS);
@@ -207,7 +234,12 @@ class ProcessFundsMigrationTest {
         void updateCollections_pastMigrationAge_withOneSpendableRetiringUtxo_shouldCreateMigrationTxAndClearRetiringFed() throws IOException {
             // Arrange
             Federation retiringFederation = buildP2shP2wshFederation();
-            List<UTXO> retiringUtxos = buildUtxos(retiringFederation, 1, Coin.COIN);
+            List<UTXO> retiringUtxos = List.of(
+                UTXOBuilder.builder()
+                .withValue(Coin.COIN)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .build()
+            );
 
             long executionBlockNumber = pastMigrationBlockNumber(ALL_ACTIVATIONS);
             setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
@@ -226,7 +258,11 @@ class ProcessFundsMigrationTest {
         void updateCollections_pastMigrationAge_withManySpendableRetiringUtxos_shouldCreateMigrationTxAndClearRetiringFed() throws IOException {
             // Arrange
             Federation retiringFederation = buildP2shP2wshFederation();
-            List<UTXO> retiringUtxos = buildUtxos(retiringFederation, 3, Coin.COIN);
+            int numberOfUtxos = 3;
+            List<UTXO> retiringUtxos = UTXOBuilder.builder()
+                .withValue(Coin.COIN)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = pastMigrationBlockNumber(ALL_ACTIVATIONS);
             setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
@@ -246,7 +282,11 @@ class ProcessFundsMigrationTest {
             // Arrange
             Federation retiringFederation = buildP2shP2wshFederation();
             int maxInputs = BRIDGE_CONSTANTS.getMaxInputsPerPegoutTransaction();
-            List<UTXO> retiringUtxos = buildUtxos(retiringFederation, maxInputs + 2, Coin.COIN);
+            int numberOfUtxos = maxInputs + 2;
+            List<UTXO> retiringUtxos = UTXOBuilder.builder()
+                .withValue(Coin.COIN)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = pastMigrationBlockNumber(ALL_ACTIVATIONS);
             setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
@@ -283,7 +323,12 @@ class ProcessFundsMigrationTest {
         void updateCollections_pastMigrationAge_withMinNonDustRetiringUtxo_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
             // Arrange
             Federation retiringFederation = buildP2shP2wshFederation();
-            List<UTXO> retiringUtxos = buildUtxos(retiringFederation, 1, MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT);
+            List<UTXO> retiringUtxos = List.of(
+                UTXOBuilder.builder()
+                .withValue(MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .build()
+            );
 
             long executionBlockNumber = pastMigrationBlockNumber(ALL_ACTIVATIONS);
             setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
@@ -303,7 +348,12 @@ class ProcessFundsMigrationTest {
             // Arrange
             Federation retiringFederation = buildP2shP2wshFederation();
             Coin highFeePerKb = Coin.COIN.multiply(2).subtract(Coin.SATOSHI);
-            List<UTXO> retiringUtxos = buildUtxos(retiringFederation, 1, Coin.COIN);
+            List<UTXO> retiringUtxos = List.of(
+                UTXOBuilder.builder()
+                .withValue(Coin.COIN)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .build()
+            );
 
             long executionBlockNumber = pastMigrationBlockNumber(ALL_ACTIVATIONS);
             setUpBridgeAndFederationSupport(highFeePerKb, executionBlockNumber);
@@ -378,13 +428,6 @@ class ProcessFundsMigrationTest {
             .withNetworkParameters(NETWORK_PARAMETERS)
             .withCreationBlockNumber(ACTIVE_FEDERATION_CREATION_BLOCK)
             .build();
-    }
-
-    private List<UTXO> buildUtxos(Federation federation, int count, Coin value) {
-        return UTXOBuilder.builder()
-            .withValue(value)
-            .withScriptPubKey(federation.getP2SHScript())
-            .buildMany(count, i -> createHash(i + 1));
     }
 
     private long blockNumberBeforeMigrationBegins(ActivationConfig.ForBlock activations) {

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -69,7 +69,10 @@ class ProcessFundsMigrationTest {
     @Nested
     class P2shP2wshErpFederationTest {
 
-        private final Federation activeFederation = buildP2shP2wshFederation();
+        private final Federation retiringFederation = P2shP2wshErpFederationBuilder.builder().build();
+        private final Federation activeFederation = P2shP2wshErpFederationBuilder.builder()
+            .withCreationBlockNumber(ACTIVE_FEDERATION_CREATION_BLOCK)
+            .build();
         private final Transaction updateCollectionsTransaction = buildUpdateCollectionsTransaction();
 
         @Test
@@ -88,7 +91,6 @@ class ProcessFundsMigrationTest {
         @Test
         void updateCollections_withNewFederationAgeBeforeMigrationBegins_shouldNotCreateMigrationTx() throws IOException {
             // Arrange
-            Federation retiringFederation = buildP2shP2wshFederation();
             List<UTXO> retiringUtxos = List.of(
                 UTXOBuilder.builder()
                 .withValue(Coin.COIN)
@@ -112,7 +114,6 @@ class ProcessFundsMigrationTest {
         @Test
         void updateCollections_duringMigration_withOneSpendableRetiringUtxo_shouldCreateMigrationTx() throws IOException {
             // Arrange
-            Federation retiringFederation = buildP2shP2wshFederation();
             List<UTXO> retiringUtxos = List.of(
                 UTXOBuilder.builder()
                 .withValue(Coin.COIN)
@@ -136,7 +137,6 @@ class ProcessFundsMigrationTest {
         @Test
         void updateCollections_duringMigration_withMultipleSpendableRetiringUtxos_shouldCreateMigrationTx() throws IOException {
             // Arrange
-            Federation retiringFederation = buildP2shP2wshFederation();
             int numberOfUtxos = 3;
             List<UTXO> retiringUtxos = UTXOBuilder.builder()
                 .withValue(Coin.COIN)
@@ -159,7 +159,6 @@ class ProcessFundsMigrationTest {
         @Test
         void updateCollections_duringMigration_withManyMinNonDustRetiringUtxos_shouldCreateMigrationTx() throws IOException {
             // Arrange
-            Federation retiringFederation = buildP2shP2wshFederation();
             Coin lowSpendableValue = MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT.add(FEE_PER_KB);
             int numberOfUtxos = 5;
             List<UTXO> retiringUtxos = UTXOBuilder.builder()
@@ -183,7 +182,6 @@ class ProcessFundsMigrationTest {
         @Test
         void updateCollections_duringMigration_withBalanceBelowThreshold_shouldNotCreateMigrationTx() throws IOException {
             // Arrange
-            Federation retiringFederation = buildP2shP2wshFederation();
             List<UTXO> retiringUtxos = List.of(
                 UTXOBuilder.builder()
                 .withValue(FEE_PER_KB.divide(2))
@@ -207,7 +205,6 @@ class ProcessFundsMigrationTest {
         @Test
         void updateCollections_duringMigration_withMoreUtxosThanMaxInputs_whenCalledRepeatedly_shouldCreateAMigrationTxEachTime() throws IOException {
             // Arrange
-            Federation retiringFederation = buildP2shP2wshFederation();
             int maxInputs = BRIDGE_CONSTANTS.getMaxInputsPerPegoutTransaction();
             int numberOfUtxos = maxInputs + 2;
             List<UTXO> retiringUtxos = UTXOBuilder.builder()
@@ -241,7 +238,6 @@ class ProcessFundsMigrationTest {
         @Test
         void updateCollections_pastMigrationAge_withOneSpendableRetiringUtxo_shouldCreateMigrationTxAndClearRetiringFed() throws IOException {
             // Arrange
-            Federation retiringFederation = buildP2shP2wshFederation();
             List<UTXO> retiringUtxos = List.of(
                 UTXOBuilder.builder()
                 .withValue(Coin.COIN)
@@ -265,7 +261,6 @@ class ProcessFundsMigrationTest {
         @Test
         void updateCollections_pastMigrationAge_withManySpendableRetiringUtxos_shouldCreateMigrationTxAndClearRetiringFed() throws IOException {
             // Arrange
-            Federation retiringFederation = buildP2shP2wshFederation();
             int numberOfUtxos = 3;
             List<UTXO> retiringUtxos = UTXOBuilder.builder()
                 .withValue(Coin.COIN)
@@ -288,7 +283,6 @@ class ProcessFundsMigrationTest {
         @Test
         void updateCollections_pastMigrationAge_withMoreUtxosThanMaxInputs_shouldClearRetiringFedEvenIfUtxosRemain() throws IOException {
             // Arrange
-            Federation retiringFederation = buildP2shP2wshFederation();
             int maxInputs = BRIDGE_CONSTANTS.getMaxInputsPerPegoutTransaction();
             int numberOfUtxos = maxInputs + 2;
             List<UTXO> retiringUtxos = UTXOBuilder.builder()
@@ -312,8 +306,6 @@ class ProcessFundsMigrationTest {
         @Test
         void updateCollections_pastMigrationAge_withZeroBalance_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
             // Arrange
-            Federation retiringFederation = buildP2shP2wshFederation();
-
             long executionBlockNumber = pastMigrationBlockNumber(ALL_ACTIVATIONS);
             setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, List.of());
@@ -330,7 +322,6 @@ class ProcessFundsMigrationTest {
         @Test
         void updateCollections_pastMigrationAge_withMinNonDustRetiringUtxo_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
             // Arrange
-            Federation retiringFederation = buildP2shP2wshFederation();
             List<UTXO> retiringUtxos = List.of(
                 UTXOBuilder.builder()
                 .withValue(MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT)
@@ -354,7 +345,6 @@ class ProcessFundsMigrationTest {
         @Test
         void updateCollections_pastMigrationAge_withHighFees_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
             // Arrange
-            Federation retiringFederation = buildP2shP2wshFederation();
             Coin highFeePerKb = Coin.COIN.multiply(2).subtract(Coin.SATOSHI);
             List<UTXO> retiringUtxos = List.of(
                 UTXOBuilder.builder()
@@ -429,13 +419,6 @@ class ProcessFundsMigrationTest {
             retiringUtxos,
             BridgeSerializationUtils::serializeUTXOList
         );
-    }
-
-    private Federation buildP2shP2wshFederation() {
-        return P2shP2wshErpFederationBuilder.builder()
-            .withNetworkParameters(NETWORK_PARAMETERS)
-            .withCreationBlockNumber(ACTIVE_FEDERATION_CREATION_BLOCK)
-            .build();
     }
 
     private long blockNumberBeforeMigrationBegins(ActivationConfig.ForBlock activations) {

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionAssertions.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionAssertions.java
@@ -42,8 +42,8 @@ public class ReleaseTransactionAssertions {
         assertEquals(expectedNumberOfUtxos, matchingUtxos);
     }
 
-    public static void assertBtcTxVersionIs2(BtcTransaction migrationTransaction) {
-        assertEquals(BTC_TX_VERSION_2, migrationTransaction.getVersion());
+    public static void assertBtcTxVersionIs2(BtcTransaction btcTransaction) {
+        assertEquals(BTC_TX_VERSION_2, btcTransaction.getVersion());
     }
 
     public static void assertSelectedUtxosBelongToTheInputs(List<UTXO> selectedUtxos, List<TransactionInput> inputs) {
@@ -73,13 +73,13 @@ public class ReleaseTransactionAssertions {
     }
 
     private static void assertReleaseTxInputsHasProperFormatAndBelongsToP2shP2wshErpFederation(
-        BtcTransaction migrationTransaction,
+        BtcTransaction releaseTransaction,
         Script retiringFederationRedeemScript,
         List<UTXO> retiringFederationUtxos
     ) {
-        List<TransactionInput> inputs = migrationTransaction.getInputs();
+        List<TransactionInput> inputs = releaseTransaction.getInputs();
         for (int inputIndex = 0; inputIndex < inputs.size(); inputIndex++) {
-            TransactionWitness witness = migrationTransaction.getWitness(inputIndex);
+            TransactionWitness witness = releaseTransaction.getWitness(inputIndex);
             assertP2shP2wshWitnessWithoutSignaturesHasProperFormat(witness, retiringFederationRedeemScript);
             assertInputIsFromFederationUTXOsWallet(inputs.get(inputIndex), retiringFederationUtxos);
         }

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionAssertions.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionAssertions.java
@@ -30,6 +30,19 @@ public class ReleaseTransactionAssertions {
         }
     }
 
+    public static void assertMigrationTxWithOnlyMigrationOutputs(
+        BtcTransaction migrationTransaction,
+        Coin migratedAmount,
+        Address destination,
+        NetworkParameters networkParameters
+    ) {
+        int expectedNumberOfOutputs = 1;
+        List<TransactionOutput> migrationTransactionOutputs = migrationTransaction.getOutputs();
+        assertEquals(expectedNumberOfOutputs, migrationTransactionOutputs.size());
+        assertDestinationAddress(migrationTransactionOutputs, destination, networkParameters);
+        assertOutputsWithNoChange(migrationTransaction, migratedAmount);
+    }
+
     public static void assertInputIsFromFederationUTXOsWallet(TransactionInput input, List<UTXO> federationUtxos) {
         Predicate<UTXO> isUTXOAndReleaseInputFromTheSameOutpoint = utxo ->
             utxo.getHash().equals(input.getOutpoint().getHash())

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionAssertions.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionAssertions.java
@@ -1,14 +1,25 @@
 package co.rsk.peg;
 
-import co.rsk.bitcoinj.core.*;
-import co.rsk.bitcoinj.script.Script;
-
-import java.util.List;
-import java.util.function.Predicate;
-
 import static co.rsk.peg.bitcoin.BitcoinTestAssertions.assertP2shP2wshWitnessWithoutSignaturesHasProperFormat;
+import static co.rsk.peg.bitcoin.BitcoinTestAssertions.assertScriptSigFromP2shErpWithoutSignaturesHasProperFormat;
+import static co.rsk.peg.bitcoin.BitcoinTestAssertions.assertScriptSigFromStandardMultisigWithoutSignaturesHasProperFormat;
+import static co.rsk.peg.bitcoin.BitcoinTestUtils.MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT;
+import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_1;
 import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import co.rsk.bitcoinj.core.Address;
+import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.core.TransactionInput;
+import co.rsk.bitcoinj.core.TransactionOutput;
+import co.rsk.bitcoinj.core.TransactionWitness;
+import co.rsk.bitcoinj.core.UTXO;
+import co.rsk.bitcoinj.script.Script;
+import java.util.List;
+import java.util.function.Predicate;
 
 public class ReleaseTransactionAssertions {
 
@@ -55,8 +66,59 @@ public class ReleaseTransactionAssertions {
         assertEquals(expectedNumberOfUtxos, matchingUtxos);
     }
 
+    public static void assertBtcTxVersionIs1(BtcTransaction releaseTransaction) {
+        assertEquals(BTC_TX_VERSION_1, releaseTransaction.getVersion());
+    }
+
     public static void assertBtcTxVersionIs2(BtcTransaction btcTransaction) {
         assertEquals(BTC_TX_VERSION_2, btcTransaction.getVersion());
+    }
+
+    public static void assertOutputsWithDustChange(BtcTransaction releaseTransaction,
+        List<TransactionOutput> releaseTransactionChangeOutputs,
+        Coin requestedAmount) {
+        Coin inputTotalAmount = releaseTransaction.getInputSum();
+        Coin originalChangeAmount = inputTotalAmount.subtract(requestedAmount);
+        assertTrue(isDust(originalChangeAmount));
+
+        Coin amountToGetNonDustValue = MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT.subtract(originalChangeAmount);
+        Coin amountToSend = requestedAmount.subtract(amountToGetNonDustValue);
+
+        assertOutputsUserAndChangeValues(releaseTransaction, releaseTransactionChangeOutputs, amountToSend, MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT);
+    }
+
+    public static void assertOutputsWithNonDustChange(BtcTransaction releaseTransaction,
+        List<TransactionOutput> releaseTransactionChangeOutputs,
+        Coin requestedAmount) {
+        Coin inputTotalAmount = releaseTransaction.getInputSum();
+        Coin expectedChangeAmount = inputTotalAmount.subtract(requestedAmount);
+        assertOutputsUserAndChangeValues(releaseTransaction, releaseTransactionChangeOutputs, requestedAmount, expectedChangeAmount);
+    }
+
+    private static void assertOutputsUserAndChangeValues(BtcTransaction releaseTransaction,
+        List<TransactionOutput> releaseTransactionChangeOutputs,
+        Coin amountToSend,
+        Coin expectedChangeAmount) {
+        Coin changeOutputsAmount = getOutputsAmount(releaseTransactionChangeOutputs);
+        assertEquals(expectedChangeAmount, changeOutputsAmount);
+
+        Coin userOutputsAmount = releaseTransaction.getOutputSum().subtract(changeOutputsAmount);
+        Coin releaseTransactionFees = releaseTransaction.getFee();
+        Coin userOutputsAndFeesAmount = releaseTransactionFees.add(userOutputsAmount);
+        assertEquals(amountToSend, userOutputsAndFeesAmount);
+        Coin inputTotalAmount = releaseTransaction.getInputSum();
+        assertEquals(inputTotalAmount, userOutputsAndFeesAmount.add(changeOutputsAmount));
+    }
+
+    private static Coin getOutputsAmount(List<TransactionOutput> outputs) {
+        return outputs.stream()
+            .map(TransactionOutput::getValue)
+            .reduce(Coin::add)
+            .orElse(Coin.ZERO);
+    }
+
+    private static boolean isDust(Coin expectedChangeAmount) {
+        return expectedChangeAmount.compareTo(MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT) < 0;
     }
 
     public static void assertSelectedUtxosBelongToTheInputs(List<UTXO> selectedUtxos, List<TransactionInput> inputs) {
@@ -68,6 +130,33 @@ public class ReleaseTransactionAssertions {
                 .count();
             assertEquals(1, matchingInputs);
         }
+    }
+
+    /** Input count, script format, and selected-UTXO alignment for peg-out / batched flows. */
+    public static void assertReleaseTxInputsStandardMultisig(
+        BtcTransaction tx,
+        int expectedInputCount,
+        Script federationRedeemScript,
+        List<UTXO> federationUtxos,
+        List<UTXO> selectedUtxos) {
+        List<TransactionInput> inputs = tx.getInputs();
+        assertEquals(expectedInputCount, inputs.size());
+        assertReleaseTxInputsHasProperFormatAndBelongsToStandardMultisigFederation(
+            tx, federationRedeemScript, federationUtxos);
+        assertSelectedUtxosBelongToTheInputs(selectedUtxos, inputs);
+    }
+
+    public static void assertReleaseTxInputsP2shErp(
+        BtcTransaction tx,
+        int expectedInputCount,
+        Script federationRedeemScript,
+        List<UTXO> federationUtxos,
+        List<UTXO> selectedUtxos) {
+        List<TransactionInput> inputs = tx.getInputs();
+        assertEquals(expectedInputCount, inputs.size());
+        assertReleaseTxInputsHasProperFormatAndBelongsToP2shErpFederation(
+            tx, federationRedeemScript, federationUtxos);
+        assertSelectedUtxosBelongToTheInputs(selectedUtxos, inputs);
     }
 
     public static void assertReleaseTxInputsP2shP2wshErp(
@@ -85,6 +174,28 @@ public class ReleaseTransactionAssertions {
         assertSelectedUtxosBelongToTheInputs(selectedUtxos, inputs);
     }
 
+    public static void assertReleaseTxInputsHasProperFormatAndBelongsToStandardMultisigFederation(
+        BtcTransaction releaseTransaction,
+        Script federationRedeemScript,
+        List<UTXO> federationUTXOs) {
+        for (TransactionInput input : releaseTransaction.getInputs()) {
+            Script scriptSig = input.getScriptSig();
+            assertScriptSigFromStandardMultisigWithoutSignaturesHasProperFormat(scriptSig, federationRedeemScript);
+            assertInputIsFromFederationUTXOsWallet(input, federationUTXOs);
+        }
+    }
+
+    public static void assertReleaseTxInputsHasProperFormatAndBelongsToP2shErpFederation(
+        BtcTransaction releaseTransaction,
+        Script federationRedeemScript,
+        List<UTXO> federationUTXOs) {
+        for (TransactionInput input : releaseTransaction.getInputs()) {
+            Script scriptSig = input.getScriptSig();
+            assertScriptSigFromP2shErpWithoutSignaturesHasProperFormat(scriptSig, federationRedeemScript);
+            assertInputIsFromFederationUTXOsWallet(input, federationUTXOs);
+        }
+    }
+
     private static void assertReleaseTxInputsHasProperFormatAndBelongsToP2shP2wshErpFederation(
         BtcTransaction releaseTransaction,
         Script federationRedeemScript,
@@ -96,5 +207,58 @@ public class ReleaseTransactionAssertions {
             assertP2shP2wshWitnessWithoutSignaturesHasProperFormat(witness, federationRedeemScript);
             assertInputIsFromFederationUTXOsWallet(inputs.get(inputIndex), federationUtxos);
         }
+    }
+
+    /**
+     * Like {@link #assertReleaseTxInputsStandardMultisig} but for migration: all retiring federation UTXOs
+     * are spent and {@code selectedUtxos} must match that set exactly.
+     */
+    public static void assertMigrationReleaseTxInputsStandardMultisig(
+        BtcTransaction migrationTransaction,
+        Script retiringFederationRedeemScript,
+        List<UTXO> retiringFederationUtxos,
+        List<UTXO> selectedUtxos) {
+        List<TransactionInput> inputs = migrationTransaction.getInputs();
+        assertEquals(retiringFederationUtxos.size(), inputs.size());
+        assertReleaseTxInputsHasProperFormatAndBelongsToStandardMultisigFederation(
+            migrationTransaction, retiringFederationRedeemScript, retiringFederationUtxos);
+        assertEquals(retiringFederationUtxos, selectedUtxos);
+        assertSelectedUtxosBelongToTheInputs(selectedUtxos, inputs);
+    }
+
+    public static void assertMigrationReleaseTxInputsP2shErp(
+        BtcTransaction migrationTransaction,
+        Script retiringFederationRedeemScript,
+        List<UTXO> retiringFederationUtxos,
+        List<UTXO> selectedUtxos) {
+        List<TransactionInput> inputs = migrationTransaction.getInputs();
+        assertEquals(retiringFederationUtxos.size(), inputs.size());
+        assertReleaseTxInputsHasProperFormatAndBelongsToP2shErpFederation(
+            migrationTransaction, retiringFederationRedeemScript, retiringFederationUtxos);
+        assertEquals(retiringFederationUtxos, selectedUtxos);
+        assertSelectedUtxosBelongToTheInputs(selectedUtxos, inputs);
+    }
+
+    public static void assertMigrationReleaseTxInputsP2shP2wshErp(
+        BtcTransaction migrationTransaction,
+        Script retiringFederationRedeemScript,
+        List<UTXO> retiringFederationUtxos,
+        List<UTXO> selectedUtxos) {
+        assertReleaseTxInputsP2shP2wshErp(
+            migrationTransaction,
+            retiringFederationRedeemScript,
+            retiringFederationUtxos,
+            selectedUtxos,
+            retiringFederationUtxos.size()
+        );
+        assertEquals(retiringFederationUtxos, selectedUtxos);
+    }
+
+    public static void assertReleaseTxNumberOfOutputs(
+        int expectedNumberOfOutputs,
+        List<TransactionOutput> releaseTransactionOutputs
+    ) {
+        int actualNumberOfOutputs = releaseTransactionOutputs.size();
+        assertEquals(expectedNumberOfOutputs, actualNumberOfOutputs);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionAssertions.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionAssertions.java
@@ -87,14 +87,14 @@ public class ReleaseTransactionAssertions {
 
     private static void assertReleaseTxInputsHasProperFormatAndBelongsToP2shP2wshErpFederation(
         BtcTransaction releaseTransaction,
-        Script retiringFederationRedeemScript,
-        List<UTXO> retiringFederationUtxos
+        Script federationRedeemScript,
+        List<UTXO> federationUtxos
     ) {
         List<TransactionInput> inputs = releaseTransaction.getInputs();
         for (int inputIndex = 0; inputIndex < inputs.size(); inputIndex++) {
             TransactionWitness witness = releaseTransaction.getWitness(inputIndex);
-            assertP2shP2wshWitnessWithoutSignaturesHasProperFormat(witness, retiringFederationRedeemScript);
-            assertInputIsFromFederationUTXOsWallet(inputs.get(inputIndex), retiringFederationUtxos);
+            assertP2shP2wshWitnessWithoutSignaturesHasProperFormat(witness, federationRedeemScript);
+            assertInputIsFromFederationUTXOsWallet(inputs.get(inputIndex), federationUtxos);
         }
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionAssertions.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionAssertions.java
@@ -1,0 +1,87 @@
+package co.rsk.peg;
+
+import co.rsk.bitcoinj.core.*;
+import co.rsk.bitcoinj.script.Script;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import static co.rsk.peg.bitcoin.BitcoinTestAssertions.assertP2shP2wshWitnessWithoutSignaturesHasProperFormat;
+import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ReleaseTransactionAssertions {
+
+    private ReleaseTransactionAssertions() {
+    }
+
+    public static void assertOutputsWithNoChange(BtcTransaction btcTransaction, Coin expectedSentAmount) {
+        Coin outputsAmount = btcTransaction.getOutputSum();
+        Coin fees = btcTransaction.getFee();
+        Coin totalAmountSent = fees.add(outputsAmount);
+        assertEquals(expectedSentAmount, totalAmountSent);
+        assertEquals(btcTransaction.getInputSum(), totalAmountSent);
+    }
+
+    public static void assertDestinationAddress(List<TransactionOutput> outputs, Address expectedDestinationAddress, NetworkParameters networkParams) {
+        for (TransactionOutput output : outputs) {
+            Address destinationAddress = output.getScriptPubKey().getToAddress(networkParams);
+            assertEquals(expectedDestinationAddress, destinationAddress);
+        }
+    }
+
+    public static void assertInputIsFromFederationUTXOsWallet(TransactionInput input, List<UTXO> federationUtxos) {
+        Predicate<UTXO> isUTXOAndReleaseInputFromTheSameOutpoint = utxo ->
+            utxo.getHash().equals(input.getOutpoint().getHash())
+                && utxo.getIndex() == input.getOutpoint().getIndex();
+        long matchingUtxos = federationUtxos.stream()
+            .filter(isUTXOAndReleaseInputFromTheSameOutpoint)
+            .count();
+
+        int expectedNumberOfUtxos = 1;
+        assertEquals(expectedNumberOfUtxos, matchingUtxos);
+    }
+
+    public static void assertBtcTxVersionIs2(BtcTransaction migrationTransaction) {
+        assertEquals(BTC_TX_VERSION_2, migrationTransaction.getVersion());
+    }
+
+    public static void assertSelectedUtxosBelongToTheInputs(List<UTXO> selectedUtxos, List<TransactionInput> inputs) {
+        assertEquals(inputs.size(), selectedUtxos.size());
+        for (UTXO selectedUtxo : selectedUtxos) {
+            long matchingInputs = inputs.stream()
+                .filter(input -> input.getOutpoint().getHash().equals(selectedUtxo.getHash()) &&
+                    input.getOutpoint().getIndex() == selectedUtxo.getIndex())
+                .count();
+            assertEquals(1, matchingInputs);
+        }
+    }
+
+    public static void assertReleaseTxInputsP2shP2wshErp(
+        BtcTransaction releaseTx,
+        Script federationRedeemScript,
+        List<UTXO> federationUtxos,
+        List<UTXO> selectedUtxos,
+        int expectedInputCount) {
+        List<TransactionInput> inputs = releaseTx.getInputs();
+        assertEquals(expectedInputCount, inputs.size());
+        assertReleaseTxInputsHasProperFormatAndBelongsToP2shP2wshErpFederation(
+            releaseTx,
+            federationRedeemScript,
+            federationUtxos);
+        assertSelectedUtxosBelongToTheInputs(selectedUtxos, inputs);
+    }
+
+    private static void assertReleaseTxInputsHasProperFormatAndBelongsToP2shP2wshErpFederation(
+        BtcTransaction migrationTransaction,
+        Script retiringFederationRedeemScript,
+        List<UTXO> retiringFederationUtxos
+    ) {
+        List<TransactionInput> inputs = migrationTransaction.getInputs();
+        for (int inputIndex = 0; inputIndex < inputs.size(); inputIndex++) {
+            TransactionWitness witness = migrationTransaction.getWitness(inputIndex);
+            assertP2shP2wshWitnessWithoutSignaturesHasProperFormat(witness, retiringFederationRedeemScript);
+            assertInputIsFromFederationUTXOsWallet(inputs.get(inputIndex), retiringFederationUtxos);
+        }
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -19,6 +19,7 @@
 package co.rsk.peg;
 
 import static co.rsk.RskTestUtils.createRepository;
+import static co.rsk.peg.ReleaseTransactionAssertions.*;
 import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_1;
 import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
 import static co.rsk.peg.ReleaseTransactionBuilder.Response.COULD_NOT_ADJUST_DOWNWARDS;
@@ -26,7 +27,6 @@ import static co.rsk.peg.ReleaseTransactionBuilder.Response.DUSTY_SEND_REQUESTED
 import static co.rsk.peg.ReleaseTransactionBuilder.Response.EXCEED_MAX_TRANSACTION_SIZE;
 import static co.rsk.peg.ReleaseTransactionBuilder.Response.INSUFFICIENT_MONEY;
 import static co.rsk.peg.ReleaseTransactionBuilder.Response.SUCCESS;
-import static co.rsk.peg.bitcoin.BitcoinTestAssertions.assertP2shP2wshWitnessWithoutSignaturesHasProperFormat;
 import static co.rsk.peg.bitcoin.BitcoinTestAssertions.assertScriptSigFromP2shErpWithoutSignaturesHasProperFormat;
 import static co.rsk.peg.bitcoin.BitcoinTestAssertions.assertScriptSigFromStandardMultisigWithoutSignaturesHasProperFormat;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT;
@@ -55,7 +55,6 @@ import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.bitcoinj.core.TransactionInput;
 import co.rsk.bitcoinj.core.TransactionOutput;
-import co.rsk.bitcoinj.core.TransactionWitness;
 import co.rsk.bitcoinj.core.UTXO;
 import co.rsk.bitcoinj.core.UTXOProvider;
 import co.rsk.bitcoinj.core.UTXOProviderException;
@@ -90,7 +89,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.core.Repository;
@@ -250,10 +248,10 @@ class ReleaseTransactionBuilderTest {
 
             assertReleaseTxInputsP2shP2wshErp(
                 svpFundTransaction,
-                1,
                 activeP2shP2wshErpFederation.getRedeemScript(),
                 utxos,
-                buildResult.selectedUTXOs()
+                buildResult.selectedUTXOs(),
+                1
             );
         }
 
@@ -283,10 +281,10 @@ class ReleaseTransactionBuilderTest {
             BtcTransaction svpFundTransaction = buildResult.btcTx();
             assertReleaseTxInputsP2shP2wshErp(
                 svpFundTransaction,
-                expectedSelectedUtxos.size(),
                 activeP2shP2wshErpFederation.getRedeemScript(),
                 utxos,
-                selectedUtxos
+                selectedUtxos,
+                expectedSelectedUtxos.size()
             );
         }
 
@@ -1182,10 +1180,10 @@ class ReleaseTransactionBuilderTest {
             assertPegoutTxOutputAndChangeOutputsNumbers(pegoutTransaction, expectedNumberOfUserOutputs, EXPECTED_NUMBER_OF_CHANGE_OUTPUTS);
 
             List<TransactionOutput> userOutputs = getUserOutputs(pegoutTransaction);
-            assertDestinationAddress(userOutputs, RECIPIENT_ADDRESS);
+            assertDestinationAddress(userOutputs, RECIPIENT_ADDRESS, BTC_MAINNET_PARAMS);
 
             List<TransactionOutput> changeOutputs = getChangeOutputs(pegoutTransaction);
-            assertDestinationAddress(changeOutputs, federationAddress);
+            assertDestinationAddress(changeOutputs, federationAddress, BTC_MAINNET_PARAMS);
         }
 
         private void assertOutputsWithNoChange(
@@ -1197,9 +1195,9 @@ class ReleaseTransactionBuilderTest {
             assertPegoutTxOutputAndChangeOutputsNumbers(pegoutTransaction, expectedNumberOfUserOutputs, expectedNumberOfChangeOutputs);
 
             List<TransactionOutput> pegoutTransactionOutputs = pegoutTransaction.getOutputs();
-            assertDestinationAddress(pegoutTransactionOutputs, RECIPIENT_ADDRESS);
+            assertDestinationAddress(pegoutTransactionOutputs, RECIPIENT_ADDRESS, BTC_MAINNET_PARAMS);
 
-            ReleaseTransactionBuilderTest.assertOutputsWithNoChange(pegoutTransaction, requestedAmount);
+            ReleaseTransactionAssertions.assertOutputsWithNoChange(pegoutTransaction, requestedAmount);
         }
 
         private List<TransactionOutput> getUserOutputs(BtcTransaction pegoutTransaction) {
@@ -1648,7 +1646,7 @@ class ReleaseTransactionBuilderTest {
                 assertSuccessfulEmptyWalletRefundWithBtcVersion2(
                     emptyWalletResult,
                     (tx, res) -> assertReleaseTxInputsP2shP2wshErp(
-                        tx, federationUTXOs.size(), federationRedeemScript, federationUTXOs, res.selectedUTXOs())
+                        tx, federationRedeemScript, federationUTXOs, res.selectedUTXOs(), federationUTXOs.size())
                 );
             }
 
@@ -1664,7 +1662,7 @@ class ReleaseTransactionBuilderTest {
                 assertSuccessfulEmptyWalletRefundWithBtcVersion2(
                     emptyWalletResult,
                     (tx, res) -> assertReleaseTxInputsP2shP2wshErp(
-                        tx, federationUTXOs.size(), federationRedeemScript, federationUTXOs, res.selectedUTXOs())
+                        tx, federationRedeemScript, federationUTXOs, res.selectedUTXOs(), federationUTXOs.size())
                 );
             }
 
@@ -1703,7 +1701,7 @@ class ReleaseTransactionBuilderTest {
                 assertSuccessfulEmptyWalletRefundWithBtcVersion2(
                     emptyWalletResult,
                     (tx, res) -> assertReleaseTxInputsP2shP2wshErp(
-                        tx, federationUTXOs.size(), federationRedeemScript, federationUTXOs, res.selectedUTXOs())
+                        tx, federationRedeemScript, federationUTXOs, res.selectedUTXOs(), federationUTXOs.size())
                 );
             }
 
@@ -1773,7 +1771,7 @@ class ReleaseTransactionBuilderTest {
             assertEquals(expectedNumberOfOutputs, refundTransaction.getOutputs().size());
 
             TransactionOutput onlyOutput = outputs.get(0);
-            assertDestinationAddress(outputs, RECIPIENT_ADDRESS);
+            assertDestinationAddress(outputs, RECIPIENT_ADDRESS, BTC_MAINNET_PARAMS);
             assertTrue(onlyOutput.getValue().isPositive());
 
             List<TransactionOutput> changeOutputs = outputs.stream()
@@ -2710,7 +2708,7 @@ class ReleaseTransactionBuilderTest {
             int expectedNumberOfOutputs = 2;
             List<TransactionOutput> migrationTransactionOutputs = migrationTransaction.getOutputs();
             assertReleaseTxNumberOfOutputs(expectedNumberOfOutputs, migrationTransactionOutputs);
-            assertDestinationAddress(migrationTransactionOutputs, newFederationAddress);
+            assertDestinationAddress(migrationTransactionOutputs, newFederationAddress, BTC_MAINNET_PARAMS);
             assertMigrationTransactionIsMigratingMoreThanRequestedValue(migrationValueRequested, migrationTransaction);
         }
 
@@ -2723,7 +2721,7 @@ class ReleaseTransactionBuilderTest {
             int expectedNumberOfOutputs = expectedNumberOfMigrationOutputs + expectedNumberOfChangeOutputs;
             List<TransactionOutput> migrationTransactionOutputs = migrationTransaction.getOutputs();
             assertReleaseTxNumberOfOutputs(expectedNumberOfOutputs, migrationTransactionOutputs);
-            assertDestinationAddress(migrationTransactionOutputs, newFederationAddress);
+            assertDestinationAddress(migrationTransactionOutputs, newFederationAddress, BTC_MAINNET_PARAMS);
 
             List<TransactionOutput> migrationTransactionChangeOutputs = getChangeOutputs(migrationTransaction);
             assertEquals(expectedNumberOfChangeOutputs, migrationTransactionChangeOutputs.size());
@@ -3616,10 +3614,11 @@ class ReleaseTransactionBuilderTest {
 
                 assertReleaseTxInputsP2shP2wshErp(
                     batchedPegoutsTransaction,
-                    1,
                     federationRedeemScript,
                     federationUTXOs,
-                    batchedPegoutsResult.selectedUTXOs());
+                    batchedPegoutsResult.selectedUTXOs(),
+                    1
+                );
                 assertOutputsWithNonDustChange(batchedPegoutsTransaction, pegoutRequests);
             }
 
@@ -3642,10 +3641,11 @@ class ReleaseTransactionBuilderTest {
 
                 assertReleaseTxInputsP2shP2wshErp(
                     batchedPegoutsTransaction,
-                    3,
                     federationRedeemScript,
                     federationUTXOs,
-                    batchedPegoutsResult.selectedUTXOs());
+                    batchedPegoutsResult.selectedUTXOs(),
+                    3
+                );
                 assertOutputsWithNonDustChange(batchedPegoutsTransaction, pegoutRequests);
             }
 
@@ -3674,10 +3674,11 @@ class ReleaseTransactionBuilderTest {
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
                 assertReleaseTxInputsP2shP2wshErp(
                     batchedPegoutsTransaction,
-                    1,
                     federationRedeemScript,
                     federationUTXOs,
-                    batchedPegoutsResult.selectedUTXOs());
+                    batchedPegoutsResult.selectedUTXOs(),
+                    1
+                );
                 assertOutputsWithNoChange(batchedPegoutsTransaction, pegoutRequests);
             }
 
@@ -3730,10 +3731,11 @@ class ReleaseTransactionBuilderTest {
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
                 assertReleaseTxInputsP2shP2wshErp(
                     batchedPegoutsTransaction,
-                    1,
                     federationRedeemScript,
                     federationUTXOs,
-                    batchedPegoutsResult.selectedUTXOs());
+                    batchedPegoutsResult.selectedUTXOs(),
+                    1
+                );
                 assertOutputsWithDustChange(batchedPegoutsTransaction, pegoutRequests);
             }
 
@@ -3761,10 +3763,11 @@ class ReleaseTransactionBuilderTest {
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
                 assertReleaseTxInputsP2shP2wshErp(
                     batchedPegoutsTransaction,
-                    1,
                     federationRedeemScript,
                     federationUTXOs,
-                    batchedPegoutsResult.selectedUTXOs());
+                    batchedPegoutsResult.selectedUTXOs(),
+                    1
+                );
                 assertOutputsWithNonDustChange(batchedPegoutsTransaction, pegoutRequests);
             }
 
@@ -3792,10 +3795,11 @@ class ReleaseTransactionBuilderTest {
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
                 assertReleaseTxInputsP2shP2wshErp(
                     batchedPegoutsTransaction,
-                    1,
                     federationRedeemScript,
                     federationUTXOs,
-                    batchedPegoutsResult.selectedUTXOs());
+                    batchedPegoutsResult.selectedUTXOs(),
+                    1
+                );
                 assertOutputsWithDustChange(batchedPegoutsTransaction, pegoutRequests);
             }
 
@@ -3920,10 +3924,11 @@ class ReleaseTransactionBuilderTest {
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
                 assertReleaseTxInputsP2shP2wshErp(
                     batchedPegoutsTransaction,
-                    expectedNumberOfUtxos,
                     federationRedeemScript,
                     federationUTXOs,
-                    batchedPegoutsResult.selectedUTXOs());
+                    batchedPegoutsResult.selectedUTXOs(),
+                    expectedNumberOfUtxos
+                );
                 assertOutputsWithNonDustChange(batchedPegoutsTransaction, pegoutRequests);
             }
         }
@@ -4051,7 +4056,7 @@ class ReleaseTransactionBuilderTest {
             assertPegoutRequestsAreIncludedInBatchedPegoutsTx(batchedPegoutsTransaction, pegoutRequests);
 
             List<TransactionOutput> batchedPegoutsTransactionChangeOutputs = getChangeOutputs(batchedPegoutsTransaction);
-            assertDestinationAddress(batchedPegoutsTransactionChangeOutputs, federationAddress);
+            assertDestinationAddress(batchedPegoutsTransactionChangeOutputs, federationAddress, BTC_MAINNET_PARAMS);
 
             Coin totalPegoutRequestsAmount = getTotalPegoutRequestsAmount(pegoutRequests);
             ReleaseTransactionBuilderTest.assertOutputsWithNonDustChange(
@@ -4073,7 +4078,7 @@ class ReleaseTransactionBuilderTest {
             assertPegoutRequestsAreIncludedInBatchedPegoutsTx(batchedPegoutsTransaction, pegoutRequests);
 
             List<TransactionOutput> batchedPegoutsTransactionChangeOutputs = getChangeOutputs(batchedPegoutsTransaction);
-            assertDestinationAddress(batchedPegoutsTransactionChangeOutputs, federationAddress);
+            assertDestinationAddress(batchedPegoutsTransactionChangeOutputs, federationAddress, BTC_MAINNET_PARAMS);
 
             Coin totalPegoutRequestsAmount = getTotalPegoutRequestsAmount(pegoutRequests);
             ReleaseTransactionBuilderTest.assertOutputsWithDustChange(
@@ -4100,7 +4105,7 @@ class ReleaseTransactionBuilderTest {
 
             assertPegoutRequestsAreIncludedInBatchedPegoutsTx(batchedPegoutsTransaction, pegoutRequests);
             Coin totalPegoutRequestsAmount = getTotalPegoutRequestsAmount(pegoutRequests);
-            ReleaseTransactionBuilderTest.assertOutputsWithNoChange(batchedPegoutsTransaction, totalPegoutRequestsAmount);
+            ReleaseTransactionAssertions.assertOutputsWithNoChange(batchedPegoutsTransaction, totalPegoutRequestsAmount);
         }
     }
 
@@ -4123,40 +4128,6 @@ class ReleaseTransactionBuilderTest {
             Script scriptSig = input.getScriptSig();
             assertScriptSigFromP2shErpWithoutSignaturesHasProperFormat(scriptSig, federationRedeemScript);
             assertInputIsFromFederationUTXOsWallet(input, federationUTXOs);
-        }
-    }
-
-    private static void assertReleaseTxInputsHasProperFormatAndBelongsToP2shP2wshErpFederation(
-        BtcTransaction releaseTransaction,
-        Script federationRedeemScript,
-        List<UTXO> federationUTXOs) {
-        List<TransactionInput> releaseTransactionInputs = releaseTransaction.getInputs();
-        for (int inputIndex = 0; inputIndex < releaseTransactionInputs.size(); inputIndex++) {
-            TransactionWitness witness = releaseTransaction.getWitness(inputIndex);
-            assertP2shP2wshWitnessWithoutSignaturesHasProperFormat(witness, federationRedeemScript);
-            TransactionInput input = releaseTransactionInputs.get(inputIndex);
-            assertInputIsFromFederationUTXOsWallet(input, federationUTXOs);
-        }
-    }
-
-    private static void assertInputIsFromFederationUTXOsWallet(TransactionInput input, List<UTXO> federationUtxos) {
-        Predicate<UTXO> isUTXOAndReleaseInputFromTheSameOutpoint = utxo ->
-            utxo.getHash().equals(input.getOutpoint().getHash())
-                && utxo.getIndex() == input.getOutpoint().getIndex();
-        List<UTXO> matchingUtxos = federationUtxos.stream()
-            .filter(isUTXOAndReleaseInputFromTheSameOutpoint).toList();
-        int expectedNumberOfUtxos = 1;
-        assertEquals(expectedNumberOfUtxos, matchingUtxos.size());
-    }
-
-    private static void assertSelectedUtxosBelongToTheInputs(List<UTXO> selectedUtxos,
-        List<TransactionInput> releaseTransactionInputs) {
-        assertEquals(releaseTransactionInputs.size(), selectedUtxos.size());
-        for (UTXO utxo : selectedUtxos) {
-            List<TransactionInput> matchingInputs = releaseTransactionInputs.stream().
-                filter(input -> input.getOutpoint().getHash().equals(utxo.getHash())
-                    && input.getOutpoint().getIndex() == utxo.getIndex()).toList();
-            assertEquals(1, matchingInputs.size());
         }
     }
 
@@ -4183,19 +4154,6 @@ class ReleaseTransactionBuilderTest {
         List<TransactionInput> inputs = tx.getInputs();
         assertEquals(expectedInputCount, inputs.size());
         assertReleaseTxInputsHasProperFormatAndBelongsToP2shErpFederation(
-            tx, federationRedeemScript, federationUtxos);
-        assertSelectedUtxosBelongToTheInputs(selectedUtxos, inputs);
-    }
-
-    private static void assertReleaseTxInputsP2shP2wshErp(
-        BtcTransaction tx,
-        int expectedInputCount,
-        Script federationRedeemScript,
-        List<UTXO> federationUtxos,
-        List<UTXO> selectedUtxos) {
-        List<TransactionInput> inputs = tx.getInputs();
-        assertEquals(expectedInputCount, inputs.size());
-        assertReleaseTxInputsHasProperFormatAndBelongsToP2shP2wshErpFederation(
             tx, federationRedeemScript, federationUtxos);
         assertSelectedUtxosBelongToTheInputs(selectedUtxos, inputs);
     }
@@ -4235,12 +4193,14 @@ class ReleaseTransactionBuilderTest {
         Script retiringFederationRedeemScript,
         List<UTXO> retiringFederationUtxos,
         List<UTXO> selectedUtxos) {
-        List<TransactionInput> inputs = migrationTransaction.getInputs();
-        assertEquals(retiringFederationUtxos.size(), inputs.size());
-        assertReleaseTxInputsHasProperFormatAndBelongsToP2shP2wshErpFederation(
-            migrationTransaction, retiringFederationRedeemScript, retiringFederationUtxos);
+        assertReleaseTxInputsP2shP2wshErp(
+            migrationTransaction,
+            retiringFederationRedeemScript,
+            retiringFederationUtxos,
+            selectedUtxos,
+            retiringFederationUtxos.size()
+        );
         assertEquals(retiringFederationUtxos, selectedUtxos);
-        assertSelectedUtxosBelongToTheInputs(selectedUtxos, inputs);
     }
 
     private static void assertBuildResultResponseCode(ReleaseTransactionBuilder.Response expectedResponseCode,
@@ -4251,19 +4211,6 @@ class ReleaseTransactionBuilderTest {
 
     private static void assertBtcTxVersionIs1(BtcTransaction releaseTransaction) {
         assertEquals(BTC_TX_VERSION_1, releaseTransaction.getVersion());
-    }
-
-    private static void assertBtcTxVersionIs2(BtcTransaction releaseTransaction) {
-        assertEquals(BTC_TX_VERSION_2, releaseTransaction.getVersion());
-    }
-
-    private static void assertDestinationAddress(
-        List<TransactionOutput> releaseTransactionOutputs,
-        Address expectedDestinationAddress) {
-        for (TransactionOutput output : releaseTransactionOutputs) {
-            Address destinationAddress = output.getScriptPubKey().getToAddress(BTC_MAINNET_PARAMS);
-            assertEquals(expectedDestinationAddress, destinationAddress);
-        }
     }
 
     private static void assertOutputsWithDustChange(BtcTransaction releaseTransaction,
@@ -4311,17 +4258,6 @@ class ReleaseTransactionBuilderTest {
 
     private static boolean isDust(Coin expectedChangeAmount) {
         return expectedChangeAmount.compareTo(MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT) < 0;
-    }
-
-    private static void assertOutputsWithNoChange(BtcTransaction releaseTransaction,
-        Coin expectedSentAmount) {
-        Coin outputsAmount = releaseTransaction.getOutputSum();
-        Coin fees = releaseTransaction.getFee();
-        Coin totalAmountSent = fees.add(outputsAmount);
-        assertEquals(expectedSentAmount, totalAmountSent);
-
-        Coin inputTotalAmount = releaseTransaction.getInputSum();
-        assertEquals(inputTotalAmount, totalAmountSent);
     }
 
     private static void assertReleaseTxNumberOfOutputs(int expectedNumberOfOutputs,

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -19,9 +19,13 @@
 package co.rsk.peg;
 
 import static co.rsk.RskTestUtils.createRepository;
-import static co.rsk.peg.ReleaseTransactionAssertions.*;
-import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_1;
-import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
+import static co.rsk.peg.ReleaseTransactionAssertions.assertBtcTxVersionIs2;
+import static co.rsk.peg.ReleaseTransactionAssertions.assertDestinationAddress;
+import static co.rsk.peg.ReleaseTransactionAssertions.assertInputIsFromFederationUTXOsWallet;
+import static co.rsk.peg.ReleaseTransactionAssertions.assertMigrationTxWithOnlyMigrationOutputs;
+import static co.rsk.peg.ReleaseTransactionAssertions.assertOutputsWithNoChange;
+import static co.rsk.peg.ReleaseTransactionAssertions.assertReleaseTxInputsP2shP2wshErp;
+import static co.rsk.peg.ReleaseTransactionAssertions.assertSelectedUtxosBelongToTheInputs;
 import static co.rsk.peg.ReleaseTransactionBuilder.Response.COULD_NOT_ADJUST_DOWNWARDS;
 import static co.rsk.peg.ReleaseTransactionBuilder.Response.DUSTY_SEND_REQUESTED;
 import static co.rsk.peg.ReleaseTransactionBuilder.Response.EXCEED_MAX_TRANSACTION_SIZE;
@@ -31,6 +35,8 @@ import static co.rsk.peg.bitcoin.BitcoinTestAssertions.assertScriptSigFromP2shEr
 import static co.rsk.peg.bitcoin.BitcoinTestAssertions.assertScriptSigFromStandardMultisigWithoutSignaturesHasProperFormat;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.createHash;
+import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_1;
+import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -1114,7 +1120,7 @@ class ReleaseTransactionBuilderTest {
             Coin requestedAmount,
             PegoutChangeOutputExpectation outputExpectation
         ) {
-            assertBuildResultResponseCode(SUCCESS, buildResult);
+            assertSuccessBuildResult(buildResult);
             BtcTransaction pegoutTransaction = buildResult.btcTx();
             assertEquals(expectedBtcTxVersion, pegoutTransaction.getVersion());
 
@@ -1351,7 +1357,7 @@ class ReleaseTransactionBuilderTest {
                 BuildResult emptyWalletResult = releaseTransactionBuilder.buildEmptyWalletTo(RECIPIENT_ADDRESS);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, emptyWalletResult);
+                assertSuccessBuildResult(emptyWalletResult);
                 BtcTransaction refundTransaction = emptyWalletResult.btcTx();
                 assertBtcTxVersionIs1(refundTransaction);
 
@@ -1733,7 +1739,7 @@ class ReleaseTransactionBuilderTest {
             BuildResult emptyWalletResult,
             RefundTxInputsAssertion assertRefundInputs
         ) {
-            assertBuildResultResponseCode(SUCCESS, emptyWalletResult);
+            assertSuccessBuildResult(emptyWalletResult);
             BtcTransaction refundTransaction = emptyWalletResult.btcTx();
             assertBtcTxVersionIs2(refundTransaction);
             assertRefundInputs.run(refundTransaction, emptyWalletResult);
@@ -1861,7 +1867,7 @@ class ReleaseTransactionBuilderTest {
                     migrationValue, newFederationAddress);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, migrationTransactionResult);
+                assertSuccessBuildResult(migrationTransactionResult);
                 BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
                 assertBtcTxVersionIs1(migrationTransaction);
 
@@ -1896,7 +1902,7 @@ class ReleaseTransactionBuilderTest {
                     migrationValue, newFederationAddress);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, migrationTransactionResult);
+                assertSuccessBuildResult(migrationTransactionResult);
                 BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
                 assertBtcTxVersionIs2(migrationTransaction);
 
@@ -1929,7 +1935,7 @@ class ReleaseTransactionBuilderTest {
                     migrationValue, newFederationAddress);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, migrationTransactionResult);
+                assertSuccessBuildResult(migrationTransactionResult);
                 BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
                 assertBtcTxVersionIs2(migrationTransaction);
 
@@ -1989,7 +1995,7 @@ class ReleaseTransactionBuilderTest {
                     migrationValue, newFederationAddress);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, migrationTransactionResult);
+                assertSuccessBuildResult(migrationTransactionResult);
                 BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
                 assertBtcTxVersionIs2(migrationTransaction);
 
@@ -2055,7 +2061,7 @@ class ReleaseTransactionBuilderTest {
                 );
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, migrationTransactionResult);
+                assertSuccessBuildResult(migrationTransactionResult);
                 BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
                 assertBtcTxVersionIs2(migrationTransaction);
 
@@ -2123,7 +2129,7 @@ class ReleaseTransactionBuilderTest {
                     migrationValue, newFederationAddress);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, migrationTransactionResult);
+                assertSuccessBuildResult(migrationTransactionResult);
                 BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
                 assertBtcTxVersionIs2(migrationTransaction);
 
@@ -2189,7 +2195,7 @@ class ReleaseTransactionBuilderTest {
                     migrationValue, newFederationAddress);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, migrationTransactionResult);
+                assertSuccessBuildResult(migrationTransactionResult);
                 BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
                 assertBtcTxVersionIs1(migrationTransaction);
 
@@ -2224,7 +2230,7 @@ class ReleaseTransactionBuilderTest {
                     migrationValue, newFederationAddress);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, migrationTransactionResult);
+                assertSuccessBuildResult(migrationTransactionResult);
                 BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
                 assertBtcTxVersionIs2(migrationTransaction);
 
@@ -2257,7 +2263,7 @@ class ReleaseTransactionBuilderTest {
                     migrationValue, newFederationAddress);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, migrationTransactionResult);
+                assertSuccessBuildResult(migrationTransactionResult);
                 BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
                 assertBtcTxVersionIs2(migrationTransaction);
 
@@ -2317,7 +2323,7 @@ class ReleaseTransactionBuilderTest {
                     migrationValue, newFederationAddress);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, migrationTransactionResult);
+                assertSuccessBuildResult(migrationTransactionResult);
                 BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
                 assertBtcTxVersionIs2(migrationTransaction);
 
@@ -2384,7 +2390,7 @@ class ReleaseTransactionBuilderTest {
                 );
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, migrationTransactionResult);
+                assertSuccessBuildResult(migrationTransactionResult);
                 BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
                 assertBtcTxVersionIs2(migrationTransaction);
 
@@ -2452,7 +2458,7 @@ class ReleaseTransactionBuilderTest {
                     migrationValue, newFederationAddress);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, migrationTransactionResult);
+                assertSuccessBuildResult(migrationTransactionResult);
                 BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
                 assertBtcTxVersionIs2(migrationTransaction);
 
@@ -2519,7 +2525,7 @@ class ReleaseTransactionBuilderTest {
                     migrationValue, newFederationAddress);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, migrationTransactionResult);
+                assertSuccessBuildResult(migrationTransactionResult);
                 BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
                 assertBtcTxVersionIs2(migrationTransaction);
 
@@ -2552,7 +2558,7 @@ class ReleaseTransactionBuilderTest {
                     migrationValue, newFederationAddress);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, migrationTransactionResult);
+                assertSuccessBuildResult(migrationTransactionResult);
                 BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
                 assertBtcTxVersionIs2(migrationTransaction);
 
@@ -2612,7 +2618,7 @@ class ReleaseTransactionBuilderTest {
                     migrationValue, newFederationAddress);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, migrationTransactionResult);
+                assertSuccessBuildResult(migrationTransactionResult);
                 BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
                 assertBtcTxVersionIs2(migrationTransaction);
 
@@ -2679,7 +2685,7 @@ class ReleaseTransactionBuilderTest {
                 );
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, migrationTransactionResult);
+                assertSuccessBuildResult(migrationTransactionResult);
                 BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
                 assertBtcTxVersionIs2(migrationTransaction);
 
@@ -2747,7 +2753,7 @@ class ReleaseTransactionBuilderTest {
                     migrationValue, newFederationAddress);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, migrationTransactionResult);
+                assertSuccessBuildResult(migrationTransactionResult);
                 BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
                 assertBtcTxVersionIs2(migrationTransaction);
 
@@ -2898,7 +2904,7 @@ class ReleaseTransactionBuilderTest {
                     pegoutRequests);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
 
                 BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
                 assertBtcTxVersionIs1(batchedPegoutsTransaction);
@@ -2923,7 +2929,7 @@ class ReleaseTransactionBuilderTest {
                     pegoutRequests);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
 
                 BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
@@ -2948,7 +2954,7 @@ class ReleaseTransactionBuilderTest {
                     pegoutRequests);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
 
                 BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
@@ -2982,7 +2988,7 @@ class ReleaseTransactionBuilderTest {
                     pegoutRequests);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
 
                 BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
@@ -3038,7 +3044,7 @@ class ReleaseTransactionBuilderTest {
                     pegoutRequests);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
 
                 BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
@@ -3070,7 +3076,7 @@ class ReleaseTransactionBuilderTest {
                     pegoutRequests);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
 
                 BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
@@ -3102,7 +3108,7 @@ class ReleaseTransactionBuilderTest {
                     pegoutRequests);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
 
                 BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
@@ -3230,7 +3236,7 @@ class ReleaseTransactionBuilderTest {
                     pegoutRequests);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
                 BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
 
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
@@ -3285,7 +3291,7 @@ class ReleaseTransactionBuilderTest {
                     pegoutRequests);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
 
                 BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
@@ -3311,7 +3317,7 @@ class ReleaseTransactionBuilderTest {
                     pegoutRequests);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
 
                 BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
@@ -3343,7 +3349,7 @@ class ReleaseTransactionBuilderTest {
                     pegoutRequests);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
 
                 BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
@@ -3400,7 +3406,7 @@ class ReleaseTransactionBuilderTest {
                     pegoutRequests);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
 
                 BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
@@ -3432,7 +3438,7 @@ class ReleaseTransactionBuilderTest {
                     pegoutRequests);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
 
                 BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
@@ -3464,7 +3470,7 @@ class ReleaseTransactionBuilderTest {
                     pegoutRequests);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
 
                 BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
@@ -3591,7 +3597,7 @@ class ReleaseTransactionBuilderTest {
                     pegoutRequests);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
                 BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
 
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
@@ -3631,7 +3637,7 @@ class ReleaseTransactionBuilderTest {
                 // Act & Assert
                 BuildResult batchedPegoutsResult = releaseTransactionBuilder.buildBatchedPegouts(
                     NO_PEGOUT_REQUESTS);
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
 
                 BtcTransaction batchedPegoutsTx = batchedPegoutsResult.btcTx();
                 assertTrue(batchedPegoutsTx.getOutputs().isEmpty());
@@ -3650,7 +3656,7 @@ class ReleaseTransactionBuilderTest {
                     pegoutRequests);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
 
                 BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
@@ -3677,7 +3683,7 @@ class ReleaseTransactionBuilderTest {
                     pegoutRequests);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
 
                 BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
@@ -3711,7 +3717,7 @@ class ReleaseTransactionBuilderTest {
                     pegoutRequests);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
 
                 BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
@@ -3768,7 +3774,7 @@ class ReleaseTransactionBuilderTest {
                     pegoutRequests);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
 
                 BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
@@ -3800,7 +3806,7 @@ class ReleaseTransactionBuilderTest {
                     pegoutRequests);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
 
                 BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
@@ -3832,7 +3838,7 @@ class ReleaseTransactionBuilderTest {
                     pegoutRequests);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
 
                 BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
@@ -3961,7 +3967,7 @@ class ReleaseTransactionBuilderTest {
                     pegoutRequests);
 
                 // Assert
-                assertBuildResultResponseCode(SUCCESS, batchedPegoutsResult);
+                assertSuccessBuildResult(batchedPegoutsResult);
                 BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
 
                 assertBtcTxVersionIs2(batchedPegoutsTransaction);
@@ -4246,10 +4252,9 @@ class ReleaseTransactionBuilderTest {
         assertEquals(retiringFederationUtxos, selectedUtxos);
     }
 
-    private static void assertBuildResultResponseCode(ReleaseTransactionBuilder.Response expectedResponseCode,
-        ReleaseTransactionBuilder.BuildResult buildResult) {
+    private static void assertSuccessBuildResult(ReleaseTransactionBuilder.BuildResult buildResult) {
         ReleaseTransactionBuilder.Response actualResponseCode = buildResult.responseCode();
-        assertEquals(expectedResponseCode, actualResponseCode);
+        assertEquals(SUCCESS, actualResponseCode);
     }
 
     private static void assertBtcTxVersionIs1(BtcTransaction releaseTransaction) {

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -1870,7 +1870,12 @@ class ReleaseTransactionBuilderTest {
                     retiringFederationRedeemScript,
                     retiringFederationUTXOs,
                     migrationTransactionResult.selectedUTXOs());
-                assertMigrationTxWithOnlyMigrationOutputs(migrationTransaction, migrationValue);
+                assertMigrationTxWithOnlyMigrationOutputs(
+                    migrationTransaction,
+                    migrationValue,
+                    newFederationAddress,
+                    BTC_MAINNET_PARAMS
+                );
             }
 
             @Test
@@ -1900,7 +1905,12 @@ class ReleaseTransactionBuilderTest {
                     retiringFederationRedeemScript,
                     retiringFederationUTXOs,
                     migrationTransactionResult.selectedUTXOs());
-                assertMigrationTxWithOnlyMigrationOutputs(migrationTransaction, migrationValue);
+                assertMigrationTxWithOnlyMigrationOutputs(
+                    migrationTransaction,
+                    migrationValue,
+                    newFederationAddress,
+                    BTC_MAINNET_PARAMS
+                );
             }
 
             @Test
@@ -1928,7 +1938,12 @@ class ReleaseTransactionBuilderTest {
                     retiringFederationRedeemScript,
                     retiringFederationUTXOs,
                     migrationTransactionResult.selectedUTXOs());
-                assertMigrationTxWithOnlyMigrationOutputs(migrationTransaction, migrationValue);
+                assertMigrationTxWithOnlyMigrationOutputs(
+                    migrationTransaction,
+                    migrationValue,
+                    newFederationAddress,
+                    BTC_MAINNET_PARAMS
+                );
             }
 
             /** DUSTY_AMOUNT_SEND_REQUESTED is unrealistic; the minimum UTXO the Federation
@@ -1983,7 +1998,12 @@ class ReleaseTransactionBuilderTest {
                     retiringFederationRedeemScript,
                     retiringFederationUTXOs,
                     migrationTransactionResult.selectedUTXOs());
-                assertMigrationTxWithOnlyMigrationOutputs(migrationTransaction, migrationValue);
+                assertMigrationTxWithOnlyMigrationOutputs(
+                    migrationTransaction,
+                    migrationValue,
+                    newFederationAddress,
+                    BTC_MAINNET_PARAMS
+                );
             }
 
             @Test
@@ -2112,7 +2132,12 @@ class ReleaseTransactionBuilderTest {
                     retiringFederationRedeemScript,
                     retiringFederationUTXOs,
                     migrationTransactionResult.selectedUTXOs());
-                assertMigrationTxWithOnlyMigrationOutputs(migrationTransaction, migrationValue);
+                assertMigrationTxWithOnlyMigrationOutputs(
+                    migrationTransaction,
+                    migrationValue,
+                    newFederationAddress,
+                    BTC_MAINNET_PARAMS
+                );
             }
         }
 
@@ -2173,7 +2198,12 @@ class ReleaseTransactionBuilderTest {
                     retiringFederationRedeemScript,
                     retiringFederationUTXOs,
                     migrationTransactionResult.selectedUTXOs());
-                assertMigrationTxWithOnlyMigrationOutputs(migrationTransaction, migrationValue);
+                assertMigrationTxWithOnlyMigrationOutputs(
+                    migrationTransaction,
+                    migrationValue,
+                    newFederationAddress,
+                    BTC_MAINNET_PARAMS
+                );
             }
 
             @Test
@@ -2203,7 +2233,12 @@ class ReleaseTransactionBuilderTest {
                     retiringFederationRedeemScript,
                     retiringFederationUTXOs,
                     migrationTransactionResult.selectedUTXOs());
-                assertMigrationTxWithOnlyMigrationOutputs(migrationTransaction, migrationValue);
+                assertMigrationTxWithOnlyMigrationOutputs(
+                    migrationTransaction,
+                    migrationValue,
+                    newFederationAddress,
+                    BTC_MAINNET_PARAMS
+                );
             }
 
             @Test
@@ -2231,7 +2266,12 @@ class ReleaseTransactionBuilderTest {
                     retiringFederationRedeemScript,
                     retiringFederationUTXOs,
                     migrationTransactionResult.selectedUTXOs());
-                assertMigrationTxWithOnlyMigrationOutputs(migrationTransaction, migrationValue);
+                assertMigrationTxWithOnlyMigrationOutputs(
+                    migrationTransaction,
+                    migrationValue,
+                    newFederationAddress,
+                    BTC_MAINNET_PARAMS
+                );
             }
 
             /** DUSTY_AMOUNT_SEND_REQUESTED is unrealistic; the minimum UTXO the Federation
@@ -2286,7 +2326,12 @@ class ReleaseTransactionBuilderTest {
                     retiringFederationRedeemScript,
                     retiringFederationUTXOs,
                     migrationTransactionResult.selectedUTXOs());
-                assertMigrationTxWithOnlyMigrationOutputs(migrationTransaction, migrationValue);
+                assertMigrationTxWithOnlyMigrationOutputs(
+                    migrationTransaction,
+                    migrationValue,
+                    newFederationAddress,
+                    BTC_MAINNET_PARAMS
+                );
             }
 
             @Test
@@ -2416,7 +2461,12 @@ class ReleaseTransactionBuilderTest {
                     retiringFederationRedeemScript,
                     retiringFederationUTXOs,
                     migrationTransactionResult.selectedUTXOs());
-                assertMigrationTxWithOnlyMigrationOutputs(migrationTransaction, migrationValue);
+                assertMigrationTxWithOnlyMigrationOutputs(
+                    migrationTransaction,
+                    migrationValue,
+                    newFederationAddress,
+                    BTC_MAINNET_PARAMS
+                );
             }
         }
 
@@ -2478,7 +2528,12 @@ class ReleaseTransactionBuilderTest {
                     retiringFederationRedeemScript,
                     retiringFederationUTXOs,
                     migrationTransactionResult.selectedUTXOs());
-                assertMigrationTxWithOnlyMigrationOutputs(migrationTransaction, migrationValue);
+                assertMigrationTxWithOnlyMigrationOutputs(
+                    migrationTransaction,
+                    migrationValue,
+                    newFederationAddress,
+                    BTC_MAINNET_PARAMS
+                );
             }
 
             @Test
@@ -2506,7 +2561,12 @@ class ReleaseTransactionBuilderTest {
                     retiringFederationRedeemScript,
                     retiringFederationUTXOs,
                     migrationTransactionResult.selectedUTXOs());
-                assertMigrationTxWithOnlyMigrationOutputs(migrationTransaction, migrationValue);
+                assertMigrationTxWithOnlyMigrationOutputs(
+                    migrationTransaction,
+                    migrationValue,
+                    newFederationAddress,
+                    BTC_MAINNET_PARAMS
+                );
             }
 
             /** DUSTY_AMOUNT_SEND_REQUESTED is unrealistic; the minimum UTXO the Federation
@@ -2561,7 +2621,12 @@ class ReleaseTransactionBuilderTest {
                     retiringFederationRedeemScript,
                     retiringFederationUTXOs,
                     migrationTransactionResult.selectedUTXOs());
-                assertMigrationTxWithOnlyMigrationOutputs(migrationTransaction, migrationValue);
+                assertMigrationTxWithOnlyMigrationOutputs(
+                    migrationTransaction,
+                    migrationValue,
+                    newFederationAddress,
+                    BTC_MAINNET_PARAMS
+                );
             }
 
             @Test
@@ -2692,7 +2757,12 @@ class ReleaseTransactionBuilderTest {
                     retiringFederationUTXOs,
                     migrationTransactionResult.selectedUTXOs());
 
-                assertMigrationTxWithOnlyMigrationOutputs(migrationTransaction, migrationValue);
+                assertMigrationTxWithOnlyMigrationOutputs(
+                    migrationTransaction,
+                    migrationValue,
+                    newFederationAddress,
+                    BTC_MAINNET_PARAMS
+                );
             }
         }
 
@@ -2710,17 +2780,6 @@ class ReleaseTransactionBuilderTest {
             assertReleaseTxNumberOfOutputs(expectedNumberOfOutputs, migrationTransactionOutputs);
             assertDestinationAddress(migrationTransactionOutputs, newFederationAddress, BTC_MAINNET_PARAMS);
             assertMigrationTransactionIsMigratingMoreThanRequestedValue(migrationValueRequested, migrationTransaction);
-        }
-
-        private void assertMigrationTxWithOnlyMigrationOutputs(
-            BtcTransaction migrationTransaction,
-            Coin migratedAmount
-        ) {
-            int expectedNumberOfMigrationOutputs = 1;
-            List<TransactionOutput> migrationTransactionOutputs = migrationTransaction.getOutputs();
-            assertReleaseTxNumberOfOutputs(expectedNumberOfMigrationOutputs, migrationTransactionOutputs);
-            assertDestinationAddress(migrationTransactionOutputs, newFederationAddress, BTC_MAINNET_PARAMS);
-            assertOutputsWithNoChange(migrationTransaction, migratedAmount);
         }
 
         private void setUpActivationConfig(ActivationConfig.ForBlock activationConfig) {

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -2716,27 +2716,11 @@ class ReleaseTransactionBuilderTest {
             BtcTransaction migrationTransaction,
             Coin migratedAmount
         ) {
-            int expectedNumberOfChangeOutputs = 0;
             int expectedNumberOfMigrationOutputs = 1;
-            int expectedNumberOfOutputs = expectedNumberOfMigrationOutputs + expectedNumberOfChangeOutputs;
             List<TransactionOutput> migrationTransactionOutputs = migrationTransaction.getOutputs();
-            assertReleaseTxNumberOfOutputs(expectedNumberOfOutputs, migrationTransactionOutputs);
+            assertReleaseTxNumberOfOutputs(expectedNumberOfMigrationOutputs, migrationTransactionOutputs);
             assertDestinationAddress(migrationTransactionOutputs, newFederationAddress, BTC_MAINNET_PARAMS);
-
-            List<TransactionOutput> migrationTransactionChangeOutputs = getChangeOutputs(migrationTransaction);
-            assertEquals(expectedNumberOfChangeOutputs, migrationTransactionChangeOutputs.size());
             assertOutputsWithNoChange(migrationTransaction, migratedAmount);
-        }
-
-        private List<TransactionOutput> getChangeOutputs(BtcTransaction migrationTransaction) {
-            return migrationTransaction.getOutputs().stream()
-                .filter(this::isFederationOutput)
-                .toList();
-        }
-
-        private boolean isFederationOutput(TransactionOutput output) {
-            Address destination = output.getScriptPubKey().getToAddress(BTC_MAINNET_PARAMS);
-            return destination.equals(retiringFederationAddress);
         }
 
         private void setUpActivationConfig(ActivationConfig.ForBlock activationConfig) {

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -19,20 +19,23 @@
 package co.rsk.peg;
 
 import static co.rsk.RskTestUtils.createRepository;
+import static co.rsk.peg.ReleaseTransactionAssertions.assertBtcTxVersionIs1;
 import static co.rsk.peg.ReleaseTransactionAssertions.assertBtcTxVersionIs2;
 import static co.rsk.peg.ReleaseTransactionAssertions.assertDestinationAddress;
-import static co.rsk.peg.ReleaseTransactionAssertions.assertInputIsFromFederationUTXOsWallet;
+import static co.rsk.peg.ReleaseTransactionAssertions.assertMigrationReleaseTxInputsP2shErp;
+import static co.rsk.peg.ReleaseTransactionAssertions.assertMigrationReleaseTxInputsP2shP2wshErp;
+import static co.rsk.peg.ReleaseTransactionAssertions.assertMigrationReleaseTxInputsStandardMultisig;
 import static co.rsk.peg.ReleaseTransactionAssertions.assertMigrationTxWithOnlyMigrationOutputs;
 import static co.rsk.peg.ReleaseTransactionAssertions.assertOutputsWithNoChange;
+import static co.rsk.peg.ReleaseTransactionAssertions.assertReleaseTxInputsP2shErp;
 import static co.rsk.peg.ReleaseTransactionAssertions.assertReleaseTxInputsP2shP2wshErp;
-import static co.rsk.peg.ReleaseTransactionAssertions.assertSelectedUtxosBelongToTheInputs;
+import static co.rsk.peg.ReleaseTransactionAssertions.assertReleaseTxInputsStandardMultisig;
+import static co.rsk.peg.ReleaseTransactionAssertions.assertReleaseTxNumberOfOutputs;
 import static co.rsk.peg.ReleaseTransactionBuilder.Response.COULD_NOT_ADJUST_DOWNWARDS;
 import static co.rsk.peg.ReleaseTransactionBuilder.Response.DUSTY_SEND_REQUESTED;
 import static co.rsk.peg.ReleaseTransactionBuilder.Response.EXCEED_MAX_TRANSACTION_SIZE;
 import static co.rsk.peg.ReleaseTransactionBuilder.Response.INSUFFICIENT_MONEY;
 import static co.rsk.peg.ReleaseTransactionBuilder.Response.SUCCESS;
-import static co.rsk.peg.bitcoin.BitcoinTestAssertions.assertScriptSigFromP2shErpWithoutSignaturesHasProperFormat;
-import static co.rsk.peg.bitcoin.BitcoinTestAssertions.assertScriptSigFromStandardMultisigWithoutSignaturesHasProperFormat;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.createHash;
 import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_1;
@@ -59,7 +62,6 @@ import co.rsk.bitcoinj.core.Context;
 import co.rsk.bitcoinj.core.InsufficientMoneyException;
 import co.rsk.bitcoinj.core.NetworkParameters;
 import co.rsk.bitcoinj.core.Sha256Hash;
-import co.rsk.bitcoinj.core.TransactionInput;
 import co.rsk.bitcoinj.core.TransactionOutput;
 import co.rsk.bitcoinj.core.UTXO;
 import co.rsk.bitcoinj.core.UTXOProvider;
@@ -1161,7 +1163,7 @@ class ReleaseTransactionBuilderTest {
         ) {
             assertNumberOfOutputs(pegoutTransaction);
             List<TransactionOutput> changeOutputs = getChangeOutputs(pegoutTransaction);
-            ReleaseTransactionBuilderTest.assertOutputsWithNonDustChange(
+            ReleaseTransactionAssertions.assertOutputsWithNonDustChange(
                 pegoutTransaction,
                 changeOutputs,
                 requestedAmount
@@ -1174,7 +1176,7 @@ class ReleaseTransactionBuilderTest {
         ) {
             assertNumberOfOutputs(pegoutTransaction);
             List<TransactionOutput> changeOutputs = getChangeOutputs(pegoutTransaction);
-            ReleaseTransactionBuilderTest.assertOutputsWithDustChange(
+            ReleaseTransactionAssertions.assertOutputsWithDustChange(
                 pegoutTransaction,
                 changeOutputs,
                 requestedAmount
@@ -4093,8 +4095,10 @@ class ReleaseTransactionBuilderTest {
             assertReleaseTxNumberOfOutputs(expectedNumberOfOutputs, pegoutTransaction.getOutputs());
         }
 
-        private void assertOutputsWithNonDustChange(BtcTransaction batchedPegoutsTransaction,
-                                                                                                List<Entry> pegoutRequests) {
+        private void assertOutputsWithNonDustChange(
+            BtcTransaction batchedPegoutsTransaction,
+            List<Entry> pegoutRequests
+        ) {
             int pegoutRequestsNumber = pegoutRequests.size();
             assertBatchedPegoutsTxOutputAndChangeOutputsNumbers(
                 batchedPegoutsTransaction,
@@ -4108,15 +4112,17 @@ class ReleaseTransactionBuilderTest {
             assertDestinationAddress(batchedPegoutsTransactionChangeOutputs, federationAddress, BTC_MAINNET_PARAMS);
 
             Coin totalPegoutRequestsAmount = getTotalPegoutRequestsAmount(pegoutRequests);
-            ReleaseTransactionBuilderTest.assertOutputsWithNonDustChange(
+            ReleaseTransactionAssertions.assertOutputsWithNonDustChange(
                 batchedPegoutsTransaction,
                 batchedPegoutsTransactionChangeOutputs,
                 totalPegoutRequestsAmount
             );
         }
 
-        private void assertOutputsWithDustChange(BtcTransaction batchedPegoutsTransaction,
-                                                                                             List<Entry> pegoutRequests) {
+        private void assertOutputsWithDustChange(
+            BtcTransaction batchedPegoutsTransaction,
+            List<Entry> pegoutRequests
+        ) {
             int pegoutRequestsNumber = pegoutRequests.size();
             assertBatchedPegoutsTxOutputAndChangeOutputsNumbers(
                 batchedPegoutsTransaction,
@@ -4130,7 +4136,7 @@ class ReleaseTransactionBuilderTest {
             assertDestinationAddress(batchedPegoutsTransactionChangeOutputs, federationAddress, BTC_MAINNET_PARAMS);
 
             Coin totalPegoutRequestsAmount = getTotalPegoutRequestsAmount(pegoutRequests);
-            ReleaseTransactionBuilderTest.assertOutputsWithDustChange(
+            ReleaseTransactionAssertions.assertOutputsWithDustChange(
                 batchedPegoutsTransaction,
                 batchedPegoutsTransactionChangeOutputs,
                 totalPegoutRequestsAmount
@@ -4142,8 +4148,10 @@ class ReleaseTransactionBuilderTest {
                 .reduce(Coin.ZERO, Coin::add);
         }
 
-        private void assertOutputsWithNoChange(BtcTransaction batchedPegoutsTransaction,
-                                                                List<Entry> pegoutRequests) {
+        public void assertOutputsWithNoChange(
+            BtcTransaction batchedPegoutsTransaction,
+            List<Entry> pegoutRequests
+        ) {
             int expectedNumberOfChangeOutputs = 0;
             int expectedNumberOfOutputs = pegoutRequests.size();
             assertBatchedPegoutsTxOutputAndChangeOutputsNumbers(
@@ -4158,160 +4166,9 @@ class ReleaseTransactionBuilderTest {
         }
     }
 
-    private static void assertReleaseTxInputsHasProperFormatAndBelongsToStandardMultisigFederation(
-        BtcTransaction releaseTransaction,
-        Script federationRedeemScript,
-        List<UTXO> federationUTXOs) {
-        for (TransactionInput input : releaseTransaction.getInputs()) {
-            Script scriptSig = input.getScriptSig();
-            assertScriptSigFromStandardMultisigWithoutSignaturesHasProperFormat(scriptSig, federationRedeemScript);
-            assertInputIsFromFederationUTXOsWallet(input, federationUTXOs);
-        }
-    }
-
-    private static void assertReleaseTxInputsHasProperFormatAndBelongsToP2shErpFederation(
-        BtcTransaction releaseTransaction,
-        Script federationRedeemScript,
-        List<UTXO> federationUTXOs) {
-        for (TransactionInput input : releaseTransaction.getInputs()) {
-            Script scriptSig = input.getScriptSig();
-            assertScriptSigFromP2shErpWithoutSignaturesHasProperFormat(scriptSig, federationRedeemScript);
-            assertInputIsFromFederationUTXOsWallet(input, federationUTXOs);
-        }
-    }
-
-    /** Input count, script format, and selected-UTXO alignment for peg-out / batched flows. */
-    private static void assertReleaseTxInputsStandardMultisig(
-        BtcTransaction tx,
-        int expectedInputCount,
-        Script federationRedeemScript,
-        List<UTXO> federationUtxos,
-        List<UTXO> selectedUtxos) {
-        List<TransactionInput> inputs = tx.getInputs();
-        assertEquals(expectedInputCount, inputs.size());
-        assertReleaseTxInputsHasProperFormatAndBelongsToStandardMultisigFederation(
-            tx, federationRedeemScript, federationUtxos);
-        assertSelectedUtxosBelongToTheInputs(selectedUtxos, inputs);
-    }
-
-    private static void assertReleaseTxInputsP2shErp(
-        BtcTransaction tx,
-        int expectedInputCount,
-        Script federationRedeemScript,
-        List<UTXO> federationUtxos,
-        List<UTXO> selectedUtxos) {
-        List<TransactionInput> inputs = tx.getInputs();
-        assertEquals(expectedInputCount, inputs.size());
-        assertReleaseTxInputsHasProperFormatAndBelongsToP2shErpFederation(
-            tx, federationRedeemScript, federationUtxos);
-        assertSelectedUtxosBelongToTheInputs(selectedUtxos, inputs);
-    }
-
-    /**
-     * Like {@link #assertReleaseTxInputsStandardMultisig} but for migration: all retiring federation UTXOs
-     * are spent and {@code selectedUtxos} must match that set exactly.
-     */
-    private static void assertMigrationReleaseTxInputsStandardMultisig(
-        BtcTransaction migrationTransaction,
-        Script retiringFederationRedeemScript,
-        List<UTXO> retiringFederationUtxos,
-        List<UTXO> selectedUtxos) {
-        List<TransactionInput> inputs = migrationTransaction.getInputs();
-        assertEquals(retiringFederationUtxos.size(), inputs.size());
-        assertReleaseTxInputsHasProperFormatAndBelongsToStandardMultisigFederation(
-            migrationTransaction, retiringFederationRedeemScript, retiringFederationUtxos);
-        assertEquals(retiringFederationUtxos, selectedUtxos);
-        assertSelectedUtxosBelongToTheInputs(selectedUtxos, inputs);
-    }
-
-    private static void assertMigrationReleaseTxInputsP2shErp(
-        BtcTransaction migrationTransaction,
-        Script retiringFederationRedeemScript,
-        List<UTXO> retiringFederationUtxos,
-        List<UTXO> selectedUtxos) {
-        List<TransactionInput> inputs = migrationTransaction.getInputs();
-        assertEquals(retiringFederationUtxos.size(), inputs.size());
-        assertReleaseTxInputsHasProperFormatAndBelongsToP2shErpFederation(
-            migrationTransaction, retiringFederationRedeemScript, retiringFederationUtxos);
-        assertEquals(retiringFederationUtxos, selectedUtxos);
-        assertSelectedUtxosBelongToTheInputs(selectedUtxos, inputs);
-    }
-
-    private static void assertMigrationReleaseTxInputsP2shP2wshErp(
-        BtcTransaction migrationTransaction,
-        Script retiringFederationRedeemScript,
-        List<UTXO> retiringFederationUtxos,
-        List<UTXO> selectedUtxos) {
-        assertReleaseTxInputsP2shP2wshErp(
-            migrationTransaction,
-            retiringFederationRedeemScript,
-            retiringFederationUtxos,
-            selectedUtxos,
-            retiringFederationUtxos.size()
-        );
-        assertEquals(retiringFederationUtxos, selectedUtxos);
-    }
-
     private static void assertSuccessBuildResult(ReleaseTransactionBuilder.BuildResult buildResult) {
         ReleaseTransactionBuilder.Response actualResponseCode = buildResult.responseCode();
         assertEquals(SUCCESS, actualResponseCode);
-    }
-
-    private static void assertBtcTxVersionIs1(BtcTransaction releaseTransaction) {
-        assertEquals(BTC_TX_VERSION_1, releaseTransaction.getVersion());
-    }
-
-    private static void assertOutputsWithDustChange(BtcTransaction releaseTransaction,
-        List<TransactionOutput> releaseTransactionChangeOutputs,
-        Coin requestedAmount) {
-        Coin inputTotalAmount = releaseTransaction.getInputSum();
-        Coin originalChangeAmount = inputTotalAmount.subtract(requestedAmount);
-        assertTrue(isDust(originalChangeAmount));
-
-        Coin amountToGetNonDustValue = MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT.subtract(originalChangeAmount);
-        Coin amountToSend = requestedAmount.subtract(amountToGetNonDustValue);
-
-        assertOutputsUserAndChangeValues(releaseTransaction, releaseTransactionChangeOutputs, amountToSend, MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT);
-    }
-
-    private static void assertOutputsWithNonDustChange(BtcTransaction releaseTransaction,
-        List<TransactionOutput> releaseTransactionChangeOutputs,
-        Coin requestedAmount) {
-        Coin inputTotalAmount = releaseTransaction.getInputSum();
-        Coin expectedChangeAmount = inputTotalAmount.subtract(requestedAmount);
-        assertOutputsUserAndChangeValues(releaseTransaction, releaseTransactionChangeOutputs, requestedAmount, expectedChangeAmount);
-    }
-
-    private static void assertOutputsUserAndChangeValues(BtcTransaction releaseTransaction,
-        List<TransactionOutput> releaseTransactionChangeOutputs,
-        Coin amountToSend,
-        Coin expectedChangeAmount) {
-        Coin changeOutputsAmount = getOutputsAmount(releaseTransactionChangeOutputs);
-        assertEquals(expectedChangeAmount, changeOutputsAmount);
-
-        Coin userOutputsAmount = releaseTransaction.getOutputSum().subtract(changeOutputsAmount);
-        Coin releaseTransactionFees = releaseTransaction.getFee();
-        Coin userOutputsAndFeesAmount = releaseTransactionFees.add(userOutputsAmount);
-        assertEquals(amountToSend, userOutputsAndFeesAmount);
-        Coin inputTotalAmount = releaseTransaction.getInputSum();
-        assertEquals(inputTotalAmount, userOutputsAndFeesAmount.add(changeOutputsAmount));
-    }
-
-    private static Coin getOutputsAmount(List<TransactionOutput> outputs) {
-        return outputs.stream()
-            .map(TransactionOutput::getValue)
-            .reduce(Coin::add)
-            .orElse(Coin.ZERO);
-    }
-
-    private static boolean isDust(Coin expectedChangeAmount) {
-        return expectedChangeAmount.compareTo(MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT) < 0;
-    }
-
-    private static void assertReleaseTxNumberOfOutputs(int expectedNumberOfOutputs,
-        List<TransactionOutput> releaseTransactionOutputs) {
-        int actualNumberOfOutputs = releaseTransactionOutputs.size();
-        assertEquals(expectedNumberOfOutputs, actualNumberOfOutputs);
     }
 
     private static void assertFailedBuildResult(


### PR DESCRIPTION
## Description

Added a new `ProcessFundsMigrationTest` suite covering `BridgeSupport.updateCollections` scenarios that exercise `processFundsMigration` for P2SH-P2WSH ERP federations.

The tests cover:
- no retiring federation
- migration boundary before/during/past migration age
- spendable retiring UTXOs
- multiple retiring UTXOs
- max-input chunking across repeated `updateCollections` calls
- zero-balance retiring federation cleanup
- final migration failure paths where the retiring federation is still cleared

Also refactored shared BTC release/migration transaction assertions into `ReleaseTransactionAssertions`, and updated `ReleaseTransactionBuilderTest` to reuse those helpers where applicable.

## Motivation and Context

`processFundsMigration` has several state-dependent paths that were not directly covered through `updateCollections`. This adds focused coverage for migration transaction creation, retiring UTXO removal, retiring federation cleanup, and migration tx format.

The shared assertion refactor reduces duplication between `ProcessFundsMigrationTest` and `ReleaseTransactionBuilderTest`.
