### PR TITLE
Fix Union Bridge regtest authorizer addresses for UnionBridgeAuthoriz…

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/union/constants/UnionBridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/union/constants/UnionBridgeRegTestConstants.java
@@ -22,19 +22,22 @@ public class UnionBridgeRegTestConstants extends UnionBridgeConstants {
         initialLockingCap = new Coin(oneRbtc);
         lockingCapIncrementsMultiplier = 2;
 
-        // seed: changeUnionBridgeContractAddressAuthorizer
+        // EOA authorizer (seed: changeUnionBridgeContractAddressAuthorizer) — calls the bridge directly.
         changeUnionBridgeContractAddressAuthorizer = AddressBasedAuthorizerFactory.buildSingleAuthorizer(
             new RskAddress("6c9dfd950bf748bb26f893f7e5f693c7f60a8f85")
         );
 
-        // contract deployer seed: UnionBridgeAuthorizerDeployer
+        // Contract authorizer (deployer seed: UnionBridgeAuthorizerDeployer).
+        // Deployer is a deterministic EOA from that seed; authorizer is its first deployment (nonce 0).
+        // Address = last 20 bytes of keccak256(RLP([deployer, 0])) — standard CREATE addressing.
+        // Resulting regtest authorizer contract: 0xff6f4ff09c54561e1476203e56fcfc834911aa64
         changeLockingCapAuthorizer = AddressBasedAuthorizerFactory.buildSingleAuthorizer(
-            new RskAddress("377e67e16c13994A4d44791Daf0a4d4Cac445783")
+            new RskAddress("ff6f4ff09c54561e1476203e56fcfc834911aa64")
         );
 
-        // contract deployer seed: UnionBridgeAuthorizerDeployer
+        // Same authorizer as the locking cap authorizer above
         changeTransferPermissionsAuthorizer = AddressBasedAuthorizerFactory.buildSingleAuthorizer(
-            new RskAddress("377e67e16c13994A4d44791Daf0a4d4Cac445783")
+            new RskAddress("ff6f4ff09c54561e1476203e56fcfc834911aa64")
         );
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/union/constants/UnionBridgeConstantsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/union/constants/UnionBridgeConstantsTest.java
@@ -60,7 +60,7 @@ class UnionBridgeConstantsTest {
         return Stream.of(
             Arguments.of(UnionBridgeMainNetConstants.getInstance(), ZERO_ADDRESS),
             Arguments.of(UnionBridgeTestNetConstants.getInstance(), new RskAddress("1a8109af0f019ED3045Fbcdf45E5e90d6b6AAfaF")),
-            Arguments.of(UnionBridgeRegTestConstants.getInstance(), new RskAddress("377e67e16c13994A4d44791Daf0a4d4Cac445783"))
+            Arguments.of(UnionBridgeRegTestConstants.getInstance(), new RskAddress("ff6f4ff09c54561e1476203e56fcfc834911aa64"))
         );
     }
 
@@ -81,7 +81,7 @@ class UnionBridgeConstantsTest {
         return Stream.of(
             Arguments.of(UnionBridgeMainNetConstants.getInstance(), ZERO_ADDRESS),
             Arguments.of(UnionBridgeTestNetConstants.getInstance(), new RskAddress("8db1F83E8119E4Dce5bC708ec2f4390FFd910B19")),
-            Arguments.of(UnionBridgeRegTestConstants.getInstance(), new RskAddress("377e67e16c13994A4d44791Daf0a4d4Cac445783"))
+            Arguments.of(UnionBridgeRegTestConstants.getInstance(), new RskAddress("ff6f4ff09c54561e1476203e56fcfc834911aa64"))
         );
     }
 


### PR DESCRIPTION
Fix Union Bridge regtest authorizer addresses for UnionBridgeAuthorizerDeployer seed.

changeLockingCapAuthorizer and changeTransferPermissionsAuthorizer used an incorrect address; update both to the address derived from the UnionBridgeAuthorizerDeployer seed.

`rit:updates-UNION_BRIDGE_AUTHORIZER_DEPLOYER_PK`
