### PR TITLE
Add network upgrade config for upcoming version 10.0.0

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/NetworkUpgrade.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/NetworkUpgrade.java
@@ -36,9 +36,10 @@ public enum NetworkUpgrade {
     LOVELL700("lovell700"),
     REED800("reed800"),
     REED810("reed810"),
-    VETIVER900("vetiver900");
+    VETIVER900("vetiver900"),
+    TBD1000("tbd1000");
 
-    private String name;
+    private final String name;
 
     NetworkUpgrade(String name) {
         this.name = name;

--- a/rskj-core/src/main/resources/config/main.conf
+++ b/rskj-core/src/main/resources/config/main.conf
@@ -17,7 +17,8 @@ blockchain.config {
         lovell700 = 7338024,
         reed800 = 8052200,
         reed810 = -1,
-        vetiver900 = 8804200
+        vetiver900 = 8804200,
+        tbd1000 = -1
     },
     consensusRules = {
         rskip536 = 8804200 # Already in testnet as part of Reed 8.1.0, configuring same height as Vetiver activation

--- a/rskj-core/src/main/resources/config/regtest.conf
+++ b/rskj-core/src/main/resources/config/regtest.conf
@@ -17,7 +17,8 @@ blockchain.config {
         lovell700 = 0,
         reed800 = 0,
         reed810 = 0,
-        vetiver900 = 0
+        vetiver900 = 0,
+        tbd1000 = 0
     },
     consensusRules = {
         rskip97 = -1 # disable orchid difficulty drop

--- a/rskj-core/src/main/resources/config/testnet.conf
+++ b/rskj-core/src/main/resources/config/testnet.conf
@@ -17,7 +17,8 @@ blockchain.config {
         lovell700 = 6110487,
         reed800 = 6835700,
         reed810 = 7139600,
-        vetiver900 = 7604200
+        vetiver900 = 7604200,
+        tbd1000 = -1
     },
     consensusRules = {
         rskip97 = -1, # disable orchid difficulty drop

--- a/rskj-core/src/main/resources/config/testnet2.conf
+++ b/rskj-core/src/main/resources/config/testnet2.conf
@@ -17,7 +17,8 @@ blockchain.config {
         lovell700 = -1,
         reed800 = -1,
         reed810 = -1,
-        vetiver900 = -1
+        vetiver900 = -1,
+        tbd1000 = -1
     },
     consensusRules = {
         rskip97 = -1, # disable orchid difficulty drop

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -21,6 +21,7 @@ blockchain = {
             reed800 = <height>
             reed810 = <height>
             vetiver900 = <height>
+            tbd1000 = <height>
         }
         consensusRules = {
             areBridgeTxsPaid = <hardforkName>

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -18,12 +18,6 @@
 
 package org.ethereum.config.blockchain.upgrades;
 
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-import com.typesafe.config.ConfigValueFactory;
-import org.hamcrest.MatcherAssert;
-import org.junit.jupiter.api.Test;
-
 import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP103;
 import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP351;
 import static org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP535;
@@ -35,6 +29,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
 
 class ActivationConfigTest {
     private static final Config BASE_CONFIG = ConfigFactory.parseString(String.join("\n",
@@ -57,6 +57,7 @@ class ActivationConfigTest {
         "    reed800: 0",
         "    reed810: 0",
         "    vetiver900: 0",
+        "    tbd1000: 0",
         "},",
         "consensusRules: {",
         "    areBridgeTxsPaid: afterBridgeSync,",

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
@@ -490,7 +490,7 @@ public class ActivationConfigsForTest {
     }
 
     public static ActivationConfig tbd1000() {
-        return vetiver900(Collections.emptyList());
+        return tbd1000(Collections.emptyList());
     }
 
     public static ActivationConfig tbd1000(List<ConsensusRule> except) {

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
@@ -19,9 +19,6 @@
 package org.ethereum.config.blockchain.upgrades;
 
 import com.typesafe.config.ConfigFactory;
-import org.ethereum.config.SystemProperties;
-
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -30,6 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.ethereum.config.SystemProperties;
 
 @SuppressWarnings({"squid:S2187"}) // used from another class
 public class ActivationConfigsForTest {
@@ -214,6 +213,12 @@ public class ActivationConfigsForTest {
             ConsensusRule.RSKIP544,
             ConsensusRule.RSKIP551,
             ConsensusRule.RSKIP552
+        ));
+    }
+
+    private static List<ConsensusRule> getTbdRskips() {
+        return new ArrayList<>(List.of(
+            // TBD
         ));
     }
 
@@ -480,6 +485,34 @@ public class ActivationConfigsForTest {
         rskips.addAll(getReed800Rskips());
         rskips.addAll(getReed810Rskips());
         rskips.addAll(getVetiverRskips());
+
+        return enableTheseDisableThose(rskips, except);
+    }
+
+    public static ActivationConfig tbd1000() {
+        return vetiver900(Collections.emptyList());
+    }
+
+    public static ActivationConfig tbd1000(List<ConsensusRule> except) {
+        List<ConsensusRule> rskips = new ArrayList<>();
+        rskips.addAll(getPaidBridgeTxsRskip());
+        rskips.addAll(getOrchidRskips());
+        rskips.addAll(getOrchid060Rskips());
+        rskips.addAll(getWasabi100Rskips());
+        rskips.addAll(getBahamasRskips());
+        rskips.addAll(getTwoToThreeRskips());
+        rskips.addAll(getPapyrus200Rskips());
+        rskips.addAll(getIris300Rskips());
+        rskips.addAll(getHop400Rskips());
+        rskips.addAll(getHop401Rskips());
+        rskips.addAll(getFingerroot500Rskips());
+        rskips.addAll(getArrowhead600Rskips());
+        rskips.addAll(getArrowhead631Rskips());
+        rskips.addAll(getLovell700Rskips());
+        rskips.addAll(getReed800Rskips());
+        rskips.addAll(getReed810Rskips());
+        rskips.addAll(getVetiverRskips());
+        rskips.addAll(getTbdRskips());
 
         return enableTheseDisableThose(rskips, except);
     }


### PR DESCRIPTION
This pull request introduces support for a new network upgrade, `tbd1000`, across the codebase. The main changes include updating configuration files to include the new upgrade, extending the `NetworkUpgrade` enum, and adding test support for `tbd1000`.

**Network upgrade support:**

* Added `TBD1000` to the `NetworkUpgrade` enum in `NetworkUpgrade.java`, ensuring it is recognized as a valid network upgrade.
* Updated all main, testnet, regtest, and testnet2 config files (`main.conf`, `testnet.conf`, `regtest.conf`, `testnet2.conf`, `expected.conf`) to include activation height entries for `tbd1000`. [[1]](diffhunk://#diff-8bf15243506cb7b8fa608c181426bfb92cdb3e3913273f0557c50d7145d439ceL20-R21) [[2]](diffhunk://#diff-417cf8805d1d2f915396931196185be2befe73345ad856af5bc638aa2abe8d87L20-R21) [[3]](diffhunk://#diff-1dd4b3838c62daa47bbfc9598269f7ae09ac0d1a56eda1255719a3751cb88424L20-R21) [[4]](diffhunk://#diff-e509d16a0b0cde289d6ecca8a9c5e26a3fd092a5ee1d023c7c526ad1d5882b26L20-R21) [[5]](diffhunk://#diff-2572da6381e2d05659399cd69cc76545b8c2da4b5399d8226fa08000d8972175R24)

**Test support:**

* Updated `ActivationConfigTest.java` to include `tbd1000` in the test configuration, ensuring tests cover the new upgrade.
* Refactored imports in `ActivationConfigTest.java` for clarity and organization. [[1]](diffhunk://#diff-38c5f765460ba8c01658ec41319f665f06a9c4a40fc4b49872c1a3967dc5f9bdL21-L26) [[2]](diffhunk://#diff-38c5f765460ba8c01658ec41319f665f06a9c4a40fc4b49872c1a3967dc5f9bdR33-R38)
* In `ActivationConfigsForTest.java`, added methods and lists to support `tbd1000`, including a new method to generate the appropriate consensus rules for this upgrade. [[1]](diffhunk://#diff-50c85824820bb55cf1abea194e7caf5e6dedec1cfbe589efc094f1af5f9aa32dR219-R224) [[2]](diffhunk://#diff-50c85824820bb55cf1abea194e7caf5e6dedec1cfbe589efc094f1af5f9aa32dR492-R519)
* Minor import reordering for consistency in `ActivationConfigsForTest.java`. [[1]](diffhunk://#diff-50c85824820bb55cf1abea194e7caf5e6dedec1cfbe589efc094f1af5f9aa32dL22-L24) [[2]](diffhunk://#diff-50c85824820bb55cf1abea194e7caf5e6dedec1cfbe589efc094f1af5f9aa32dR30-R31)

These changes ensure that the codebase is ready to handle the new `tbd1000` network upgrade in both production and test environments.