### PR TITLE
fix: stub areActive(RSKIP351, RSKIP144) in setupRskip535Test

### DIFF
--- a/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
@@ -1246,8 +1246,10 @@ class BlockFactoryTest {
         when(activationConfig.getHeaderVersion(geq(blockNumber))).thenReturn((byte) 0x2);
         when(activationConfig.isActive(eq(RSKIP351), geq(blockNumber))).thenReturn(true);
         when(activationConfig.areActive(geq(blockNumber), eq(RSKIP351), eq(RSKIP144)))
-                .thenAnswer(inv -> activationConfig.isActive(RSKIP351, blockNumber)
-                        && activationConfig.isActive(RSKIP144, blockNumber));
+                .thenAnswer(inv -> {
+                    long n = inv.getArgument(0, Long.class);
+                    return activationConfig.isActive(RSKIP351, n) && activationConfig.isActive(RSKIP144, n);
+                });
     }
 
     private BlockHeader createBlockHeaderWithMergedMiningFields(

--- a/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/BlockFactoryTest.java
@@ -1245,6 +1245,9 @@ class BlockFactoryTest {
         when(activationConfig.getHeaderVersion(lt(blockNumber))).thenReturn((byte) 0x0);
         when(activationConfig.getHeaderVersion(geq(blockNumber))).thenReturn((byte) 0x2);
         when(activationConfig.isActive(eq(RSKIP351), geq(blockNumber))).thenReturn(true);
+        when(activationConfig.areActive(geq(blockNumber), eq(RSKIP351), eq(RSKIP144)))
+                .thenAnswer(inv -> activationConfig.isActive(RSKIP351, blockNumber)
+                        && activationConfig.isActive(RSKIP144, blockNumber));
     }
 
     private BlockHeader createBlockHeaderWithMergedMiningFields(


### PR DESCRIPTION
## Description

`BlockFactoryTest` had four failing tests after the VETIVER-9.0.2 baseEvent changes were ported onto `master`:

- `emptyBaseEventPreservedAcrossExtensionRoundTripWithMining`
- `emptyBaseEventPreservedAcrossExtensionRoundTripNoMining`
- `headerOneElementShortDecodableOnTestnetWithinBoundWithMining`
- `headerOneElementShortDecodableOnTestnetWithinBoundNoMining`

All four use the `setupRskip535Test` helper, which was carried over verbatim from the VETIVER-9.0.1 base. That helper stubs the activation mock with the individual `isActive(RSKIP351)` and `isActive(RSKIP144)` calls, but never stubs the `areActive(blockNumber, RSKIP351, RSKIP144)` overload. With that overload left at Mockito's default `false`, the decoder skipped the `txExecutionSublistsEdges` field while the encoder still wrote it, shifting the RLP read offset by one. The 8-byte edges array was then mis-read into the `baseEvent` slot (with-mining) or the read ran past the end of the list (`IndexOutOfBoundsException`, no-mining).

This is a test-only stubbing gap, not a production decode bug: in production `areActive` is a real implementation and RSKIP351 is always active alongside RSKIP144, so the encoder and decoder stay consistent.

The fix makes `setupRskip535Test` stub the `areActive(RSKIP351, RSKIP144)` overload to mirror the individual `isActive` stubs — true only when both rules are active. This keeps the gate consistent for every test that uses the helper, including the negative cases that enable RSKIP351 but not RSKIP144.

## Motivation and Context

The header layout gate for the `txExecutionSublistsEdges` field was tightened on `master` from a single `isActive(RSKIP144)` check to a combined `areActive(RSKIP351, RSKIP144)` check, in both `BlockFactory` (decoder) and `BlockHeaderBuilder` (encoder).

That tightening was introduced by **PR #3467 — "rskip-144-requires-rskip-351"** (merged to `master` on **2026-04-28**, merge commit `4ee586c8`). The semantic change — ensuring no execution path runs RSKIP-144 logic without RSKIP-351 active — landed in commit `5cda23fd` (2026-02-27) and was later refactored onto the `areActive(...)` overload in commits `05bf8b9b` / `ba2d623b`.

Crucially, **PR #3467 is not part of the `VETIVER-9.0.1` tag** that the `VETIVER-9.0.2-rc` branch was based on. On that base the decoder still gated the edges field on `isActive(RSKIP144)` alone — which `setupRskip535Test` *does* stub — so encoder and decoder agreed and the tests passed. When the baseEvent changes were ported onto `master` (which already contains #3467), the decoder now calls the unstubbed `areActive` overload, exposing the gap. This is why the tests are green on `VETIVER-9.0.2-rc` but red on the master-bound branch.

Other tests in the same file that were updated for the new gate already stub the overload explicitly (`when(activationConfig.areActive(number, RSKIP351, RSKIP144)).thenReturn(true)`); the shared `setupRskip535Test` helper was simply missed in that adaptation.

## How Has This Been Tested?

- `./gradlew :rskj-core:test --tests "co.rsk.core.BlockFactoryTest"` — all 52 tests pass (the four previously-failing tests now pass; the negative-case tests that enable RSKIP351 but not RSKIP144 remain correct).
- Full `./gradlew :rskj-core:test` unit-test suite — `BUILD SUCCESSFUL`, confirming no other test class is affected.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**: Test-only change; no production code is modified.
