### PR TITLE
ci: add cross-repo automated-tests orchestrator workflow

### DIFF
--- a/.github/workflows/_dispatch-suite.yml
+++ b/.github/workflows/_dispatch-suite.yml
@@ -1,0 +1,128 @@
+name: Dispatch external test suite
+
+# Reusable building block for the RSKj Core Automated Tests umbrella
+# (rskj-core-automated-tests.yml). Mints a short-lived GitHub App token scoped to
+# one test repo, dispatches that repo's test workflow against an rskj ref, then
+# polls the created run to completion and returns its conclusion. The umbrella
+# calls this once per suite (JSON-RPC / Hardhat / K6); keeping the dispatch + poll
+# logic here means a fix lands in one place instead of three copies.
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        description: "Human-readable suite label, used in log lines."
+        type: string
+        required: true
+      repo:
+        description: "Test repo name under rsksmart/ (e.g. rskj-json-rpc-tests)."
+        type: string
+        required: true
+      workflow:
+        description: "workflow_dispatch file to trigger in that repo."
+        type: string
+        required: true
+      test_input:
+        description: "Name of the test-branch input that workflow expects (test_branch | hardhat_branch)."
+        type: string
+        required: true
+      rskj_ref:
+        description: "rskj branch the suite builds the node from."
+        type: string
+        required: true
+      test_ref:
+        description: "Branch of the test repo to run."
+        type: string
+        required: true
+    outputs:
+      conclusion:
+        description: "Conclusion of the downstream run (success/failure/timed_out/…)."
+        value: ${{ jobs.run.outputs.conclusion }}
+      run_url:
+        description: "HTML URL of the downstream run."
+        value: ${{ jobs.run.outputs.run_url }}
+    secrets:
+      app_id:
+        required: true
+      app_key:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    name: ${{ inputs.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 55
+    outputs:
+      conclusion: ${{ steps.run.outputs.conclusion }}
+      run_url: ${{ steps.run.outputs.run_url }}
+    steps:
+      # Fresh ~1h token, minted at job start so the full dispatch + poll fits inside it.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.app_id }}
+          private-key: ${{ secrets.app_key }}
+          owner: rsksmart
+          repositories: ${{ inputs.repo }}
+      - name: Dispatch and wait
+        id: run
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          NAME: ${{ inputs.name }}
+          REPO: rsksmart/${{ inputs.repo }}
+          WORKFLOW: ${{ inputs.workflow }}
+          TEST_INPUT: ${{ inputs.test_input }}
+          RSKJ_REF: ${{ inputs.rskj_ref }}
+          TEST_REF: ${{ inputs.test_ref }}
+        run: |
+          set -euo pipefail
+          INPUTS=$(jq -n --arg rskj "$RSKJ_REF" --arg k "$TEST_INPUT" --arg v "$TEST_REF" \
+            '{rskj_branch: $rskj, ($k): $v}')
+          BODY=$(jq -n --arg ref "$TEST_REF" --argjson inputs "$INPUTS" \
+            '{ref: $ref, inputs: $inputs, return_run_details: true}')
+          echo "Dispatching $WORKFLOW in $REPO on '$TEST_REF' (rskj_branch=$RSKJ_REF)"
+          if ! RESP=$(printf '%s' "$BODY" | gh api -X POST \
+              "repos/$REPO/actions/workflows/$WORKFLOW/dispatches" --input -); then
+            echo "::error::failed to dispatch $WORKFLOW in $REPO"
+            exit 1
+          fi
+          RUN_ID=$(jq -r '.workflow_run_id // empty' <<<"$RESP" 2>/dev/null || true)
+          RUN_URL=$(jq -r '.html_url // empty' <<<"$RESP" 2>/dev/null || true)
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::dispatch did not return a run id; response: $RESP"
+            exit 1
+          fi
+          echo "run_url=$RUN_URL" >> "$GITHUB_OUTPUT"
+          echo "Triggered run $RUN_ID — $RUN_URL"
+          # If THIS job is cancelled (e.g. concurrency cancel-in-progress on a new
+          # push), cancel the downstream run too so it doesn't keep burning minutes
+          # orphaned. Best-effort: fires on the grace-period INT/TERM during the
+          # poll's sleep below; a hard kill may skip it.
+          cleanup() { gh api -X POST "repos/$REPO/actions/runs/$RUN_ID/cancel" >/dev/null 2>&1 || true; }
+          trap cleanup INT TERM
+          # Wait for completion by polling the run status (keyed on the id we
+          # already hold — deterministic, unlike `gh run watch`, which can race a
+          # just-created run). 100 * 30s = 50m of polling, kept under this job's
+          # timeout-minutes: 55 so a run finishing near the top of the window is
+          # still observed (not falsely marked timed_out) and the conclusion can be
+          # written to $GITHUB_OUTPUT before the job is killed mid-step. status and
+          # conclusion are read in one API call per tick. A downstream *test* failure
+          # is captured as the conclusion (not raised here) so the report job can
+          # gate centrally; a dispatch/infra error already exited non-zero above.
+          CONCLUSION=""
+          for _ in $(seq 1 100); do
+            read -r STATUS RUN_CONCLUSION < <(gh api "repos/$REPO/actions/runs/$RUN_ID" \
+              --jq '"\(.status) \(.conclusion // "unknown")"' 2>/dev/null || echo " ")
+            if [ "$STATUS" = "completed" ]; then
+              CONCLUSION="$RUN_CONCLUSION"
+              break
+            fi
+            sleep 30
+          done
+          [ -n "$CONCLUSION" ] || CONCLUSION="timed_out"
+          echo "conclusion=$CONCLUSION" >> "$GITHUB_OUTPUT"
+          echo "$NAME suite concluded: $CONCLUSION"

--- a/.github/workflows/_dispatch-suite.yml
+++ b/.github/workflows/_dispatch-suite.yml
@@ -115,9 +115,16 @@ jobs:
           # gate centrally; a dispatch/infra error already exited non-zero above.
           CONCLUSION=""
           for _ in $(seq 1 100); do
+            # `|| true`: read returns non-zero on EOF-without-newline, which would
+            # otherwise abort the step under `set -e`. A transient API error makes
+            # the substitution empty, leaving STATUS unset → another tick.
+            STATUS=""; RUN_CONCLUSION=""
             read -r STATUS RUN_CONCLUSION < <(gh api "repos/$REPO/actions/runs/$RUN_ID" \
-              --jq '"\(.status) \(.conclusion // "unknown")"' 2>/dev/null || echo " ")
-            if [ "$STATUS" = "completed" ]; then
+              --jq '"\(.status) \(.conclusion // "unknown")"' 2>/dev/null || echo " ") || true
+            # Require a non-empty conclusion too: a completed run always has one, so
+            # an empty value here means a partial/blipped read — keep polling rather
+            # than recording a spurious empty conclusion (which reports as a failure).
+            if [ "$STATUS" = "completed" ] && [ -n "$RUN_CONCLUSION" ]; then
               CONCLUSION="$RUN_CONCLUSION"
               break
             fi

--- a/.github/workflows/rskj-core-automated-tests.yml
+++ b/.github/workflows/rskj-core-automated-tests.yml
@@ -41,6 +41,11 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  # issues: write is required because the sticky PR comment is posted via the
+  # issue-comments REST endpoint (repos/.../issues/<n>/comments); pull-requests:
+  # write alone can 403 there, which would fail the report job even when all
+  # suites pass.
+  issues: write
 
 concurrency:
   group: rskj-core-automated-tests-${{ github.ref }}
@@ -155,8 +160,8 @@ jobs:
             echo "::error::failed to dispatch $WORKFLOW in $REPO"
             exit 1
           fi
-          RUN_ID=$(jq -r '.workflow_run_id // empty' <<<"$RESP")
-          RUN_URL=$(jq -r '.html_url // empty' <<<"$RESP")
+          RUN_ID=$(jq -r '.workflow_run_id // empty' <<<"$RESP" 2>/dev/null || true)
+          RUN_URL=$(jq -r '.html_url // empty' <<<"$RESP" 2>/dev/null || true)
           if [ -z "$RUN_ID" ]; then
             echo "::error::dispatch did not return a run id; response: $RESP"
             exit 1
@@ -211,8 +216,8 @@ jobs:
             echo "::error::failed to dispatch $WORKFLOW in $REPO"
             exit 1
           fi
-          RUN_ID=$(jq -r '.workflow_run_id // empty' <<<"$RESP")
-          RUN_URL=$(jq -r '.html_url // empty' <<<"$RESP")
+          RUN_ID=$(jq -r '.workflow_run_id // empty' <<<"$RESP" 2>/dev/null || true)
+          RUN_URL=$(jq -r '.html_url // empty' <<<"$RESP" 2>/dev/null || true)
           if [ -z "$RUN_ID" ]; then
             echo "::error::dispatch did not return a run id; response: $RESP"
             exit 1
@@ -255,8 +260,8 @@ jobs:
             echo "::error::failed to dispatch $WORKFLOW in $REPO"
             exit 1
           fi
-          RUN_ID=$(jq -r '.workflow_run_id // empty' <<<"$RESP")
-          RUN_URL=$(jq -r '.html_url // empty' <<<"$RESP")
+          RUN_ID=$(jq -r '.workflow_run_id // empty' <<<"$RESP" 2>/dev/null || true)
+          RUN_URL=$(jq -r '.html_url // empty' <<<"$RESP" 2>/dev/null || true)
           if [ -z "$RUN_ID" ]; then
             echo "::error::dispatch did not return a run id; response: $RESP"
             exit 1

--- a/.github/workflows/rskj-core-automated-tests.yml
+++ b/.github/workflows/rskj-core-automated-tests.yml
@@ -152,21 +152,30 @@ jobs:
           # test repo, run that branch there (so companion test/workflow changes on
           # a same-named branch are exercised); otherwise fall back to main. An
           # explicit dispatch input always wins.
+          #
+          # Only a genuine 404 (branch absent) may fall back to main. Any OTHER API
+          # failure (rate limit, auth, transient outage) must fail the job loudly:
+          # silently treating it as "branch missing" would exercise the wrong test
+          # branch and could produce a false-green run. Result is returned in
+          # RESOLVED so the non-404 error path can `return 1` and trip `set -e` in
+          # the caller (an `exit` inside $(...) would only leave the subshell).
           resolve_ref() {
             repo="$1"; override="$2"
             if [ -n "$override" ]; then
-              echo "$override"; return
+              RESOLVED="$override"; return 0
             fi
-            if gh api "repos/$repo/branches/$RSKJ_REF" >/dev/null 2>&1; then
-              echo "$RSKJ_REF"
-            else
-              echo "main"
+            if err=$(gh api "repos/$repo/branches/$RSKJ_REF" 2>&1 >/dev/null); then
+              RESOLVED="$RSKJ_REF"; return 0
             fi
+            case "$err" in
+              *"HTTP 404"*) RESOLVED="main"; return 0;;
+              *) echo "::error::could not check for branch '$RSKJ_REF' in $repo (non-404 API error; refusing to fall back to main): $err"; return 1;;
+            esac
           }
 
-          JSONRPC_REF=$(resolve_ref rsksmart/rskj-json-rpc-tests "$IN_JSONRPC")
-          HARDHAT_REF=$(resolve_ref rsksmart/rskj-hardhat-tests "$IN_HARDHAT")
-          K6_REF=$(resolve_ref rsksmart/rskj-k6-tests "$IN_K6")
+          resolve_ref rsksmart/rskj-json-rpc-tests "$IN_JSONRPC"; JSONRPC_REF="$RESOLVED"
+          resolve_ref rsksmart/rskj-hardhat-tests "$IN_HARDHAT"; HARDHAT_REF="$RESOLVED"
+          resolve_ref rsksmart/rskj-k6-tests "$IN_K6"; K6_REF="$RESOLVED"
 
           {
             echo "jsonrpc_ref=$JSONRPC_REF"

--- a/.github/workflows/rskj-core-automated-tests.yml
+++ b/.github/workflows/rskj-core-automated-tests.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Generate GitHub App token
         id: app-token
         if: steps.token.outputs.has_token == 'true'
-        uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
@@ -159,7 +159,7 @@ jobs:
       # Fresh ~1h token, minted at job start so the full dispatch + poll fits inside it.
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
@@ -228,7 +228,7 @@ jobs:
       # Fresh ~1h token, minted at job start so the full dispatch + poll fits inside it.
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
@@ -293,7 +293,7 @@ jobs:
       # Fresh ~1h token, minted at job start so the full dispatch + poll fits inside it.
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/rskj-core-automated-tests.yml
+++ b/.github/workflows/rskj-core-automated-tests.yml
@@ -8,12 +8,15 @@ name: RSKj Core Automated Tests
 #   Hardhat   -> rsksmart/rskj-hardhat-tests     (rskj-smart-contract-tests.yml, hardhat_branch)
 #   K6        -> rsksmart/rskj-k6-tests           (rskj-k6-tests.yml,           test_branch)
 #
-# Pure first-party tooling — gh / gh api / jq are all preinstalled on the runner;
-# there are no third-party (marketplace) actions. Cross-repo dispatch uses the
-# AUTOMATED_TESTS_GH_TOKEN fine-grained PAT (Actions: read+write, Contents: read
-# on the three test repos). The dispatch endpoint returns the created run id
-# directly via return_run_details=true (GitHub, 2026-02-19), so there is no
-# poll-to-correlate step.
+# gh / gh api / jq are all preinstalled on the runner. Cross-repo auth uses a
+# short-lived GitHub App installation token, minted per job via
+# actions/create-github-app-token (pinned by SHA) from the GH_APP_ID /
+# GH_APP_PRIVATE_KEY secrets. The App is installed on the three test repos with
+# Actions: read+write and Contents: read. Each token lasts ~1h, which comfortably
+# covers a job's dispatch + poll-to-completion (all suites finish well under that,
+# and timeout-minutes keeps every job inside the token's lifetime). The dispatch
+# endpoint returns the created run id directly via return_run_details=true
+# (GitHub, 2026-02-19), so there is no poll-to-correlate step.
 
 on:
   pull_request:
@@ -58,26 +61,41 @@ jobs:
       hardhat_ref: ${{ steps.refs.outputs.hardhat_ref }}
       k6_ref: ${{ steps.refs.outputs.k6_ref }}
     steps:
-      # The PAT is a secret, so it is empty on fork PRs (GitHub withholds secrets
-      # from pull_request runs triggered by forks). Detect that here so the rest
-      # of the workflow can degrade gracefully instead of erroring on every gh call.
-      - name: Check cross-repo token
+      # App secrets are withheld from fork pull_request runs (GitHub does not expose
+      # secrets to runs triggered by forks). An empty private key is our fork-PR
+      # signal: detect it here so the rest of the workflow degrades gracefully
+      # (skip + stay green) instead of failing token mint / every gh call.
+      - name: Check cross-repo App credentials
         id: token
         env:
-          TOKEN: ${{ secrets.AUTOMATED_TESTS_GH_TOKEN }}
+          APP_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
         run: |
-          if [ -n "$TOKEN" ]; then
+          if [ -n "$APP_KEY" ]; then
             echo "has_token=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_token=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::AUTOMATED_TESTS_GH_TOKEN is empty (fork PR?) — downstream suites will be skipped."
+            echo "::warning::GH_APP_PRIVATE_KEY is empty (fork PR?) — downstream suites will be skipped."
           fi
+
+      # Mint a short-lived (~1h) installation token scoped to the three test repos.
+      - name: Generate GitHub App token
+        id: app-token
+        if: steps.token.outputs.has_token == 'true'
+        uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: rsksmart
+          repositories: |
+            rskj-json-rpc-tests
+            rskj-hardhat-tests
+            rskj-k6-tests
 
       - name: Resolve rskj + per-suite test refs
         id: refs
         if: steps.token.outputs.has_token == 'true'
         env:
-          GH_TOKEN: ${{ secrets.AUTOMATED_TESTS_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           EVENT: ${{ github.event_name }}
           HEAD_REF: ${{ github.head_ref }}
           REF_NAME: ${{ github.ref_name }}
@@ -130,15 +148,24 @@ jobs:
     needs: resolve
     if: needs.resolve.outputs.has_token == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 300
+    timeout-minutes: 50
     outputs:
       conclusion: ${{ steps.run.outputs.conclusion }}
       run_url: ${{ steps.run.outputs.run_url }}
     steps:
+      # Fresh ~1h token, minted at job start so the full dispatch + poll fits inside it.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: rsksmart
+          repositories: rskj-json-rpc-tests
       - name: Dispatch and wait
         id: run
         env:
-          GH_TOKEN: ${{ secrets.AUTOMATED_TESTS_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: rsksmart/rskj-json-rpc-tests
           WORKFLOW: rskj-json-rpc-tests.yml
           TEST_INPUT: test_branch
@@ -166,12 +193,12 @@ jobs:
           echo "Triggered run $RUN_ID — $RUN_URL"
           # Wait for completion by polling the run status (keyed on the id we
           # already hold — deterministic, unlike `gh run watch`, which can race a
-          # just-created run). ~600 * 30s = 5h, matching this job's timeout. A
+          # just-created run). ~100 * 30s = 50m, matching this job's timeout. A
           # downstream *test* failure is captured as the conclusion (not raised
           # here) so the report job can gate centrally; a dispatch/infra error
           # already exited non-zero above.
           CONCLUSION=""
-          for _ in $(seq 1 600); do
+          for _ in $(seq 1 100); do
             STATUS=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.status' 2>/dev/null || echo "")
             if [ "$STATUS" = "completed" ]; then
               CONCLUSION=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.conclusion // "unknown"' || echo "unknown")
@@ -188,15 +215,24 @@ jobs:
     needs: resolve
     if: needs.resolve.outputs.has_token == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 300
+    timeout-minutes: 50
     outputs:
       conclusion: ${{ steps.run.outputs.conclusion }}
       run_url: ${{ steps.run.outputs.run_url }}
     steps:
+      # Fresh ~1h token, minted at job start so the full dispatch + poll fits inside it.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: rsksmart
+          repositories: rskj-hardhat-tests
       - name: Dispatch and wait
         id: run
         env:
-          GH_TOKEN: ${{ secrets.AUTOMATED_TESTS_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: rsksmart/rskj-hardhat-tests
           WORKFLOW: rskj-smart-contract-tests.yml
           TEST_INPUT: hardhat_branch
@@ -232,15 +268,24 @@ jobs:
     needs: resolve
     if: needs.resolve.outputs.has_token == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 300
+    timeout-minutes: 50
     outputs:
       conclusion: ${{ steps.run.outputs.conclusion }}
       run_url: ${{ steps.run.outputs.run_url }}
     steps:
+      # Fresh ~1h token, minted at job start so the full dispatch + poll fits inside it.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@31c86eb3b33c9b601a1f60f98dcbfd1d70f379b4 # v1.10.3
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: rsksmart
+          repositories: rskj-k6-tests
       - name: Dispatch and wait
         id: run
         env:
-          GH_TOKEN: ${{ secrets.AUTOMATED_TESTS_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO: rsksmart/rskj-k6-tests
           WORKFLOW: rskj-k6-tests.yml
           TEST_INPUT: test_branch
@@ -277,7 +322,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     # Only this job writes with GITHUB_TOKEN (the sticky PR comment). The other
-    # jobs use the PAT, so they keep the top-level contents: read default.
+    # jobs use the App token, so they keep the top-level contents: read default.
     permissions:
       pull-requests: write
     steps:
@@ -301,15 +346,15 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Fork PR: the cross-repo token was unavailable, so nothing was
-          # dispatched. Report the skip and stay green — the PR cannot supply the
-          # secret, so we do not block it.
+          # Fork PR: the App credentials were unavailable, so no token could be
+          # minted and nothing was dispatched. Report the skip and stay green — the
+          # PR cannot supply the secret, so we do not block it.
           if [ "$HAS_TOKEN" != "true" ]; then
             {
               echo "### RSKj Core Automated Tests — ⏭️ skipped"
               echo ""
-              echo "Cross-repo token \`AUTOMATED_TESTS_GH_TOKEN\` was unavailable"
-              echo "(expected on fork PRs, where secrets are withheld). The"
+              echo "GitHub App credentials (\`GH_APP_ID\` / \`GH_APP_PRIVATE_KEY\`) were"
+              echo "unavailable (expected on fork PRs, where secrets are withheld). The"
               echo "JSON-RPC / Hardhat / K6 suites were not dispatched."
             } >> "$GITHUB_STEP_SUMMARY"
             exit 0

--- a/.github/workflows/rskj-core-automated-tests.yml
+++ b/.github/workflows/rskj-core-automated-tests.yml
@@ -70,14 +70,26 @@ jobs:
         env:
           APP_ID: ${{ secrets.GH_APP_ID }}
           APP_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          # Only a PR whose head is a fork has secrets withheld by GitHub. Same-repo
+          # PRs and workflow_dispatch always have them (head.repo.fork is empty on
+          # dispatch → treated as non-fork).
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
         run: |
           # Require BOTH secrets: a present key with a missing/misconfigured id
           # would still fail token mint later, in a less obvious way.
           if [ -n "$APP_ID" ] && [ -n "$APP_KEY" ]; then
             echo "has_token=true" >> "$GITHUB_OUTPUT"
-          else
+          elif [ "$IS_FORK" = "true" ]; then
+            # Fork PR: secrets are legitimately unavailable. Skip + stay green —
+            # the PR cannot supply them, so we do not block it.
             echo "has_token=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::GH_APP_ID / GH_APP_PRIVATE_KEY unavailable (fork PR?) — downstream suites will be skipped."
+            echo "::warning::GH_APP_ID / GH_APP_PRIVATE_KEY unavailable (fork PR — secrets are withheld); downstream suites will be skipped."
+          else
+            # Non-fork run with missing secrets means they were removed or
+            # misconfigured on this repo. Fail loudly rather than silently
+            # skipping, which would defeat this check's required-gate purpose.
+            echo "::error::GH_APP_ID / GH_APP_PRIVATE_KEY are missing on a non-fork run; configure the GitHub App secrets so the cross-repo suites can be dispatched."
+            exit 1
           fi
 
       # Mint a short-lived (~1h) installation token scoped to the three test repos.
@@ -375,10 +387,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Fork PR: the App credentials were unavailable, so no token could be
-          # minted and nothing was dispatched. Report the skip and stay green — the
-          # PR cannot supply the secret, so we do not block it.
-          if [ "$HAS_TOKEN" != "true" ]; then
+          # Fork PR (has_token == "false"): the App credentials were legitimately
+          # unavailable, so no token could be minted and nothing was dispatched.
+          # Report the skip and stay green — the PR cannot supply the secret, so we
+          # do not block it. A missing-secret failure on a non-fork run is a
+          # different case: resolve exits non-zero there, leaving has_token empty,
+          # which falls through to the normal report below and gates the PR red.
+          if [ "$HAS_TOKEN" = "false" ]; then
             {
               echo "### RSKj Core Automated Tests — ⏭️ skipped"
               echo ""

--- a/.github/workflows/rskj-core-automated-tests.yml
+++ b/.github/workflows/rskj-core-automated-tests.yml
@@ -163,7 +163,7 @@ jobs:
     needs: resolve
     if: needs.resolve.outputs.has_token == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 55
     outputs:
       conclusion: ${{ steps.run.outputs.conclusion }}
       run_url: ${{ steps.run.outputs.run_url }}
@@ -206,19 +206,27 @@ jobs:
           fi
           echo "run_url=$RUN_URL" >> "$GITHUB_OUTPUT"
           echo "Triggered run $RUN_ID — $RUN_URL"
+          # If THIS job is cancelled (e.g. concurrency cancel-in-progress on a new
+          # push), cancel the downstream run too so it doesn't keep burning minutes
+          # orphaned. Best-effort: fires on the grace-period INT/TERM during the
+          # poll's sleep below; a hard kill may skip it.
+          cleanup() { gh api -X POST "repos/$REPO/actions/runs/$RUN_ID/cancel" >/dev/null 2>&1 || true; }
+          trap cleanup INT TERM
           # Wait for completion by polling the run status (keyed on the id we
           # already hold — deterministic, unlike `gh run watch`, which can race a
-          # just-created run). ~90 * 30s = 45m, leaving a buffer under this job's
-          # timeout-minutes: 50 so the conclusion can still be written to
-          # $GITHUB_OUTPUT instead of the job being killed mid-step. A downstream
-          # *test* failure is captured as the conclusion (not raised here) so the
-          # report job can gate centrally; a dispatch/infra error already exited
-          # non-zero above.
+          # just-created run). 100 * 30s = 50m of polling, kept under this job's
+          # timeout-minutes: 55 so a run finishing near the top of the window is
+          # still observed (not falsely marked timed_out) and the conclusion can be
+          # written to $GITHUB_OUTPUT before the job is killed mid-step. status and
+          # conclusion are read in one API call per tick. A downstream *test* failure
+          # is captured as the conclusion (not raised here) so the report job can
+          # gate centrally; a dispatch/infra error already exited non-zero above.
           CONCLUSION=""
-          for _ in $(seq 1 90); do
-            STATUS=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.status' 2>/dev/null || echo "")
+          for _ in $(seq 1 100); do
+            read -r STATUS RUN_CONCLUSION < <(gh api "repos/$REPO/actions/runs/$RUN_ID" \
+              --jq '"\(.status) \(.conclusion // "unknown")"' 2>/dev/null || echo " ")
             if [ "$STATUS" = "completed" ]; then
-              CONCLUSION=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.conclusion // "unknown"' || echo "unknown")
+              CONCLUSION="$RUN_CONCLUSION"
               break
             fi
             sleep 30
@@ -232,7 +240,7 @@ jobs:
     needs: resolve
     if: needs.resolve.outputs.has_token == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 55
     outputs:
       conclusion: ${{ steps.run.outputs.conclusion }}
       run_url: ${{ steps.run.outputs.run_url }}
@@ -275,15 +283,20 @@ jobs:
           fi
           echo "run_url=$RUN_URL" >> "$GITHUB_OUTPUT"
           echo "Triggered run $RUN_ID — $RUN_URL"
+          # Cancel the downstream run if THIS job is cancelled (see JSON-RPC job).
+          cleanup() { gh api -X POST "repos/$REPO/actions/runs/$RUN_ID/cancel" >/dev/null 2>&1 || true; }
+          trap cleanup INT TERM
           # Deterministic poll on the id we hold (see JSON-RPC job): `gh run watch`
           # can return early on a transient error or a just-created run, leaving
           # .conclusion null → coerced to "unknown" → a false gate failure even
-          # though the run later succeeds. Poll to status=completed (or time out).
+          # though the run later succeeds. 100 * 30s = 50m, kept under timeout-minutes: 55;
+          # status and conclusion are read in one API call per tick.
           CONCLUSION=""
-          for _ in $(seq 1 90); do
-            STATUS=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.status' 2>/dev/null || echo "")
+          for _ in $(seq 1 100); do
+            read -r STATUS RUN_CONCLUSION < <(gh api "repos/$REPO/actions/runs/$RUN_ID" \
+              --jq '"\(.status) \(.conclusion // "unknown")"' 2>/dev/null || echo " ")
             if [ "$STATUS" = "completed" ]; then
-              CONCLUSION=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.conclusion // "unknown"' || echo "unknown")
+              CONCLUSION="$RUN_CONCLUSION"
               break
             fi
             sleep 30
@@ -297,7 +310,7 @@ jobs:
     needs: resolve
     if: needs.resolve.outputs.has_token == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 55
     outputs:
       conclusion: ${{ steps.run.outputs.conclusion }}
       run_url: ${{ steps.run.outputs.run_url }}
@@ -340,15 +353,20 @@ jobs:
           fi
           echo "run_url=$RUN_URL" >> "$GITHUB_OUTPUT"
           echo "Triggered run $RUN_ID — $RUN_URL"
+          # Cancel the downstream run if THIS job is cancelled (see JSON-RPC job).
+          cleanup() { gh api -X POST "repos/$REPO/actions/runs/$RUN_ID/cancel" >/dev/null 2>&1 || true; }
+          trap cleanup INT TERM
           # Deterministic poll on the id we hold (see JSON-RPC job): `gh run watch`
           # can return early on a transient error or a just-created run, leaving
           # .conclusion null → coerced to "unknown" → a false gate failure even
-          # though the run later succeeds. Poll to status=completed (or time out).
+          # though the run later succeeds. 100 * 30s = 50m, kept under timeout-minutes: 55;
+          # status and conclusion are read in one API call per tick.
           CONCLUSION=""
-          for _ in $(seq 1 90); do
-            STATUS=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.status' 2>/dev/null || echo "")
+          for _ in $(seq 1 100); do
+            read -r STATUS RUN_CONCLUSION < <(gh api "repos/$REPO/actions/runs/$RUN_ID" \
+              --jq '"\(.status) \(.conclusion // "unknown")"' 2>/dev/null || echo " ")
             if [ "$STATUS" = "completed" ]; then
-              CONCLUSION=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.conclusion // "unknown"' || echo "unknown")
+              CONCLUSION="$RUN_CONCLUSION"
               break
             fi
             sleep 30

--- a/.github/workflows/rskj-core-automated-tests.yml
+++ b/.github/workflows/rskj-core-automated-tests.yml
@@ -166,8 +166,10 @@ jobs:
           echo "Triggered run $RUN_ID — $RUN_URL"
           # Wait for completion by polling the run status (keyed on the id we
           # already hold — deterministic, unlike `gh run watch`, which can race a
-          # just-created run). ~600 * 30s = 5h, matching this job's timeout; the
-          # report job gates centrally on the conclusion, so we never fail here.
+          # just-created run). ~600 * 30s = 5h, matching this job's timeout. A
+          # downstream *test* failure is captured as the conclusion (not raised
+          # here) so the report job can gate centrally; a dispatch/infra error
+          # already exited non-zero above.
           CONCLUSION=""
           for _ in $(seq 1 600); do
             STATUS=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.status' 2>/dev/null || echo "")

--- a/.github/workflows/rskj-core-automated-tests.yml
+++ b/.github/workflows/rskj-core-automated-tests.yml
@@ -214,8 +214,14 @@ jobs:
       app_id: ${{ secrets.GH_APP_ID }}
       app_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
+  # This is the authoritative gate: it always runs (if: always()), consolidates
+  # the three suite conclusions, and exits non-zero on any failure. Pin THIS check
+  # (name: "Automated Regression Report") as the required status check in branch
+  # protection — never the per-suite checks, whose names change if the suites are
+  # refactored (e.g. the reusable-workflow extraction renamed them to
+  # "<suite> suite / <suite>"). Its name is intentionally stable for that reason.
   report:
-    name: Report
+    name: Automated Regression Report
     needs: [resolve, json_rpc, hardhat, k6]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/rskj-core-automated-tests.yml
+++ b/.github/workflows/rskj-core-automated-tests.yml
@@ -133,6 +133,18 @@ jobs:
           else
             RSKJ_REF="$HEAD_REF"
           fi
+
+          # Validate the ref before it is ever interpolated, unencoded, into a
+          # gh api REST path below (resolve_ref's "repos/<repo>/branches/$RSKJ_REF").
+          # github.head_ref and the workflow_dispatch inputs are caller-controlled
+          # and the dispatch inputs are not constrained to real ref syntax, so a
+          # crafted value containing ".." or path/control characters could redirect
+          # the call. Restrict to safe git-ref characters and reject any "..".
+          case "$RSKJ_REF" in
+            ""|*..*) echo "::error::invalid rskj ref (empty or contains '..'): '$RSKJ_REF'"; exit 1;;
+            *[!A-Za-z0-9._/-]*) echo "::error::rskj ref has disallowed characters: '$RSKJ_REF'"; exit 1;;
+          esac
+
           echo "rskj_ref=$RSKJ_REF" >> "$GITHUB_OUTPUT"
           echo "rskj ref: $RSKJ_REF"
 
@@ -239,12 +251,15 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           RSKJ_REF: ${{ needs.resolve.outputs.rskj_ref }}
           JSONRPC_CONCLUSION: ${{ needs.json_rpc.outputs.conclusion }}
+          JSONRPC_RESULT: ${{ needs.json_rpc.result }}
           JSONRPC_URL: ${{ needs.json_rpc.outputs.run_url }}
           JSONRPC_REF: ${{ needs.resolve.outputs.jsonrpc_ref }}
           HARDHAT_CONCLUSION: ${{ needs.hardhat.outputs.conclusion }}
+          HARDHAT_RESULT: ${{ needs.hardhat.result }}
           HARDHAT_URL: ${{ needs.hardhat.outputs.run_url }}
           HARDHAT_REF: ${{ needs.resolve.outputs.hardhat_ref }}
           K6_CONCLUSION: ${{ needs.k6.outputs.conclusion }}
+          K6_RESULT: ${{ needs.k6.result }}
           K6_URL: ${{ needs.k6.outputs.run_url }}
           K6_REF: ${{ needs.resolve.outputs.k6_ref }}
         run: |
@@ -266,6 +281,16 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
+
+          # A suite that failed at the infrastructure level (token mint, dispatch,
+          # runner death, job timeout) never wrote its `conclusion` output, so it
+          # arrives here empty. Fall back to the job's own result (failure /
+          # cancelled / skipped) so the table and gate report the real outcome
+          # instead of a blank "no result" cell. The gate already fails closed on a
+          # non-success value either way; this only makes the report honest.
+          JSONRPC_CONCLUSION="${JSONRPC_CONCLUSION:-$JSONRPC_RESULT}"
+          HARDHAT_CONCLUSION="${HARDHAT_CONCLUSION:-$HARDHAT_RESULT}"
+          K6_CONCLUSION="${K6_CONCLUSION:-$K6_RESULT}"
 
           emoji() {
             case "$1" in

--- a/.github/workflows/rskj-core-automated-tests.yml
+++ b/.github/workflows/rskj-core-automated-tests.yml
@@ -279,14 +279,13 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Build report, comment, notify and gate
+      - name: Build report, comment and gate
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HAS_TOKEN: ${{ needs.resolve.outputs.has_token }}
           EVENT: ${{ github.event_name }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
           RSKJ_REF: ${{ needs.resolve.outputs.rskj_ref }}
           JSONRPC_CONCLUSION: ${{ needs.json_rpc.outputs.conclusion }}
           JSONRPC_URL: ${{ needs.json_rpc.outputs.run_url }}
@@ -297,8 +296,6 @@ jobs:
           K6_CONCLUSION: ${{ needs.k6.outputs.conclusion }}
           K6_URL: ${{ needs.k6.outputs.run_url }}
           K6_REF: ${{ needs.resolve.outputs.k6_ref }}
-          SLACK_TOKEN: ${{ secrets.GHA_SLACK_NOTIFICATION_TOKEN }}
-          SLACK_CHANNEL: ${{ vars.GHA_SLACK_NOTIFICATION_CHANNEL }}
         run: |
           set -euo pipefail
 
@@ -350,8 +347,7 @@ jobs:
 
           cat "$REPORT_FILE" >> "$GITHUB_STEP_SUMMARY"
 
-          # Determine overall result up front (drives the PR-comment marker,
-          # Slack styling, and the final gate).
+          # Determine overall result up front (drives the final gate).
           OVERALL=success
           for c in "$JSONRPC_CONCLUSION" "$HARDHAT_CONCLUSION" "$K6_CONCLUSION"; do
             [ "$c" = "success" ] || OVERALL=failure
@@ -375,23 +371,6 @@ jobs:
                 -f body="$(cat "$BODY_FILE")" >/dev/null
               echo "Created sticky PR comment"
             fi
-          fi
-
-          # Slack: only for rsksmart-owned PRs (mirrors rit.yml) and only when the
-          # bot token is present. curl, not a marketplace action.
-          if [ "$EVENT" = "pull_request" ] && [ "$PR_OWNER" = "rsksmart" ] && [ -n "${SLACK_TOKEN:-}" ]; then
-            if [ "$OVERALL" = "success" ]; then HEADER="✅ PASSED — Core Automated Tests"; else HEADER="❌ FAILED — Core Automated Tests"; fi
-            TEXT=$(printf '*%s* — %s #%s\n• JSON-RPC: %s %s\n• Hardhat: %s %s\n• K6: %s %s' \
-              "$HEADER" "$REPO" "$PR_NUMBER" \
-              "$(emoji "$JSONRPC_CONCLUSION")" "${JSONRPC_CONCLUSION:-no result}" \
-              "$(emoji "$HARDHAT_CONCLUSION")" "${HARDHAT_CONCLUSION:-no result}" \
-              "$(emoji "$K6_CONCLUSION")" "${K6_CONCLUSION:-no result}")
-            PAYLOAD=$(jq -n --arg ch "$SLACK_CHANNEL" --arg text "$TEXT" \
-              '{channel: $ch, text: $text}')
-            curl -sS -X POST https://slack.com/api/chat.postMessage \
-              -H "Authorization: Bearer $SLACK_TOKEN" \
-              -H "Content-type: application/json; charset=utf-8" \
-              --data "$PAYLOAD" >/dev/null || echo "::warning::Slack notification failed"
           fi
 
           # Authoritative gate.

--- a/.github/workflows/rskj-core-automated-tests.yml
+++ b/.github/workflows/rskj-core-automated-tests.yml
@@ -68,13 +68,16 @@ jobs:
       - name: Check cross-repo App credentials
         id: token
         env:
+          APP_ID: ${{ secrets.GH_APP_ID }}
           APP_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
         run: |
-          if [ -n "$APP_KEY" ]; then
+          # Require BOTH secrets: a present key with a missing/misconfigured id
+          # would still fail token mint later, in a less obvious way.
+          if [ -n "$APP_ID" ] && [ -n "$APP_KEY" ]; then
             echo "has_token=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_token=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::GH_APP_PRIVATE_KEY is empty (fork PR?) — downstream suites will be skipped."
+            echo "::warning::GH_APP_ID / GH_APP_PRIVATE_KEY unavailable (fork PR?) — downstream suites will be skipped."
           fi
 
       # Mint a short-lived (~1h) installation token scoped to the three test repos.
@@ -86,10 +89,10 @@ jobs:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: rsksmart
-          repositories: |
-            rskj-json-rpc-tests
-            rskj-hardhat-tests
-            rskj-k6-tests
+          # Comma-separated single line: this action version does not split a
+          # multi-line block into a list (it took the whole newline-joined string
+          # as one repo name and 404'd looking up its installation).
+          repositories: rskj-json-rpc-tests,rskj-hardhat-tests,rskj-k6-tests
 
       - name: Resolve rskj + per-suite test refs
         id: refs
@@ -193,12 +196,14 @@ jobs:
           echo "Triggered run $RUN_ID — $RUN_URL"
           # Wait for completion by polling the run status (keyed on the id we
           # already hold — deterministic, unlike `gh run watch`, which can race a
-          # just-created run). ~100 * 30s = 50m, matching this job's timeout. A
-          # downstream *test* failure is captured as the conclusion (not raised
-          # here) so the report job can gate centrally; a dispatch/infra error
-          # already exited non-zero above.
+          # just-created run). ~90 * 30s = 45m, leaving a buffer under this job's
+          # timeout-minutes: 50 so the conclusion can still be written to
+          # $GITHUB_OUTPUT instead of the job being killed mid-step. A downstream
+          # *test* failure is captured as the conclusion (not raised here) so the
+          # report job can gate centrally; a dispatch/infra error already exited
+          # non-zero above.
           CONCLUSION=""
-          for _ in $(seq 1 100); do
+          for _ in $(seq 1 90); do
             STATUS=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.status' 2>/dev/null || echo "")
             if [ "$STATUS" = "completed" ]; then
               CONCLUSION=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.conclusion // "unknown"' || echo "unknown")
@@ -258,8 +263,20 @@ jobs:
           fi
           echo "run_url=$RUN_URL" >> "$GITHUB_OUTPUT"
           echo "Triggered run $RUN_ID — $RUN_URL"
-          gh run watch "$RUN_ID" -R "$REPO" --exit-status --interval 30 || true
-          CONCLUSION=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.conclusion // "unknown"' || echo "unknown")
+          # Deterministic poll on the id we hold (see JSON-RPC job): `gh run watch`
+          # can return early on a transient error or a just-created run, leaving
+          # .conclusion null → coerced to "unknown" → a false gate failure even
+          # though the run later succeeds. Poll to status=completed (or time out).
+          CONCLUSION=""
+          for _ in $(seq 1 90); do
+            STATUS=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.status' 2>/dev/null || echo "")
+            if [ "$STATUS" = "completed" ]; then
+              CONCLUSION=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.conclusion // "unknown"' || echo "unknown")
+              break
+            fi
+            sleep 30
+          done
+          [ -n "$CONCLUSION" ] || CONCLUSION="timed_out"
           echo "conclusion=$CONCLUSION" >> "$GITHUB_OUTPUT"
           echo "Hardhat suite concluded: $CONCLUSION"
 
@@ -311,8 +328,20 @@ jobs:
           fi
           echo "run_url=$RUN_URL" >> "$GITHUB_OUTPUT"
           echo "Triggered run $RUN_ID — $RUN_URL"
-          gh run watch "$RUN_ID" -R "$REPO" --exit-status --interval 30 || true
-          CONCLUSION=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.conclusion // "unknown"' || echo "unknown")
+          # Deterministic poll on the id we hold (see JSON-RPC job): `gh run watch`
+          # can return early on a transient error or a just-created run, leaving
+          # .conclusion null → coerced to "unknown" → a false gate failure even
+          # though the run later succeeds. Poll to status=completed (or time out).
+          CONCLUSION=""
+          for _ in $(seq 1 90); do
+            STATUS=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.status' 2>/dev/null || echo "")
+            if [ "$STATUS" = "completed" ]; then
+              CONCLUSION=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.conclusion // "unknown"' || echo "unknown")
+              break
+            fi
+            sleep 30
+          done
+          [ -n "$CONCLUSION" ] || CONCLUSION="timed_out"
           echo "conclusion=$CONCLUSION" >> "$GITHUB_OUTPUT"
           echo "K6 suite concluded: $CONCLUSION"
 

--- a/.github/workflows/rskj-core-automated-tests.yml
+++ b/.github/workflows/rskj-core-automated-tests.yml
@@ -38,14 +38,10 @@ on:
         type: string
         required: false
 
+# Least privilege at the top level; the only job that needs a write scope
+# (pull-requests: write, for the sticky PR comment) declares it itself.
 permissions:
   contents: read
-  pull-requests: write
-  # issues: write is required because the sticky PR comment is posted via the
-  # issue-comments REST endpoint (repos/.../issues/<n>/comments); pull-requests:
-  # write alone can 403 there, which would fail the report job even when all
-  # suites pass.
-  issues: write
 
 concurrency:
   group: rskj-core-automated-tests-${{ github.ref }}
@@ -278,6 +274,10 @@ jobs:
     needs: [resolve, json_rpc, hardhat, k6]
     if: always()
     runs-on: ubuntu-latest
+    # Only this job writes with GITHUB_TOKEN (the sticky PR comment). The other
+    # jobs use the PAT, so they keep the top-level contents: read default.
+    permissions:
+      pull-requests: write
     steps:
       - name: Build report, comment and gate
         env:

--- a/.github/workflows/rskj-core-automated-tests.yml
+++ b/.github/workflows/rskj-core-automated-tests.yml
@@ -1,0 +1,397 @@
+name: RSKj Core Automated Tests
+
+# Umbrella check: on an rskj PR (or manual dispatch), trigger the three external
+# test suites against this rskj change in parallel, wait for all of them, and
+# surface a single concise pass/fail report.
+#
+#   JSON-RPC  -> rsksmart/rskj-json-rpc-tests   (rskj-json-rpc-tests.yml,     test_branch)
+#   Hardhat   -> rsksmart/rskj-hardhat-tests     (rskj-smart-contract-tests.yml, hardhat_branch)
+#   K6        -> rsksmart/rskj-k6-tests           (rskj-k6-tests.yml,           test_branch)
+#
+# Pure first-party tooling — gh / gh api / jq are all preinstalled on the runner;
+# there are no third-party (marketplace) actions. Cross-repo dispatch uses the
+# AUTOMATED_TESTS_GH_TOKEN fine-grained PAT (Actions: read+write, Contents: read
+# on the three test repos). The dispatch endpoint returns the created run id
+# directly via return_run_details=true (GitHub, 2026-02-19), so there is no
+# poll-to-correlate step.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches: ["master", "*-rc"]
+  workflow_dispatch:
+    inputs:
+      rskj_branch:
+        description: "rskj branch the suites build the node from (default: this ref)"
+        type: string
+        required: false
+      jsonrpc_branch:
+        description: "rskj-json-rpc-tests branch (default: auto-match, else main)"
+        type: string
+        required: false
+      hardhat_branch:
+        description: "rskj-hardhat-tests branch (default: auto-match, else main)"
+        type: string
+        required: false
+      k6_branch:
+        description: "rskj-k6-tests branch (default: auto-match, else main)"
+        type: string
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: rskj-core-automated-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  resolve:
+    name: Resolve refs
+    runs-on: ubuntu-latest
+    outputs:
+      has_token: ${{ steps.token.outputs.has_token }}
+      rskj_ref: ${{ steps.refs.outputs.rskj_ref }}
+      jsonrpc_ref: ${{ steps.refs.outputs.jsonrpc_ref }}
+      hardhat_ref: ${{ steps.refs.outputs.hardhat_ref }}
+      k6_ref: ${{ steps.refs.outputs.k6_ref }}
+    steps:
+      # The PAT is a secret, so it is empty on fork PRs (GitHub withholds secrets
+      # from pull_request runs triggered by forks). Detect that here so the rest
+      # of the workflow can degrade gracefully instead of erroring on every gh call.
+      - name: Check cross-repo token
+        id: token
+        env:
+          TOKEN: ${{ secrets.AUTOMATED_TESTS_GH_TOKEN }}
+        run: |
+          if [ -n "$TOKEN" ]; then
+            echo "has_token=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_token=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::AUTOMATED_TESTS_GH_TOKEN is empty (fork PR?) — downstream suites will be skipped."
+          fi
+
+      - name: Resolve rskj + per-suite test refs
+        id: refs
+        if: steps.token.outputs.has_token == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMATED_TESTS_GH_TOKEN }}
+          EVENT: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
+          IN_RSKJ: ${{ inputs.rskj_branch }}
+          IN_JSONRPC: ${{ inputs.jsonrpc_branch }}
+          IN_HARDHAT: ${{ inputs.hardhat_branch }}
+          IN_K6: ${{ inputs.k6_branch }}
+        run: |
+          set -euo pipefail
+
+          # rskj ref: PR head branch on PRs; the dispatch input (or the dispatched
+          # ref) on manual runs. The three suites build the node from this.
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            RSKJ_REF="${IN_RSKJ:-$REF_NAME}"
+          else
+            RSKJ_REF="$HEAD_REF"
+          fi
+          echo "rskj_ref=$RSKJ_REF" >> "$GITHUB_OUTPUT"
+          echo "rskj ref: $RSKJ_REF"
+
+          # Matching-branch convention: if a branch named "$RSKJ_REF" exists in a
+          # test repo, run that branch there (so companion test/workflow changes on
+          # a same-named branch are exercised); otherwise fall back to main. An
+          # explicit dispatch input always wins.
+          resolve_ref() {
+            repo="$1"; override="$2"
+            if [ -n "$override" ]; then
+              echo "$override"; return
+            fi
+            if gh api "repos/$repo/branches/$RSKJ_REF" >/dev/null 2>&1; then
+              echo "$RSKJ_REF"
+            else
+              echo "main"
+            fi
+          }
+
+          JSONRPC_REF=$(resolve_ref rsksmart/rskj-json-rpc-tests "$IN_JSONRPC")
+          HARDHAT_REF=$(resolve_ref rsksmart/rskj-hardhat-tests "$IN_HARDHAT")
+          K6_REF=$(resolve_ref rsksmart/rskj-k6-tests "$IN_K6")
+
+          {
+            echo "jsonrpc_ref=$JSONRPC_REF"
+            echo "hardhat_ref=$HARDHAT_REF"
+            echo "k6_ref=$K6_REF"
+          } >> "$GITHUB_OUTPUT"
+          echo "json-rpc ref: $JSONRPC_REF | hardhat ref: $HARDHAT_REF | k6 ref: $K6_REF"
+
+  json_rpc:
+    name: JSON-RPC suite
+    needs: resolve
+    if: needs.resolve.outputs.has_token == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+    outputs:
+      conclusion: ${{ steps.run.outputs.conclusion }}
+      run_url: ${{ steps.run.outputs.run_url }}
+    steps:
+      - name: Dispatch and wait
+        id: run
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMATED_TESTS_GH_TOKEN }}
+          REPO: rsksmart/rskj-json-rpc-tests
+          WORKFLOW: rskj-json-rpc-tests.yml
+          TEST_INPUT: test_branch
+          RSKJ_REF: ${{ needs.resolve.outputs.rskj_ref }}
+          TEST_REF: ${{ needs.resolve.outputs.jsonrpc_ref }}
+        run: |
+          set -euo pipefail
+          INPUTS=$(jq -n --arg rskj "$RSKJ_REF" --arg k "$TEST_INPUT" --arg v "$TEST_REF" \
+            '{rskj_branch: $rskj, ($k): $v}')
+          BODY=$(jq -n --arg ref "$TEST_REF" --argjson inputs "$INPUTS" \
+            '{ref: $ref, inputs: $inputs, return_run_details: true}')
+          echo "Dispatching $WORKFLOW in $REPO on '$TEST_REF' (rskj_branch=$RSKJ_REF)"
+          if ! RESP=$(printf '%s' "$BODY" | gh api -X POST \
+              "repos/$REPO/actions/workflows/$WORKFLOW/dispatches" --input -); then
+            echo "::error::failed to dispatch $WORKFLOW in $REPO"
+            exit 1
+          fi
+          RUN_ID=$(jq -r '.workflow_run_id // empty' <<<"$RESP")
+          RUN_URL=$(jq -r '.html_url // empty' <<<"$RESP")
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::dispatch did not return a run id; response: $RESP"
+            exit 1
+          fi
+          echo "run_url=$RUN_URL" >> "$GITHUB_OUTPUT"
+          echo "Triggered run $RUN_ID — $RUN_URL"
+          # Wait for completion by polling the run status (keyed on the id we
+          # already hold — deterministic, unlike `gh run watch`, which can race a
+          # just-created run). ~600 * 30s = 5h, matching this job's timeout; the
+          # report job gates centrally on the conclusion, so we never fail here.
+          CONCLUSION=""
+          for _ in $(seq 1 600); do
+            STATUS=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.status' 2>/dev/null || echo "")
+            if [ "$STATUS" = "completed" ]; then
+              CONCLUSION=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.conclusion // "unknown"' || echo "unknown")
+              break
+            fi
+            sleep 30
+          done
+          [ -n "$CONCLUSION" ] || CONCLUSION="timed_out"
+          echo "conclusion=$CONCLUSION" >> "$GITHUB_OUTPUT"
+          echo "JSON-RPC suite concluded: $CONCLUSION"
+
+  hardhat:
+    name: Hardhat suite
+    needs: resolve
+    if: needs.resolve.outputs.has_token == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+    outputs:
+      conclusion: ${{ steps.run.outputs.conclusion }}
+      run_url: ${{ steps.run.outputs.run_url }}
+    steps:
+      - name: Dispatch and wait
+        id: run
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMATED_TESTS_GH_TOKEN }}
+          REPO: rsksmart/rskj-hardhat-tests
+          WORKFLOW: rskj-smart-contract-tests.yml
+          TEST_INPUT: hardhat_branch
+          RSKJ_REF: ${{ needs.resolve.outputs.rskj_ref }}
+          TEST_REF: ${{ needs.resolve.outputs.hardhat_ref }}
+        run: |
+          set -euo pipefail
+          INPUTS=$(jq -n --arg rskj "$RSKJ_REF" --arg k "$TEST_INPUT" --arg v "$TEST_REF" \
+            '{rskj_branch: $rskj, ($k): $v}')
+          BODY=$(jq -n --arg ref "$TEST_REF" --argjson inputs "$INPUTS" \
+            '{ref: $ref, inputs: $inputs, return_run_details: true}')
+          echo "Dispatching $WORKFLOW in $REPO on '$TEST_REF' (rskj_branch=$RSKJ_REF)"
+          if ! RESP=$(printf '%s' "$BODY" | gh api -X POST \
+              "repos/$REPO/actions/workflows/$WORKFLOW/dispatches" --input -); then
+            echo "::error::failed to dispatch $WORKFLOW in $REPO"
+            exit 1
+          fi
+          RUN_ID=$(jq -r '.workflow_run_id // empty' <<<"$RESP")
+          RUN_URL=$(jq -r '.html_url // empty' <<<"$RESP")
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::dispatch did not return a run id; response: $RESP"
+            exit 1
+          fi
+          echo "run_url=$RUN_URL" >> "$GITHUB_OUTPUT"
+          echo "Triggered run $RUN_ID — $RUN_URL"
+          gh run watch "$RUN_ID" -R "$REPO" --exit-status --interval 30 || true
+          CONCLUSION=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.conclusion // "unknown"' || echo "unknown")
+          echo "conclusion=$CONCLUSION" >> "$GITHUB_OUTPUT"
+          echo "Hardhat suite concluded: $CONCLUSION"
+
+  k6:
+    name: K6 suite
+    needs: resolve
+    if: needs.resolve.outputs.has_token == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+    outputs:
+      conclusion: ${{ steps.run.outputs.conclusion }}
+      run_url: ${{ steps.run.outputs.run_url }}
+    steps:
+      - name: Dispatch and wait
+        id: run
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMATED_TESTS_GH_TOKEN }}
+          REPO: rsksmart/rskj-k6-tests
+          WORKFLOW: rskj-k6-tests.yml
+          TEST_INPUT: test_branch
+          RSKJ_REF: ${{ needs.resolve.outputs.rskj_ref }}
+          TEST_REF: ${{ needs.resolve.outputs.k6_ref }}
+        run: |
+          set -euo pipefail
+          INPUTS=$(jq -n --arg rskj "$RSKJ_REF" --arg k "$TEST_INPUT" --arg v "$TEST_REF" \
+            '{rskj_branch: $rskj, ($k): $v}')
+          BODY=$(jq -n --arg ref "$TEST_REF" --argjson inputs "$INPUTS" \
+            '{ref: $ref, inputs: $inputs, return_run_details: true}')
+          echo "Dispatching $WORKFLOW in $REPO on '$TEST_REF' (rskj_branch=$RSKJ_REF)"
+          if ! RESP=$(printf '%s' "$BODY" | gh api -X POST \
+              "repos/$REPO/actions/workflows/$WORKFLOW/dispatches" --input -); then
+            echo "::error::failed to dispatch $WORKFLOW in $REPO"
+            exit 1
+          fi
+          RUN_ID=$(jq -r '.workflow_run_id // empty' <<<"$RESP")
+          RUN_URL=$(jq -r '.html_url // empty' <<<"$RESP")
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::dispatch did not return a run id; response: $RESP"
+            exit 1
+          fi
+          echo "run_url=$RUN_URL" >> "$GITHUB_OUTPUT"
+          echo "Triggered run $RUN_ID — $RUN_URL"
+          gh run watch "$RUN_ID" -R "$REPO" --exit-status --interval 30 || true
+          CONCLUSION=$(gh api "repos/$REPO/actions/runs/$RUN_ID" --jq '.conclusion // "unknown"' || echo "unknown")
+          echo "conclusion=$CONCLUSION" >> "$GITHUB_OUTPUT"
+          echo "K6 suite concluded: $CONCLUSION"
+
+  report:
+    name: Report
+    needs: [resolve, json_rpc, hardhat, k6]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build report, comment, notify and gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HAS_TOKEN: ${{ needs.resolve.outputs.has_token }}
+          EVENT: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
+          RSKJ_REF: ${{ needs.resolve.outputs.rskj_ref }}
+          JSONRPC_CONCLUSION: ${{ needs.json_rpc.outputs.conclusion }}
+          JSONRPC_URL: ${{ needs.json_rpc.outputs.run_url }}
+          JSONRPC_REF: ${{ needs.resolve.outputs.jsonrpc_ref }}
+          HARDHAT_CONCLUSION: ${{ needs.hardhat.outputs.conclusion }}
+          HARDHAT_URL: ${{ needs.hardhat.outputs.run_url }}
+          HARDHAT_REF: ${{ needs.resolve.outputs.hardhat_ref }}
+          K6_CONCLUSION: ${{ needs.k6.outputs.conclusion }}
+          K6_URL: ${{ needs.k6.outputs.run_url }}
+          K6_REF: ${{ needs.resolve.outputs.k6_ref }}
+          SLACK_TOKEN: ${{ secrets.GHA_SLACK_NOTIFICATION_TOKEN }}
+          SLACK_CHANNEL: ${{ vars.GHA_SLACK_NOTIFICATION_CHANNEL }}
+        run: |
+          set -euo pipefail
+
+          # Fork PR: the cross-repo token was unavailable, so nothing was
+          # dispatched. Report the skip and stay green — the PR cannot supply the
+          # secret, so we do not block it.
+          if [ "$HAS_TOKEN" != "true" ]; then
+            {
+              echo "### RSKj Core Automated Tests — ⏭️ skipped"
+              echo ""
+              echo "Cross-repo token \`AUTOMATED_TESTS_GH_TOKEN\` was unavailable"
+              echo "(expected on fork PRs, where secrets are withheld). The"
+              echo "JSON-RPC / Hardhat / K6 suites were not dispatched."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          emoji() {
+            case "$1" in
+              success) echo "✅";;
+              failure) echo "❌";;
+              cancelled) echo "🚫";;
+              timed_out) echo "⏱️";;
+              skipped) echo "⏭️";;
+              "") echo "⚠️";;
+              *) echo "❓";;
+            esac
+          }
+
+          row() { # name conclusion ref url
+            # shellcheck disable=SC2016  # the backticks are literal markdown, not command substitution
+            printf '| %s | %s %s | `%s` | [run](%s) |\n' \
+              "$1" "$(emoji "$2")" "${2:-no result}" "${3:-?}" "${4:-#}"
+          }
+
+          # Header + table, reused for the summary and the PR comment.
+          REPORT_FILE="$(mktemp)"
+          {
+            echo "### RSKj Core Automated Tests"
+            echo ""
+            echo "rskj node built from \`${RSKJ_REF}\`."
+            echo ""
+            echo "| Suite | Result | Branch tested | Run |"
+            echo "| --- | --- | --- | --- |"
+            row "JSON-RPC" "$JSONRPC_CONCLUSION" "$JSONRPC_REF" "$JSONRPC_URL"
+            row "Hardhat"  "$HARDHAT_CONCLUSION" "$HARDHAT_REF" "$HARDHAT_URL"
+            row "K6"       "$K6_CONCLUSION"      "$K6_REF"      "$K6_URL"
+          } > "$REPORT_FILE"
+
+          cat "$REPORT_FILE" >> "$GITHUB_STEP_SUMMARY"
+
+          # Determine overall result up front (drives the PR-comment marker,
+          # Slack styling, and the final gate).
+          OVERALL=success
+          for c in "$JSONRPC_CONCLUSION" "$HARDHAT_CONCLUSION" "$K6_CONCLUSION"; do
+            [ "$c" = "success" ] || OVERALL=failure
+          done
+
+          # Sticky PR comment: upsert by a hidden marker so each push updates the
+          # same comment instead of stacking new ones. Uses the built-in token.
+          if [ "$EVENT" = "pull_request" ] && [ -n "${PR_NUMBER:-}" ]; then
+            MARKER="<!-- rskj-core-automated-tests -->"
+            BODY_FILE="$(mktemp)"
+            { printf '%s\n' "$MARKER"; cat "$REPORT_FILE"; } > "$BODY_FILE"
+            CID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+              --jq "map(select(.body | startswith(\"$MARKER\"))) | .[0].id // empty" 2>/dev/null \
+              | head -n1 || true)
+            if [ -n "$CID" ]; then
+              gh api -X PATCH "repos/$REPO/issues/comments/$CID" \
+                -f body="$(cat "$BODY_FILE")" >/dev/null
+              echo "Updated sticky PR comment $CID"
+            else
+              gh api -X POST "repos/$REPO/issues/$PR_NUMBER/comments" \
+                -f body="$(cat "$BODY_FILE")" >/dev/null
+              echo "Created sticky PR comment"
+            fi
+          fi
+
+          # Slack: only for rsksmart-owned PRs (mirrors rit.yml) and only when the
+          # bot token is present. curl, not a marketplace action.
+          if [ "$EVENT" = "pull_request" ] && [ "$PR_OWNER" = "rsksmart" ] && [ -n "${SLACK_TOKEN:-}" ]; then
+            if [ "$OVERALL" = "success" ]; then HEADER="✅ PASSED — Core Automated Tests"; else HEADER="❌ FAILED — Core Automated Tests"; fi
+            TEXT=$(printf '*%s* — %s #%s\n• JSON-RPC: %s %s\n• Hardhat: %s %s\n• K6: %s %s' \
+              "$HEADER" "$REPO" "$PR_NUMBER" \
+              "$(emoji "$JSONRPC_CONCLUSION")" "${JSONRPC_CONCLUSION:-no result}" \
+              "$(emoji "$HARDHAT_CONCLUSION")" "${HARDHAT_CONCLUSION:-no result}" \
+              "$(emoji "$K6_CONCLUSION")" "${K6_CONCLUSION:-no result}")
+            PAYLOAD=$(jq -n --arg ch "$SLACK_CHANNEL" --arg text "$TEXT" \
+              '{channel: $ch, text: $text}')
+            curl -sS -X POST https://slack.com/api/chat.postMessage \
+              -H "Authorization: Bearer $SLACK_TOKEN" \
+              -H "Content-type: application/json; charset=utf-8" \
+              --data "$PAYLOAD" >/dev/null || echo "::warning::Slack notification failed"
+          fi
+
+          # Authoritative gate.
+          if [ "$OVERALL" != "success" ]; then
+            echo "::error::one or more downstream suites did not succeed (JSON-RPC=$JSONRPC_CONCLUSION, Hardhat=$HARDHAT_CONCLUSION, K6=$K6_CONCLUSION)"
+            exit 1
+          fi
+          echo "All downstream suites passed."

--- a/.github/workflows/rskj-core-automated-tests.yml
+++ b/.github/workflows/rskj-core-automated-tests.yml
@@ -9,7 +9,7 @@ name: RSKj Core Automated Tests
 #   K6        -> rsksmart/rskj-k6-tests           (rskj-k6-tests.yml,           test_branch)
 #
 # gh / gh api / jq are all preinstalled on the runner. Cross-repo auth uses a
-# short-lived GitHub App installation token, minted per job via
+# short-lived GitHub App installation token, minted per suite via
 # actions/create-github-app-token (pinned by SHA) from the GH_APP_ID /
 # GH_APP_PRIVATE_KEY secrets. The App is installed on the three test repos with
 # Actions: read+write and Contents: read. Each token lasts ~1h, which comfortably
@@ -17,6 +17,11 @@ name: RSKj Core Automated Tests
 # and timeout-minutes keeps every job inside the token's lifetime). The dispatch
 # endpoint returns the created run id directly via return_run_details=true
 # (GitHub, 2026-02-19), so there is no poll-to-correlate step.
+#
+# The per-suite dispatch + poll logic lives once in the reusable workflow
+# .github/workflows/_dispatch-suite.yml; the three suite jobs below are thin
+# callers that pass per-suite parameters and expose its conclusion / run_url
+# outputs to the report job.
 
 on:
   pull_request:
@@ -158,222 +163,56 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "json-rpc ref: $JSONRPC_REF | hardhat ref: $HARDHAT_REF | k6 ref: $K6_REF"
 
+  # Each suite is dispatched + polled by the shared reusable workflow
+  # (_dispatch-suite.yml); these jobs only supply the per-suite parameters. Their
+  # named outputs (conclusion / run_url) are consumed by the report job below.
   json_rpc:
     name: JSON-RPC suite
     needs: resolve
     if: needs.resolve.outputs.has_token == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 55
-    outputs:
-      conclusion: ${{ steps.run.outputs.conclusion }}
-      run_url: ${{ steps.run.outputs.run_url }}
-    steps:
-      # Fresh ~1h token, minted at job start so the full dispatch + poll fits inside it.
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: rsksmart
-          repositories: rskj-json-rpc-tests
-      - name: Dispatch and wait
-        id: run
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          REPO: rsksmart/rskj-json-rpc-tests
-          WORKFLOW: rskj-json-rpc-tests.yml
-          TEST_INPUT: test_branch
-          RSKJ_REF: ${{ needs.resolve.outputs.rskj_ref }}
-          TEST_REF: ${{ needs.resolve.outputs.jsonrpc_ref }}
-        run: |
-          set -euo pipefail
-          INPUTS=$(jq -n --arg rskj "$RSKJ_REF" --arg k "$TEST_INPUT" --arg v "$TEST_REF" \
-            '{rskj_branch: $rskj, ($k): $v}')
-          BODY=$(jq -n --arg ref "$TEST_REF" --argjson inputs "$INPUTS" \
-            '{ref: $ref, inputs: $inputs, return_run_details: true}')
-          echo "Dispatching $WORKFLOW in $REPO on '$TEST_REF' (rskj_branch=$RSKJ_REF)"
-          if ! RESP=$(printf '%s' "$BODY" | gh api -X POST \
-              "repos/$REPO/actions/workflows/$WORKFLOW/dispatches" --input -); then
-            echo "::error::failed to dispatch $WORKFLOW in $REPO"
-            exit 1
-          fi
-          RUN_ID=$(jq -r '.workflow_run_id // empty' <<<"$RESP" 2>/dev/null || true)
-          RUN_URL=$(jq -r '.html_url // empty' <<<"$RESP" 2>/dev/null || true)
-          if [ -z "$RUN_ID" ]; then
-            echo "::error::dispatch did not return a run id; response: $RESP"
-            exit 1
-          fi
-          echo "run_url=$RUN_URL" >> "$GITHUB_OUTPUT"
-          echo "Triggered run $RUN_ID — $RUN_URL"
-          # If THIS job is cancelled (e.g. concurrency cancel-in-progress on a new
-          # push), cancel the downstream run too so it doesn't keep burning minutes
-          # orphaned. Best-effort: fires on the grace-period INT/TERM during the
-          # poll's sleep below; a hard kill may skip it.
-          cleanup() { gh api -X POST "repos/$REPO/actions/runs/$RUN_ID/cancel" >/dev/null 2>&1 || true; }
-          trap cleanup INT TERM
-          # Wait for completion by polling the run status (keyed on the id we
-          # already hold — deterministic, unlike `gh run watch`, which can race a
-          # just-created run). 100 * 30s = 50m of polling, kept under this job's
-          # timeout-minutes: 55 so a run finishing near the top of the window is
-          # still observed (not falsely marked timed_out) and the conclusion can be
-          # written to $GITHUB_OUTPUT before the job is killed mid-step. status and
-          # conclusion are read in one API call per tick. A downstream *test* failure
-          # is captured as the conclusion (not raised here) so the report job can
-          # gate centrally; a dispatch/infra error already exited non-zero above.
-          CONCLUSION=""
-          for _ in $(seq 1 100); do
-            read -r STATUS RUN_CONCLUSION < <(gh api "repos/$REPO/actions/runs/$RUN_ID" \
-              --jq '"\(.status) \(.conclusion // "unknown")"' 2>/dev/null || echo " ")
-            if [ "$STATUS" = "completed" ]; then
-              CONCLUSION="$RUN_CONCLUSION"
-              break
-            fi
-            sleep 30
-          done
-          [ -n "$CONCLUSION" ] || CONCLUSION="timed_out"
-          echo "conclusion=$CONCLUSION" >> "$GITHUB_OUTPUT"
-          echo "JSON-RPC suite concluded: $CONCLUSION"
+    uses: ./.github/workflows/_dispatch-suite.yml
+    with:
+      name: JSON-RPC
+      repo: rskj-json-rpc-tests
+      workflow: rskj-json-rpc-tests.yml
+      test_input: test_branch
+      rskj_ref: ${{ needs.resolve.outputs.rskj_ref }}
+      test_ref: ${{ needs.resolve.outputs.jsonrpc_ref }}
+    secrets:
+      app_id: ${{ secrets.GH_APP_ID }}
+      app_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
   hardhat:
     name: Hardhat suite
     needs: resolve
     if: needs.resolve.outputs.has_token == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 55
-    outputs:
-      conclusion: ${{ steps.run.outputs.conclusion }}
-      run_url: ${{ steps.run.outputs.run_url }}
-    steps:
-      # Fresh ~1h token, minted at job start so the full dispatch + poll fits inside it.
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: rsksmart
-          repositories: rskj-hardhat-tests
-      - name: Dispatch and wait
-        id: run
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          REPO: rsksmart/rskj-hardhat-tests
-          WORKFLOW: rskj-smart-contract-tests.yml
-          TEST_INPUT: hardhat_branch
-          RSKJ_REF: ${{ needs.resolve.outputs.rskj_ref }}
-          TEST_REF: ${{ needs.resolve.outputs.hardhat_ref }}
-        run: |
-          set -euo pipefail
-          INPUTS=$(jq -n --arg rskj "$RSKJ_REF" --arg k "$TEST_INPUT" --arg v "$TEST_REF" \
-            '{rskj_branch: $rskj, ($k): $v}')
-          BODY=$(jq -n --arg ref "$TEST_REF" --argjson inputs "$INPUTS" \
-            '{ref: $ref, inputs: $inputs, return_run_details: true}')
-          echo "Dispatching $WORKFLOW in $REPO on '$TEST_REF' (rskj_branch=$RSKJ_REF)"
-          if ! RESP=$(printf '%s' "$BODY" | gh api -X POST \
-              "repos/$REPO/actions/workflows/$WORKFLOW/dispatches" --input -); then
-            echo "::error::failed to dispatch $WORKFLOW in $REPO"
-            exit 1
-          fi
-          RUN_ID=$(jq -r '.workflow_run_id // empty' <<<"$RESP" 2>/dev/null || true)
-          RUN_URL=$(jq -r '.html_url // empty' <<<"$RESP" 2>/dev/null || true)
-          if [ -z "$RUN_ID" ]; then
-            echo "::error::dispatch did not return a run id; response: $RESP"
-            exit 1
-          fi
-          echo "run_url=$RUN_URL" >> "$GITHUB_OUTPUT"
-          echo "Triggered run $RUN_ID — $RUN_URL"
-          # Cancel the downstream run if THIS job is cancelled (see JSON-RPC job).
-          cleanup() { gh api -X POST "repos/$REPO/actions/runs/$RUN_ID/cancel" >/dev/null 2>&1 || true; }
-          trap cleanup INT TERM
-          # Deterministic poll on the id we hold (see JSON-RPC job): `gh run watch`
-          # can return early on a transient error or a just-created run, leaving
-          # .conclusion null → coerced to "unknown" → a false gate failure even
-          # though the run later succeeds. 100 * 30s = 50m, kept under timeout-minutes: 55;
-          # status and conclusion are read in one API call per tick.
-          CONCLUSION=""
-          for _ in $(seq 1 100); do
-            read -r STATUS RUN_CONCLUSION < <(gh api "repos/$REPO/actions/runs/$RUN_ID" \
-              --jq '"\(.status) \(.conclusion // "unknown")"' 2>/dev/null || echo " ")
-            if [ "$STATUS" = "completed" ]; then
-              CONCLUSION="$RUN_CONCLUSION"
-              break
-            fi
-            sleep 30
-          done
-          [ -n "$CONCLUSION" ] || CONCLUSION="timed_out"
-          echo "conclusion=$CONCLUSION" >> "$GITHUB_OUTPUT"
-          echo "Hardhat suite concluded: $CONCLUSION"
+    uses: ./.github/workflows/_dispatch-suite.yml
+    with:
+      name: Hardhat
+      repo: rskj-hardhat-tests
+      workflow: rskj-smart-contract-tests.yml
+      test_input: hardhat_branch
+      rskj_ref: ${{ needs.resolve.outputs.rskj_ref }}
+      test_ref: ${{ needs.resolve.outputs.hardhat_ref }}
+    secrets:
+      app_id: ${{ secrets.GH_APP_ID }}
+      app_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
   k6:
     name: K6 suite
     needs: resolve
     if: needs.resolve.outputs.has_token == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 55
-    outputs:
-      conclusion: ${{ steps.run.outputs.conclusion }}
-      run_url: ${{ steps.run.outputs.run_url }}
-    steps:
-      # Fresh ~1h token, minted at job start so the full dispatch + poll fits inside it.
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
-          owner: rsksmart
-          repositories: rskj-k6-tests
-      - name: Dispatch and wait
-        id: run
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          REPO: rsksmart/rskj-k6-tests
-          WORKFLOW: rskj-k6-tests.yml
-          TEST_INPUT: test_branch
-          RSKJ_REF: ${{ needs.resolve.outputs.rskj_ref }}
-          TEST_REF: ${{ needs.resolve.outputs.k6_ref }}
-        run: |
-          set -euo pipefail
-          INPUTS=$(jq -n --arg rskj "$RSKJ_REF" --arg k "$TEST_INPUT" --arg v "$TEST_REF" \
-            '{rskj_branch: $rskj, ($k): $v}')
-          BODY=$(jq -n --arg ref "$TEST_REF" --argjson inputs "$INPUTS" \
-            '{ref: $ref, inputs: $inputs, return_run_details: true}')
-          echo "Dispatching $WORKFLOW in $REPO on '$TEST_REF' (rskj_branch=$RSKJ_REF)"
-          if ! RESP=$(printf '%s' "$BODY" | gh api -X POST \
-              "repos/$REPO/actions/workflows/$WORKFLOW/dispatches" --input -); then
-            echo "::error::failed to dispatch $WORKFLOW in $REPO"
-            exit 1
-          fi
-          RUN_ID=$(jq -r '.workflow_run_id // empty' <<<"$RESP" 2>/dev/null || true)
-          RUN_URL=$(jq -r '.html_url // empty' <<<"$RESP" 2>/dev/null || true)
-          if [ -z "$RUN_ID" ]; then
-            echo "::error::dispatch did not return a run id; response: $RESP"
-            exit 1
-          fi
-          echo "run_url=$RUN_URL" >> "$GITHUB_OUTPUT"
-          echo "Triggered run $RUN_ID — $RUN_URL"
-          # Cancel the downstream run if THIS job is cancelled (see JSON-RPC job).
-          cleanup() { gh api -X POST "repos/$REPO/actions/runs/$RUN_ID/cancel" >/dev/null 2>&1 || true; }
-          trap cleanup INT TERM
-          # Deterministic poll on the id we hold (see JSON-RPC job): `gh run watch`
-          # can return early on a transient error or a just-created run, leaving
-          # .conclusion null → coerced to "unknown" → a false gate failure even
-          # though the run later succeeds. 100 * 30s = 50m, kept under timeout-minutes: 55;
-          # status and conclusion are read in one API call per tick.
-          CONCLUSION=""
-          for _ in $(seq 1 100); do
-            read -r STATUS RUN_CONCLUSION < <(gh api "repos/$REPO/actions/runs/$RUN_ID" \
-              --jq '"\(.status) \(.conclusion // "unknown")"' 2>/dev/null || echo " ")
-            if [ "$STATUS" = "completed" ]; then
-              CONCLUSION="$RUN_CONCLUSION"
-              break
-            fi
-            sleep 30
-          done
-          [ -n "$CONCLUSION" ] || CONCLUSION="timed_out"
-          echo "conclusion=$CONCLUSION" >> "$GITHUB_OUTPUT"
-          echo "K6 suite concluded: $CONCLUSION"
+    uses: ./.github/workflows/_dispatch-suite.yml
+    with:
+      name: K6
+      repo: rskj-k6-tests
+      workflow: rskj-k6-tests.yml
+      test_input: test_branch
+      rskj_ref: ${{ needs.resolve.outputs.rskj_ref }}
+      test_ref: ${{ needs.resolve.outputs.k6_ref }}
+    secrets:
+      app_id: ${{ secrets.GH_APP_ID }}
+      app_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
   report:
     name: Report


### PR DESCRIPTION
Dispatches the JSON-RPC, Hardhat, and K6 test suites (each in its own repo) against the rskj change in parallel on PRs / manual dispatch, waits for all three, and reports a concise pass/fail summary to the job summary and a sticky PR comment. Gates the PR red on any downstream failure.

Pure first-party tooling (`gh` / `gh api` / `jq`); cross-repo dispatch is authenticated with a short-lived GitHub App installation token (minted per job via `actions/create-github-app-token` from the `GH_APP_ID` / `GH_APP_PRIVATE_KEY` secrets) and uses the `return_run_details` dispatch response to obtain the run id directly.

## Description
Adds `.github/workflows/rskj-core-automated-tests.yml`, an umbrella workflow that:
- Resolves the per-suite test ref using a "matching branch if it exists, else `main`" convention (overridable via `workflow_dispatch` inputs).
- Mints a short-lived GitHub App installation token per job (scoped to the three test repos), then dispatches each suite's `workflow_dispatch` with the rskj ref to build the node from.
- Polls each downstream run deterministically by run id to completion, then consolidates the results into a job summary and a sticky PR comment, gating the PR on any non-success.
- Degrades gracefully on fork PRs (App secrets are withheld there): it skips the suites and stays green rather than failing.

## Motivation and Context
The JSON-RPC, Hardhat, and K6 suites live in separate repos and previously had to be triggered and checked manually against an rskj change. This provides a single required check on rskj PRs that exercises all three against the PR's node automatically.

## How Has This Been Tested?
- `actionlint` clean on the workflow.
- Iterated on this PR's own CI runs: validated ref resolution, per-job App token minting, dispatch + deterministic poll-to-completion, the consolidated report, the sticky-comment upsert, and the fork-PR skip path.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**: Requires the GitHub App to be installed on `rsksmart/rskj-json-rpc-tests`, `rsksmart/rskj-hardhat-tests`, and `rsksmart/rskj-k6-tests` (Actions: read+write, Contents: read), and the `GH_APP_ID` / `GH_APP_PRIVATE_KEY` repo secrets to be set on rskj.
