### PR TITLE
test: added standard multisig fed in the tests

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -2,10 +2,12 @@ package co.rsk.peg;
 
 import static co.rsk.RskTestUtils.createRepository;
 import static co.rsk.peg.BridgeSupportTestUtil.buildUpdateCollectionsTransaction;
-import static co.rsk.peg.ReleaseTransactionAssertions.assertBtcTxVersionIs2;
 import static co.rsk.peg.ReleaseTransactionAssertions.assertMigrationTxWithOnlyMigrationOutputs;
+import static co.rsk.peg.ReleaseTransactionAssertions.assertReleaseTxInputsStandardMultisig;
 import static co.rsk.peg.ReleaseTransactionAssertions.assertReleaseTxInputsP2shErp;
 import static co.rsk.peg.ReleaseTransactionAssertions.assertReleaseTxInputsP2shP2wshErp;
+import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_1;
+import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.createHash;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.getBtcEcKeysFromSeeds;
@@ -27,6 +29,8 @@ import co.rsk.peg.federation.FederationStorageProviderImpl;
 import co.rsk.peg.federation.FederationSupport;
 import co.rsk.peg.federation.P2shErpFederationBuilder;
 import co.rsk.peg.federation.P2shP2wshErpFederationBuilder;
+import co.rsk.peg.federation.StandardMultiSigFederationBuilder;
+import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.feeperkb.FeePerKbStorageIndexKey;
 import co.rsk.peg.feeperkb.FeePerKbStorageProvider;
 import co.rsk.peg.feeperkb.FeePerKbStorageProviderImpl;
@@ -51,8 +55,10 @@ import org.junit.jupiter.api.Test;
 class ProcessFundsMigrationTest {
 
     private static final BridgeConstants BRIDGE_CONSTANTS = BridgeMainNetConstants.getInstance();
+    private static final FederationConstants FEDERATION_CONSTANTS = BRIDGE_CONSTANTS.getFederationConstants();
     private static final NetworkParameters NETWORK_PARAMETERS = BRIDGE_CONSTANTS.getBtcParams();
     private static final ActivationConfig.ForBlock ALL_ACTIVATIONS = ActivationConfigsForTest.all().forBlock(0L);
+    private static final ActivationConfig.ForBlock PRE_RSKIP294_ACTIVATIONS = ActivationConfigsForTest.iris300().forBlock(0L);
     private static final Coin FEE_PER_KB = Coin.valueOf(8_000L);
     private static final long ACTIVE_FEDERATION_CREATION_BLOCK = 100L;
     private static final int EXPECTED_MULTIPLE_MIGRATION_TX_COUNT = 2;
@@ -151,7 +157,8 @@ class ProcessFundsMigrationTest {
                 retiringFederation,
                 retiringUtxos,
                 retiringUtxos.size(),
-                migrationTxInputsAssertion
+                migrationTxInputsAssertion,
+                BTC_TX_VERSION_2
             );
             assertRetiringFederationStillPresent();
             assertNoRemainingRetiringUtxos();
@@ -178,7 +185,8 @@ class ProcessFundsMigrationTest {
                 retiringFederation,
                 retiringUtxos,
                 retiringUtxos.size(),
-                migrationTxInputsAssertion
+                migrationTxInputsAssertion,
+                BTC_TX_VERSION_2
             );
             assertRetiringFederationStillPresent();
             assertNoRemainingRetiringUtxos();
@@ -247,7 +255,13 @@ class ProcessFundsMigrationTest {
             bridgeSupport.updateCollections(updateCollectionsTransaction);
 
             // Assert
-            assertOneMigrationTransactionWasBuiltAsExpected(retiringFederation, retiringUtxos, maxInputs, migrationTxInputsAssertion);
+            assertOneMigrationTransactionWasBuiltAsExpected(
+                retiringFederation,
+                retiringUtxos,
+                maxInputs,
+                migrationTxInputsAssertion,
+                BTC_TX_VERSION_2
+            );
             assertRetiringFederationStillPresent();
 
             int remainingUtxos = retiringUtxos.size() - maxInputs;
@@ -287,7 +301,8 @@ class ProcessFundsMigrationTest {
                 retiringFederation,
                 retiringUtxos,
                 retiringUtxos.size(),
-                migrationTxInputsAssertion
+                migrationTxInputsAssertion,
+                BTC_TX_VERSION_2
             );
             assertRetiringFederationCleared();
             assertNoRemainingRetiringUtxos();
@@ -314,7 +329,8 @@ class ProcessFundsMigrationTest {
                 retiringFederation,
                 retiringUtxos,
                 retiringUtxos.size(),
-                migrationTxInputsAssertion
+                migrationTxInputsAssertion,
+                BTC_TX_VERSION_2
             );
             assertRetiringFederationCleared();
             assertNoRemainingRetiringUtxos();
@@ -338,7 +354,13 @@ class ProcessFundsMigrationTest {
             bridgeSupport.updateCollections(updateCollectionsTransaction);
 
             // Assert
-            assertOneMigrationTransactionWasBuiltAsExpected(retiringFederation, retiringUtxos, maxInputs, migrationTxInputsAssertion);
+            assertOneMigrationTransactionWasBuiltAsExpected(
+                retiringFederation,
+                retiringUtxos,
+                maxInputs,
+                migrationTxInputsAssertion,
+                BTC_TX_VERSION_2
+            );
             assertRetiringFederationCleared();
 
             int expectedRemainingUtxos = retiringUtxos.size() - maxInputs;
@@ -493,7 +515,8 @@ class ProcessFundsMigrationTest {
                 retiringFederation,
                 retiringUtxos,
                 retiringUtxos.size(),
-                migrationTxInputsAssertion
+                migrationTxInputsAssertion,
+                BTC_TX_VERSION_2
             );
             assertRetiringFederationStillPresent();
             assertNoRemainingRetiringUtxos();
@@ -520,7 +543,8 @@ class ProcessFundsMigrationTest {
                 retiringFederation,
                 retiringUtxos,
                 retiringUtxos.size(),
-                migrationTxInputsAssertion
+                migrationTxInputsAssertion,
+                BTC_TX_VERSION_2
             );
             assertRetiringFederationStillPresent();
             assertNoRemainingRetiringUtxos();
@@ -589,7 +613,13 @@ class ProcessFundsMigrationTest {
             bridgeSupport.updateCollections(updateCollectionsTransaction);
 
             // Assert
-            assertOneMigrationTransactionWasBuiltAsExpected(retiringFederation, retiringUtxos, maxInputs, migrationTxInputsAssertion);
+            assertOneMigrationTransactionWasBuiltAsExpected(
+                retiringFederation,
+                retiringUtxos,
+                maxInputs,
+                migrationTxInputsAssertion,
+                BTC_TX_VERSION_2
+            );
             assertRetiringFederationStillPresent();
 
             int remainingUtxos = retiringUtxos.size() - maxInputs;
@@ -629,7 +659,8 @@ class ProcessFundsMigrationTest {
                 retiringFederation,
                 retiringUtxos,
                 retiringUtxos.size(),
-                migrationTxInputsAssertion
+                migrationTxInputsAssertion,
+                BTC_TX_VERSION_2
             );
             assertRetiringFederationCleared();
             assertNoRemainingRetiringUtxos();
@@ -656,7 +687,8 @@ class ProcessFundsMigrationTest {
                 retiringFederation,
                 retiringUtxos,
                 retiringUtxos.size(),
-                migrationTxInputsAssertion
+                migrationTxInputsAssertion,
+                BTC_TX_VERSION_2
             );
             assertRetiringFederationCleared();
             assertNoRemainingRetiringUtxos();
@@ -680,7 +712,429 @@ class ProcessFundsMigrationTest {
             bridgeSupport.updateCollections(updateCollectionsTransaction);
 
             // Assert
-            assertOneMigrationTransactionWasBuiltAsExpected(retiringFederation, retiringUtxos, maxInputs, migrationTxInputsAssertion);
+            assertOneMigrationTransactionWasBuiltAsExpected(
+                retiringFederation,
+                retiringUtxos,
+                maxInputs,
+                migrationTxInputsAssertion,
+                BTC_TX_VERSION_2
+            );
+            assertRetiringFederationCleared();
+
+            int expectedRemainingUtxos = retiringUtxos.size() - maxInputs;
+            assertRetiringUtxosCount(expectedRemainingUtxos);
+        }
+
+        @Test
+        void updateCollections_pastMigrationAge_withZeroBalance_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
+            // Arrange
+            long executionBlockNumber = pastMigrationBlockNumber();
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, List.of());
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertNoMigrationTxCreated();
+            assertRetiringFederationCleared();
+            assertNoRemainingRetiringUtxos();
+        }
+
+        @Test
+        void updateCollections_pastMigrationAge_withMinNonDustRetiringUtxo_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
+            // Arrange
+            List<UTXO> retiringUtxos = List.of(
+                UTXOBuilder.builder()
+                .withValue(MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .build()
+            );
+
+            long executionBlockNumber = pastMigrationBlockNumber();
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertNoMigrationTxCreated();
+            assertRetiringFederationCleared();
+            assertRetiringUtxosCount(retiringUtxos.size());
+        }
+
+        @Test
+        void updateCollections_pastMigrationAge_withManyMinNonDustRetiringUtxo_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
+            // Arrange
+            int numberOfUtxos = 5;
+            List<UTXO> retiringUtxos = UTXOBuilder.builder()
+                .withValue(MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .buildMany(numberOfUtxos, i -> createHash(i + 1));
+
+            long executionBlockNumber = pastMigrationBlockNumber();
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertNoMigrationTxCreated();
+            assertRetiringFederationCleared();
+            assertRetiringUtxosCount(retiringUtxos.size());
+        }
+
+        @Test
+        void updateCollections_pastMigrationAge_withHighFees_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
+            // Arrange
+            List<UTXO> retiringUtxos = List.of(
+                UTXOBuilder.builder()
+                .withValue(Coin.COIN)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .build()
+            );
+
+            Coin highFeePerKb = Coin.COIN.multiply(2);
+            long executionBlockNumber = pastMigrationBlockNumber();
+            setUpBridgeAndFederationSupport(highFeePerKb, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertNoMigrationTxCreated();
+            assertRetiringFederationCleared();
+            assertRetiringUtxosCount(retiringUtxos.size());
+        }
+    }
+
+    @Nested
+    class StandardMultisigFederationTest {
+
+        private final Federation retiringFederation = StandardMultiSigFederationBuilder.builder().build();
+        private final Federation activeFederation = StandardMultiSigFederationBuilder.builder()
+            .withCreationBlockNumber(ACTIVE_FEDERATION_CREATION_BLOCK)
+            .withMembersBtcPublicKeys(getActiveMemberKeys(9))
+            .build();
+        private final MigrationTxInputsAssertion migrationTxInputsAssertion = (migrationTransaction, retiringFederation, retiringFederationUtxos,
+            selectedUtxos, expectedInputCount) -> assertReleaseTxInputsStandardMultisig(
+                migrationTransaction,
+                expectedInputCount,
+                retiringFederation.getRedeemScript(),
+                retiringFederationUtxos,
+                selectedUtxos
+            );
+
+        @Test
+        void updateCollections_withNewFederationAgeBeforeMigrationBegins_shouldNotCreateMigrationTx() throws IOException {
+            // Arrange
+            List<UTXO> retiringUtxos = List.of(
+                UTXOBuilder.builder()
+                .withValue(Coin.COIN)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .build()
+            );
+
+            long executionBlockNumber = blockNumberBeforeMigrationBegins();
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertNoMigrationTxCreated();
+            assertRetiringFederationStillPresent();
+            assertRetiringUtxosCount(retiringUtxos.size());
+        }
+
+        @Test
+        void updateCollections_duringMigration_withOneSpendableRetiringUtxo_shouldCreateMigrationTx() throws IOException {
+            // Arrange
+            List<UTXO> retiringUtxos = List.of(
+                UTXOBuilder.builder()
+                .withValue(Coin.COIN)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .build()
+            );
+
+            long executionBlockNumber = duringMigrationBlockNumber();
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertOneMigrationTransactionWasBuiltAsExpected(
+                retiringFederation,
+                retiringUtxos,
+                retiringUtxos.size(),
+                migrationTxInputsAssertion,
+                BTC_TX_VERSION_2
+            );
+            assertRetiringFederationStillPresent();
+            assertNoRemainingRetiringUtxos();
+        }
+
+        @Test
+        void updateCollections_duringMigration_withMultipleSpendableRetiringUtxos_shouldCreateMigrationTx() throws IOException {
+            // Arrange
+            int numberOfUtxos = 3;
+            List<UTXO> retiringUtxos = UTXOBuilder.builder()
+                .withValue(Coin.COIN)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .buildMany(numberOfUtxos, i -> createHash(i + 1));
+
+            long executionBlockNumber = duringMigrationBlockNumber();
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertOneMigrationTransactionWasBuiltAsExpected(
+                retiringFederation,
+                retiringUtxos,
+                retiringUtxos.size(),
+                migrationTxInputsAssertion,
+                BTC_TX_VERSION_2
+            );
+            assertRetiringFederationStillPresent();
+            assertNoRemainingRetiringUtxos();
+        }
+
+        @Test
+        void updateCollections_duringMigration_withManyMinNonDustRetiringUtxos_whenMigrationBuildFails_shouldThrowIllegalStateException() throws IOException {
+            // Arrange
+            int numberOfUtxos = 5;
+            List<UTXO> retiringUtxos = UTXOBuilder.builder()
+                .withValue(MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .buildMany(numberOfUtxos, i -> createHash(i + 1));
+
+            long executionBlockNumber = duringMigrationBlockNumber();
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act & Assert
+            assertThrows(IllegalStateException.class,
+                () -> bridgeSupport.updateCollections(updateCollectionsTransaction));
+            assertNoMigrationTxCreated();
+            assertRetiringFederationStillPresent();
+            assertRetiringUtxosCount(retiringUtxos.size());
+        }
+
+        @Test
+        void updateCollections_duringMigration_withBalanceBelowThreshold_shouldNotCreateMigrationTx() throws IOException {
+            // Arrange
+            Coin valueBelowThreshold = FEE_PER_KB.divide(2);
+            List<UTXO> retiringUtxos = List.of(
+                UTXOBuilder.builder()
+                .withValue(valueBelowThreshold)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .build()
+            );
+
+            long executionBlockNumber = duringMigrationBlockNumber();
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertNoMigrationTxCreated();
+            assertRetiringFederationStillPresent();
+            assertRetiringUtxosCount(retiringUtxos.size());
+        }
+
+        @Test
+        void updateCollections_duringMigration_preRSKIP294_withMoreUtxosThanMaxInputs_shouldUseAllRetiringUtxos() throws IOException {
+            // Arrange
+            int maxInputs = BRIDGE_CONSTANTS.getMaxInputsPerPegoutTransaction();
+            int numberOfUtxos = maxInputs + 1;
+            List<UTXO> retiringUtxos = UTXOBuilder.builder()
+                .withValue(Coin.COIN)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .buildMany(numberOfUtxos, i -> createHash(i + 1));
+
+            long executionBlockNumber = duringMigrationBlockNumberPreRSKIP294();
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber, PRE_RSKIP294_ACTIVATIONS);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertOneMigrationTransactionWasBuiltAsExpected(
+                retiringFederation,
+                retiringUtxos,
+                retiringUtxos.size(),
+                migrationTxInputsAssertion,
+                BTC_TX_VERSION_1
+            );
+            assertRetiringFederationStillPresent();
+            assertNoRemainingRetiringUtxos();
+        }
+
+        @Test
+        void updateCollections_duringMigration_withMoreUtxosThanMaxInputs_whenCalledRepeatedly_shouldCreateAMigrationTxEachTime() throws IOException {
+            // Arrange
+            int maxInputs = BRIDGE_CONSTANTS.getMaxInputsPerPegoutTransaction();
+            int numberOfUtxos = maxInputs + 1;
+            List<UTXO> retiringUtxos = UTXOBuilder.builder()
+                .withValue(Coin.COIN)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .buildMany(numberOfUtxos, i -> createHash(i + 1));
+
+            long executionBlockNumber = duringMigrationBlockNumber();
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertOneMigrationTransactionWasBuiltAsExpected(
+                retiringFederation,
+                retiringUtxos,
+                maxInputs,
+                migrationTxInputsAssertion,
+                BTC_TX_VERSION_2
+            );
+            assertRetiringFederationStillPresent();
+
+            int remainingUtxos = retiringUtxos.size() - maxInputs;
+            assertRetiringUtxosCount(remainingUtxos);
+
+            // Act
+            long secondExecutionBlockNumber = executionBlockNumber + 1;
+            setUpBridgeAndFederationSupportForExecutionBlock(secondExecutionBlockNumber);
+            Transaction secondUpdateCollectionsTransaction = buildUpdateCollectionsTransaction(1);
+            bridgeSupport.updateCollections(secondUpdateCollectionsTransaction);
+
+            // Assert
+            assertMultipleMigrationTransactionsWereBuiltAsExpected(retiringFederation, retiringUtxos, migrationTxInputsAssertion);
+            assertRetiringFederationStillPresent();
+            assertNoRemainingRetiringUtxos();
+        }
+
+        @Test
+        void updateCollections_pastMigrationAge_withOneSpendableRetiringUtxo_shouldCreateMigrationTxAndClearRetiringFed() throws IOException {
+            // Arrange
+            List<UTXO> retiringUtxos = List.of(
+                UTXOBuilder.builder()
+                .withValue(Coin.COIN)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .build()
+            );
+
+            long executionBlockNumber = pastMigrationBlockNumber();
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertOneMigrationTransactionWasBuiltAsExpected(
+                retiringFederation,
+                retiringUtxos,
+                retiringUtxos.size(),
+                migrationTxInputsAssertion,
+                BTC_TX_VERSION_2
+            );
+            assertRetiringFederationCleared();
+            assertNoRemainingRetiringUtxos();
+        }
+
+        @Test
+        void updateCollections_pastMigrationAge_withManySpendableRetiringUtxos_shouldCreateMigrationTxAndClearRetiringFed() throws IOException {
+            // Arrange
+            int numberOfUtxos = 3;
+            List<UTXO> retiringUtxos = UTXOBuilder.builder()
+                .withValue(Coin.COIN)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .buildMany(numberOfUtxos, i -> createHash(i + 1));
+
+            long executionBlockNumber = pastMigrationBlockNumber();
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertOneMigrationTransactionWasBuiltAsExpected(
+                retiringFederation,
+                retiringUtxos,
+                retiringUtxos.size(),
+                migrationTxInputsAssertion,
+                BTC_TX_VERSION_2
+            );
+            assertRetiringFederationCleared();
+            assertNoRemainingRetiringUtxos();
+        }
+
+        @Test
+        void updateCollections_pastMigrationAge_preRSKIP294_withMoreUtxosThanMaxInputs_shouldCreateLastMigrationTxAndClearRetiringFedEvenIfUtxosRemain() throws IOException {
+            // Arrange
+            int maxInputs = BRIDGE_CONSTANTS.getMaxInputsPerPegoutTransaction();
+            int numberOfUtxos = maxInputs + 1;
+            List<UTXO> retiringUtxos = UTXOBuilder.builder()
+                .withValue(Coin.COIN)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .buildMany(numberOfUtxos, i -> createHash(i + 1));
+
+            long executionBlockNumber = pastMigrationBlockNumber(PRE_RSKIP294_ACTIVATIONS);
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber, PRE_RSKIP294_ACTIVATIONS);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertOneMigrationTransactionWasBuiltAsExpected(
+                retiringFederation,
+                retiringUtxos,
+                numberOfUtxos,
+                migrationTxInputsAssertion,
+                BTC_TX_VERSION_1
+            );
+            assertRetiringFederationCleared();
+            assertNoRemainingRetiringUtxos();
+        }
+
+        @Test
+        void updateCollections_pastMigrationAge_withMoreUtxosThanMaxInputs_shouldCreateLastMigrationTxWithMaxInputsAndClearRetiringFedEvenIfUtxosRemain() throws IOException {
+            // Arrange
+            int maxInputs = BRIDGE_CONSTANTS.getMaxInputsPerPegoutTransaction();
+            int numberOfUtxos = maxInputs + 1;
+            List<UTXO> retiringUtxos = UTXOBuilder.builder()
+                .withValue(Coin.COIN)
+                .withScriptPubKey(retiringFederation.getP2SHScript())
+                .buildMany(numberOfUtxos, i -> createHash(i + 1));
+
+            long executionBlockNumber = pastMigrationBlockNumber();
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
+
+            // Act
+            bridgeSupport.updateCollections(updateCollectionsTransaction);
+
+            // Assert
+            assertOneMigrationTransactionWasBuiltAsExpected(
+                retiringFederation,
+                retiringUtxos,
+                maxInputs,
+                migrationTxInputsAssertion,
+                BTC_TX_VERSION_2
+            );
             assertRetiringFederationCleared();
 
             int expectedRemainingUtxos = retiringUtxos.size() - maxInputs;
@@ -777,30 +1231,45 @@ class ProcessFundsMigrationTest {
         Coin feePerKb,
         long executionBlockNumber
     ) {
+        setUpBridgeAndFederationSupport(feePerKb, executionBlockNumber, ALL_ACTIVATIONS);
+    }
+
+    private void setUpBridgeAndFederationSupport(
+        Coin feePerKb,
+        long executionBlockNumber,
+        ActivationConfig.ForBlock activations
+    ) {
         Repository repository = createRepository();
-        bridgeStorageProvider = new BridgeStorageProvider(repository, NETWORK_PARAMETERS, ALL_ACTIVATIONS);
+        bridgeStorageProvider = new BridgeStorageProvider(repository, NETWORK_PARAMETERS, activations);
         bridgeStorageAccessor = new InMemoryStorage();
         setUpFeePerKb(feePerKb);
         federationStorageProvider = new FederationStorageProviderImpl(bridgeStorageAccessor);
 
-        setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
+        setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber, activations);
     }
 
     private void setUpBridgeAndFederationSupportForExecutionBlock(long executionBlockNumber) {
+        setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber, ALL_ACTIVATIONS);
+    }
+
+    private void setUpBridgeAndFederationSupportForExecutionBlock(
+        long executionBlockNumber,
+        ActivationConfig.ForBlock activations
+    ) {
         org.ethereum.core.Block executionBlock = new BlockGenerator().createBlock(executionBlockNumber, 1);
 
         federationSupport = FederationSupportBuilder.builder()
-            .withFederationConstants(BRIDGE_CONSTANTS.getFederationConstants())
+            .withFederationConstants(FEDERATION_CONSTANTS)
             .withFederationStorageProvider(federationStorageProvider)
             .withRskExecutionBlock(executionBlock)
-            .withActivations(ALL_ACTIVATIONS)
+            .withActivations(activations)
             .build();
 
         bridgeSupport = BridgeSupportBuilder.builder()
             .withBridgeConstants(BRIDGE_CONSTANTS)
             .withProvider(bridgeStorageProvider)
             .withExecutionBlock(executionBlock)
-            .withActivations(ALL_ACTIVATIONS)
+            .withActivations(activations)
             .withFederationSupport(federationSupport)
             .withFeePerKbSupport(feePerKbSupport)
             .build();
@@ -832,20 +1301,32 @@ class ProcessFundsMigrationTest {
     }
 
     private long blockNumberBeforeMigrationBegins() {
-        long activationAge = BRIDGE_CONSTANTS.getFederationConstants().getFederationActivationAge(ALL_ACTIVATIONS);
+        return blockNumberBeforeMigrationBegins(ALL_ACTIVATIONS);
+    }
+
+    private long blockNumberBeforeMigrationBegins(ActivationConfig.ForBlock activations) {
+        long activationAge = FEDERATION_CONSTANTS.getFederationActivationAge(activations);
         return ACTIVE_FEDERATION_CREATION_BLOCK +
             activationAge +
-            BRIDGE_CONSTANTS.getFederationConstants().getFundsMigrationAgeSinceActivationBegin();
+            FEDERATION_CONSTANTS.getFundsMigrationAgeSinceActivationBegin();
     }
 
     private long duringMigrationBlockNumber() {
         return blockNumberBeforeMigrationBegins() + 1;
     }
 
+    private long duringMigrationBlockNumberPreRSKIP294() {
+        return blockNumberBeforeMigrationBegins(PRE_RSKIP294_ACTIVATIONS) + 1;
+    }
+
     private long pastMigrationBlockNumber() {
-        long migrationPeriodDuration = BRIDGE_CONSTANTS.getFederationConstants().getFundsMigrationAgeSinceActivationEnd(ALL_ACTIVATIONS) -
-            BRIDGE_CONSTANTS.getFederationConstants().getFundsMigrationAgeSinceActivationBegin();
-        return blockNumberBeforeMigrationBegins() + migrationPeriodDuration;
+        return pastMigrationBlockNumber(ALL_ACTIVATIONS);
+    }
+
+    private long pastMigrationBlockNumber(ActivationConfig.ForBlock activations) {
+        long migrationPeriodDuration = FEDERATION_CONSTANTS.getFundsMigrationAgeSinceActivationEnd(activations) -
+            FEDERATION_CONSTANTS.getFundsMigrationAgeSinceActivationBegin();
+        return blockNumberBeforeMigrationBegins(activations) + migrationPeriodDuration;
     }
 
     private void assertNoMigrationTxCreated() throws IOException {
@@ -856,7 +1337,8 @@ class ProcessFundsMigrationTest {
         Federation retiringFederation,
         List<UTXO> retiringFederationUtxos,
         int expectedInputCount,
-        MigrationTxInputsAssertion migrationTxInputsAssertion
+        MigrationTxInputsAssertion migrationTxInputsAssertion,
+        int expectedBtcTxVersion
     ) throws IOException {
         assertMigrationTxCount(1);
         BtcTransaction migrationTransaction = bridgeStorageProvider.getPegoutsWaitingForConfirmations()
@@ -870,6 +1352,7 @@ class ProcessFundsMigrationTest {
             retiringFederation,
             retiringFederationUtxos,
             expectedInputCount,
+            expectedBtcTxVersion,
             migrationTxInputsAssertion
         );
     }
@@ -905,6 +1388,7 @@ class ProcessFundsMigrationTest {
                 retiringFederation,
                 retiringFederationUtxos,
                 expectedInputCount,
+                BTC_TX_VERSION_2,
                 migrationTxInputsAssertion
             );
             remainingRetiringFederationUtxos -= expectedInputCount;
@@ -916,11 +1400,12 @@ class ProcessFundsMigrationTest {
         Federation retiringFederation,
         List<UTXO> retiringFederationUtxos,
         int expectedInputCount,
+        int expectedBtcTxVersion,
         MigrationTxInputsAssertion migrationTxInputsAssertion
     ) {
-        List<UTXO> selectedUtxos = getSelectedUtxos(migrationTransaction, retiringFederationUtxos);
+        assertEquals(expectedBtcTxVersion, migrationTransaction.getVersion());
 
-        assertBtcTxVersionIs2(migrationTransaction);
+        List<UTXO> selectedUtxos = getSelectedUtxos(migrationTransaction, retiringFederationUtxos);
         migrationTxInputsAssertion.assertInputs(
             migrationTransaction,
             retiringFederation,

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -1238,9 +1238,7 @@ class ProcessFundsMigrationTest {
             return blockNumberBeforeMigrationBegins(IRIS_ACTIVATIONS) + 1;
         }
 
-        private void setUpBridgeAndFederationSupportForIRIS(
-            long executionBlockNumber
-            ) {
+        private void setUpBridgeAndFederationSupportForIRIS(long executionBlockNumber) {
             bridgeStorageProvider = new BridgeStorageProvider(repository, NETWORK_PARAMETERS, IRIS_ACTIVATIONS);
             setUpFeePerKb(FEE_PER_KB);
             federationStorageProvider = new FederationStorageProviderImpl(bridgeStorageAccessor);

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -116,7 +116,7 @@ class ProcessFundsMigrationTest {
         @Test
         void updateCollections_withNoRetiringFederation_shouldNotCreateMigrationTx() throws IOException {
             // Arrange
-            setUpBridgeAndFederationSupport(ACTIVE_FEDERATION_CREATION_BLOCK + 1);
+            setUpBridgeAndFederationSupportForExecutionBlock(ACTIVE_FEDERATION_CREATION_BLOCK + 1);
             setUpActiveFederation(activeFederation);
 
             // Act
@@ -137,7 +137,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = blockNumberBeforeMigrationBegins();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -160,7 +160,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -188,7 +188,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -216,7 +216,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act & Assert
@@ -239,7 +239,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -262,7 +262,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -283,7 +283,7 @@ class ProcessFundsMigrationTest {
 
             // Act
             long secondExecutionBlockNumber = executionBlockNumber + 1;
-            setUpBridgeAndFederationSupport(secondExecutionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(secondExecutionBlockNumber);
             Transaction secondUpdateCollectionsTransaction = buildUpdateCollectionsTransaction(1);
             bridgeSupport.updateCollections(secondUpdateCollectionsTransaction);
 
@@ -304,7 +304,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -332,7 +332,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -361,7 +361,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -385,7 +385,7 @@ class ProcessFundsMigrationTest {
         void updateCollections_pastMigrationAge_withZeroBalance_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
             // Arrange
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, List.of());
 
             // Act
@@ -408,7 +408,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -430,7 +430,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -454,7 +454,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -495,7 +495,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = blockNumberBeforeMigrationBegins();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -518,7 +518,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -546,7 +546,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -574,7 +574,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act & Assert
@@ -597,7 +597,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -620,7 +620,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -641,7 +641,7 @@ class ProcessFundsMigrationTest {
 
             // Act
             long secondExecutionBlockNumber = executionBlockNumber + 1;
-            setUpBridgeAndFederationSupport(secondExecutionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(secondExecutionBlockNumber);
             Transaction secondUpdateCollectionsTransaction = buildUpdateCollectionsTransaction(1);
             bridgeSupport.updateCollections(secondUpdateCollectionsTransaction);
 
@@ -662,7 +662,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -690,7 +690,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -719,7 +719,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -743,7 +743,7 @@ class ProcessFundsMigrationTest {
         void updateCollections_pastMigrationAge_withZeroBalance_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
             // Arrange
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, List.of());
 
             // Act
@@ -766,7 +766,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -788,7 +788,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -811,7 +811,7 @@ class ProcessFundsMigrationTest {
                 .build()
             );
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -853,7 +853,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = blockNumberBeforeMigrationBegins();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -876,7 +876,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -904,7 +904,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -932,7 +932,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act & Assert
@@ -955,7 +955,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -978,7 +978,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumberForIRIS();
-            setUpBridgeAndFederationSupportForIRIS(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlockForIRIS(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -1007,7 +1007,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -1028,7 +1028,7 @@ class ProcessFundsMigrationTest {
 
             // Act
             long secondExecutionBlockNumber = executionBlockNumber + 1;
-            setUpBridgeAndFederationSupport(secondExecutionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(secondExecutionBlockNumber);
             Transaction secondUpdateCollectionsTransaction = buildUpdateCollectionsTransaction(1);
             bridgeSupport.updateCollections(secondUpdateCollectionsTransaction);
 
@@ -1049,7 +1049,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -1077,7 +1077,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -1106,7 +1106,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = pastMigrationBlockNumber(IRIS_ACTIVATIONS);
-            setUpBridgeAndFederationSupportForIRIS(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlockForIRIS(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -1135,7 +1135,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -1159,7 +1159,7 @@ class ProcessFundsMigrationTest {
         void updateCollections_pastMigrationAge_withZeroBalance_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
             // Arrange
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, List.of());
 
             // Act
@@ -1182,7 +1182,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -1204,7 +1204,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -1228,7 +1228,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(executionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -1244,9 +1244,25 @@ class ProcessFundsMigrationTest {
             return blockNumberBeforeMigrationBegins(IRIS_ACTIVATIONS) + 1;
         }
 
-        private void setUpBridgeAndFederationSupportForIRIS(long executionBlockNumber) {
+        private void setUpBridgeAndFederationSupportForExecutionBlockForIRIS(long executionBlockNumber) {
             bridgeStorageProvider = new BridgeStorageProvider(repository, NETWORK_PARAMETERS, IRIS_ACTIVATIONS);
-            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber, IRIS_ACTIVATIONS);
+            org.ethereum.core.Block executionBlock = new BlockGenerator().createBlock(executionBlockNumber, 1);
+
+            federationSupport = FederationSupportBuilder.builder()
+                .withFederationConstants(FEDERATION_CONSTANTS)
+                .withFederationStorageProvider(federationStorageProvider)
+                .withRskExecutionBlock(executionBlock)
+                .withActivations(IRIS_ACTIVATIONS)
+                .build();
+
+            bridgeSupport = BridgeSupportBuilder.builder()
+                .withBridgeConstants(BRIDGE_CONSTANTS)
+                .withProvider(bridgeStorageProvider)
+                .withExecutionBlock(executionBlock)
+                .withActivations(IRIS_ACTIVATIONS)
+                .withFederationSupport(federationSupport)
+                .withFeePerKbSupport(feePerKbSupport)
+                .build();
         }
     }
 
@@ -1255,28 +1271,21 @@ class ProcessFundsMigrationTest {
         setUpFeePerKb(highFeePerKb);
     }
 
-    private void setUpBridgeAndFederationSupport(long executionBlockNumber) {
-        setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber, ALL_ACTIVATIONS);
-    }
-
-    private void setUpBridgeAndFederationSupportForExecutionBlock(
-        long executionBlockNumber,
-        ActivationConfig.ForBlock activations
-    ) {
+    private void setUpBridgeAndFederationSupportForExecutionBlock(long executionBlockNumber) {
         org.ethereum.core.Block executionBlock = new BlockGenerator().createBlock(executionBlockNumber, 1);
 
         federationSupport = FederationSupportBuilder.builder()
             .withFederationConstants(FEDERATION_CONSTANTS)
             .withFederationStorageProvider(federationStorageProvider)
             .withRskExecutionBlock(executionBlock)
-            .withActivations(activations)
+            .withActivations(ProcessFundsMigrationTest.ALL_ACTIVATIONS)
             .build();
 
         bridgeSupport = BridgeSupportBuilder.builder()
             .withBridgeConstants(BRIDGE_CONSTANTS)
             .withProvider(bridgeStorageProvider)
             .withExecutionBlock(executionBlock)
-            .withActivations(activations)
+            .withActivations(ProcessFundsMigrationTest.ALL_ACTIVATIONS)
             .withFederationSupport(federationSupport)
             .withFeePerKbSupport(feePerKbSupport)
             .build();

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -58,7 +58,6 @@ class ProcessFundsMigrationTest {
     private static final FederationConstants FEDERATION_CONSTANTS = BRIDGE_CONSTANTS.getFederationConstants();
     private static final NetworkParameters NETWORK_PARAMETERS = BRIDGE_CONSTANTS.getBtcParams();
     private static final ActivationConfig.ForBlock ALL_ACTIVATIONS = ActivationConfigsForTest.all().forBlock(0L);
-    private static final ActivationConfig.ForBlock PRE_RSKIP294_ACTIVATIONS = ActivationConfigsForTest.iris300().forBlock(0L);
     private static final Coin FEE_PER_KB = Coin.valueOf(8_000L);
     private static final long ACTIVE_FEDERATION_CREATION_BLOCK = 100L;
     private static final int EXPECTED_MULTIPLE_MIGRATION_TX_COUNT = 2;
@@ -814,6 +813,7 @@ class ProcessFundsMigrationTest {
     @Nested
     class StandardMultisigFederationTest {
 
+        private static final ActivationConfig.ForBlock IRIS_ACTIVATIONS = ActivationConfigsForTest.iris300().forBlock(0L);
         private final Federation retiringFederation = StandardMultiSigFederationBuilder.builder().build();
         private final Federation activeFederation = StandardMultiSigFederationBuilder.builder()
             .withCreationBlockNumber(ACTIVE_FEDERATION_CREATION_BLOCK)
@@ -964,7 +964,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumberPreRSKIP294();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber, PRE_RSKIP294_ACTIVATIONS);
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber, IRIS_ACTIVATIONS);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -1091,8 +1091,8 @@ class ProcessFundsMigrationTest {
                 .withScriptPubKey(retiringFederation.getP2SHScript())
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
-            long executionBlockNumber = pastMigrationBlockNumber(PRE_RSKIP294_ACTIVATIONS);
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber, PRE_RSKIP294_ACTIVATIONS);
+            long executionBlockNumber = pastMigrationBlockNumber(IRIS_ACTIVATIONS);
+            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber, IRIS_ACTIVATIONS);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -1225,6 +1225,10 @@ class ProcessFundsMigrationTest {
             assertRetiringFederationCleared();
             assertRetiringUtxosCount(retiringUtxos.size());
         }
+
+        private long duringMigrationBlockNumberPreRSKIP294() {
+            return blockNumberBeforeMigrationBegins(IRIS_ACTIVATIONS) + 1;
+        }
     }
 
     private void setUpBridgeAndFederationSupport(
@@ -1313,10 +1317,6 @@ class ProcessFundsMigrationTest {
 
     private long duringMigrationBlockNumber() {
         return blockNumberBeforeMigrationBegins() + 1;
-    }
-
-    private long duringMigrationBlockNumberPreRSKIP294() {
-        return blockNumberBeforeMigrationBegins(PRE_RSKIP294_ACTIVATIONS) + 1;
     }
 
     private long pastMigrationBlockNumber() {

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -88,6 +88,12 @@ class ProcessFundsMigrationTest {
         repository = createRepository();
         bridgeStorageProvider = new BridgeStorageProvider(repository, NETWORK_PARAMETERS, ALL_ACTIVATIONS);
         bridgeStorageAccessor = new InMemoryStorage();
+        federationStorageProvider = new FederationStorageProviderImpl(bridgeStorageAccessor);
+
+        FeePerKbStorageProvider feePerKbStorageProvider = new FeePerKbStorageProviderImpl(bridgeStorageAccessor);
+        FeePerKbConstants feePerKbConstants = BRIDGE_CONSTANTS.getFeePerKbConstants();
+        feePerKbSupport = new FeePerKbSupportImpl(feePerKbConstants, feePerKbStorageProvider);
+        setUpFeePerKb(FEE_PER_KB);
     }
 
     @Nested
@@ -110,7 +116,7 @@ class ProcessFundsMigrationTest {
         @Test
         void updateCollections_withNoRetiringFederation_shouldNotCreateMigrationTx() throws IOException {
             // Arrange
-            setUpBridgeAndFederationSupport(FEE_PER_KB, ACTIVE_FEDERATION_CREATION_BLOCK + 1);
+            setUpBridgeAndFederationSupport(ACTIVE_FEDERATION_CREATION_BLOCK + 1);
             setUpActiveFederation(activeFederation);
 
             // Act
@@ -131,7 +137,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = blockNumberBeforeMigrationBegins();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -154,7 +160,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -182,7 +188,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -210,7 +216,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act & Assert
@@ -233,7 +239,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -256,7 +262,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -277,7 +283,7 @@ class ProcessFundsMigrationTest {
 
             // Act
             long secondExecutionBlockNumber = executionBlockNumber + 1;
-            setUpBridgeAndFederationSupportForExecutionBlock(secondExecutionBlockNumber, ALL_ACTIVATIONS);
+            setUpBridgeAndFederationSupport(secondExecutionBlockNumber);
             Transaction secondUpdateCollectionsTransaction = buildUpdateCollectionsTransaction(1);
             bridgeSupport.updateCollections(secondUpdateCollectionsTransaction);
 
@@ -298,7 +304,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -326,7 +332,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -355,7 +361,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -379,7 +385,7 @@ class ProcessFundsMigrationTest {
         void updateCollections_pastMigrationAge_withZeroBalance_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
             // Arrange
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, List.of());
 
             // Act
@@ -402,7 +408,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -424,7 +430,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -448,7 +454,8 @@ class ProcessFundsMigrationTest {
 
             Coin highFeePerKb = Coin.COIN.multiply(2);
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(highFeePerKb, executionBlockNumber);
+            setUpFeePerKb(highFeePerKb);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -489,7 +496,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = blockNumberBeforeMigrationBegins();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -512,7 +519,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -540,7 +547,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -568,7 +575,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act & Assert
@@ -591,7 +598,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -614,7 +621,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -635,7 +642,7 @@ class ProcessFundsMigrationTest {
 
             // Act
             long secondExecutionBlockNumber = executionBlockNumber + 1;
-            setUpBridgeAndFederationSupportForExecutionBlock(secondExecutionBlockNumber, ALL_ACTIVATIONS);
+            setUpBridgeAndFederationSupport(secondExecutionBlockNumber);
             Transaction secondUpdateCollectionsTransaction = buildUpdateCollectionsTransaction(1);
             bridgeSupport.updateCollections(secondUpdateCollectionsTransaction);
 
@@ -656,7 +663,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -684,7 +691,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -713,7 +720,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -737,7 +744,7 @@ class ProcessFundsMigrationTest {
         void updateCollections_pastMigrationAge_withZeroBalance_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
             // Arrange
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, List.of());
 
             // Act
@@ -760,7 +767,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -782,7 +789,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -806,7 +813,8 @@ class ProcessFundsMigrationTest {
 
             Coin highFeePerKb = Coin.COIN.multiply(2);
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(highFeePerKb, executionBlockNumber);
+            setUpFeePerKb(highFeePerKb);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -848,7 +856,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = blockNumberBeforeMigrationBegins();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -871,7 +879,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -899,7 +907,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -927,7 +935,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act & Assert
@@ -950,7 +958,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -1002,7 +1010,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = duringMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -1023,7 +1031,7 @@ class ProcessFundsMigrationTest {
 
             // Act
             long secondExecutionBlockNumber = executionBlockNumber + 1;
-            setUpBridgeAndFederationSupportForExecutionBlock(secondExecutionBlockNumber, ALL_ACTIVATIONS);
+            setUpBridgeAndFederationSupport(secondExecutionBlockNumber);
             Transaction secondUpdateCollectionsTransaction = buildUpdateCollectionsTransaction(1);
             bridgeSupport.updateCollections(secondUpdateCollectionsTransaction);
 
@@ -1044,7 +1052,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -1072,7 +1080,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -1130,7 +1138,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -1154,7 +1162,7 @@ class ProcessFundsMigrationTest {
         void updateCollections_pastMigrationAge_withZeroBalance_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
             // Arrange
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, List.of());
 
             // Act
@@ -1177,7 +1185,7 @@ class ProcessFundsMigrationTest {
             );
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -1199,7 +1207,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -1223,7 +1231,8 @@ class ProcessFundsMigrationTest {
 
             Coin highFeePerKb = Coin.COIN.multiply(2);
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpBridgeAndFederationSupport(highFeePerKb, executionBlockNumber);
+            setUpFeePerKb(highFeePerKb);
+            setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -1241,18 +1250,11 @@ class ProcessFundsMigrationTest {
 
         private void setUpBridgeAndFederationSupportForIRIS(long executionBlockNumber) {
             bridgeStorageProvider = new BridgeStorageProvider(repository, NETWORK_PARAMETERS, IRIS_ACTIVATIONS);
-            setUpFeePerKb(FEE_PER_KB);
-            federationStorageProvider = new FederationStorageProviderImpl(bridgeStorageAccessor);
             setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber, IRIS_ACTIVATIONS);
         }
     }
 
-    private void setUpBridgeAndFederationSupport(
-        Coin feePerKb,
-        long executionBlockNumber
-    ) {
-        setUpFeePerKb(feePerKb);
-        federationStorageProvider = new FederationStorageProviderImpl(bridgeStorageAccessor);
+    private void setUpBridgeAndFederationSupport(long executionBlockNumber) {
         setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber, ALL_ACTIVATIONS);
     }
 
@@ -1281,9 +1283,6 @@ class ProcessFundsMigrationTest {
 
     private void setUpFeePerKb(Coin feePerKb) {
         bridgeStorageAccessor.saveToRepository(FeePerKbStorageIndexKey.FEE_PER_KB.getKey(), feePerKb, BridgeSerializationUtils::serializeCoin);
-        FeePerKbConstants feePerKbConstants = BRIDGE_CONSTANTS.getFeePerKbConstants();
-        FeePerKbStorageProvider feePerKbStorageProvider = new FeePerKbStorageProviderImpl(bridgeStorageAccessor);
-        feePerKbSupport = new FeePerKbSupportImpl(feePerKbConstants, feePerKbStorageProvider);
     }
 
     private void setUpActiveFederation(Federation activeFederation) {

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -63,7 +63,6 @@ class ProcessFundsMigrationTest {
     private static final long ACTIVE_FEDERATION_CREATION_BLOCK = 100L;
     private static final int EXPECTED_MULTIPLE_MIGRATION_TX_COUNT = 2;
     private final Transaction updateCollectionsTransaction = buildUpdateCollectionsTransaction();
-    private final Repository repository = createRepository();
 
     private StorageAccessor bridgeStorageAccessor;
     private BridgeStorageProvider bridgeStorageProvider;
@@ -71,6 +70,7 @@ class ProcessFundsMigrationTest {
     private FederationSupport federationSupport;
     private BridgeSupport bridgeSupport;
     private FeePerKbSupport feePerKbSupport;
+    private Repository repository;
 
     @FunctionalInterface
     private interface MigrationTxInputsAssertion {
@@ -85,6 +85,7 @@ class ProcessFundsMigrationTest {
 
     @BeforeEach
     void setUp() {
+        repository = createRepository();
         bridgeStorageProvider = new BridgeStorageProvider(repository, NETWORK_PARAMETERS, ALL_ACTIVATIONS);
         bridgeStorageAccessor = new InMemoryStorage();
     }

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -49,6 +49,7 @@ import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -62,6 +63,7 @@ class ProcessFundsMigrationTest {
     private static final long ACTIVE_FEDERATION_CREATION_BLOCK = 100L;
     private static final int EXPECTED_MULTIPLE_MIGRATION_TX_COUNT = 2;
     private final Transaction updateCollectionsTransaction = buildUpdateCollectionsTransaction();
+    private final Repository repository = createRepository();
 
     private StorageAccessor bridgeStorageAccessor;
     private BridgeStorageProvider bridgeStorageProvider;
@@ -79,6 +81,12 @@ class ProcessFundsMigrationTest {
             List<UTXO> selectedUtxos,
             int expectedInputCount
         );
+    }
+
+    @BeforeEach
+    void setUp() {
+        bridgeStorageProvider = new BridgeStorageProvider(repository, NETWORK_PARAMETERS, ALL_ACTIVATIONS);
+        bridgeStorageAccessor = new InMemoryStorage();
     }
 
     @Nested
@@ -268,7 +276,7 @@ class ProcessFundsMigrationTest {
 
             // Act
             long secondExecutionBlockNumber = executionBlockNumber + 1;
-            setUpBridgeAndFederationSupportForExecutionBlock(secondExecutionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(secondExecutionBlockNumber, ALL_ACTIVATIONS);
             Transaction secondUpdateCollectionsTransaction = buildUpdateCollectionsTransaction(1);
             bridgeSupport.updateCollections(secondUpdateCollectionsTransaction);
 
@@ -626,7 +634,7 @@ class ProcessFundsMigrationTest {
 
             // Act
             long secondExecutionBlockNumber = executionBlockNumber + 1;
-            setUpBridgeAndFederationSupportForExecutionBlock(secondExecutionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(secondExecutionBlockNumber, ALL_ACTIVATIONS);
             Transaction secondUpdateCollectionsTransaction = buildUpdateCollectionsTransaction(1);
             bridgeSupport.updateCollections(secondUpdateCollectionsTransaction);
 
@@ -963,8 +971,8 @@ class ProcessFundsMigrationTest {
                 .withScriptPubKey(retiringFederation.getP2SHScript())
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
-            long executionBlockNumber = duringMigrationBlockNumberPreRSKIP294();
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber, IRIS_ACTIVATIONS);
+            long executionBlockNumber = duringMigrationBlockNumberForIRIS();
+            setUpBridgeAndFederationSupportForIRIS(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -1014,7 +1022,7 @@ class ProcessFundsMigrationTest {
 
             // Act
             long secondExecutionBlockNumber = executionBlockNumber + 1;
-            setUpBridgeAndFederationSupportForExecutionBlock(secondExecutionBlockNumber);
+            setUpBridgeAndFederationSupportForExecutionBlock(secondExecutionBlockNumber, ALL_ACTIVATIONS);
             Transaction secondUpdateCollectionsTransaction = buildUpdateCollectionsTransaction(1);
             bridgeSupport.updateCollections(secondUpdateCollectionsTransaction);
 
@@ -1092,7 +1100,7 @@ class ProcessFundsMigrationTest {
                 .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
             long executionBlockNumber = pastMigrationBlockNumber(IRIS_ACTIVATIONS);
-            setUpBridgeAndFederationSupport(FEE_PER_KB, executionBlockNumber, IRIS_ACTIVATIONS);
+            setUpBridgeAndFederationSupportForIRIS(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
             // Act
@@ -1226,8 +1234,17 @@ class ProcessFundsMigrationTest {
             assertRetiringUtxosCount(retiringUtxos.size());
         }
 
-        private long duringMigrationBlockNumberPreRSKIP294() {
+        private long duringMigrationBlockNumberForIRIS() {
             return blockNumberBeforeMigrationBegins(IRIS_ACTIVATIONS) + 1;
+        }
+
+        private void setUpBridgeAndFederationSupportForIRIS(
+            long executionBlockNumber
+            ) {
+            bridgeStorageProvider = new BridgeStorageProvider(repository, NETWORK_PARAMETERS, IRIS_ACTIVATIONS);
+            setUpFeePerKb(FEE_PER_KB);
+            federationStorageProvider = new FederationStorageProviderImpl(bridgeStorageAccessor);
+            setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber, IRIS_ACTIVATIONS);
         }
     }
 
@@ -1235,24 +1252,8 @@ class ProcessFundsMigrationTest {
         Coin feePerKb,
         long executionBlockNumber
     ) {
-        setUpBridgeAndFederationSupport(feePerKb, executionBlockNumber, ALL_ACTIVATIONS);
-    }
-
-    private void setUpBridgeAndFederationSupport(
-        Coin feePerKb,
-        long executionBlockNumber,
-        ActivationConfig.ForBlock activations
-    ) {
-        Repository repository = createRepository();
-        bridgeStorageProvider = new BridgeStorageProvider(repository, NETWORK_PARAMETERS, activations);
-        bridgeStorageAccessor = new InMemoryStorage();
         setUpFeePerKb(feePerKb);
         federationStorageProvider = new FederationStorageProviderImpl(bridgeStorageAccessor);
-
-        setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber, activations);
-    }
-
-    private void setUpBridgeAndFederationSupportForExecutionBlock(long executionBlockNumber) {
         setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber, ALL_ACTIVATIONS);
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -1082,7 +1082,7 @@ class ProcessFundsMigrationTest {
         }
 
         @Test
-        void updateCollections_pastMigrationAge_preRSKIP294_withMoreUtxosThanMaxInputs_shouldCreateLastMigrationTxAndClearRetiringFedEvenIfUtxosRemain() throws IOException {
+        void updateCollections_pastMigrationAge_preRSKIP294_withMoreUtxosThanMaxInputs_shouldUseAllRetiringUtxos() throws IOException {
             // Arrange
             int maxInputs = BRIDGE_CONSTANTS.getMaxInputsPerPegoutTransaction();
             int numberOfUtxos = maxInputs + 1;

--- a/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ProcessFundsMigrationTest.java
@@ -445,6 +445,7 @@ class ProcessFundsMigrationTest {
         @Test
         void updateCollections_pastMigrationAge_withHighFees_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
             // Arrange
+            setUpHighFeePerKb();
             List<UTXO> retiringUtxos = List.of(
                 UTXOBuilder.builder()
                 .withValue(Coin.COIN)
@@ -452,9 +453,7 @@ class ProcessFundsMigrationTest {
                 .build()
             );
 
-            Coin highFeePerKb = Coin.COIN.multiply(2);
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpFeePerKb(highFeePerKb);
             setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
@@ -804,16 +803,14 @@ class ProcessFundsMigrationTest {
         @Test
         void updateCollections_pastMigrationAge_withHighFees_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
             // Arrange
+            setUpHighFeePerKb();
             List<UTXO> retiringUtxos = List.of(
                 UTXOBuilder.builder()
                 .withValue(Coin.COIN)
                 .withScriptPubKey(retiringFederation.getP2SHScript())
                 .build()
             );
-
-            Coin highFeePerKb = Coin.COIN.multiply(2);
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpFeePerKb(highFeePerKb);
             setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
@@ -1222,6 +1219,7 @@ class ProcessFundsMigrationTest {
         @Test
         void updateCollections_pastMigrationAge_withHighFees_shouldClearRetiringFedWithoutMigrationTx() throws IOException {
             // Arrange
+            setUpHighFeePerKb();
             List<UTXO> retiringUtxos = List.of(
                 UTXOBuilder.builder()
                 .withValue(Coin.COIN)
@@ -1229,9 +1227,7 @@ class ProcessFundsMigrationTest {
                 .build()
             );
 
-            Coin highFeePerKb = Coin.COIN.multiply(2);
             long executionBlockNumber = pastMigrationBlockNumber();
-            setUpFeePerKb(highFeePerKb);
             setUpBridgeAndFederationSupport(executionBlockNumber);
             setUpActiveAndRetiringFederations(activeFederation, retiringFederation, retiringUtxos);
 
@@ -1252,6 +1248,11 @@ class ProcessFundsMigrationTest {
             bridgeStorageProvider = new BridgeStorageProvider(repository, NETWORK_PARAMETERS, IRIS_ACTIVATIONS);
             setUpBridgeAndFederationSupportForExecutionBlock(executionBlockNumber, IRIS_ACTIVATIONS);
         }
+    }
+
+    private void setUpHighFeePerKb() {
+        Coin highFeePerKb = Coin.COIN.multiply(2);
+        setUpFeePerKb(highFeePerKb);
     }
 
     private void setUpBridgeAndFederationSupport(long executionBlockNumber) {

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionAssertions.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionAssertions.java
@@ -18,8 +18,13 @@ import co.rsk.bitcoinj.core.TransactionOutput;
 import co.rsk.bitcoinj.core.TransactionWitness;
 import co.rsk.bitcoinj.core.UTXO;
 import co.rsk.bitcoinj.script.Script;
+
 import java.util.List;
 import java.util.function.Predicate;
+
+import static co.rsk.peg.bitcoin.BitcoinTestAssertions.assertP2shP2wshWitnessWithoutSignaturesHasProperFormat;
+import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ReleaseTransactionAssertions {
 

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionAssertions.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionAssertions.java
@@ -18,13 +18,8 @@ import co.rsk.bitcoinj.core.TransactionOutput;
 import co.rsk.bitcoinj.core.TransactionWitness;
 import co.rsk.bitcoinj.core.UTXO;
 import co.rsk.bitcoinj.script.Script;
-
 import java.util.List;
 import java.util.function.Predicate;
-
-import static co.rsk.peg.bitcoin.BitcoinTestAssertions.assertP2shP2wshWitnessWithoutSignaturesHasProperFormat;
-import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ReleaseTransactionAssertions {
 


### PR DESCRIPTION
## Description
Adds and expands `ProcessFundsMigrationTest` coverage for `BridgeSupport.updateCollections` `processFundsMigration` by adding a Standard multisig fed

The new tests cover migration behavior across federation types:
- Standard multisig federations

The suite validates behavior before migration starts, during migration, and after the migration age has passed, including no migration before the window, successful migrations, failed migration attempts, repeated calls when UTXOs exceed max inputs, final cleanup, and pre-RSKIP294 standard multisig behavior.

## Motivation and Context
`processFundsMigration` has several behavior branches depending on migration age, federation type, UTXO shape, transaction buildability, and active RSKIPs.

These tests make that behavior explicit and easier to maintain, especially around RSKIP294 max-input behavior, pre-RSKIP294 standard multisig behavior, final migration cleanup, and migration transaction format by federation type.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [] Tests for the changes have been added (for bug fixes / features)
- [] Requires Activation Code (Hard Fork)

* **Other information**:
It adds coverage for migration behavior affected by hard fork activations, especially RSKIP294 and pre-RSKIP294 standard multisig behavior.