### PR TITLE
test: make PTERaceConditionTest deterministic via on-demand mining

### DIFF
--- a/rskj-core/src/integrationTest/java/co/rsk/pte/PTERaceConditionTest.java
+++ b/rskj-core/src/integrationTest/java/co/rsk/pte/PTERaceConditionTest.java
@@ -50,7 +50,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -111,8 +110,11 @@ class PTERaceConditionTest {
         String rskConfFileChangedServer = configureServerWithGeneratedInformation(serverDbDir);
         serverNode = new NodeIntegrationTestCommandLine(rskConfFileChangedServer, "--regtest");
         serverNode.startNode();
-        IntegrationTestUtils.waitFor(8, SECONDS);
+        awaitNodeReady(rpcPort);
 
+        // Mining is on demand only (autonomous miner disabled), so leave genesis by
+        // mining one block before capturing the baseline used by the assertions below.
+        RPCBlockRequests.mineBlock(rpcPort);
         initialBlock = RPCBlockRequests.getLatestBlockNumber(rpcPort);
         assertTrue(initialBlock > 0);
 
@@ -129,20 +131,46 @@ class PTERaceConditionTest {
         //call reset method
         String resetData = SimpleAbi.encode("reset(bytes32)", List.of(RACE_ID));
         Optional<String> resetTx = racePOCContractCaller.callIgnoreFailure(coordinatorAccount, resetData);
+        RPCBlockRequests.mineBlock(rpcPort);
         resetTx.ifPresent(txHash -> RpcTransactionAssertions.assertMined(rpcPort, 50, 2000, txHash));
 
         //call register method
         String registerData = SimpleAbi.encode("register(bytes32)", List.of(RACE_ID));
         Optional<String> registerTx = racePOCContractCaller.call(coordinatorAccount, registerData);
         String registerTxHash = registerTx.orElseThrow(() -> new AssertionError("register tx was not sent"));
+        RPCBlockRequests.mineBlock(rpcPort);
         RpcTransactionAssertions.assertMined(rpcPort, 50, 2000, registerTxHash);
 
         // allow bridge to be called by this.racePOCContractCaller contract
         String setBridgeData = SimpleAbi.encode("setUnionBridgeContractAddressForTestnet(address)", List.of(racePOCContractAddress));
         String setBridgeTx = bridgeContractCaller.call(authorizedBridgeAccount, setBridgeData).orElseThrow(() -> new AssertionError("setBridge tx not sent"));
+        RPCBlockRequests.mineBlock(rpcPort);
         RpcTransactionAssertions.assertMined(rpcPort, 50, 2000, setBridgeTx);
+    }
 
-        IntegrationTestUtils.waitFor(10, SECONDS);
+    /**
+     * Polls the node's RPC endpoint until it is ready to serve requests, replacing a
+     * fixed boot sleep with a deterministic readiness check.
+     */
+    private static void awaitNodeReady(int rpcPort) throws InterruptedException, IOException {
+        int maxAttempts = 60;
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            com.squareup.okhttp.Response response = null;
+            try {
+                response = OkHttpClientTestFixture.sendHealthProbe(rpcPort, 1000);
+                if (response.code() == 200) {
+                    return;
+                }
+            } catch (IOException ignored) {
+                // node not up yet, retry
+            } finally {
+                if (response != null && response.body() != null) {
+                    response.body().close();
+                }
+            }
+            Thread.sleep(500);
+        }
+        throw new IllegalStateException("Node RPC did not become ready on port " + rpcPort);
     }
 
     @AfterAll
@@ -162,7 +190,10 @@ class PTERaceConditionTest {
                     .orElseThrow(() -> new AssertionError("acceptSimple tx not sent for " + from));
             sameBlockTransactions.add(txHash);
         }
-        IntegrationTestUtils.waitFor(10, SECONDS);
+        // All transactions are now in the pending pool; mine exactly one block so
+        // they are all included together, then assert they share that block.
+        RpcTransactionAssertions.awaitTransactionsInPool(rpcPort, 50, 200, sameBlockTransactions);
+        RPCBlockRequests.mineBlock(rpcPort);
 
         long minedBlock = RpcTransactionAssertions.assertAllMinedInSameBlock(this.rpcPort, sameBlockTransactions);
 
@@ -189,7 +220,10 @@ class PTERaceConditionTest {
             sameBlockTransactions.add(txHash);
         }
 
-        IntegrationTestUtils.waitFor(10, SECONDS);
+        // All transactions are now in the pending pool; mine exactly one block so
+        // they are all included together, then assert they share that block.
+        RpcTransactionAssertions.awaitTransactionsInPool(rpcPort, 50, 200, sameBlockTransactions);
+        RPCBlockRequests.mineBlock(rpcPort);
 
         long minedBlock = RpcTransactionAssertions.assertAllMinedInSameBlock(rpcPort, sameBlockTransactions);
 
@@ -219,7 +253,10 @@ class PTERaceConditionTest {
             sameBlockTransactions.add(txHash);
         }
 
-        IntegrationTestUtils.waitFor(10, SECONDS);
+        // All transactions are now in the pending pool; mine exactly one block so
+        // they are all included together, then assert they share that block.
+        RpcTransactionAssertions.awaitTransactionsInPool(rpcPort, 50, 200, sameBlockTransactions);
+        RPCBlockRequests.mineBlock(rpcPort);
 
         long minedBlock = RpcTransactionAssertions.assertAllMinedInSameBlock(rpcPort, sameBlockTransactions);
 

--- a/rskj-core/src/integrationTest/java/co/rsk/util/OkHttpClientTestFixture.java
+++ b/rskj-core/src/integrationTest/java/co/rsk/util/OkHttpClientTestFixture.java
@@ -129,6 +129,15 @@ public class OkHttpClientTestFixture {
         }
         """;
 
+    public static final String ETH_GET_TRANSACTION_BY_HASH = """
+        {
+            "jsonrpc": "2.0",
+            "method": "eth_getTransactionByHash",
+            "id": 1,
+            "params": ["<TX_HASH>"]
+        }
+        """;
+
     private OkHttpClientTestFixture() {
     }
 
@@ -231,6 +240,17 @@ public class OkHttpClientTestFixture {
 
     public static JsonNode getJsonResponseForGetTransactionReceipt(int port, String txHash) throws IOException {
         Response response = sendJsonRpcGetTransactionReceiptMessage(port, txHash);
+        try {
+            return new ObjectMapper().readTree(response.body().string());
+        } finally {
+            if (response.body() != null) {
+                response.body().close();
+            }
+        }
+    }
+
+    public static JsonNode getJsonResponseForGetTransactionByHash(int port, String txHash) throws IOException {
+        Response response = sendJsonRpcMessage(ETH_GET_TRANSACTION_BY_HASH.replace("<TX_HASH>", txHash), port);
         try {
             return new ObjectMapper().readTree(response.body().string());
         } finally {

--- a/rskj-core/src/integrationTest/java/co/rsk/util/RpcTransactionAssertions.java
+++ b/rskj-core/src/integrationTest/java/co/rsk/util/RpcTransactionAssertions.java
@@ -28,6 +28,35 @@ public final class RpcTransactionAssertions {
     private RpcTransactionAssertions() {}
 
 
+    /**
+     * Waits until every transaction is known to the node's pending pool (i.e.
+     * {@code eth_getTransactionByHash} returns a result for it). This is the
+     * deterministic gate to run before mining a single block: it guarantees all
+     * transactions are queued so that one {@code evm_mine} includes them together.
+     */
+    public static void awaitTransactionsInPool(int rpcPort, final int maxAttempts, final long sleepMills, List<String> txHashes) {
+        for (String txHash : txHashes) {
+            try {
+                boolean known = false;
+                for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+                    JsonNode response = OkHttpClientTestFixture.getJsonResponseForGetTransactionByHash(rpcPort, txHash);
+                    JsonNode result = response.get("result");
+                    if (result != null && !result.isNull()) {
+                        known = true;
+                        break;
+                    }
+                    Thread.sleep(sleepMills);
+                }
+                Assertions.assertTrue(known, () -> "Transaction not found in pool after " + maxAttempts + " attempts for tx " + txHash);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                Assertions.fail("Interrupted while waiting for tx in pool " + txHash, e);
+            } catch (Exception e) {
+                Assertions.fail("Failed while waiting for tx in pool " + txHash, e);
+            }
+        }
+    }
+
     public static long assertMined(int rpcPort, final int maxAttempts, final long sleepMills, String txHash) {
         try {
             JsonNode receipt = null;

--- a/rskj-core/src/integrationTest/java/co/rsk/util/rpc/ContractDeployer.java
+++ b/rskj-core/src/integrationTest/java/co/rsk/util/rpc/ContractDeployer.java
@@ -107,6 +107,10 @@ public final class ContractDeployer {
             }
         }
 
+        // The node mines only on demand (autonomous miner disabled), so mine the
+        // block that includes this deployment transaction before polling for it.
+        RPCBlockRequests.mineBlock(rpcPort);
+
         // 2) poll for receipt
         long deadline = System.currentTimeMillis() + timeoutMs;
         while (System.currentTimeMillis() < deadline) {

--- a/rskj-core/src/integrationTest/java/co/rsk/util/rpc/RPCBlockRequests.java
+++ b/rskj-core/src/integrationTest/java/co/rsk/util/rpc/RPCBlockRequests.java
@@ -20,10 +20,44 @@ package co.rsk.util.rpc;
 import co.rsk.util.HexUtils;
 import co.rsk.util.OkHttpClientTestFixture;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.squareup.okhttp.Response;
 
 import java.io.IOException;
 
 public final class RPCBlockRequests {
+
+    private static final String EVM_MINE = """
+            {
+                "jsonrpc": "2.0",
+                "method": "evm_mine",
+                "params": [],
+                "id": 1
+            }
+            """;
+
+    /**
+     * Mines exactly one block on demand via the {@code evm_mine} RPC. Used to make
+     * mining deterministic: callers submit all transactions into the pending pool
+     * and then trigger a single block that contains them.
+     */
+    public static void mineBlock(int rpcPort) throws IOException {
+        Response response = OkHttpClientTestFixture.sendJsonRpcMessage(EVM_MINE, rpcPort);
+        try {
+            if (response.code() != 200) {
+                throw new IOException("evm_mine failed: HTTP " + response.code());
+            }
+            JsonNode json = new ObjectMapper().readTree(response.body().string());
+            JsonNode error = json.get("error");
+            if (error != null && !error.isNull()) {
+                throw new IOException("evm_mine RPC error: " + error);
+            }
+        } finally {
+            if (response.body() != null) {
+                response.body().close();
+            }
+        }
+    }
 
     public static long getLatestBlockNumber(int rpcPort) throws IOException {
         JsonNode response = OkHttpClientTestFixture

--- a/rskj-core/src/integrationTest/resources/pte-race-condition.conf
+++ b/rskj-core/src/integrationTest/resources/pte-race-condition.conf
@@ -9,9 +9,22 @@ database {
    dir = <SERVER_NODE_DATABASE_PATH>
 }
 
+# Disable the per-account tx rate limiter. It is an anti-DoS feature orthogonal to
+# what these tests verify (PTE sequentialization), and its time/virtual-gas based
+# quota would otherwise reject the rapid back-to-back setup transactions now that
+# mining is on demand rather than spread across a wall-clock block timer.
+transaction.accountTxRateLimit.enabled = false
+
+# The autonomous miner client is disabled so blocks are produced only on demand
+# (via the evm_mine RPC). This makes mining deterministic for the race tests: all
+# transactions are submitted into the pending pool first, then a single block is
+# mined containing all of them, instead of racing against a wall-clock block timer.
 miner {
   client {
-    delayBetweenBlocks = 5 seconds
+    enabled = false
+  }
+  server {
+    enabled = true
   }
 }
 


### PR DESCRIPTION
## Description

Makes `co.rsk.pte.PTERaceConditionTest` deterministic by switching it from autonomous (wall-clock) mining to on-demand mining.

The PTE race-condition tests submit N transactions from different senders and assert they are all mined in the **same** block (with empty `rskPteEdges`, i.e. forced sequential execution). The node ran an autonomous miner producing a block every 5 seconds, while each test sent its transactions one-by-one over RPC and then slept a fixed `waitFor(10, SECONDS)`. Whenever a 5-second block boundary fell during the submission window, the transactions split across two blocks and `assertAllMinedInSameBlock` failed intermittently.

The fix removes the wall-clock dependency entirely:

- **Disable the autonomous miner client** (`miner.client.enabled = false`, `miner.server.enabled = true`) so blocks are produced only on demand via the `evm_mine` RPC.
- **In each test**, submit all transactions (`eth_sendTransaction` adds them to the pending pool synchronously), wait until they are all known to the pool (`eth_getTransactionByHash`), then mine exactly one block that contains them together.
- **Drive setup mining explicitly** (deploy, reset, register, setBridge) and replace the fixed boot sleep with an RPC readiness poll.
- **Disable the per-account tx rate limiter** for this node (`transaction.accountTxRateLimit.enabled = false`): it is an anti-DoS feature orthogonal to PTE behaviour, and its time/virtual-gas based quota would otherwise reject the now back-to-back setup transactions.

The supporting integration-test helpers touched here (`RPCBlockRequests`, `RpcTransactionAssertions`, `OkHttpClientTestFixture`, `ContractDeployer`) are used **only** by this test, so no other integration test is affected.

The transactions, contract calls and assertions (`assertAllMinedInSameBlock`, `minedBlock > initialBlock`, empty `rskPteEdges`) are unchanged — only the mining trigger moves from a timer to an explicit single `evm_mine`. `evm_mine` drives the same real block-building path as normal mining, so PTE edge computation is identical and the property under test is preserved.

## Motivation and Context

`PTERaceConditionTest.whenMultipleSendersCallAcceptUnionPrecheckAllMustBeSequential_noPteEdges` failed in CI (`integration-tests` job) at `assertAllMinedInSameBlock`, while every other job was green. Investigation showed the failure was not caused by any production change — the only code added since the test last passed was a unit-test edit — but by the inherent race between the autonomous miner and the fixed-sleep, single-block expectation in the test. This change makes the test deterministic so it stops failing intermittently on CI.

## How Has This Been Tested?

- Ran `co.rsk.pte.PTERaceConditionTest` **8 consecutive times** with `--rerun-tasks`: **8/8 passed** (determinism check).
- All 3 test methods execute and pass.
- `compileIntegrationTestJava`, `checkstyleIntegrationTest` and `spotlessJavaCheck` all pass (spotless required no reformatting).
- Runtime drops from ~25 min to ~30 s for the class (the fixed sleeps are gone).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**: Test-only change (integration-test sources, resources and test-only helpers); no production code is modified.
