### PR TITLE
Fixing commitHash on docker images

### DIFF
--- a/.github/workflows/docker-release-master-to-edge.yml
+++ b/.github/workflows/docker-release-master-to-edge.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - master
 
-# Declare default permissions as read only.
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   docker:
@@ -31,6 +31,10 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Get short commit SHA
+        id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
       - name: Build and push to registry
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 #v6.19.2
         with:
@@ -38,3 +42,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            COMMIT_HASH=${{ steps.sha.outputs.short }}
+            COMMIT_BRANCH=${{ github.ref_name }}

--- a/.github/workflows/docker-release-tags-to-latest.yml
+++ b/.github/workflows/docker-release-tags-to-latest.yml
@@ -5,8 +5,8 @@ on:
     tags:
       - '*'
 
-# Declare default permissions as read only.
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   docker:
@@ -33,6 +33,10 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Get short commit SHA
+        id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
       - name: Build and push to registry
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 #v6.19.2
         with:
@@ -40,3 +44,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            COMMIT_HASH=${{ steps.sha.outputs.short }}
+            COMMIT_BRANCH=${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
 FROM eclipse-temurin:17-jdk@sha256:0613a19436dc8f745914b25235d43f3b0eddb8d432d19edce30ffaf2d2f95403 AS build
 
 RUN apt-get update -y && \
-    apt-get install -y git curl gnupg
+    apt-get install -y --no-install-recommends curl git gnupg
 
 RUN useradd -ms /bin/bash rsk
 USER rsk
 
 WORKDIR /home/rsk
 COPY --chown=rsk:rsk . ./
+
+ARG COMMIT_HASH=unknown
+ARG COMMIT_BRANCH=unknown
+ENV COMMIT_HASH=${COMMIT_HASH}
+ENV COMMIT_BRANCH=${COMMIT_BRANCH}
 
 RUN gpg --keyserver https://secchannel.rsk.co/SUPPORT.asc --recv-keys 1DC9157991323D23FD37BAA7A6DBEAC640C5A14B && \
     gpg --verify --output SHA256SUMS SHA256SUMS.asc && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM eclipse-temurin:17-jdk@sha256:0613a19436dc8f745914b25235d43f3b0eddb8d432d19edce30ffaf2d2f95403 AS build
 
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends curl git gnupg
+    apt-get install -y --no-install-recommends curl git gnupg && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN useradd -ms /bin/bash rsk
 USER rsk

--- a/README.md
+++ b/README.md
@@ -11,10 +11,16 @@ RskJ is a Java implementation of the Rootstock node. For more information about 
 # Generate reproducible build from branch
 To be able to generate a reproducible build from the current branch, we can use the Dockerfile in the root to do so.
 For example, let's consider that we are using the version 9.0.0 and version name `vetiver`.
+
+The `.git` directory is excluded from the Docker build context (via `.dockerignore`), so the commit hash and branch must be passed explicitly as build arguments to be embedded in the produced jars:
 ```bash
-$ docker build -t rskj/9.0.0-vetiver .
-$ docker run -d --name rskj-temp rskj/9.0.0-vetiver
+$ docker build \
+    --build-arg COMMIT_HASH=$(git rev-parse --short HEAD) \
+    --build-arg COMMIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) \
+    -t rskj/9.0.0-vetiver .
+$ docker create --name rskj-temp rskj/9.0.0-vetiver
 $ docker cp rskj-temp:/var/lib/rsk/. ./artifacts/
+$ docker rm -f rskj-temp
 $ cd artifacts/
 $ sha256sum *.jar *.pom
 ```

--- a/rskj-core/build.gradle
+++ b/rskj-core/build.gradle
@@ -612,17 +612,25 @@ artifacts {
 }
 
 static def gitCurrentBranch() {
-    def envBranch = System.getenv("COMMIT_BRANCH")
-    if (envBranch) return envBranch
-    def process = "git rev-parse --abbrev-ref HEAD".execute()
-    return process.text.trim()
+    return resolveGitValue("COMMIT_BRANCH", "git rev-parse --abbrev-ref HEAD")
 }
 
 static def gitCommitHash() {
-    def envHash = System.getenv("COMMIT_HASH")
-    if (envHash) return envHash
-    def process = "git rev-parse --short HEAD".execute()
-    return process.text.trim()
+    return resolveGitValue("COMMIT_HASH", "git rev-parse --short HEAD")
+}
+
+static def resolveGitValue(String envVar, String gitCommand) {
+    def envValue = System.getenv(envVar)?.trim()
+    if (envValue) return envValue
+    try {
+        def process = gitCommand.execute()
+        process.waitFor()
+        if (process.exitValue() == 0) {
+            def result = process.text.trim()
+            if (result) return result
+        }
+    } catch (Exception ignored) {}
+    return "unknown"
 }
 
 static def amendPathIfNeeded(details) {

--- a/rskj-core/build.gradle
+++ b/rskj-core/build.gradle
@@ -612,11 +612,15 @@ artifacts {
 }
 
 static def gitCurrentBranch() {
+    def envBranch = System.getenv("COMMIT_BRANCH")
+    if (envBranch) return envBranch
     def process = "git rev-parse --abbrev-ref HEAD".execute()
     return process.text.trim()
 }
 
 static def gitCommitHash() {
+    def envHash = System.getenv("COMMIT_HASH")
+    if (envHash) return envHash
     def process = "git rev-parse --short HEAD".execute()
     return process.text.trim()
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When we were using docker images, the commitHash wasn't being set in the binary. This impact the information from protocol version.

## Motivation and Context
- To have the proper information about the binary built.

## How Has This Been Tested?
- Locally with images generated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
