### PR TITLE
Add coding guidelines for Copilot review

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,6 +28,22 @@ Review-ability is the top priority. Use these heuristics to flag PRs and to auth
 
 Java style conventions are defined in `CONTRIBUTING.md`. Key reviewer-facing rules: prefer constructor injection with `private final` fields and `Objects.requireNonNull` on parameters; prefer `Optional<T>` over `null` (annotate nullable returns with `@Nullable`); always brace control structures; treat `@VisibleForTesting` as a design smell and flag accordingly. Standard Java naming applies: lowercase packages, `UpperCamelCase` classes, `lowerCamelCase` members, `CONSTANT_CASE` for static final immutable constants.
 
+## Rootstock coding principles
+
+Follow the coding principles documented in `docs/coding-principles.md`.
+
+Key rules:
+
+* Code is read more often than written. Optimize for readability and maintainability.
+* Use intention-revealing names.
+* Include units in monetary and time-related names, such as `amountInSatoshis`, `amountInWei`, `amountInRBTC`, and `timeoutMillis`.
+* Never rely on implicit monetary units.
+* Prefer focused functions and classes with clear responsibilities.
+* Eliminate duplication when practical.
+* Prefer self-explanatory code over explanatory comments.
+* Tests should be readable, independent, and cover boundary/error cases.
+* Refactors must improve clarity, maintainability, or correctness. Do not introduce abstractions, indirection, or code movement without a clear benefit.
+
 ## CI gates a reviewer must predict
 
 Every build job uses JDK 17 and the in-repo Gradle wrapper 8.6. Workflows live in `.github/workflows/`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,11 +26,11 @@ Review-ability is the top priority. Use these heuristics to flag PRs and to auth
 - **Review the change holistically.** Do not raise a finding that another part of the same diff already prevents (e.g. an early validation guard that makes a later branch unreachable). Read the whole changed unit before commenting on a line in isolation.
 - **PR template compliance.** PRs targeted at **master** or a branch ending with the **-rc** sufix must populate every section of `.github/pull_request_template.md`: **Description**, **Motivation and Context**, **How Has This Been Tested?**, **Types of changes**, **Checklist**. The checklist contains a deliberate "Requires Activation Code (Hard Fork)" question — flag PRs that touch consensus, validators, VM, peg, mining, or activation logic without answering it.
 
-Java style conventions are defined in `CONTRIBUTING.md`. Key reviewer-facing rules: prefer constructor injection with `private final` fields and `Objects.requireNonNull` on parameters; prefer `Optional<T>` over `null` (annotate nullable returns with `@Nullable`); always brace control structures; treat `@VisibleForTesting` as a design smell and flag accordingly. Standard Java naming applies: lowercase packages, `UpperCamelCase` classes, `lowerCamelCase` members, `CONSTANT_CASE` for static final immutable constants.
+Java style conventions are defined in `./CONTRIBUTING.md`. Key reviewer-facing rules: prefer constructor injection with `private final` fields and `Objects.requireNonNull` on parameters; prefer `Optional<T>` over `null` (annotate nullable returns with `@Nullable`); always brace control structures; treat `@VisibleForTesting` as a design smell and flag accordingly. Standard Java naming applies: lowercase packages, `UpperCamelCase` classes, `lowerCamelCase` members, `CONSTANT_CASE` for static final immutable constants.
 
 ## Rootstock coding principles
 
-Follow the coding principles documented in `docs/coding-principles.md`.
+Follow the coding principles documented in `./coding-principles.md`.
 
 Key rules:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,3 +222,4 @@ For automatic formatting in IntelliJ IDEA, the following `xml` files can be plac
   </code_scheme>
 </component>
 ```
+See [coding principle](./coding-principles.md) for more guidelines.

--- a/coding-principles.md
+++ b/coding-principles.md
@@ -23,7 +23,7 @@ Names are one of the most important parts of readability.
 * Use intention-revealing names.
 * Prefer names that reveal intent without requiring comments.
 * Names should describe domain concepts, not implementation details.
-* Include units in names when working with monetary values, time values, or measurements, such as amountInSatoshis, amountInWei, amountInRBTC, timeoutMillis, and blockHeight.
+* Include units in names when working with monetary values, time values, or measurements, such as `amountInSatoshis`, `amountInWei`, `amountInRBTC`, `timeoutMillis`, and `blockHeight`.
 * Never rely on implicit monetary units.
 * Avoid vague suffixes such as Data, Info, Manager, Processor, or Helper unless they accurately describe the abstraction.
 * Avoid names that differ only in small or unclear ways.

--- a/coding-principles.md
+++ b/coding-principles.md
@@ -25,7 +25,7 @@ Names are one of the most important parts of readability.
 * Names should describe domain concepts, not implementation details.
 * Include units in names when working with monetary values, time values, or measurements, such as `amountInSatoshis`, `amountInWei`, `amountInRBTC`, `timeoutMillis`, and `blockHeight`.
 * Never rely on implicit monetary units.
-* Avoid vague suffixes such as Data, Info, Manager, Processor, or Helper unless they accurately describe the abstraction.
+* Avoid vague suffixes such as `Data`, `Info`, `Manager`, `Processor`, or `Helper` unless they accurately describe the abstraction.
 * Avoid names that differ only in small or unclear ways.
 * Prefer searchable names over overly short names.
 * Prefer pronounceable names.

--- a/docs/coding-principles.md
+++ b/docs/coding-principles.md
@@ -1,0 +1,158 @@
+# Rootstock coding principles
+
+These guidelines are inspired by Clean Code (Robert C. Martin), but are adapted to Rootstock’s blockchain and security requirements.
+
+They are guidelines, not dogma. Apply them with judgment. In security-sensitive or money-related code, correctness and behavior preservation are more important than stylistic cleanup.
+
+## General principles
+
+* Code is read far more often than it is written. Optimize for readability and maintainability.
+* Leave touched code in a better state than you found it.
+* Keep consistency with the rest of the codebase whenever possible.
+* Small improvements are valuable: rename unclear variables, remove duplication, simplify conditions, and delete dead code when safe.
+* Clarity is more important than cleverness.
+* Avoid introducing unnecessary dependencies.
+* Prefer boring, obvious code over surprising code.
+* Code should look like it was written by someone who cared.
+* Keep source files clean, well organized, and free of unnecessary whitespace.
+
+## Naming
+
+Names are one of the most important parts of readability.
+
+* Use intention-revealing names.
+* Prefer names that reveal intent without requiring comments.
+* Names should describe domain concepts, not implementation details.
+* Include units in names when working with monetary values, time values, or measurements, such as amountInSatoshis, amountInWei, amountInRBTC, timeoutMillis, and blockHeight.
+* Never rely on implicit monetary units.
+* Avoid vague suffixes such as Data, Info, Manager, Processor, or Helper unless they accurately describe the abstraction.
+* Avoid names that differ only in small or unclear ways.
+* Prefer searchable names over overly short names.
+* Prefer pronounceable names.
+* Use one word for one concept and use it consistently.
+* Avoid using the same word for different concepts.
+* Do not add unnecessary context or prefixes.
+* Classes and objects should usually have noun or noun-phrase names.
+* Methods should usually have verb or verb-phrase names.
+* Avoid cute names. Choose clarity over entertainment value.
+* Reevaluate names as the code evolves.
+
+## Functions
+
+Functions are the first line of organization in a program.
+
+* Functions should do one thing and do it well.
+* Prefer focused functions with a clear responsibility and consistent level of abstraction.
+* Prefer descriptive function names over short names.
+* Avoid deeply nested conditionals; use guard clauses when appropriate.
+* Keep indentation shallow when practical.
+* Prefer small parameter lists. If a function consistently requires many related parameters, consider introducing a parameter object.
+* Avoid boolean selector arguments. Split behavior into separate methods when practical.
+* Avoid other selector arguments, such as enums or integers, when they only choose between different behaviors that should be separate functions.
+* Functions should either perform an action or return information, but avoid mixing both responsibilities.
+* Avoid hidden side effects.
+* Avoid output arguments. If state must change, prefer changing the owning object.
+* Keep variables close to where they are used.
+* Do not assign constants to local variables unless it clearly improves readability.
+* Replace magic numbers with named constants.
+* Remove unused methods.
+
+## Classes
+
+* Classes should have a single responsibility and a single reason to change.
+* Prefer many focused classes over large multi-purpose classes.
+* Avoid "god classes".
+* Class names with vague words such as Manager, Processor, Super, Data, or Info may indicate unclear responsibilities.
+* Prefer composition over inheritance.
+* Base classes should not know implementation details of derived classes.
+* Keep interfaces small and focused.
+* Keep coupling low by limiting what each class exposes.
+* Hide data, utility functions, constants, and temporary details when possible.
+* Avoid weakening encapsulation just to make testing easier unless there is no better option.
+* Public constants should come first, followed by private static fields, then private instance fields.
+* Public methods should generally appear before private helpers.
+* Private helpers may be placed near the public method that uses them to preserve readability.
+
+## Abstractions
+
+* Eliminate duplication whenever practical.
+* Create abstractions only when they simplify the code, remove duplication, or represent a stable domain concept.
+* Do not introduce abstractions that are more complicated than the duplicated code they replace.
+* Introduce abstractions to represent stable domain concepts, not merely to reduce line count.
+* Separate high-level business concepts from low-level implementation details.
+* Avoid mixing different abstraction levels in the same function.
+* Consider polymorphism before introducing large switch statements.
+* Prefer explicit code over premature abstraction in security-sensitive paths.
+* Do not hide important protocol, consensus, signing, or transaction-building behavior behind vague abstractions.
+
+## Objects and data structures
+
+* Think carefully about how data should be represented.
+* Do not add getters and setters automatically.
+* Objects should usually hide data behind behavior.
+* Data structures may expose data when they are intentionally simple carriers.
+* Avoid hybrid structures that expose data while also pretending to own complex behavior.
+* Follow the Law of Demeter: avoid reaching through one object to manipulate another object's internals.
+* Tell objects what to do instead of asking them for their internals and doing the work elsewhere.
+
+## Error handling
+
+* Error handling should not obscure business logic.
+* Prefer exceptions over error codes.
+* Use informative exception messages.
+* Define exception types around the caller's needs.
+* Do not return null when a safer alternative exists.
+* Do not pass null unless the API explicitly requires it and the behavior is documented.
+* Leave the system in a consistent state after failures.
+* Never log secrets, private keys, credentials, or sensitive transaction data.
+* Extract complex try/catch bodies when it improves readability.
+* Robustness and readability are not conflicting goals.
+
+## Comments
+
+* Prefer self-explanatory code over explanatory comments.
+* Comments should explain intent, rationale, protocol constraints, security considerations, or non-obvious decisions.
+* Comments should say what the code cannot say for itself.
+* Do not add comments that merely restate the code.
+* Do not use comments to compensate for unclear code when the code can be improved instead.
+* Remove obsolete comments and commented-out code.
+* Do not add author attribution comments; Git history already provides this information.
+* Do not add journal-style comments describing historical changes.
+* A useful comment should be accurate, clear, and maintained with the code.
+
+## Testing
+
+* New behavior should include tests.
+* Tests should be readable and easy to maintain.
+* Prefer Arrange-Act-Assert structure.
+* Test observable behavior rather than implementation details.
+* Cover success paths, failure paths, edge cases, and boundary conditions.
+* Tests must be independent and runnable in any order.
+* Do not disable failing tests.
+* Do not skip trivial tests when the behavior could break.
+* When fixing a bug, add focused tests around the bug and nearby boundary conditions.
+* Test code should be clean, but it does not need to be optimized like production code.
+* Use helper methods or fixtures when they make tests easier to read.
+* Avoid excessive test cleverness.
+
+## Pull requests and refactoring
+
+* Keep changes focused and reviewable.
+* Avoid large refactorings unrelated to the goal of the change.
+* Do not mix formatting-only changes with behavioral changes.
+* If a cleanup would significantly obscure the purpose of a PR, perform it separately.
+* AI-generated suggestions are not automatically improvements. Evaluate them critically.
+* Refactors must improve clarity, maintainability, or correctness.
+* Do not introduce abstractions, indirection, or code movement without a clear benefit.
+* Sometimes the right choice is to stop optimizing and move forward.
+
+## Java-specific guidance
+
+* Follow standard Java naming conventions.
+* Prefer enums over integer constants when representing a closed set of values.
+* Avoid inheriting constants.
+* Prefer static imports for constants when it improves readability.
+* Avoid wildcard imports; prefer explicit imports to keep diffs predictable and consistent with the existing codebase.
+* Prefer constructor injection and immutable fields for new code when practical.
+* Validate required constructor arguments.
+* Avoid nullable returns where Optional<T> would make behavior clearer.

--- a/docs/coding-principles.md
+++ b/docs/coding-principles.md
@@ -155,4 +155,4 @@ Functions are the first line of organization in a program.
 * Avoid wildcard imports; prefer explicit imports to keep diffs predictable and consistent with the existing codebase.
 * Prefer constructor injection and immutable fields for new code when practical.
 * Validate required constructor arguments.
-* Avoid nullable returns where Optional<T> would make behavior clearer.
+* Avoid nullable returns where `Optional<T>` would make behavior clearer.


### PR DESCRIPTION
This pull request introduces a new set of coding principles for the project, focusing on readability, maintainability, and clarity, and integrates these guidelines into the contributor documentation. The main changes include adding a comprehensive `docs/coding-principles.md` file and referencing it from the reviewer instructions to ensure consistency across the codebase.

Copies principles from powpeg-node, introduced in https://github.com/rsksmart/powpeg-node/pull/591

**Documentation updates:**

* Added a new `docs/coding-principles.md` file detailing Rootstock's coding principles, including guidelines for naming, functions, classes, abstractions, error handling, comments, testing, pull requests, and Java-specific advice.
* Updated `.github/copilot-instructions.md` to reference the new coding principles and summarized the key rules for reviewers, emphasizing readability, intention-revealing names, explicit units in identifiers, and disciplined refactoring.