### PR TITLE
test: RSKIP-559 deterministic pegout ordering coverage (RSKCORE-5409)

### DIFF
--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -1690,8 +1690,8 @@ class BridgeSupportReleaseBtcTest {
         Map<Keccak256, BtcTransaction> signatures = runConfirmationSelection(buildPegoutEntries(6), ACTIVATIONS_RSKIP559_OFF);
         assertEquals(1, signatures.size(), "Exactly one pegout is confirmed per updateCollections");
 
+        // To refresh the golden: temporarily print `selected`, run on Java 17, and paste it into PROCESS_CONFIRMED_OFF_GOLDEN.
         String selected = signatures.values().iterator().next().getHash().toString();
-        System.out.println("PROCESS_CONFIRMED_OFF_SELECTED=" + selected);
         assertEquals(PROCESS_CONFIRMED_OFF_GOLDEN, selected,
             "Pre-fork HashSet-order selection diverged from the Java-17 golden (Java 17/21 mismatch?)");
     }
@@ -1797,8 +1797,8 @@ class BridgeSupportReleaseBtcTest {
         // (i.e. the Java-17 HashSet emulation reproduces on Java 21).
         runConfirmationSelection(entries, ACTIVATIONS_RSKIP559_OFF);
         provider.save();
+        // To refresh the golden: temporarily print `rootOff`, run on Java 17, and paste it into PEGOUT_STATE_ROOT_OFF_GOLDEN.
         String rootOff = Hex.toHexString(repository.getRoot());
-        System.out.println("PEGOUT_STATE_ROOT_OFF=" + rootOff);
         assertEquals(PEGOUT_STATE_ROOT_OFF_GOLDEN, rootOff,
             "Pre-fork bridge storage root diverged from the Java-17 golden (Java 17/21 mismatch?)");
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -1660,6 +1660,155 @@ class BridgeSupportReleaseBtcTest {
         );
     }
 
+    // ===== RSKIP-559 (RSKCORE-5409) differential pegout-confirmation selection =====
+    // Drives the real updateCollections -> processConfirmedPegouts path with several pegouts
+    // simultaneously eligible, and checks WHICH one is moved to pegoutsWaitingForSignatures.
+
+    private static final ActivationConfig.ForBlock ACTIVATIONS_RSKIP559_OFF = ActivationConfigsForTest.vetiver900().forBlock(0L);
+    private static final ActivationConfig.ForBlock ACTIVATIONS_RSKIP559_ON = ActivationConfigsForTest.nextRelease().forBlock(0L);
+
+    // Pre-fork (HashSet-order) selection. Captured on Java 17; must reproduce on Java 21.
+    private static final String PROCESS_CONFIRMED_OFF_GOLDEN = "2b5bbcb852ee544e3a758cafb2403cda0241b110f5a486a39389cd1024f0b8eb";
+
+    @Test
+    void processConfirmedPegouts_rskip559On_selectsComparatorMinIndependentOfInsertionOrder() throws IOException {
+        List<PegoutsWaitingForConfirmations.Entry> entries = buildPegoutEntries(6);
+        Sha256Hash expected = comparatorMinBtcTxHash(entries);
+
+        List<PegoutsWaitingForConfirmations.Entry> reversed = new ArrayList<>(entries);
+        Collections.reverse(reversed);
+        for (List<PegoutsWaitingForConfirmations.Entry> order : Arrays.asList(entries, reversed)) {
+            Map<Keccak256, BtcTransaction> signatures = runConfirmationSelection(order, ACTIVATIONS_RSKIP559_ON);
+            assertEquals(1, signatures.size(), "Exactly one pegout is confirmed per updateCollections");
+            assertEquals(expected, signatures.values().iterator().next().getHash(),
+                "Post-fork must move the BTC_TX_COMPARATOR-minimum pegout to signatures, regardless of insertion order");
+        }
+    }
+
+    @Test
+    void processConfirmedPegouts_rskip559Off_selectsJava17Golden() throws IOException {
+        Map<Keccak256, BtcTransaction> signatures = runConfirmationSelection(buildPegoutEntries(6), ACTIVATIONS_RSKIP559_OFF);
+        assertEquals(1, signatures.size(), "Exactly one pegout is confirmed per updateCollections");
+
+        String selected = signatures.values().iterator().next().getHash().toString();
+        System.out.println("PROCESS_CONFIRMED_OFF_SELECTED=" + selected);
+        assertEquals(PROCESS_CONFIRMED_OFF_GOLDEN, selected,
+            "Pre-fork HashSet-order selection diverged from the Java-17 golden (Java 17/21 mismatch?)");
+    }
+
+    @Test
+    void processConfirmedPegouts_selectionFlipsAtRskip559ActivationHeight() throws IOException {
+        long activationBlock = 500L;
+        ActivationConfig config = ActivationConfigsForTest.nextReleaseWithRskip559ActivatingAt(activationBlock);
+
+        List<PegoutsWaitingForConfirmations.Entry> entries = buildPegoutEntries(6);
+        Sha256Hash comparatorMin = comparatorMinBtcTxHash(entries);
+
+        Map<Keccak256, BtcTransaction> before = runConfirmationSelection(entries, config.forBlock(activationBlock - 1));
+        Map<Keccak256, BtcTransaction> atActivation = runConfirmationSelection(entries, config.forBlock(activationBlock));
+
+        // Guard: the test is only meaningful if the two strategies pick different pegouts for this pool;
+        // otherwise both asserts below could pass without any actual flip at the boundary.
+        assertNotEquals(PROCESS_CONFIRMED_OFF_GOLDEN, comparatorMin.toString(),
+            "Pre-fork (HashSet-order) and post-fork (comparator-min) picks must differ for this pool, else the test proves nothing");
+
+        // Before the fork: HashSet-order selection (same pool/order as the vetiver900 off test -> same golden).
+        assertEquals(PROCESS_CONFIRMED_OFF_GOLDEN, before.values().iterator().next().getHash().toString(),
+            "Before activation height the pre-fork selection must hold");
+        // At the fork height: deterministic comparator-minimum selection.
+        assertEquals(comparatorMin, atActivation.values().iterator().next().getHash(),
+            "At activation height the selection must switch to the BTC_TX_COMPARATOR minimum");
+    }
+
+    // 6 distinct pegouts, each with its own (tx-bound) pegoutCreationRskTxHash, all created at block 1.
+    private List<PegoutsWaitingForConfirmations.Entry> buildPegoutEntries(int n) {
+        List<PegoutsWaitingForConfirmations.Entry> entries = new ArrayList<>();
+        for (int i = 1; i <= n; i++) {
+            entries.add(new PegoutsWaitingForConfirmations.Entry(createDistinctPegoutBtcTx(i), 1L, PegTestUtils.createHash3(i)));
+        }
+        return entries;
+    }
+
+    private Sha256Hash comparatorMinBtcTxHash(List<PegoutsWaitingForConfirmations.Entry> entries) {
+        return entries.stream()
+            .min(PegoutsWaitingForConfirmations.Entry.BTC_TX_COMPARATOR)
+            .orElseThrow()
+            .getBtcTransaction()
+            .getHash();
+    }
+
+    private Map<Keccak256, BtcTransaction> runConfirmationSelection(List<PegoutsWaitingForConfirmations.Entry> entries, ActivationConfig.ForBlock activations) throws IOException {
+        repository = spy(RskTestUtils.createRepository());
+        federationStorageProvider = initFederationStorageProvider();
+        BridgeStorageProvider seededProvider = new BridgeStorageProvider(repository, NETWORK_PARAMETERS, activations);
+
+        PegoutsWaitingForConfirmations pegouts = seededProvider.getPegoutsWaitingForConfirmations();
+        entries.forEach(pegouts::add);
+
+        Block executionBlock = mock(Block.class);
+        when(executionBlock.getNumber()).thenReturn(1_000_000L); // far beyond min confirmations -> all eligible
+
+        FederationSupport federationSupport = FederationSupportBuilder.builder()
+            .withFederationConstants(FEDERATION_CONSTANTS)
+            .withFederationStorageProvider(federationStorageProvider)
+            .build();
+
+        BridgeSupport bridgeSupportToTest = BridgeSupportBuilder.builder()
+            .withBridgeConstants(BRIDGE_CONSTANTS)
+            .withProvider(seededProvider)
+            .withRepository(repository)
+            .withEventLogger(eventLogger)
+            .withActivations(activations)
+            .withSignatureCache(signatureCache)
+            .withFederationSupport(federationSupport)
+            .withFeePerKbSupport(feePerKbSupport)
+            .withExecutionBlock(executionBlock)
+            .build();
+
+        bridgeSupportToTest.updateCollections(buildUpdateTx());
+
+        this.provider = seededProvider; // expose for storage-root snapshot
+        return seededProvider.getPegoutsWaitingForSignatures();
+    }
+
+    // Pre-fork bridge pegout storage root after one confirmation cycle. Captured on Java 17; must hold on Java 21.
+    private static final String PEGOUT_STATE_ROOT_OFF_GOLDEN = "85329683f4d0da9a466f99e71f93612143ddc4ba47fd91622221d8e612d567ea";
+
+    @Test
+    void processConfirmedPegouts_pegoutStorageRootIsDeterministic() throws IOException {
+        List<PegoutsWaitingForConfirmations.Entry> entries = buildPegoutEntries(6);
+        List<PegoutsWaitingForConfirmations.Entry> reversed = new ArrayList<>(entries);
+        Collections.reverse(reversed);
+
+        // Determinism guard (NOT RSKIP-559-specific: serialization always sorts, so this also holds pre-fork):
+        // the persisted bridge storage root must be identical regardless of insertion order.
+        runConfirmationSelection(entries, ACTIVATIONS_RSKIP559_ON);
+        provider.save();
+        String rootOnForward = Hex.toHexString(repository.getRoot());
+
+        runConfirmationSelection(reversed, ACTIVATIONS_RSKIP559_ON);
+        provider.save();
+        String rootOnReversed = Hex.toHexString(repository.getRoot());
+
+        assertEquals(rootOnForward, rootOnReversed,
+            "Bridge storage root must be insertion-order independent (determinism regression guard)");
+
+        // Load-bearing cross-JVM check: the pre-fork persisted root must match the Java-17 golden
+        // (i.e. the Java-17 HashSet emulation reproduces on Java 21).
+        runConfirmationSelection(entries, ACTIVATIONS_RSKIP559_OFF);
+        provider.save();
+        String rootOff = Hex.toHexString(repository.getRoot());
+        System.out.println("PEGOUT_STATE_ROOT_OFF=" + rootOff);
+        assertEquals(PEGOUT_STATE_ROOT_OFF_GOLDEN, rootOff,
+            "Pre-fork bridge storage root diverged from the Java-17 golden (Java 17/21 mismatch?)");
+    }
+
+    private BtcTransaction createDistinctPegoutBtcTx(int i) {
+        BtcTransaction tx = new BtcTransaction(NETWORK_PARAMETERS);
+        tx.addOutput(Coin.COIN.add(Coin.valueOf(i)), BitcoinTestUtils.createP2PKHAddress(NETWORK_PARAMETERS, "dest" + i));
+        return tx;
+    }
+
     private Transaction buildUpdateTx() {
         final BigInteger value = new BigInteger("1");
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -1665,7 +1665,7 @@ class BridgeSupportReleaseBtcTest {
     // simultaneously eligible, and checks WHICH one is moved to pegoutsWaitingForSignatures.
 
     private static final ActivationConfig.ForBlock ACTIVATIONS_RSKIP559_OFF = ActivationConfigsForTest.vetiver900().forBlock(0L);
-    private static final ActivationConfig.ForBlock ACTIVATIONS_RSKIP559_ON = ActivationConfigsForTest.nextRelease().forBlock(0L);
+    private static final ActivationConfig.ForBlock ACTIVATIONS_RSKIP559_ON = ActivationConfigsForTest.tbd1000().forBlock(0L);
 
     // Pre-fork (HashSet-order) selection. Captured on Java 17; must reproduce on Java 21.
     private static final String PROCESS_CONFIRMED_OFF_GOLDEN = "2b5bbcb852ee544e3a758cafb2403cda0241b110f5a486a39389cd1024f0b8eb";
@@ -1699,7 +1699,7 @@ class BridgeSupportReleaseBtcTest {
     @Test
     void processConfirmedPegouts_selectionFlipsAtRskip559ActivationHeight() throws IOException {
         long activationBlock = 500L;
-        ActivationConfig config = ActivationConfigsForTest.nextReleaseWithRskip559ActivatingAt(activationBlock);
+        ActivationConfig config = ActivationConfigsForTest.tbd1000WithRskip559ActivatingAt(activationBlock);
 
         List<PegoutsWaitingForConfirmations.Entry> entries = buildPegoutEntries(6);
         Sha256Hash comparatorMin = comparatorMinBtcTxHash(entries);

--- a/rskj-core/src/test/java/co/rsk/peg/PegoutsWaitingForConfirmationsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegoutsWaitingForConfirmationsTest.java
@@ -406,10 +406,7 @@ class PegoutsWaitingForConfirmationsTest {
             pegouts.removeEntry(next.get());
         }
 
-        System.out.println("PREFORK_DRAIN_ORDER=" + drainOrder);
-        if (PREFORK_GOLDEN_ORDER.isEmpty()) {
-            Assertions.fail("Golden vector not yet captured; copy PREFORK_DRAIN_ORDER above into PREFORK_GOLDEN_ORDER");
-        }
+        // To refresh the golden: temporarily print `drainOrder`, run on Java 17, and paste it into PREFORK_GOLDEN_ORDER.
         Assertions.assertEquals(PREFORK_GOLDEN_ORDER, drainOrder,
             "Pre-fork HashSet iteration order diverged from the Java-17 golden (Java 17/21 mismatch?)");
     }

--- a/rskj-core/src/test/java/co/rsk/peg/PegoutsWaitingForConfirmationsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegoutsWaitingForConfirmationsTest.java
@@ -23,6 +23,7 @@ import co.rsk.config.TestSystemProperties;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -226,6 +227,199 @@ class PegoutsWaitingForConfirmationsTest {
             hash,
             "Valid candidate for non fixed pegouts sorting"
         );
+    }
+
+    // RSKIP559 disabled (pre-fork): selection follows HashSet iteration order.
+    private static final ActivationConfig.ForBlock ACTIVATIONS_RSKIP559_OFF = ActivationConfigsForTest.vetiver900().forBlock(10L);
+    // RSKIP559 enabled (post-fork): selection follows Entry.BTC_TX_COMPARATOR.
+    private static final ActivationConfig.ForBlock ACTIVATIONS_RSKIP559_ON = ActivationConfigsForTest.all().forBlock(1L);
+
+    // ----- Mechanism B (RSKIP559 on): deterministic sorted selection -----
+
+    @Test
+    void getNextPegoutWithEnoughConfirmations_rskip559On_picksComparatorMinAndIsOrderIndependent() {
+        // All created at block 5; with current=10, min=5 every entry has enough confirmations,
+        // so the selected one must be the BTC_TX_COMPARATOR minimum of the whole set.
+        List<BtcTransaction> txs = Arrays.asList(
+            createTransaction(8, Coin.CENT.times(5)),
+            createTransaction(11, Coin.MILLICOIN),
+            createTransaction(12, Coin.MILLICOIN),
+            createTransaction(13, Coin.MILLICOIN),
+            createTransaction(21, Coin.COIN),
+            createTransaction(34, Coin.SATOSHI)
+        );
+        BtcTransaction expected = txs.stream()
+            .min((a, b) -> com.google.common.primitives.UnsignedBytes.lexicographicalComparator()
+                .compare(a.bitcoinSerialize(), b.bitcoinSerialize()))
+            .orElseThrow();
+
+        // Build with two different insertion orders; selection must be identical and equal to expected.
+        List<BtcTransaction> reversed = new ArrayList<>(txs);
+        Collections.reverse(reversed);
+        for (List<BtcTransaction> order : Arrays.asList(txs, reversed)) {
+            PegoutsWaitingForConfirmations pegouts = new PegoutsWaitingForConfirmations(new HashSet<>());
+            order.forEach(tx -> pegouts.add(new PegoutsWaitingForConfirmations.Entry(tx, 5L)));
+
+            Optional<PegoutsWaitingForConfirmations.Entry> selected =
+                pegouts.getNextPegoutWithEnoughConfirmations(10L, 5, ACTIVATIONS_RSKIP559_ON);
+
+            Assertions.assertTrue(selected.isPresent());
+            Assertions.assertEquals(expected, selected.get().getBtcTransaction(),
+                "Post-fork selection must be the comparator minimum, independent of insertion order");
+        }
+    }
+
+    @Test
+    void getNextPegoutWithEnoughConfirmations_rskip559On_drainsInComparatorOrder() {
+        // current high enough that every entry is confirmed; draining must yield ascending comparator order.
+        List<PegoutsWaitingForConfirmations.Entry> drained = new ArrayList<>();
+        Optional<PegoutsWaitingForConfirmations.Entry> next;
+        while ((next = set.getNextPegoutWithEnoughConfirmations(1000L, 5, ACTIVATIONS_RSKIP559_ON)).isPresent()) {
+            drained.add(next.get());
+            set.removeEntry(next.get());
+        }
+
+        List<PegoutsWaitingForConfirmations.Entry> expected = new ArrayList<>(drained);
+        expected.sort(PegoutsWaitingForConfirmations.Entry.BTC_TX_COMPARATOR);
+
+        Assertions.assertEquals(expected, drained, "Post-fork draining must be in BTC_TX_COMPARATOR order");
+        Assertions.assertEquals(0, set.getEntries(ACTIVATIONS_RSKIP559_ON).size());
+    }
+
+    @Test
+    void getEntries_rskip559On_returnsSortedByBtcTxComparator() {
+        List<PegoutsWaitingForConfirmations.Entry> entries = new ArrayList<>(set.getEntries(ACTIVATIONS_RSKIP559_ON));
+        assertSortedByComparator(entries);
+    }
+
+    @Test
+    void orderedGetters_areSortedAndPartitionedByHash() {
+        Set<PegoutsWaitingForConfirmations.Entry> mixed = new HashSet<>(Arrays.asList(
+            new PegoutsWaitingForConfirmations.Entry(createTransaction(2, Coin.valueOf(150)), 32L),
+            new PegoutsWaitingForConfirmations.Entry(createTransaction(5, Coin.COIN), 100L),
+            new PegoutsWaitingForConfirmations.Entry(createTransaction(4, Coin.FIFTY_COINS), 7L, PegTestUtils.createHash3(1)),
+            new PegoutsWaitingForConfirmations.Entry(createTransaction(3, Coin.MILLICOIN), 10L, PegTestUtils.createHash3(2))
+        ));
+        PegoutsWaitingForConfirmations pegouts = new PegoutsWaitingForConfirmations(mixed);
+
+        List<PegoutsWaitingForConfirmations.Entry> withoutHash = new ArrayList<>(pegouts.getEntriesWithoutHashOrdered());
+        List<PegoutsWaitingForConfirmations.Entry> withHash = new ArrayList<>(pegouts.getEntriesWithHashOrdered());
+
+        Assertions.assertEquals(2, withoutHash.size());
+        Assertions.assertEquals(2, withHash.size());
+        withoutHash.forEach(e -> Assertions.assertNull(e.getPegoutCreationRskTxHash()));
+        withHash.forEach(e -> Assertions.assertNotNull(e.getPegoutCreationRskTxHash()));
+        assertSortedByComparator(withoutHash);
+        assertSortedByComparator(withHash);
+    }
+
+    @Test
+    void edgeCases_emptyAndSingle() {
+        PegoutsWaitingForConfirmations empty = new PegoutsWaitingForConfirmations(Collections.emptySet());
+        Assertions.assertTrue(empty.getEntries(ACTIVATIONS_RSKIP559_ON).isEmpty());
+        Assertions.assertFalse(empty.getNextPegoutWithEnoughConfirmations(10L, 5, ACTIVATIONS_RSKIP559_ON).isPresent());
+        Assertions.assertFalse(empty.getNextPegoutWithEnoughConfirmations(10L, 5, ACTIVATIONS_RSKIP559_OFF).isPresent());
+
+        BtcTransaction onlyTx = createTransaction(7, Coin.COIN);
+        PegoutsWaitingForConfirmations single = new PegoutsWaitingForConfirmations(
+            new HashSet<>(Collections.singletonList(new PegoutsWaitingForConfirmations.Entry(onlyTx, 1L))));
+
+        Optional<PegoutsWaitingForConfirmations.Entry> onSel = single.getNextPegoutWithEnoughConfirmations(10L, 5, ACTIVATIONS_RSKIP559_ON);
+        Optional<PegoutsWaitingForConfirmations.Entry> offSel = single.getNextPegoutWithEnoughConfirmations(10L, 5, ACTIVATIONS_RSKIP559_OFF);
+        Assertions.assertEquals(onlyTx, onSel.orElseThrow().getBtcTransaction());
+        Assertions.assertEquals(onlyTx, offSel.orElseThrow().getBtcTransaction());
+    }
+
+    // ----- Activation transition (Layer 5): selection strategy flips exactly at the RSKIP559 fork height -----
+
+    @Test
+    void selectionFlipsExactlyAtRskip559ActivationHeight() {
+        long activationBlock = 500L;
+        ActivationConfig config = ActivationConfigsForTest.nextReleaseWithRskip559ActivatingAt(activationBlock);
+
+        // Sanity: the rule is off one block before the fork and on at the fork height.
+        Assertions.assertFalse(config.forBlock(activationBlock - 1).isActive(ConsensusRule.RSKIP559));
+        Assertions.assertTrue(config.forBlock(activationBlock).isActive(ConsensusRule.RSKIP559));
+
+        // Same pool as the off/on unit tests (current=10, min=5 -> only the block-5 pegouts are confirmed).
+        Optional<PegoutsWaitingForConfirmations.Entry> before =
+            set.getNextPegoutWithEnoughConfirmations(10L, 5, config.forBlock(activationBlock - 1));
+        Optional<PegoutsWaitingForConfirmations.Entry> atActivation =
+            set.getNextPegoutWithEnoughConfirmations(10L, 5, config.forBlock(activationBlock));
+
+        Assertions.assertEquals(
+            "53efc6f78eb9d159cfee76ec45bcffb08fd11f85c762e1eacf54e5c014da219d",
+            before.orElseThrow().getBtcTransaction().getHash().toString(),
+            "Before activation: HashSet-order (pre-fork) selection");
+        Assertions.assertEquals(
+            "fdd781c46b5ad7993b3f133e3af94b2e3cbcc8d19e443dfc6b555a1b0bac1527",
+            atActivation.orElseThrow().getBtcTransaction().getHash().toString(),
+            "At activation height: deterministic sorted (post-fork) selection");
+
+        // Querying does not mutate the set; it is identical across the boundary (no entry lost/duplicated).
+        Assertions.assertEquals(
+            set.getEntries(config.forBlock(activationBlock - 1)).size(),
+            set.getEntries(config.forBlock(activationBlock)).size());
+    }
+
+    // ----- Mechanism A (RSKIP559 off): Java-17 HashSet iteration order must be reproduced on every JVM -----
+    // This golden vector pins the pre-fork (HashSet-order) selection sequence across a set whose size
+    // crosses the 16 -> 32 resize boundary. It MUST hold identically on Java 17 and Java 21; a mismatch
+    // means EntriesStore.setOfEntries() failed to emulate the Java-17 HashSet sizing.
+    private static final List<String> PREFORK_GOLDEN_ORDER = Arrays.asList(
+        // Captured on Java 17 (Zulu 17.0.15). Must reproduce identically on Java 21.
+        "4c34f81d9c9457cb1d395ae10f88511fb3584d881a3b9e7b8797396ea459ac2b",
+        "b0ecfeddcc2ee5f40f58c0abeabc40f859aed5e8639dd0007f313e690002b514",
+        "8af5a2bffa8b359b4d3435231a447412513789bc41b2ec3566793b9c20ef7ee2",
+        "0cf28a426732b021d20ae36a34626e846e6f85a9c76f847b1e369a14705219f2",
+        "2cdc2ebb2f388ab1d4479f696703cccb542a7c615e2782000f60f7a3a2dd90f4",
+        "edac23065ab1ebb61f52ce58b3bb9cdd3340409eab63a0f5237cdbeaef1a02fa",
+        "0358b772c57699952c872e59c457e73b384ced5c4c11f77d050d53ca4e7ddbd5",
+        "356c2824ce2f08ba4be11d8bda0b93a6d6538c5904051ba4d1c4d4ed4c2308b4",
+        "93bd066c67f9c364c76866e583368da5300b791b6f566b4146be1f57d35de435",
+        "43392d1a44c3612dc3c26a59005a99ff79637aa6361d7415e71fd698358cae00",
+        "b6c9d511bc475a7f6e7038cef2e84924c29f3e43b6e1378e567b12e62d470cf1",
+        "0ea1cb058fe39af2ff4a288837355d7ca380accc3e1dc7efa1b5312276dd22de",
+        "741513d232d76898009645a2fdd26f48266e8daecee7a49b3b86ea6439e4d75f",
+        "3f479267e4830e42d1f51b9b1310054ee42390eb79c615ca60a06e8a0b4046ec",
+        "a7eb503aed07d066cf61fb56085c1e8fd330f2e74f455b049086ec037b2e1de0",
+        "8fe7ee429e03e66d81950dbed40d2767f4c251f9566b280e03665de83d15cef3",
+        "b25c1f7fe98d5f67b937eacae92f2057bcca7013a1d6a4ce1a5a4c57ab8613e1",
+        "eeb3b9601e6ce787d9e300035739e71663a70d3a7ccbd5da8c61c8da648ad5d1",
+        "25ee51c7ee37f585d8c748a757afe86e927bda29a1043a3c1b9293f5988017e8",
+        "697be80f3d26a42f8baa63579a3ba385967e8995421058cdb8a8ad0eee25c8fa"
+    );
+
+    @Test
+    void getNextPegoutWithEnoughConfirmations_rskip559Off_drainOrderMatchesJava17Golden() {
+        PegoutsWaitingForConfirmations pegouts = new PegoutsWaitingForConfirmations(new HashSet<>());
+        // 20 distinct txs (size crosses the 16 -> 32 HashSet resize boundary); vary the output amount
+        // to keep each tx unique while using a known-good key for the destination address.
+        for (int i = 1; i <= 20; i++) {
+            pegouts.add(new PegoutsWaitingForConfirmations.Entry(createTransaction(2, Coin.valueOf(i * 7L + 1)), 5L));
+        }
+
+        List<String> drainOrder = new ArrayList<>();
+        Optional<PegoutsWaitingForConfirmations.Entry> next;
+        while ((next = pegouts.getNextPegoutWithEnoughConfirmations(1000L, 5, ACTIVATIONS_RSKIP559_OFF)).isPresent()) {
+            drainOrder.add(next.get().getBtcTransaction().getHash().toString());
+            pegouts.removeEntry(next.get());
+        }
+
+        System.out.println("PREFORK_DRAIN_ORDER=" + drainOrder);
+        if (PREFORK_GOLDEN_ORDER.isEmpty()) {
+            Assertions.fail("Golden vector not yet captured; copy PREFORK_DRAIN_ORDER above into PREFORK_GOLDEN_ORDER");
+        }
+        Assertions.assertEquals(PREFORK_GOLDEN_ORDER, drainOrder,
+            "Pre-fork HashSet iteration order diverged from the Java-17 golden (Java 17/21 mismatch?)");
+    }
+
+    private static void assertSortedByComparator(List<PegoutsWaitingForConfirmations.Entry> entries) {
+        for (int i = 1; i < entries.size(); i++) {
+            Assertions.assertTrue(
+                PegoutsWaitingForConfirmations.Entry.BTC_TX_COMPARATOR.compare(entries.get(i - 1), entries.get(i)) <= 0,
+                "Entries must be sorted by BTC_TX_COMPARATOR");
+        }
     }
 
     private BtcTransaction createTransaction(int toPk, Coin value) {

--- a/rskj-core/src/test/java/co/rsk/peg/PegoutsWaitingForConfirmationsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegoutsWaitingForConfirmationsTest.java
@@ -236,6 +236,11 @@ class PegoutsWaitingForConfirmationsTest {
 
     // ----- Mechanism B (RSKIP559 on): deterministic sorted selection -----
 
+    // Expected post-fork pick for the 6-tx pool below. Pinned as a literal rather than recomputed with
+    // BTC_TX_COMPARATOR: an assertion that re-derives the expectation from the production comparator would
+    // mirror any bug in it and pass regardless. The comparator's own semantics are covered by entryComparators().
+    private static final String POSTFORK_SELECTION_GOLDEN = "f368eb190ff2479803b5ca8fe19978a91dcbf4ccaf7b9b91153bb6c85c5197e9";
+
     @Test
     void getNextPegoutWithEnoughConfirmations_rskip559On_picksComparatorMinAndIsOrderIndependent() {
         // All created at block 5; with current=10, min=5 every entry has enough confirmations,
@@ -248,12 +253,8 @@ class PegoutsWaitingForConfirmationsTest {
             createTransaction(21, Coin.COIN),
             createTransaction(34, Coin.SATOSHI)
         );
-        BtcTransaction expected = txs.stream()
-            .min((a, b) -> com.google.common.primitives.UnsignedBytes.lexicographicalComparator()
-                .compare(a.bitcoinSerialize(), b.bitcoinSerialize()))
-            .orElseThrow();
 
-        // Build with two different insertion orders; selection must be identical and equal to expected.
+        // Build with two different insertion orders; selection must be identical and equal to the pinned tx.
         List<BtcTransaction> reversed = new ArrayList<>(txs);
         Collections.reverse(reversed);
         for (List<BtcTransaction> order : Arrays.asList(txs, reversed)) {
@@ -264,7 +265,7 @@ class PegoutsWaitingForConfirmationsTest {
                 pegouts.getNextPegoutWithEnoughConfirmations(10L, 5, ACTIVATIONS_RSKIP559_ON);
 
             Assertions.assertTrue(selected.isPresent());
-            Assertions.assertEquals(expected, selected.get().getBtcTransaction(),
+            Assertions.assertEquals(POSTFORK_SELECTION_GOLDEN, selected.get().getBtcTransaction().getHash().toString(),
                 "Post-fork selection must be the comparator minimum, independent of insertion order");
         }
     }
@@ -335,7 +336,7 @@ class PegoutsWaitingForConfirmationsTest {
     @Test
     void selectionFlipsExactlyAtRskip559ActivationHeight() {
         long activationBlock = 500L;
-        ActivationConfig config = ActivationConfigsForTest.nextReleaseWithRskip559ActivatingAt(activationBlock);
+        ActivationConfig config = ActivationConfigsForTest.tbd1000WithRskip559ActivatingAt(activationBlock);
 
         // Sanity: the rule is off one block before the fork and on at the fork height.
         Assertions.assertFalse(config.forBlock(activationBlock - 1).isActive(ConsensusRule.RSKIP559));
@@ -356,10 +357,19 @@ class PegoutsWaitingForConfirmationsTest {
             atActivation.orElseThrow().getBtcTransaction().getHash().toString(),
             "At activation height: deterministic sorted (post-fork) selection");
 
-        // Querying does not mutate the set; it is identical across the boundary (no entry lost/duplicated).
-        Assertions.assertEquals(
-            set.getEntries(config.forBlock(activationBlock - 1)).size(),
-            set.getEntries(config.forBlock(activationBlock)).size());
+        // Querying does not mutate the set, so the same entries are visible on both sides of the boundary --
+        // what changes is their ORDER. Asserting sizes alone would hold before and after the fork and prove
+        // nothing, so assert the ordering itself: only post-fork is BTC_TX_COMPARATOR-sorted.
+        List<PegoutsWaitingForConfirmations.Entry> preForkOrder =
+            new ArrayList<>(set.getEntries(config.forBlock(activationBlock - 1)));
+        List<PegoutsWaitingForConfirmations.Entry> postForkOrder =
+            new ArrayList<>(set.getEntries(config.forBlock(activationBlock)));
+
+        Assertions.assertEquals(new HashSet<>(preForkOrder), new HashSet<>(postForkOrder),
+            "The boundary must not add, drop or duplicate entries");
+        assertSortedByComparator(postForkOrder);
+        Assertions.assertNotEquals(preForkOrder, postForkOrder,
+            "Pre-fork (HashSet) order must differ from the sorted order for this pool, else the test proves nothing");
     }
 
     // ----- Mechanism A (RSKIP559 off): Java-17 HashSet iteration order must be reproduced on every JVM -----
@@ -409,6 +419,50 @@ class PegoutsWaitingForConfirmationsTest {
         // To refresh the golden: temporarily print `drainOrder`, run on Java 17, and paste it into PREFORK_GOLDEN_ORDER.
         Assertions.assertEquals(PREFORK_GOLDEN_ORDER, drainOrder,
             "Pre-fork HashSet iteration order diverged from the Java-17 golden (Java 17/21 mismatch?)");
+    }
+
+    // The golden above grows the set with add() from empty, which is JVM-invariant on its own and therefore
+    // cannot detect an emulation regression. EntriesStore.setOfEntries(Collection) -- the part that actually
+    // hardcodes the Java-17 sizing -- is only reachable through the collection constructor, which is the real
+    // deserialization path (BridgeStorageProvider#getPegoutsWaitingForConfirmations). This golden goes through
+    // it with 12 entries, a size where a plain `new HashSet<>(c)` sizes differently on Java 17 (capacity 17 ->
+    // table 32) and Java 21 (capacity 16 -> table 16), so dropping the emulation flips this order on Java 21.
+    private static final List<String> PREFORK_CONSTRUCTOR_GOLDEN_ORDER = Arrays.asList(
+        // Captured on Java 17 (Zulu 17.0.15). Must reproduce identically on Java 21.
+        "e6d81cdde8b4bf0a143a14efe8277602cd0072155f5029c97b0ed0b837186113",
+        "d439506d196d92b64a2c461626984de87f048c678e77b8097582bf66b1d26eeb",
+        "cd4b89582929354b12b4b6112435cc73fc99fa74176311bbacb2511d28a9db13",
+        "1172bad965e8a860230001d86d4ea990c4fd85343149fbaffa55850cae0b2c88",
+        "75edd101c5a4407d9027bcf34225861cf0abf153a7bc03c2b3c47b2c7dbdd5eb",
+        "21c1b88438f9597c0245e0a33ced5ce33ee9406b78a2dfff836ee8f70c8dc823",
+        "4ad909d983d7e55f1723ee800237a0f14ce9feca270868b420e96cbd871409a1",
+        "5a780b9bbbf0e8a272268536c330d9982b9920798a5db2c0161af7220ed743ae",
+        "c8fa82bc043c30fabe3213658f7dc0174dbcf63af6784154dd3a41fc64f18852",
+        "e693d78465aea00509a6dde3a73fbb0c45852896c891702f208c28355106ab47",
+        "998477d0a8195f0649f7b8f84313acd4e37fed5d373a2d0ac1869c5bfdfbd89d",
+        "8fe7ee429e03e66d81950dbed40d2767f4c251f9566b280e03665de83d15cef3"
+    );
+
+    @Test
+    void getNextPegoutWithEnoughConfirmations_rskip559Off_constructorDrainOrderMatchesJava17Golden() {
+        // LinkedHashSet so the input order fed to the constructor is itself deterministic.
+        Set<PegoutsWaitingForConfirmations.Entry> seed = new LinkedHashSet<>();
+        for (int i = 1; i <= 12; i++) {
+            seed.add(new PegoutsWaitingForConfirmations.Entry(createTransaction(2, Coin.valueOf(i * 13L + 1)), 5L));
+        }
+        PegoutsWaitingForConfirmations pegouts = new PegoutsWaitingForConfirmations(seed);
+
+        List<String> drainOrder = new ArrayList<>();
+        Optional<PegoutsWaitingForConfirmations.Entry> next;
+        while ((next = pegouts.getNextPegoutWithEnoughConfirmations(1000L, 5, ACTIVATIONS_RSKIP559_OFF)).isPresent()) {
+            drainOrder.add(next.get().getBtcTransaction().getHash().toString());
+            pegouts.removeEntry(next.get());
+        }
+
+        // To refresh the golden: temporarily print `drainOrder`, run on Java 17, and paste it in.
+        Assertions.assertEquals(PREFORK_CONSTRUCTOR_GOLDEN_ORDER, drainOrder,
+            "Pre-fork order through the collection constructor diverged from the Java-17 golden "
+                + "(EntriesStore.setOfEntries(Collection) no longer emulates Java-17 HashSet sizing?)");
     }
 
     private static void assertSortedByComparator(List<PegoutsWaitingForConfirmations.Entry> entries) {

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
@@ -506,6 +506,22 @@ public class ActivationConfigsForTest {
         return enableTheseDisableThose(tbd1000AllRskips(), except);
     }
 
+    /**
+     * All vetiver900 rules active from genesis, but RSKIP559 activating only at {@code rskip559ActivationBlock}.
+     * Useful to exercise the pre-&gt;post RSKIP559 transition across a fork height (RSKCORE-5409).
+     */
+    public static ActivationConfig nextReleaseWithRskip559ActivatingAt(long rskip559ActivationBlock) {
+        Map<ConsensusRule, Long> consensusRules = EnumSet.allOf(ConsensusRule.class)
+                .stream()
+                .collect(Collectors.toMap(Function.identity(), ignored -> -1L));
+        for (ConsensusRule consensusRule : vetiver900AllRskips()) {
+            consensusRules.put(consensusRule, 0L);
+        }
+        consensusRules.put(ConsensusRule.RSKIP559, rskip559ActivationBlock);
+
+        return new ActivationConfig(consensusRules);
+    }
+
     public static ActivationConfig regtest() {
         return REGTEST;
     }

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
@@ -507,6 +507,22 @@ public class ActivationConfigsForTest {
         return enableTheseDisableThose(nextReleaseAllRskips(), except);
     }
 
+    /**
+     * All vetiver900 rules active from genesis, but RSKIP559 activating only at {@code rskip559ActivationBlock}.
+     * Useful to exercise the pre-&gt;post RSKIP559 transition across a fork height (RSKCORE-5409).
+     */
+    public static ActivationConfig nextReleaseWithRskip559ActivatingAt(long rskip559ActivationBlock) {
+        Map<ConsensusRule, Long> consensusRules = EnumSet.allOf(ConsensusRule.class)
+                .stream()
+                .collect(Collectors.toMap(Function.identity(), ignored -> -1L));
+        for (ConsensusRule consensusRule : vetiver900AllRskips()) {
+            consensusRules.put(consensusRule, 0L);
+        }
+        consensusRules.put(ConsensusRule.RSKIP559, rskip559ActivationBlock);
+
+        return new ActivationConfig(consensusRules);
+    }
+
     public static ActivationConfig regtest() {
         return REGTEST;
     }

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
@@ -510,7 +510,7 @@ public class ActivationConfigsForTest {
      * All vetiver900 rules active from genesis, but RSKIP559 activating only at {@code rskip559ActivationBlock}.
      * Useful to exercise the pre-&gt;post RSKIP559 transition across a fork height (RSKCORE-5409).
      */
-    public static ActivationConfig nextReleaseWithRskip559ActivatingAt(long rskip559ActivationBlock) {
+    public static ActivationConfig tbd1000WithRskip559ActivatingAt(long rskip559ActivationBlock) {
         Map<ConsensusRule, Long> consensusRules = EnumSet.allOf(ConsensusRule.class)
                 .stream()
                 .collect(Collectors.toMap(Function.identity(), ignored -> -1L));


### PR DESCRIPTION
## Description
Test-only coverage for the **RSKIP-559 deterministic pegout ordering** change (RSKCORE-5409), targeting the `rskip559` feature branch. 11 new tests + 1 test helper across 3 files; **no production code changed**.

- `PegoutsWaitingForConfirmationsTest` (7): post-fork comparator-min selection (order-independent), sorted draining, partitioned ordered getters, empty/single edge cases, the activation-height transition, and a Java-17 `HashSet` iteration-order **golden vector** (20 entries crossing the 16→32 resize boundary).
- `BridgeSupportReleaseBtcTest` (4): drives the real `updateCollections → processConfirmedPegouts` path with multiple simultaneously-eligible pegouts; pins the pre-fork selection and bridge storage-root goldens, asserts post-fork comparator-min selection (self-proving OFF ≠ ON), and the activation transition.
- `ActivationConfigsForTest`: `nextReleaseWithRskip559ActivatingAt(block)` helper to model the fork boundary in tests.

## Motivation and Context
RSKIP-559 fixes the Java 17→21 `HashSet` iteration-order divergence (RSKCORE-5239) that could cause pegout-selection state-root splits. These tests lock in **both** mechanisms — the always-on Java-17 `HashSet` emulation and the RSKIP559-gated deterministic sort — and guard against regressions across JVM versions.

Relates to RSKCORE-5409; complements the implementation on `rskip559` (PR #3507).

## How Has This Been Tested?
Ran `:rskj-core:test` for the affected/touched classes on **Java 17 (Zulu 17.0.15) and Java 21 (Zulu 21.0.11)**:

- `PegoutsWaitingForConfirmationsTest` (18), `BridgeSupportReleaseBtcTest` (46), `ActivationConfigTest` (12) → **76 tests, 0 failures / 0 skipped on each JVM**; `checkstyleTest` clean.
- The four pinned goldens (pre-fork unit & integration selection, and the bridge storage root) reproduce **identically on Java 21**, confirming the Java-17 `HashSet` emulation holds on the post-JDK-19 sizing (JDK-8186958).

## Types of changes
<!--- Test-only change; no production behavior change. None of the below apply. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**: Test-only PR targeting the `rskip559` feature branch (not `master`). No `src/main` changes — the RSKIP559 activation wiring lives on the parent branch.
