### PR TITLE
Add reproducible-build CI workflows (build + release PR)

### DIFF
--- a/.github/reproducible-build/Dockerfile.tmpl
+++ b/.github/reproducible-build/Dockerfile.tmpl
@@ -1,0 +1,34 @@
+FROM eclipse-temurin:17-jdk@sha256:08295ab0f5007a37cbcc6679a8447a7278d9403f9f82acd80ed08cd10921e026 AS builder
+
+RUN apt-get update -y && \
+    apt-get install -y -qq --no-install-recommends git curl gnupg && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /code/rskj
+
+RUN gitrev=__REF__ && \
+    git init && \
+    git remote add origin https://github.com/rsksmart/rskj.git && \
+    git fetch --depth 1 origin "$gitrev" && \
+    git checkout FETCH_HEAD
+
+RUN curl -sSL https://secchannel.rsk.co/SUPPORT.asc | gpg --import && \
+    gpg --verify --output SHA256SUMS SHA256SUMS.asc && \
+    sha256sum --check SHA256SUMS && \
+    ./configure.sh && \
+    ./gradlew --no-daemon clean build -x test -x checkstyleMain -x checkstyleTest -x checkstyleIntegrationTest && \
+    ./gradlew publishRskjPublicationToMavenLocal
+
+
+FROM eclipse-temurin:17-jre@sha256:f1515395c0695910a3ca665e973cc11013d1f50d265e61cb8c9156e999d914b4 AS runner
+
+RUN useradd -m rsk
+
+WORKDIR /home/rsk
+
+USER rsk
+COPY --from=builder --chown=rsk:rsk /code/rskj/rskj-core/build/libs/rskj-core-* ./
+COPY --from=builder --chown=rsk:rsk /code/rskj/rskj-core/build/rskj-core-*.pom ./
+COPY --from=builder --chown=rsk:rsk /root/.m2/repository/co/rsk/rskj-core/__VERSION__-__MODIFIER__/*.module ./
+
+CMD ["java", "-cp", "rskj-core-__VERSION__-__MODIFIER__-all.jar", "co.rsk.Start"]

--- a/.github/reproducible-build/README.md.tmpl
+++ b/.github/reproducible-build/README.md.tmpl
@@ -1,0 +1,32 @@
+# rskj __TAG__
+
+* Source: https://github.com/rsksmart/rskj
+* Tag: `__TAG__`
+
+## Build
+
+```
+$ docker build -t rskj/__VERSION__-__MODIFIER_LC__ .
+```
+
+## Verify
+
+Run the following command to verify the sha256sum of the built artifacts matches the expected values:
+
+```
+$ docker run --rm rskj/__VERSION__-__MODIFIER_LC__ sh -c 'sha256sum * | grep -v javadoc.jar'
+__HASHES__
+```
+
+## (Optional) Run RSK Node
+```
+$ docker run -d rskj/__VERSION__-__MODIFIER_LC__
+```
+
+## (Optional) Extract JAR from image
+
+```
+$ cid=$(docker run -d rskj/__VERSION__-__MODIFIER_LC__ /bin/true)
+$ docker cp "$cid":/home/rsk/ ./libs/
+$ docker rm "$cid"
+```

--- a/.github/workflows/reproducible-build-pr.yml
+++ b/.github/workflows/reproducible-build-pr.yml
@@ -1,0 +1,196 @@
+name: Reproducible build PR
+
+# Builds the canonical jars via the build-only `reproducible-build.yml`,
+# then open a PR against rsksmart/reproducible-builds adding the rskj/<version>-<modifier>
+# directory (Dockerfile + README with the hashes).
+#
+# Trust model: CI is the *first builder / PR author* only. The hashes it emits
+# are informational — merging the generated PR still REQUIRES an independent
+# rebuild confirming the same hashes. CI is intentionally not the sole witness.
+
+on:
+  # GA release tags look like NAME-1.2.3.
+  push:
+    tags:
+      - "*-[0-9]*.[0-9]*.[0-9]*"
+
+# Only read permission is needed. The cross-repo PR is opened with the
+# scoped App token, NOT GITHUB_TOKEN.
+permissions:
+  contents: read
+
+concurrency:
+  group: reproducible-build-pr-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # GA-only gate. push.tags globs match pre-release tags too, so re-check the
+  # tag here and skip (green, not red) anything that isn't a clean GA release.
+  guard:
+    runs-on: ubuntu-24.04
+    outputs:
+      is_ga: ${{ steps.check.outputs.is_ga }}
+    steps:
+      - name: Classify the pushed tag
+        id: check
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          is_ga=false
+          # All-caps release name + three-part numeric version, nothing trailing.
+          if printf '%s' "$TAG" | grep -Eq '^[A-Z]+-[0-9]+\.[0-9]+\.[0-9]+$'; then
+            is_ga=true
+          fi
+          # Belt-and-suspenders deny-list for pre-release markers (the regex above
+          # already excludes these; this makes the intent explicit and survives a
+          # future regex loosening).
+          case "$TAG" in
+            *PREVIEW*|*TESTNET*|*SNAPSHOT*|*-rc|*-rc[0-9]*|*-RC*|*-alpha*|*-beta*)
+              is_ga=false ;;
+          esac
+          echo "is_ga=$is_ga" >> "$GITHUB_OUTPUT"
+          if [ "$is_ga" = "true" ]; then
+            echo "Tag '$TAG' is a GA release — proceeding."
+          else
+            echo "::notice::Tag '$TAG' is not a GA release — skipping reproducible-build PR."
+          fi
+
+  # Build the canonical jars + hashes. NO `secrets:` passed → the build half can
+  # never see this workflow's App-token secrets. Runs only for GA tags.
+  build:
+    needs: guard
+    if: needs.guard.outputs.is_ga == 'true'
+    uses: ./.github/workflows/reproducible-build.yml
+    with:
+      ref: ${{ github.ref_name }}
+
+  # The only privileged job: mint the scoped App token and open the PR.
+  open-pr:
+    needs: [guard, build]
+    if: needs.guard.outputs.is_ga == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      TAG: ${{ github.ref_name }}
+      VERSION: ${{ needs.build.outputs.version }}
+      MODIFIER: ${{ needs.build.outputs.modifier }}
+      TARGET_REPO: rsksmart/reproducible-builds
+    steps:
+      - name: Checkout rskj at the tag (templates only)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.ref_name }}
+          sparse-checkout: |
+            .github/reproducible-build
+
+      - name: Download canonical build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.build.outputs.artifact_name }}
+          path: artifacts
+
+      - name: Render Dockerfile and README for the release directory
+        id: render
+        run: |
+          set -euo pipefail
+          # modifier_lc derivation lives HERE (the build half is modifier-case
+          # agnostic); the published dir + README use the lowercase form.
+          modifier_lc=$(printf '%s' "$MODIFIER" | tr '[:upper:]' '[:lower:]')
+          echo "modifier_lc=$modifier_lc" >> "$GITHUB_OUTPUT"
+
+          # Hashes come from the artifact's hashes.txt (authoritative copy the
+          # build job wrote), so README == artifact == a verifier's local check.
+          if [ ! -s artifacts/hashes.txt ]; then
+            echo "::error::artifacts/hashes.txt missing or empty"; exit 1
+          fi
+          hashes=$(cat artifacts/hashes.txt)
+
+          mkdir -p out
+          # Dockerfile pins the immutable tag as the build ref.
+          sed -e "s|__REF__|${TAG}|g" \
+              -e "s|__VERSION__|${VERSION}|g" \
+              -e "s|__MODIFIER__|${MODIFIER}|g" \
+              .github/reproducible-build/Dockerfile.tmpl > out/Dockerfile
+
+          # README: tag/version/modifier_lc via sed, then the multi-line hash
+          # block via awk (sed chokes on multi-line / slashed replacements).
+          sed -e "s|__TAG__|${TAG}|g" \
+              -e "s|__VERSION__|${VERSION}|g" \
+              -e "s|__MODIFIER_LC__|${modifier_lc}|g" \
+              .github/reproducible-build/README.md.tmpl > out/README.partial.md
+          awk -v hashes="$hashes" '{ gsub(/__HASHES__/, hashes); print }' \
+              out/README.partial.md > out/README.md
+
+      - name: Mint scoped GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: rsksmart
+          repositories: reproducible-builds
+
+      - name: Open the reproducible-builds PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TOKEN: ${{ steps.app-token.outputs.token }}
+          MODIFIER_LC: ${{ steps.render.outputs.modifier_lc }}
+        run: |
+          set -euo pipefail
+          rel_dir="rskj/${VERSION}-${MODIFIER_LC}"
+          branch="reproducible-build/${TAG}"
+
+          # Clone over x-access-token (devportal-update.yml pattern). The clone
+          # lands on the default branch — the reference for the existing-dir check.
+          git clone "https://x-access-token:${TOKEN}@github.com/${TARGET_REPO}.git" target
+          cd target
+          default_branch=$(git rev-parse --abbrev-ref HEAD)
+
+          # Fail-loud: never overwrite an already-published release directory.
+          if [ -e "$rel_dir" ]; then
+            echo "::error::${rel_dir} already exists in ${TARGET_REPO} — refusing to overwrite a published release."
+            exit 1
+          fi
+
+          # Dedicated per-tag branch; -B so a re-run resets cleanly off default.
+          git checkout -B "$branch"
+          mkdir -p "$rel_dir"
+          cp ../out/Dockerfile "$rel_dir/Dockerfile"
+          cp ../out/README.md  "$rel_dir/README.md"
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$rel_dir"
+          git commit -m "Add reproducible build for ${TAG}"
+          # Force-push: the branch is ours alone (per-tag), so a re-run overwrites
+          # its own prior push rather than failing.
+          git push -u -f origin "$branch"
+
+          # gh (unlike peter-evans) won't reconcile an existing PR, so check first.
+          existing=$(gh pr list --repo "$TARGET_REPO" --head "$branch" --state open \
+            --json url -q '.[0].url' || true)
+          if [ -n "$existing" ]; then
+            echo "::notice::PR already open for ${branch}: ${existing}"
+            exit 0
+          fi
+
+          body=$(cat <<EOF
+          Automated reproducible build for rskj tag \`${TAG}\`, opened by the
+          \`Reproducible build PR\` workflow in rskj.
+
+          **Before merging:** independently rebuild and confirm the hashes match.
+          CI is the first builder only — it is not the sole witness, and this PR
+          must not be auto-merged.
+
+          \`\`\`
+          $(cat ../artifacts/hashes.txt)
+          \`\`\`
+          EOF
+          )
+          gh pr create \
+            --repo "$TARGET_REPO" \
+            --base "$default_branch" \
+            --head "$branch" \
+            --title "Add reproducible build for ${TAG}" \
+            --body "$body"

--- a/.github/workflows/reproducible-build-pr.yml
+++ b/.github/workflows/reproducible-build-pr.yml
@@ -126,8 +126,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.RSK_CORE_GH_APP_ID }}
+          private-key: ${{ secrets.RSK_CORE_GH_APP_PRIVATE_KEY }}
           owner: rsksmart
           repositories: reproducible-builds
 

--- a/.github/workflows/reproducible-build-pr.yml
+++ b/.github/workflows/reproducible-build-pr.yml
@@ -2,14 +2,23 @@ name: Reproducible build PR
 
 # Builds the canonical jars via the build-only `reproducible-build.yml`,
 # then open a PR against rsksmart/reproducible-builds adding the rskj/<version>-<modifier>
-# directory (Dockerfile + README with the hashes).
+# directory (Dockerfile + README with the hashes), and pushes a sibling
+# `rskj_<tag>` tag onto reproducible-builds pointing at the PR branch HEAD.
+#
+# Scope: GA release tags (NAME-1.2.3) AND release-candidate tags
+# (NAME-1.2.3-rc / -rcN / -RC). Both build, open a PR, and push the sibling
+# tag; the sibling tag pins the build-recipe commit the platform team's
+# Maven-publish pipeline rebuilds jars from. rc builds as SNAPSHOT (intended,
+# read from version.properties) and its PR is not meant to be merged — it
+# exists only to create the commit the tag pins.
 #
 # Trust model: CI is the *first builder / PR author* only. The hashes it emits
 # are informational — merging the generated PR still REQUIRES an independent
 # rebuild confirming the same hashes. CI is intentionally not the sole witness.
 
 on:
-  # GA release tags look like NAME-1.2.3.
+  # GA release tags look like NAME-1.2.3; the glob also admits pre-release tags
+  # (e.g. NAME-1.2.3-rc), which the guard job then classifies.
   push:
     tags:
       - "*-[0-9]*.[0-9]*.[0-9]*"
@@ -24,12 +33,15 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # GA-only gate. push.tags globs match pre-release tags too, so re-check the
-  # tag here and skip (green, not red) anything that isn't a clean GA release.
+  # Release gate. push.tags globs match every pre-release tag too, so re-check
+  # the tag here and skip (green, not red) anything that is neither a clean GA
+  # release nor a release candidate. Emits is_ga / is_rc / is_release.
   guard:
     runs-on: ubuntu-24.04
     outputs:
       is_ga: ${{ steps.check.outputs.is_ga }}
+      is_rc: ${{ steps.check.outputs.is_rc }}
+      is_release: ${{ steps.check.outputs.is_release }}
     steps:
       - name: Classify the pushed tag
         id: check
@@ -38,43 +50,60 @@ jobs:
         run: |
           set -euo pipefail
           is_ga=false
+          is_rc=false
           # All-caps release name + three-part numeric version, nothing trailing.
           if printf '%s' "$TAG" | grep -Eq '^[A-Z]+-[0-9]+\.[0-9]+\.[0-9]+$'; then
             is_ga=true
           fi
-          # Belt-and-suspenders deny-list for pre-release markers (the regex above
-          # already excludes these; this makes the intent explicit and survives a
-          # future regex loosening).
+          # Same shape with an -rc / -rcN / -RC suffix (release candidate).
+          if printf '%s' "$TAG" | grep -Eq '^[A-Z]+-[0-9]+\.[0-9]+\.[0-9]+-(rc|RC)[0-9]*$'; then
+            is_rc=true
+          fi
+          # Belt-and-suspenders deny-list for pre-release markers that are NOT
+          # release candidates. The regexes above already exclude these; this
+          # makes the intent explicit and survives a future regex loosening.
+          # (-rc/-RC are deliberately absent — they are now an accepted class.)
           case "$TAG" in
-            *PREVIEW*|*TESTNET*|*SNAPSHOT*|*-rc|*-rc[0-9]*|*-RC*|*-alpha*|*-beta*)
-              is_ga=false ;;
+            *PREVIEW*|*TESTNET*|*SNAPSHOT*|*-alpha*|*-beta*)
+              is_ga=false; is_rc=false ;;
           esac
+          is_release=false
+          if [ "$is_ga" = "true" ] || [ "$is_rc" = "true" ]; then
+            is_release=true
+          fi
           echo "is_ga=$is_ga" >> "$GITHUB_OUTPUT"
+          echo "is_rc=$is_rc" >> "$GITHUB_OUTPUT"
+          echo "is_release=$is_release" >> "$GITHUB_OUTPUT"
           if [ "$is_ga" = "true" ]; then
             echo "Tag '$TAG' is a GA release — proceeding."
+          elif [ "$is_rc" = "true" ]; then
+            echo "Tag '$TAG' is a release candidate — proceeding."
           else
-            echo "::notice::Tag '$TAG' is not a GA release — skipping reproducible-build PR."
+            echo "::notice::Tag '$TAG' is neither a GA release nor an rc — skipping reproducible-build PR."
           fi
 
   # Build the canonical jars + hashes. NO `secrets:` passed → the build half can
-  # never see this workflow's App-token secrets. Runs only for GA tags.
+  # never see this workflow's App-token secrets. Runs for GA and rc tags; rc
+  # yields <version>-snapshot because version.properties carries modifier=SNAPSHOT.
   build:
     needs: guard
-    if: needs.guard.outputs.is_ga == 'true'
+    if: needs.guard.outputs.is_release == 'true'
     uses: ./.github/workflows/reproducible-build.yml
     with:
       ref: ${{ github.ref_name }}
 
-  # The only privileged job: mint the scoped App token and open the PR.
+  # The only privileged job: mint the scoped App token, open the PR, and push
+  # the sibling tag. Runs for GA and rc tags.
   open-pr:
     needs: [guard, build]
-    if: needs.guard.outputs.is_ga == 'true'
+    if: needs.guard.outputs.is_release == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:
       TAG: ${{ github.ref_name }}
       VERSION: ${{ needs.build.outputs.version }}
       MODIFIER: ${{ needs.build.outputs.modifier }}
+      IS_GA: ${{ needs.guard.outputs.is_ga }}
       TARGET_REPO: rsksmart/reproducible-builds
     steps:
       - name: Checkout rskj at the tag (templates only)
@@ -98,6 +127,17 @@ jobs:
           # agnostic); the published dir + README use the lowercase form.
           modifier_lc=$(printf '%s' "$MODIFIER" | tr '[:upper:]' '[:lower:]')
           echo "modifier_lc=$modifier_lc" >> "$GITHUB_OUTPUT"
+
+          # GA-only sanity check: a GA tag must NOT build as a pre-release
+          # modifier (a mis-cut GA built as SNAPSHOT would publish under the
+          # wrong dir). rc is EXPECTED to be SNAPSHOT, so this is GA-scoped only.
+          if [ "${IS_GA}" = "true" ]; then
+            case "$modifier_lc" in
+              snapshot|preview|testnet|*alpha*|*beta*|*rc*)
+                echo "::error::GA tag '${TAG}' derived a pre-release modifier '${MODIFIER}' — refusing to publish."
+                exit 1 ;;
+            esac
+          fi
 
           # Hashes come from the artifact's hashes.txt (authoritative copy the
           # build job wrote), so README == artifact == a verifier's local check.
@@ -194,3 +234,35 @@ jobs:
             --head "$branch" \
             --title "Add reproducible build for ${TAG}" \
             --body "$body"
+
+      - name: Push sibling tag onto reproducible-builds
+        env:
+          TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          # The sibling tag pins the PR branch HEAD — the commit that added the
+          # release dir — so the Maven-publish pipeline rebuilds jars from the
+          # build recipe on that exact commit. Naming: rskj tag with rskj_ prefix.
+          sibling="rskj_${TAG}"
+          branch="reproducible-build/${TAG}"
+
+          # Reuse the clone the previous step left on disk; it is checked out on
+          # $branch at the commit we just pushed.
+          cd target
+
+          if [ "${IS_GA}" = "true" ]; then
+            # GA sibling tags are immutable: skip if one already exists remotely.
+            if git ls-remote --tags origin "refs/tags/$sibling" | grep -q .; then
+              echo "::notice::Sibling tag '${sibling}' already exists on ${TARGET_REPO} — leaving it untouched (GA tags are immutable)."
+              exit 0
+            fi
+            # -f: a clone fetches remote tags, so overwrite any stale local ref.
+            git tag -f "$sibling"
+            git push origin "refs/tags/$sibling"
+            echo "Pushed sibling tag '${sibling}' → ${branch} HEAD."
+          else
+            # rc is re-cut: force-move the sibling tag to the new PR branch HEAD.
+            git tag -f "$sibling"
+            git push -f origin "refs/tags/$sibling"
+            echo "Force-moved sibling tag '${sibling}' → ${branch} HEAD (rc)."
+          fi

--- a/.github/workflows/reproducible-build-pr.yml
+++ b/.github/workflows/reproducible-build-pr.yml
@@ -171,19 +171,24 @@ jobs:
           owner: rsksmart
           repositories: reproducible-builds
 
+      - name: Checkout reproducible-builds
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ env.TARGET_REPO }}
+          token: ${{ steps.app-token.outputs.token }}
+          path: target
+
       - name: Open the reproducible-builds PR
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          TOKEN: ${{ steps.app-token.outputs.token }}
           MODIFIER_LC: ${{ steps.render.outputs.modifier_lc }}
         run: |
           set -euo pipefail
           rel_dir="rskj/${VERSION}-${MODIFIER_LC}"
           branch="reproducible-build/${TAG}"
 
-          # Clone over x-access-token (devportal-update.yml pattern). The clone
-          # lands on the default branch — the reference for the existing-dir check.
-          git clone "https://x-access-token:${TOKEN}@github.com/${TARGET_REPO}.git" target
+          # The checkout above landed the target repo in ./target on its default
+          # branch — the reference for the existing-dir check below.
           cd target
           default_branch=$(git rev-parse --abbrev-ref HEAD)
 
@@ -236,8 +241,6 @@ jobs:
             --body "$body"
 
       - name: Push sibling tag onto reproducible-builds
-        env:
-          TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           # The sibling tag pins the PR branch HEAD — the commit that added the

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -1,0 +1,196 @@
+name: Reproducible build
+
+# Hermetic build of an rskj git ref + the sha256 hashes of the produced jars.
+#
+# Triggers:
+#   - push to master / *-rc          -> build that commit, publish canonical hashes
+#   - workflow_dispatch (ref input)  -> build an arbitrary ref on demand
+#   - workflow_call (ref input)      -> building block for the release workflow
+#                                       (.github/workflows/reproducible-build-pr.yml),
+#                                       which opens the reproducible-builds PR
+#
+# What it does: checks out the ref for its templates + version.properties, renders
+# the pinned hermetic Dockerfile, builds it (the Dockerfile git-fetches the ref
+# itself from canonical upstream — the runner checkout is only for the templates),
+# extracts the jars, hashes them, and uploads jars + hashes.txt as a run artifact.
+#
+# Trust model: this workflow is the *first builder* only. The hashes it emits are
+# informational — NOT an authoritative attestation. A release must still be
+# independently rebuilt to confirm the same hashes; CI is not the sole witness.
+# On a non-tag push there is moreover no published release to compare against:
+# the run is a hermetic build + canonical-hash record, not a reproducibility check.
+#
+# This workflow holds no secrets and only `contents: read`. All privileged,
+# cross-repo work (App token, opening the reproducible-builds PR) lives solely in
+# .github/workflows/reproducible-build-pr.yml.
+
+on:
+  push:
+    branches: ["master", "*-rc"]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'git ref to build (branch / tag / SHA; default: this commit)'
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      ref:
+        description: 'git ref to build (branch / tag / SHA)'
+        required: true
+        type: string
+    outputs:
+      hashes:
+        description: 'sha256sum block of the canonical jars (informational)'
+        value: ${{ jobs.reproducible-build.outputs.hashes }}
+      artifact_name:
+        description: 'name of the uploaded run artifact (jars + hashes.txt)'
+        value: ${{ jobs.reproducible-build.outputs.artifact_name }}
+      version:
+        description: 'versionNumber resolved from version.properties at the ref'
+        value: ${{ jobs.reproducible-build.outputs.version }}
+      modifier:
+        description: 'modifier resolved from version.properties at the ref'
+        value: ${{ jobs.reproducible-build.outputs.modifier }}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reproducible-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  reproducible-build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    outputs:
+      hashes: ${{ steps.hashes.outputs.hashes }}
+      artifact_name: ${{ steps.meta.outputs.artifact_name }}
+      version: ${{ steps.meta.outputs.version }}
+      modifier: ${{ steps.meta.outputs.modifier }}
+    steps:
+      - name: Checkout the ref (templates + version.properties live here)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          # The job only reads the templates and version.properties; skip the
+          # rest of the tree.
+          sparse-checkout: |
+            .github/reproducible-build
+            rskj-core/src/main/resources
+
+      - name: Resolve ref, version and modifier
+        id: meta
+        env:
+          REF: ${{ inputs.ref || github.sha }}
+        run: |
+          set -euo pipefail
+          # Validate REF before it flows into a sed `s|__REF__|...|` delimiter and
+          # the Dockerfile's git refspec. Same gate style as
+          # .github/workflows/rskj-core-automated-tests.yml.
+          case "$REF" in
+            ""|*..*) echo "::error::invalid ref (empty or contains '..'): '$REF'"; exit 1;;
+            *[!A-Za-z0-9._/-]*) echo "::error::ref has disallowed characters: '$REF'"; exit 1;;
+          esac
+
+          # Read from the checked-out tree at REF (the Dockerfile's runner stage
+          # needs version+modifier for the *.module COPY and the -all.jar CMD).
+          props=rskj-core/src/main/resources/version.properties
+          version=$(sed -n "s/^versionNumber=['\"]\(.*\)['\"].*/\1/p" "$props")
+          modifier=$(sed -n "s/^modifier=['\"]\(.*\)['\"].*/\1/p" "$props")
+          if [ -z "$version" ] || [ -z "$modifier" ]; then
+            echo "::error::could not parse version.properties at ${REF}"; exit 1
+          fi
+          {
+            echo "version=$version"
+            echo "modifier=$modifier"
+            echo "artifact_name=rskj-repro-artifacts"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved ${REF} -> version=$version modifier=$modifier"
+
+      - name: Render Dockerfile from template
+        env:
+          REF: ${{ inputs.ref || github.sha }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          MODIFIER: ${{ steps.meta.outputs.modifier }}
+        run: |
+          set -euo pipefail
+          mkdir -p out
+          sed -e "s|__REF__|${REF}|g" \
+              -e "s|__VERSION__|${VERSION}|g" \
+              -e "s|__MODIFIER__|${MODIFIER}|g" \
+              .github/reproducible-build/Dockerfile.tmpl > out/Dockerfile
+
+      - name: Build the reproducible image
+        run: |
+          set -euo pipefail
+          # The Dockerfile is fully hermetic (it git-fetches the ref itself), so
+          # the build context is irrelevant — send an empty one to keep it fast.
+          # --no-cache guarantees nothing is reused from a previous run.
+          mkdir -p ctx
+          docker build --no-cache -t rskj-repro:build -f out/Dockerfile ctx
+
+      - name: Extract built artifacts
+        run: |
+          set -euo pipefail
+          # The artifacts live inside the image (runner stage WORKDIR /home/rsk).
+          # Use a created (not run) container so the node ENTRYPOINT never starts.
+          cid=$(docker create rskj-repro:build)
+          mkdir -p artifacts
+          docker cp "$cid":/home/rsk/. artifacts/
+          docker rm "$cid" >/dev/null
+          ls -l artifacts
+
+      - name: Compute artifact hashes
+        id: hashes
+        run: |
+          set -euo pipefail
+          # Same command a verifier runs locally, so the artifact's hashes.txt and
+          # any downstream README match byte for byte.
+          hashes=$(docker run --rm rskj-repro:build sh -c 'sha256sum * | grep -v javadoc.jar')
+          printf '%s\n' "$hashes"
+          # Ship the hashes alongside the jars so the release workflow (and a human)
+          # has an authoritative copy in the artifact.
+          printf '%s\n' "$hashes" > artifacts/hashes.txt
+          {
+            echo "hashes<<REPRO_EOF"
+            printf '%s\n' "$hashes"
+            echo "REPRO_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Write job summary
+        env:
+          REF: ${{ inputs.ref || github.sha }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          MODIFIER: ${{ steps.meta.outputs.modifier }}
+          HASHES: ${{ steps.hashes.outputs.hashes }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Reproducible build — \`${REF}\`"
+            echo ""
+            echo "Resolved version: \`${VERSION}-${MODIFIER}\`"
+            echo "Jars + \`hashes.txt\` attached to this run as artifact: \`rskj-repro-artifacts\`"
+            echo ""
+            echo "> Hashes are informational (first-builder only), not an attestation."
+            echo ""
+            echo "### Artifact hashes"
+            echo '```'
+            printf '%s\n' "$HASHES"
+            echo '```'
+            echo ""
+            echo "<details><summary>Generated Dockerfile</summary>"
+            echo ""
+            echo '```dockerfile'
+            cat out/Dockerfile
+            echo '```'
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rskj-repro-artifacts
+          path: artifacts/
+          if-no-files-found: error

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -57,8 +57,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: reproducible-build-${{ github.ref }}
-  cancel-in-progress: true
+  # Key by the ref actually being built (inputs.ref for dispatch/call, the commit
+  # for push) so builds of different refs never share a group. Never cancel an
+  # in-flight build: same-ref re-triggers queue instead, and a release-tag build
+  # driven via workflow_call is never aborted out from under the PR workflow.
+  group: reproducible-build-${{ inputs.ref || github.sha }}
+  cancel-in-progress: false
 
 jobs:
   reproducible-build:

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -106,6 +106,14 @@ jobs:
           if [ -z "$version" ] || [ -z "$modifier" ]; then
             echo "::error::could not parse version.properties at ${REF}"; exit 1
           fi
+          case "$version" in
+            *..*) echo "::error::versionNumber contains '..': '$version'"; exit 1;;
+            *[!A-Za-z0-9.-]*) echo "::error::versionNumber has disallowed characters (allowed: A-Za-z0-9.-): '$version'"; exit 1;;
+          esac
+          case "$modifier" in
+            *..*) echo "::error::modifier contains '..': '$modifier'"; exit 1;;
+            *[!A-Za-z0-9.-]*) echo "::error::modifier has disallowed characters (allowed: A-Za-z0-9.-): '$modifier'"; exit 1;;
+          esac
           {
             echo "version=$version"
             echo "modifier=$modifier"


### PR DESCRIPTION
## Description
Automates the reproducible-build artifacts that today are produced entirely by hand for `rsksmart/reproducible-builds`. Adds two GitHub Actions workflows plus the templates they render, split by privilege:

- `.github/workflows/reproducible-build.yml` — **build-only**, no secrets, `contents: read`.
- `.github/workflows/reproducible-build-pr.yml` — **release PR + sibling tag**, the only holder of secrets + cross-repo write scope.
- `.github/reproducible-build/Dockerfile.tmpl` — the pinned, hermetic build.
- `.github/reproducible-build/README.md.tmpl` — the published release-directory README.

### `reproducible-build.yml` — build-only
Given a git **ref** (branch / tag / SHA), it builds the rskj artifacts inside the pinned Dockerfile, computes the `sha256` hashes of the produced jars, writes a `hashes.txt`, and uploads jars + hashes as a run artifact (`rskj-repro-artifacts`).

Triggered three ways:
- **`push`** to `master` and `*-rc` branches — builds that commit and records its canonical hashes.
- **`workflow_dispatch`** — manual, optional `ref` input (defaults to the checked-out commit).
- **`workflow_call`** — reusable building block: exposes `hashes`, `version`, `modifier` and `artifact_name` as outputs, consumed by the release-PR workflow below.

It holds no secrets and only `contents: read`; it opens no PR and publishes nothing.

### `reproducible-build-pr.yml` — release PR + sibling tag
Triggered on a pushed **GA release tag** (`NAME-1.2.3`) or **release-candidate tag** (`NAME-1.2.3-rc` / `-rcN` / `-RC`); it builds the canonical artifacts via the build-only workflow, opens the corresponding PR against `rsksmart/reproducible-builds`, and pushes a sibling `rskj_<tag>` git tag pointing at that PR branch's HEAD. Three jobs:

- **`guard`** — classifies the pushed tag and emits `is_ga`, `is_rc`, and `is_release` (`is_ga || is_rc`). GA is the all-caps name + three-part version regex; rc is the same shape with an `-rc` / `-rcN` / `-RC` suffix. A belt-and-suspenders pre-release deny-list still excludes `*PREVIEW*` / `*TESTNET*` / `*SNAPSHOT*` / `*-alpha` / `*-beta` (green skip, not red). `push.tags` globs can't exclude pre-release tags, so this guard does. rc is deliberately **not** in the deny-list — it is now an accepted class.
- **`build`** — `uses: ./.github/workflows/reproducible-build.yml` with `ref: github.ref_name`. Runs for GA and rc tags (`is_release`). rc naturally builds `rskj/<version>-snapshot/` because `version.properties` carries `modifier=SNAPSHOT` at an rc tag — this is the intended snapshot-artifact semantics, not a bug.
- **`open-pr`** — the only privileged job. Downloads the build artifact (`hashes.txt`), renders the Dockerfile + README for the `rskj/<version>-<modifier>/` directory (the modifier→lowercase derivation lives here; hashes come straight from the artifact so README == artifact == a verifier's local check), mints a **scoped GitHub App token** (`create-github-app-token` v3.2.0, pinned SHA, scoped to `owner: rsksmart` + `repositories: reproducible-builds`), clones the target over `x-access-token`, opens the PR via the `gh` CLI, and pushes the sibling tag. Specifics:
  - **GA-only modifier assert** — a GA tag that derived a pre-release modifier (`snapshot`/`preview`/`testnet`/`alpha`/`beta`/`rc`) fails loudly rather than publishing under the wrong directory. rc is expected to be SNAPSHOT, so the assert is GA-scoped only.
  - **Fails loudly** if the release directory already exists (never overwrites a published release), uses a per-tag branch with `-B` reset, and a `gh pr list` idempotency check so a re-run never opens a duplicate PR.
  - **Sibling tag `rskj_<tag>`** points at the PR branch's HEAD (the commit that adds the release directory), reusing the same clone + App token. GA tags are immutable — **skip if the tag already exists**; rc tags are re-cut — **force-move**. The tag pins the exact build-recipe commit so a downstream Maven-publish pipeline can rebuild jars from it.

The **rc** PR is not intended to be merged — it exists only to create the commit the sibling tag pins, and its `-snapshot` directory therefore never lands on the target's default branch (no collision with a GA `<version>-<modifier>` directory).

**Privilege isolation:** top-level `permissions: contents: read`; `GITHUB_TOKEN` is never elevated. All secrets and all cross-repo writes are confined to `open-pr`, via the App token only. Cross-repo writes now include **creating and force-moving git tags** (`rskj_<tag>`) in addition to opening the PR — both stay within the token's existing `contents: write` scope on `reproducible-builds`; no new secret and no scope beyond what the PR-open path already used. The PR is **opened only**, merging and approving are still manual processes.

## Motivation and Context
Reproducible-build PRs against `rsksmart/reproducible-builds` (e.g. [[#139](https://github.com/rsksmart/reproducible-builds/pull/139)](https://github.com/rsksmart/reproducible-builds/pull/139) for VETIVER-9.0.3) are currently produced entirely by hand: build the pinned Dockerfile locally, run `sha256sum`, hand-template the `rskj/<version>-<modifier>/` directory, and open the PR. This is purely mechanical, so it is automated end-to-end here: a hermetic, on-demand / on-push CI build, and a release-tag-triggered workflow that renders the release directory and opens the PR — while preserving the trust model (independent rebuild still gates merge).

The sibling `rskj_<tag>` tag is the tag-generation step of the platform team's Maven-publish pipeline: `rskj tag pushed → PR opened against reproducible-builds → tag on reproducible-builds pointing at that PR branch's HEAD → (downstream, out of scope here) jars are rebuilt from the tagged commit and published to Maven`. The tag must pin the PR branch HEAD specifically, because that is the commit carrying the build recipe (Dockerfile / README) the downstream build regenerates from.


## How Has This Been Tested?

Validated in forks from both rskj and reproducible-builds:
- [Workflow run from rskj](https://github.com/italo-sampaio/rskj/actions/runs/28181053564)
- [PR generated in reproducible-builds](https://github.com/italo-sampaio/reproducible-builds/pull/1)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)