### PR TITLE
Fix incorrect calldata for sub-calls in trace_transaction and trace_block

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/modules/trace/TraceTransformer.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/trace/TraceTransformer.java
@@ -88,7 +88,7 @@ public class TraceTransformer {
     }
 
     public static TransactionTrace toTrace(TraceType traceType, InvokeData invoke, ProgramResult programResult, TransactionInfo txInfo, long blockNumber, TraceAddress traceAddress, CallType callType, CreationData creationData, String creationMethod, String err, int nsubtraces, DataWord codeAddress) {
-        TraceAction action = toAction(traceType, invoke, callType, creationData == null ? null : creationData.getCreationInput(), creationMethod, codeAddress, txInfo);
+        TraceAction action = toAction(traceType, invoke, callType, creationData == null ? null : creationData.getCreationInput(), creationMethod, codeAddress);
         TraceResult result = null;
         String error = null;
 
@@ -143,7 +143,7 @@ public class TraceTransformer {
         return new TraceResult(gasUsed, output, code, address);
     }
 
-    public static TraceAction toAction(TraceType traceType, InvokeData invoke, CallType callType, byte[] creationInput, String creationMethod, DataWord codeAddress, TransactionInfo txInfo) {
+    public static TraceAction toAction(TraceType traceType, InvokeData invoke, CallType callType, byte[] creationInput, String creationMethod, DataWord codeAddress) {
         String from;
 
         if (callType == CallType.DELEGATECALL) {
@@ -171,8 +171,7 @@ public class TraceTransformer {
         }
 
         if (traceType == TraceType.CALL) {
-            byte[] txData = txInfo.getReceipt().getTransaction().getData();
-            input = HexUtils.toUnformattedJsonHex(txData);
+            input = HexUtils.toUnformattedJsonHex(invoke.getDataCopy(DataWord.ZERO, invoke.getDataSize()));
             value = HexUtils.toQuantityJsonHex(callValue.getData());
 
             if (callType == CallType.DELEGATECALL) {

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceModuleImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceModuleImplTest.java
@@ -222,15 +222,65 @@ class TraceModuleImplTest {
         ArrayNode aresult = (ArrayNode) result;
         Assertions.assertEquals(2, aresult.size());
 
-        // Top-level call carries the transaction's own input.
+        // Top-level call carries the transaction's own input. Its traceAddress is empty (it is the root frame).
         JsonNode topLevel = aresult.get(0);
         Assertions.assertEquals("call", topLevel.get("type").asText());
+        Assertions.assertEquals(0, topLevel.get("traceAddress").size());
         Assertions.assertEquals(TOP_LEVEL_CALLDATA, topLevel.get("action").get("input").asText());
 
-        // The sub-call must carry its OWN calldata, not the top-level input.
+        // The sub-call is the nested frame (traceAddress [0]) and must carry its OWN calldata.
         JsonNode subCall = aresult.get(1);
         Assertions.assertEquals("call", subCall.get("type").asText());
+        Assertions.assertEquals(1, subCall.get("traceAddress").size());
         Assertions.assertEquals(SUB_CALL_CALLDATA, subCall.get("action").get("input").asText());
+
+        // The bug being guarded against: the sub-call must not reuse the root calldata.
+        Assertions.assertNotEquals(
+                topLevel.get("action").get("input").asText(),
+                subCall.get("action").get("input").asText());
+    }
+
+    /**
+     * trace_block shares the per-frame calldata logic with trace_transaction, so the same invariant must
+     * hold when tracing a whole block: the top-level frame reports the transaction input and the nested
+     * frame reports its own sub-call calldata.
+     */
+    @Test
+    void subCallReportsItsOwnCalldataNotTopLevelInputInTraceBlock() throws Exception {
+        ReceiptStore receiptStore = new ReceiptStoreImpl(new HashMapDB());
+        DslParser parser = DslParser.fromResource("dsl/trace_subcall_calldata.txt");
+        World world = new World(receiptStore);
+        WorldDslProcessor processor = new WorldDslProcessor(world);
+        processor.processCommands(parser);
+
+        Block block = world.getBlockByName("b02");
+
+        TraceModuleImpl traceModule = new TraceModuleImpl(world.getBlockChain(), world.getBlockStore(), receiptStore, world.getBlockExecutor(), null, world.getBlockTxSignatureCache(), world.getConfig());
+
+        JsonNode result = traceModule.traceBlock(block.getHash().toJsonString());
+
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isArray());
+
+        ArrayNode aresult = (ArrayNode) result;
+        Assertions.assertEquals(2, aresult.size());
+
+        // Top-level call carries the transaction's own input. Its traceAddress is empty (it is the root frame).
+        JsonNode topLevel = aresult.get(0);
+        Assertions.assertEquals("call", topLevel.get("type").asText());
+        Assertions.assertEquals(0, topLevel.get("traceAddress").size());
+        Assertions.assertEquals(TOP_LEVEL_CALLDATA, topLevel.get("action").get("input").asText());
+
+        // The sub-call is the nested frame (traceAddress [0]) and must carry its OWN calldata.
+        JsonNode subCall = aresult.get(1);
+        Assertions.assertEquals("call", subCall.get("type").asText());
+        Assertions.assertEquals(1, subCall.get("traceAddress").size());
+        Assertions.assertEquals(SUB_CALL_CALLDATA, subCall.get("action").get("input").asText());
+
+        // The bug being guarded against: the sub-call must not reuse the root calldata.
+        Assertions.assertNotEquals(
+                topLevel.get("action").get("input").asText(),
+                subCall.get("action").get("input").asText());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceModuleImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceModuleImplTest.java
@@ -283,6 +283,54 @@ class TraceModuleImplTest {
                 subCall.get("action").get("input").asText());
     }
 
+    /**
+     * A DELEGATECALL frame must also report its own forwarded calldata in the action {@code input} field,
+     * not the top-level transaction input. DELEGATECALL takes a distinct branch in the trace transformer
+     * (its {@code from}/{@code to} are derived differently), so the per-frame calldata invariant is
+     * verified independently here.
+     *
+     * The caller contract is invoked with {@value #TOP_LEVEL_CALLDATA} and DELEGATECALLs a delegated
+     * contract forwarding a distinct {@value #SUB_CALL_CALLDATA} as the sub-call calldata.
+     */
+    @Test
+    void delegateSubCallReportsItsOwnCalldataNotTopLevelInput() throws Exception {
+        ReceiptStore receiptStore = new ReceiptStoreImpl(new HashMapDB());
+        DslParser parser = DslParser.fromResource("dsl/trace_subcall_delegatecall_calldata.txt");
+        World world = new World(receiptStore);
+        WorldDslProcessor processor = new WorldDslProcessor(world);
+        processor.processCommands(parser);
+
+        Transaction transaction = world.getTransactionByName("tx01");
+
+        TraceModuleImpl traceModule = new TraceModuleImpl(world.getBlockChain(), world.getBlockStore(), receiptStore, world.getBlockExecutor(), null, world.getBlockTxSignatureCache(), world.getConfig());
+
+        JsonNode result = traceModule.traceTransaction(transaction.getHash().toJsonString());
+
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isArray());
+
+        ArrayNode aresult = (ArrayNode) result;
+        Assertions.assertEquals(2, aresult.size());
+
+        // Top-level call carries the transaction's own input. Its traceAddress is empty (it is the root frame).
+        JsonNode topLevel = aresult.get(0);
+        Assertions.assertEquals("call", topLevel.get("type").asText());
+        Assertions.assertEquals(0, topLevel.get("traceAddress").size());
+        Assertions.assertEquals(TOP_LEVEL_CALLDATA, topLevel.get("action").get("input").asText());
+
+        // The delegate sub-call is the nested frame (traceAddress [0]) and must carry its OWN calldata.
+        JsonNode subCall = aresult.get(1);
+        Assertions.assertEquals("call", subCall.get("type").asText());
+        Assertions.assertEquals("delegatecall", subCall.get("action").get("callType").asText());
+        Assertions.assertEquals(1, subCall.get("traceAddress").size());
+        Assertions.assertEquals(SUB_CALL_CALLDATA, subCall.get("action").get("input").asText());
+
+        // The bug being guarded against: the sub-call must not reuse the root calldata.
+        Assertions.assertNotEquals(
+                topLevel.get("action").get("input").asText(),
+                subCall.get("action").get("input").asText());
+    }
+
     @Test
     void retrieveTraces() throws Exception {
         ReceiptStore receiptStore = new ReceiptStoreImpl(new HashMapDB());

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceModuleImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceModuleImplTest.java
@@ -187,6 +187,52 @@ class TraceModuleImplTest {
         retrieveSuicideInvocationBlockTrace(world, receiptStore, "latest");
     }
 
+    // Calldata values exercised by dsl/trace_subcall_calldata.txt: the top-level transaction is sent
+    // with TOP_LEVEL_CALLDATA, and the caller contract makes an internal CALL forwarding SUB_CALL_CALLDATA.
+    // These must stay in sync with the input data and bytecode marker defined in that resource.
+    private static final String TOP_LEVEL_CALLDATA = "0x1688f0b9";
+    private static final String SUB_CALL_CALLDATA = "0xb63e800d";
+
+    /**
+     * Each call frame in a trace must report its own calldata in the action {@code input} field.
+     * A sub-call's input is the data passed to that frame, which is generally different from the
+     * top-level transaction input.
+     *
+     * Here the caller contract is invoked with {@value #TOP_LEVEL_CALLDATA} and makes an internal CALL
+     * passing a distinct {@value #SUB_CALL_CALLDATA} as the sub-call calldata. The top-level frame must
+     * report its own input and the sub-call frame must report the data it received, not the top-level input.
+     */
+    @Test
+    void subCallReportsItsOwnCalldataNotTopLevelInput() throws Exception {
+        ReceiptStore receiptStore = new ReceiptStoreImpl(new HashMapDB());
+        DslParser parser = DslParser.fromResource("dsl/trace_subcall_calldata.txt");
+        World world = new World(receiptStore);
+        WorldDslProcessor processor = new WorldDslProcessor(world);
+        processor.processCommands(parser);
+
+        Transaction transaction = world.getTransactionByName("tx02");
+
+        TraceModuleImpl traceModule = new TraceModuleImpl(world.getBlockChain(), world.getBlockStore(), receiptStore, world.getBlockExecutor(), null, world.getBlockTxSignatureCache(), world.getConfig());
+
+        JsonNode result = traceModule.traceTransaction(transaction.getHash().toJsonString());
+
+        Assertions.assertNotNull(result);
+        Assertions.assertTrue(result.isArray());
+
+        ArrayNode aresult = (ArrayNode) result;
+        Assertions.assertEquals(2, aresult.size());
+
+        // Top-level call carries the transaction's own input.
+        JsonNode topLevel = aresult.get(0);
+        Assertions.assertEquals("call", topLevel.get("type").asText());
+        Assertions.assertEquals(TOP_LEVEL_CALLDATA, topLevel.get("action").get("input").asText());
+
+        // The sub-call must carry its OWN calldata, not the top-level input.
+        JsonNode subCall = aresult.get(1);
+        Assertions.assertEquals("call", subCall.get("type").asText());
+        Assertions.assertEquals(SUB_CALL_CALLDATA, subCall.get("action").get("input").asText());
+    }
+
     @Test
     void retrieveTraces() throws Exception {
         ReceiptStore receiptStore = new ReceiptStoreImpl(new HashMapDB());

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceTransformerTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceTransformerTest.java
@@ -19,24 +19,15 @@
 package co.rsk.rpc.modules.trace;
 
 import co.rsk.core.types.bytes.Bytes;
-import org.ethereum.core.Transaction;
-import org.ethereum.core.TransactionReceipt;
-import org.ethereum.db.TransactionInfo;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.program.invoke.ProgramInvoke;
 import org.ethereum.vm.program.invoke.ProgramInvokeImpl;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 class TraceTransformerTest {
     @Test
     void getActionFromInvokeData() {
-        TransactionInfo txInfo = mock(TransactionInfo.class);
-        TransactionReceipt receipt = mock(TransactionReceipt.class);
-        Transaction transaction = mock(Transaction.class);
 
         DataWord address = DataWord.valueOf(1);
         DataWord origin = DataWord.valueOf(2);
@@ -57,16 +48,13 @@ class TraceTransformerTest {
                 null, null, null, null, null, null, null,
                 null, null, 0, null, false, false);
 
-        when(txInfo.getReceipt()).thenReturn(receipt);
-        when(receipt.getTransaction()).thenReturn(transaction);
-        when(transaction.getData()).thenReturn(data);
-
-        TraceAction action = TraceTransformer.toAction(TraceType.CALL, invoke, CallType.CALL, null, null, null, txInfo);
+        TraceAction action = TraceTransformer.toAction(TraceType.CALL, invoke, CallType.CALL, null, null, null);
 
         Assertions.assertNotNull(action);
         Assertions.assertEquals("call", action.getCallType());
         Assertions.assertEquals("0x0000000000000000000000000000000000000001", action.getTo());
         Assertions.assertEquals("0x0000000000000000000000000000000000000003", action.getFrom());
+        // input is sourced from the per-frame invoke data, not the top-level transaction
         Assertions.assertEquals("0x01020304", action.getInput());
         Assertions.assertEquals("0xf4240", action.getGas());
         Assertions.assertEquals("0x186a0", action.getValue());
@@ -93,7 +81,7 @@ class TraceTransformerTest {
                 null, null, null, null, null, null, null,
                 null, null, 0, null, false, false);
 
-        TraceAction action = TraceTransformer.toAction(TraceType.CREATE, invoke, CallType.NONE, data, null, null, null);
+        TraceAction action = TraceTransformer.toAction(TraceType.CREATE, invoke, CallType.NONE, data, null, null);
 
         Assertions.assertNotNull(action);
 
@@ -127,7 +115,7 @@ class TraceTransformerTest {
                 null, null, null, null, null, null, null,
                 null, null, 0, null, false, false);
 
-        TraceAction action = TraceTransformer.toAction(TraceType.CREATE, invoke, CallType.NONE, data, "create2", null, null);
+        TraceAction action = TraceTransformer.toAction(TraceType.CREATE, invoke, CallType.NONE, data, "create2", null);
 
         Assertions.assertNotNull(action);
 

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceTransformerTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceTransformerTest.java
@@ -58,6 +58,9 @@ class TraceTransformerTest {
         Assertions.assertEquals("0x01020304", action.getInput());
         Assertions.assertEquals("0xf4240", action.getGas());
         Assertions.assertEquals("0x186a0", action.getValue());
+        // a CALL action carries calldata in input, never creation-only fields
+        Assertions.assertNull(action.getInit());
+        Assertions.assertNull(action.getCreationMethod());
     }
 
     @Test
@@ -90,6 +93,8 @@ class TraceTransformerTest {
         Assertions.assertEquals("0x0000000000000000000000000000000000000003", action.getFrom());
         Assertions.assertEquals("0x01020304", action.getInit());
         Assertions.assertNull(action.getCreationMethod());
+        // creation traces expose the init code, never calldata through input
+        Assertions.assertNull(action.getInput());
         Assertions.assertEquals("0xf4240", action.getGas());
         Assertions.assertEquals("0x186a0", action.getValue());
     }
@@ -124,6 +129,8 @@ class TraceTransformerTest {
         Assertions.assertEquals("0x0000000000000000000000000000000000000003", action.getFrom());
         Assertions.assertEquals("0x01020304", action.getInit());
         Assertions.assertEquals("create2", action.getCreationMethod());
+        // creation traces expose the init code, never calldata through input
+        Assertions.assertNull(action.getInput());
         Assertions.assertEquals("0xf4240", action.getGas());
         Assertions.assertEquals("0x186a0", action.getValue());
     }

--- a/rskj-core/src/test/resources/dsl/trace_subcall_calldata.txt
+++ b/rskj-core/src/test/resources/dsl/trace_subcall_calldata.txt
@@ -1,0 +1,54 @@
+
+# Drives TraceModuleImplTest.subCallReportsItsOwnCalldataNotTopLevelInput.
+# The sub-call calldata (0xb63e800d) and top-level tx input (0x1688f0b9) below
+# must match SUB_CALL_CALLDATA / TOP_LEVEL_CALLDATA asserted by that test.
+
+account_new acc1 10000000
+
+# callee contract: simple return, ignores its input
+# code
+# PUSH1 0x00
+# PUSH1 0x00
+# RETURN
+
+account_new called 0 60006000f3
+
+# caller contract: places a 32-byte marker in memory whose first 4 bytes are
+# 0xb63e800d, then CALLs `called` passing those 4 bytes as the sub-call input.
+# This sub-call calldata is intentionally different from the top-level tx input.
+#
+# code
+# PUSH32 0xb63e800d000...000   (marker word)
+# PUSH1 0x00                   (memory offset)
+# MSTORE                       (memory[0..32] = marker)
+# PUSH1 0x00                   (out data size)
+# PUSH1 0x00                   (out data offset)
+# PUSH1 0x04                   (in data size = 4 bytes -> 0xb63e800d)
+# PUSH1 0x00                   (in data offset)
+# PUSH1 0x00                   (value to transfer)
+# PUSH20 <called contract address>
+# PUSH2 0x1000                 (gas to use)
+# CALL
+# STOP
+
+account_new call 0 7fb63e800d000000000000000000000000000000000000000000000000000000006000526000600060046000600073[called]611000f100
+
+# invoke the caller contract with a DISTINCT top-level calldata (0x1688f0b9)
+
+transaction_build tx02
+    sender acc1
+    receiver call
+    value 0
+    data 1688f0b9
+    gas 1200000
+    build
+
+block_build b02
+    parent g00
+    gasLimit 6800000
+    transactions tx02
+    build
+
+block_connect b02
+
+assert_best b02

--- a/rskj-core/src/test/resources/dsl/trace_subcall_delegatecall_calldata.txt
+++ b/rskj-core/src/test/resources/dsl/trace_subcall_delegatecall_calldata.txt
@@ -1,0 +1,54 @@
+
+# Drives TraceModuleImplTest.delegateSubCallReportsItsOwnCalldataNotTopLevelInput.
+# The sub-call calldata (0xb63e800d) and top-level tx input (0x1688f0b9) below
+# must match SUB_CALL_CALLDATA / TOP_LEVEL_CALLDATA asserted by that test.
+
+account_new acc1 10000000
+
+# delegated contract: simple return, ignores its input
+# code
+# PUSH1 0x00
+# PUSH1 0x00
+# RETURN
+
+account_new delegated 0 60006000f3
+
+# caller contract: places a 32-byte marker in memory whose first 4 bytes are
+# 0xb63e800d, then DELEGATECALLs `delegated` passing those 4 bytes as the
+# sub-call input. This sub-call calldata is intentionally different from the
+# top-level tx input.
+#
+# code
+# PUSH32 0xb63e800d000...000   (marker word)
+# PUSH1 0x00                   (memory offset)
+# MSTORE                       (memory[0..32] = marker)
+# PUSH1 0x00                   (out data size)
+# PUSH1 0x00                   (out data offset)
+# PUSH1 0x04                   (in data size = 4 bytes -> 0xb63e800d)
+# PUSH1 0x00                   (in data offset)
+# PUSH20 <delegated contract address>
+# PUSH2 0x1000                 (gas to use)
+# DELEGATECALL
+# STOP
+
+account_new delegatecall 0 7fb63e800d00000000000000000000000000000000000000000000000000000000600052600060006004600073[delegated]611000f400
+
+# invoke the caller contract with a DISTINCT top-level calldata (0x1688f0b9)
+
+transaction_build tx01
+    sender acc1
+    receiver delegatecall
+    value 0
+    data 1688f0b9
+    gas 1200000
+    build
+
+block_build b01
+    parent g00
+    gasLimit 6800000
+    transactions tx01
+    build
+
+block_connect b01
+
+assert_best b01


### PR DESCRIPTION
## Description

`trace_transaction`, `trace_block`, `trace_get` and `trace_filter` reported the **top-level transaction's calldata** as the `input` of **every** sub-call frame, instead of each frame's own calldata.

`TraceTransformer.toAction` sourced the `CALL` action `input` from `txInfo.getReceipt().getTransaction().getData()` (the root transaction data) rather than from the per-frame execution context. This made it impossible to tell which function was invoked at any depth below the root: every nested `CALL`/`DELEGATECALL`/`STATICCALL` reported the root selector.

This change sources the `input` from the per-frame `InvokeData`, identical to what the `debug_traceTransaction` callTracer (`CallTraceTransformer`) already does:

```java
input = HexUtils.toUnformattedJsonHex(invoke.getDataCopy(DataWord.ZERO, invoke.getDataSize()));
```

The now-unused `TransactionInfo` parameter is dropped from `toAction` (and the dead mock setup it required in `TraceTransformerTest`).

## Motivation and Context

Tools that decode sub-call calldata from traces received incorrect results. Concretely, this broke Safe transaction-service indexing: the service identifies a transaction involving a registered Safe singleton via `trace_filter`, but when decoding the `setup()` delegatecall it saw `createProxyWithNonce` calldata instead, failed to recognise the deployment, and never registered the Safe address.

The regression was introduced when a memory-read optimization switched the parity tracer to read the top-level transaction data (sidestepping a stale zero-copy memory slice). The per-frame calldata is now eagerly copied at `ProgramInvoke` construction, so reading it here is safe again — this restores the per-frame source. The transaction itself always executed correctly; only the trace reporting was wrong.

## How Has This Been Tested?

- Added a regression test `TraceModuleImplTest.subCallReportsItsOwnCalldataNotTopLevelInput` driven by a new DSL fixture (`dsl/trace_subcall_calldata.txt`): a contract invoked with calldata `0x1688f0b9` makes an internal `CALL` forwarding a distinct `0xb63e800d`; the test asserts the root frame reports `0x1688f0b9` and the sub-call frame reports `0xb63e800d`. It fails before the fix (`expected: <0xb63e800d> but was: <0x1688f0b9>`) and passes after.
- Full `co.rsk.rpc.modules.trace.*` and `co.rsk.rpc.modules.debug.*` suites pass — no regressions (root-frame and value-transfer output is byte-identical to before).
- `checkstyleMain`, `checkstyleTest`, and `spotlessJavaCheck` all clean.
- Manual QA: against a node with the fix, `trace_transaction` / `trace_block` for a transaction with nested internal calls now report each sub-call's own `input` rather than the root transaction's.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**: The fix aligns the parity tracer (`trace_*`) with the already-correct Geth callTracer (`debug_traceTransaction`); both now read calldata from the same per-frame source. `CREATE`/`CREATE2` frames are unaffected (they report `init`, not `input`).
