### PR TITLE
Add bootstrap-data v2 chunked, size-uncapped import format

### DIFF
--- a/rskj-core/src/main/java/co/rsk/db/importer/BootstrapImporter.java
+++ b/rskj-core/src/main/java/co/rsk/db/importer/BootstrapImporter.java
@@ -23,6 +23,7 @@ import co.rsk.db.importer.provider.BootstrapDataProvider;
 import co.rsk.trie.Trie;
 import co.rsk.trie.TrieStore;
 import co.rsk.trie.TrieStoreImpl;
+import com.google.common.io.CountingInputStream;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.crypto.Keccak256Helper;
@@ -34,14 +35,34 @@ import org.ethereum.util.RLPList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.Objects;
 import java.util.Queue;
+import java.util.Set;
+
+import static co.rsk.db.importer.BootstrapV2Format.MAGIC;
+import static co.rsk.db.importer.BootstrapV2Format.TAG_BLOCKS;
+import static co.rsk.db.importer.BootstrapV2Format.TAG_END;
+import static co.rsk.db.importer.BootstrapV2Format.TAG_NODES;
+import static co.rsk.db.importer.BootstrapV2Format.TAG_VALUES;
+import static co.rsk.db.importer.BootstrapV2Format.VERSION;
 
 public class BootstrapImporter {
 
     private static final Logger logger = LoggerFactory.getLogger(BootstrapImporter.class);
+
+    private static final int READ_BUFFER_SIZE = 64 * 1024;
+    // A chunk is read into a single byte[], so it must fit a Java array. CHUNK_MAX is the exporter's
+    // soft cap, but a single oversized element may exceed it; this is the hard ceiling either way.
+    private static final long MAX_CHUNK_BYTES = (long) Integer.MAX_VALUE - 8;
 
     private final BootstrapDataProvider bootstrapDataProvider;
     private final BlockStore blockStore;
@@ -51,7 +72,8 @@ public class BootstrapImporter {
     public BootstrapImporter(
             BlockStore blockStore,
             TrieStore trieStore,
-            BlockFactory blockFactory, BootstrapDataProvider bootstrapDataProvider) {
+            BlockFactory blockFactory,
+            BootstrapDataProvider bootstrapDataProvider) {
         this.blockStore = blockStore;
         this.trieStore = trieStore;
         this.blockFactory = blockFactory;
@@ -69,11 +91,24 @@ public class BootstrapImporter {
     }
 
     private void updateDatabase() {
-        Queue<RLPElement> rlpElementQueue = decodeQueue(bootstrapDataProvider.getBootstrapData());
+        Path dataPath = bootstrapDataProvider.getBootstrapDataPath();
+        if (isV2(dataPath)) {
+            logger.info("Detected bootstrap-data v2 (chunked) format");
+            updateDatabaseV2(dataPath);
+        } else {
+            logger.info("Detected bootstrap-data v1 (legacy) format");
+            updateDatabaseV1(bootstrapDataProvider.getBootstrapData());
+        }
+    }
+
+    // --- v1 (legacy) path: whole-payload in-memory decode. Kept for already-published snapshots. ---
+
+    private void updateDatabaseV1(byte[] bootstrapData) {
+        Queue<RLPElement> rlpElementQueue = decodeQueue(bootstrapData);
 
         long start = System.currentTimeMillis();
         logger.debug("Inserting blocks...");
-        insertBlocks(blockStore, blockFactory, Objects.requireNonNull(rlpElementQueue.poll()));
+        insertBlocks(Objects.requireNonNull(rlpElementQueue.poll()));
         logger.debug("Blocks have been inserted in {} mills", System.currentTimeMillis() - start);
 
         HashMapDB hashMapDB = new HashMapDB();
@@ -93,18 +128,14 @@ public class BootstrapImporter {
         logger.debug("State has been inserted in {} mills", System.currentTimeMillis() - start);
     }
 
-    private static void insertBlocks(BlockStore blockStore,
-                                     BlockFactory blockFactory,
-                                     RLPElement encodedTuples) {
+    private void insertBlocks(RLPElement encodedTuples) {
         RLPList blocksData = RLP.decodeList(encodedTuples.getRLPData());
 
         for (int k = 0; k < blocksData.size(); k++) {
             RLPElement element = blocksData.get(k);
             RLPList blockData = RLP.decodeList(element.getRLPData());
             RLPList tuple = RLP.decodeList(blockData.getRLPData());
-            Block block = blockFactory.decodeBlock(Objects.requireNonNull(tuple.get(0).getRLPData(), "block data is missing"));
-            BlockDifficulty blockDifficulty = new BlockDifficulty(new BigInteger(Objects.requireNonNull(tuple.get(1).getRLPData(), "block difficulty data is missing")));
-            blockStore.saveBlock(block, blockDifficulty, true);
+            saveBlockFromTuple(tuple);
         }
 
         blockStore.flush();
@@ -159,5 +190,188 @@ public class BootstrapImporter {
         }
 
         return result;
+    }
+
+    // --- v2 (chunked, streaming) path: bounded memory, size-uncapped. See BootstrapV2Format. ---
+
+    private void updateDatabaseV2(Path dataPath) {
+        // Long values are co-located ahead of the nodes that reference them: the exporter writes the
+        // values section before the nodes section, so a single streaming pass suffices. Each value is
+        // written straight to the destination store; every node then resolves its long value from that
+        // same store at save time (including embedded long-value children reached via parent recursion).
+        // No separate value-staging store and no second file scan are needed.
+        long start = System.currentTimeMillis();
+        logger.debug("Inserting blocks and state...");
+        // counts[0] = blocks saved, counts[1] = nodes saved. v1 implicitly required both the blocks and
+        // the nodes section to be present (it polled them off a queue); v2 dispatches by tag, so we assert
+        // non-empty results here to fail fast on a file missing either section rather than "succeeding"
+        // with no state and only crashing later at first state access.
+        long[] counts = new long[2];
+        scanSections(dataPath, Set.of(TAG_BLOCKS, TAG_VALUES, TAG_NODES), (tag, chunk) -> {
+            if (tag == TAG_BLOCKS) {
+                for (RLPElement element : RLP.decode2(chunk)) {
+                    saveBlockFromTuple(RLP.decodeList(element.getRLPData()));
+                    counts[0]++;
+                }
+            } else if (tag == TAG_VALUES) {
+                for (RLPElement element : RLP.decode2(chunk)) {
+                    trieStore.saveValue(element.getRLPData());
+                }
+            } else if (tag == TAG_NODES) {
+                for (RLPElement element : RLP.decode2(chunk)) {
+                    Trie trie = Trie.fromMessage(element.getRLPData(), trieStore);
+                    saveNode(trie);
+                    counts[1]++;
+                }
+            }
+        });
+        if (counts[0] == 0) {
+            throw new BootstrapImportException("Bootstrap-data v2 has no blocks section (or it is empty); refusing to import incomplete data");
+        }
+        if (counts[1] == 0) {
+            throw new BootstrapImportException("Bootstrap-data v2 has no state-nodes section (or it is empty); refusing to import a stateless snapshot");
+        }
+        blockStore.flush();
+        trieStore.flush();
+        logger.debug("Blocks and state inserted in {} mills", System.currentTimeMillis() - start);
+    }
+
+    /**
+     * Saves a single state node. A node's long value is resolved lazily from the destination store (where
+     * the preceding values section already wrote it), so a value missing (or length-inconsistent) there
+     * surfaces deep inside {@code save} as a generic {@link IllegalArgumentException}; we translate it into
+     * an actionable import error that points at the real cause (incomplete/corrupt bootstrap data) instead
+     * of letting the opaque exception escape.
+     */
+    private void saveNode(Trie trie) {
+        try {
+            trieStore.save(trie);
+        } catch (IllegalArgumentException e) {
+            throw new BootstrapImportException(
+                    "Failed to save a state node during bootstrap import: a referenced long value is missing "
+                            + "or inconsistent in the values section (incomplete or corrupt bootstrap data)", e);
+        }
+    }
+
+    /**
+     * Streams the v2 file, invoking {@code processor} once per chunk that belongs to a section in
+     * {@code tagsOfInterest}, in file order. Sections are dispatched by tag; the v2 import reads every
+     * section in a single pass (the exporter co-locates values before the nodes that reference them, so
+     * value/block/node chunks are processed as they stream past). Chunks for tags outside
+     * {@code tagsOfInterest} are skipped without being read into memory or decoded — including tags this
+     * reader does not recognize, so a newer exporter can add optional sections (e.g. a metadata manifest)
+     * without breaking an older reader. Each wanted chunk is read into a bounded {@code byte[]}, handed
+     * off, then discarded. The full structural scan (header, chunk-length and end-of-section sentinels,
+     * end-of-sections marker) is validated regardless of which tags are of interest.
+     */
+    private void scanSections(Path dataPath, Set<Integer> tagsOfInterest, ChunkProcessor processor) {
+        long fileSize;
+        try {
+            fileSize = Files.size(dataPath);
+        } catch (IOException e) {
+            throw new BootstrapImportException("Error reading bootstrap-data v2 from " + dataPath, e);
+        }
+        // counts every byte handed to the DataInputStream (reads and skips alike), so a declared chunk
+        // length can be bounded against the bytes actually left in the file before any byte[] is allocated.
+        try (CountingInputStream counter = new CountingInputStream(
+                new BufferedInputStream(Files.newInputStream(dataPath), READ_BUFFER_SIZE));
+             DataInputStream in = new DataInputStream(counter)) {
+            readAndVerifyHeader(in);
+
+            int tag = in.read();
+            while (tag != -1 && tag != TAG_END) {
+                // Unknown/unwanted section tags are skipped (their chunks are still length-validated), so
+                // an older reader tolerates optional sections a newer exporter may add.
+                boolean wanted = tagsOfInterest.contains(tag);
+                for (long len = in.readLong(); len != 0L; len = in.readLong()) {
+                    if (len < 0 || len > MAX_CHUNK_BYTES) {
+                        throw new BootstrapImportException("Bootstrap-data v2 chunk length out of range: " + len);
+                    }
+                    long remaining = fileSize - counter.getCount();
+                    if (len > remaining) {
+                        throw new BootstrapImportException("Bootstrap-data v2 chunk length " + len
+                                + " exceeds the " + remaining + " bytes remaining in the file; "
+                                + "the file is truncated or its length field is corrupt");
+                    }
+                    if (wanted) {
+                        byte[] chunk = new byte[(int) len];
+                        in.readFully(chunk);
+                        processor.process(tag, chunk);
+                    } else {
+                        skipFully(in, len);
+                    }
+                }
+                tag = in.read();
+            }
+            if (tag == -1) {
+                throw new BootstrapImportException("Truncated bootstrap-data v2: missing end-of-sections marker");
+            }
+        } catch (IOException e) {
+            throw new BootstrapImportException("Error reading bootstrap-data v2 from " + dataPath, e);
+        }
+    }
+
+    /**
+     * Skips exactly {@code n} bytes, falling back to reading-and-discarding when the underlying stream's
+     * {@code skip} cannot make progress, and detecting a chunk truncated below its declared length.
+     */
+    private static void skipFully(DataInputStream in, long n) throws IOException {
+        long remaining = n;
+        byte[] scratch = null;
+        while (remaining > 0) {
+            long skipped = in.skip(remaining);
+            if (skipped > 0) {
+                remaining -= skipped;
+                continue;
+            }
+            if (scratch == null) {
+                scratch = new byte[(int) Math.min(remaining, READ_BUFFER_SIZE)];
+            }
+            int read = in.read(scratch, 0, (int) Math.min(remaining, scratch.length));
+            if (read < 0) {
+                throw new BootstrapImportException(
+                        "Truncated bootstrap-data v2: section chunk shorter than its declared length");
+            }
+            remaining -= read;
+        }
+    }
+
+    private static void readAndVerifyHeader(DataInputStream in) throws IOException {
+        byte[] magic = new byte[MAGIC.length];
+        in.readFully(magic);
+        if (!Arrays.equals(magic, MAGIC)) {
+            throw new BootstrapImportException("Invalid bootstrap-data v2 magic");
+        }
+        int version = in.read();
+        if (version != (VERSION & 0xFF)) {
+            throw new BootstrapImportException("Unsupported bootstrap-data v2 version: " + version);
+        }
+    }
+
+    private boolean isV2(Path dataPath) {
+        try (InputStream in = Files.newInputStream(dataPath)) {
+            int firstByte = in.read();
+            if (firstByte == -1) {
+                throw new BootstrapImportException("Empty bootstrap data file: " + dataPath);
+            }
+            return BootstrapV2Format.isV2(firstByte);
+        } catch (IOException e) {
+            throw new BootstrapImportException("Error reading bootstrap data from " + dataPath, e);
+        }
+    }
+
+    // --- shared leaf decoding (identical between v1 and v2; only the container framing differs) ---
+
+    private void saveBlockFromTuple(RLPList tuple) {
+        Block block = blockFactory.decodeBlock(
+                Objects.requireNonNull(tuple.get(0).getRLPData(), "block data is missing"));
+        BlockDifficulty blockDifficulty = new BlockDifficulty(
+                new BigInteger(Objects.requireNonNull(tuple.get(1).getRLPData(), "block difficulty data is missing")));
+        blockStore.saveBlock(block, blockDifficulty, true);
+    }
+
+    @FunctionalInterface
+    private interface ChunkProcessor {
+        void process(int tag, byte[] chunk) throws IOException;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/db/importer/BootstrapImporter.java
+++ b/rskj-core/src/main/java/co/rsk/db/importer/BootstrapImporter.java
@@ -204,38 +204,40 @@ public class BootstrapImporter {
         // No separate value-staging store and no second file scan are needed.
         long start = System.currentTimeMillis();
         logger.debug("Inserting blocks and state...");
-        // counts[0] = blocks saved, counts[1] = nodes saved. v1 implicitly required both the blocks and
-        // the nodes section to be present (it polled them off a queue); v2 dispatches by tag, so we assert
-        // non-empty results here to fail fast on a file missing either section rather than "succeeding"
-        // with no state and only crashing later at first state access.
-        long[] counts = new long[2];
+        // v1 implicitly required both the blocks and the nodes section to be present (it polled them off a
+        // queue); v2 dispatches by tag, so we tally each section and assert non-empty blocks/nodes below to
+        // fail fast on a file missing either section rather than "succeeding" with no state and only
+        // crashing later at first state access.
+        SectionCounts counts = new SectionCounts();
         scanSections(dataPath, Set.of(TAG_BLOCKS, TAG_VALUES, TAG_NODES), (tag, chunk) -> {
             if (tag == TAG_BLOCKS) {
                 for (RLPElement element : RLP.decode2(chunk)) {
                     saveBlockFromTuple(RLP.decodeList(element.getRLPData()));
-                    counts[0]++;
+                    counts.blocks++;
                 }
             } else if (tag == TAG_VALUES) {
                 for (RLPElement element : RLP.decode2(chunk)) {
                     trieStore.saveValue(element.getRLPData());
+                    counts.values++;
                 }
             } else if (tag == TAG_NODES) {
                 for (RLPElement element : RLP.decode2(chunk)) {
                     Trie trie = Trie.fromMessage(element.getRLPData(), trieStore);
                     saveNode(trie);
-                    counts[1]++;
+                    counts.nodes++;
                 }
             }
         });
-        if (counts[0] == 0) {
+        if (counts.blocks == 0) {
             throw new BootstrapImportException("Bootstrap-data v2 has no blocks section (or it is empty); refusing to import incomplete data");
         }
-        if (counts[1] == 0) {
+        if (counts.nodes == 0) {
             throw new BootstrapImportException("Bootstrap-data v2 has no state-nodes section (or it is empty); refusing to import a stateless snapshot");
         }
         blockStore.flush();
         trieStore.flush();
-        logger.debug("Blocks and state inserted in {} mills", System.currentTimeMillis() - start);
+        logger.info("Bootstrap-data v2 imported {} blocks, {} long values and {} state nodes in {} ms",
+                counts.blocks, counts.values, counts.nodes, System.currentTimeMillis() - start);
     }
 
     /**
@@ -259,7 +261,8 @@ public class BootstrapImporter {
      * Streams the v2 file, invoking {@code processor} once per chunk that belongs to a section in
      * {@code tagsOfInterest}, in file order. Sections are dispatched by tag; the v2 import reads every
      * section in a single pass (the exporter co-locates values before the nodes that reference them, so
-     * value/block/node chunks are processed as they stream past). Chunks for tags outside
+     * value/block/node chunks are processed as they stream past). That ordering is enforced structurally:
+     * a nodes section appearing before the values section is rejected up front. Chunks for tags outside
      * {@code tagsOfInterest} are skipped without being read into memory or decoded — including tags this
      * reader does not recognize, so a newer exporter can add optional sections (e.g. a metadata manifest)
      * without breaking an older reader. Each wanted chunk is read into a bounded {@code byte[]}, handed
@@ -280,8 +283,22 @@ public class BootstrapImporter {
              DataInputStream in = new DataInputStream(counter)) {
             readAndVerifyHeader(in);
 
+            boolean valuesSectionSeen = false;
             int tag = in.read();
             while (tag != -1 && tag != TAG_END) {
+                // The nodes section resolves each long value from the destination store at save time, so the
+                // values section must be co-located ahead of it (see BootstrapV2Format). Enforce that order
+                // structurally here — before any node is processed — so a mis-ordered file is rejected up
+                // front and deterministically, rather than failing later (and only) on the first node that
+                // happens to reference a long value. The check sees empty sections too (the tag byte is read
+                // even when a section carries no chunks), so an all-short-values snapshot still passes.
+                if (tag == TAG_VALUES) {
+                    valuesSectionSeen = true;
+                } else if (tag == TAG_NODES && !valuesSectionSeen) {
+                    throw new BootstrapImportException("Bootstrap-data v2 sections are out of order: the nodes "
+                            + "section appears before the values section, but long values must be co-located "
+                            + "before the nodes that reference them");
+                }
                 // Unknown/unwanted section tags are skipped (their chunks are still length-validated), so
                 // an older reader tolerates optional sections a newer exporter may add.
                 boolean wanted = tagsOfInterest.contains(tag);
@@ -375,5 +392,12 @@ public class BootstrapImporter {
     @FunctionalInterface
     private interface ChunkProcessor {
         void process(int tag, byte[] chunk) throws IOException;
+    }
+
+    /** Per-section element tallies gathered during a v2 import (mutated from the streaming callback). */
+    private static final class SectionCounts {
+        long blocks;
+        long values;
+        long nodes;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/db/importer/BootstrapImporter.java
+++ b/rskj-core/src/main/java/co/rsk/db/importer/BootstrapImporter.java
@@ -217,12 +217,22 @@ public class BootstrapImporter {
                 }
             } else if (tag == TAG_VALUES) {
                 for (RLPElement element : RLP.decode2(chunk)) {
-                    trieStore.saveValue(element.getRLPData());
+                    byte[] value = element.getRLPData();
+                    if (value == null) {
+                        throw new BootstrapImportException("Bootstrap-data v2 values section contains an empty "
+                                + "element (a long value cannot be empty); the file is corrupt");
+                    }
+                    trieStore.saveValue(value);
                     counts.values++;
                 }
             } else if (tag == TAG_NODES) {
                 for (RLPElement element : RLP.decode2(chunk)) {
-                    Trie trie = Trie.fromMessage(element.getRLPData(), trieStore);
+                    byte[] message = element.getRLPData();
+                    if (message == null) {
+                        throw new BootstrapImportException("Bootstrap-data v2 nodes section contains an empty "
+                                + "element (a state node cannot be empty); the file is corrupt");
+                    }
+                    Trie trie = Trie.fromMessage(message, trieStore);
                     saveNode(trie);
                     counts.nodes++;
                 }
@@ -381,7 +391,15 @@ public class BootstrapImporter {
             if (firstByte == -1) {
                 throw new BootstrapImportException("Empty bootstrap data file: " + dataPath);
             }
-            return BootstrapV2Format.isV2(firstByte);
+            if (BootstrapV2Format.isV2(firstByte)) {
+                return true;
+            }
+            if (BootstrapV2Format.isV1(firstByte)) {
+                return false;
+            }
+            throw new BootstrapImportException(String.format(
+                    "Unrecognized bootstrap-data format in %s: first byte 0x%02X is neither the v2 magic "
+                            + "('R') nor a v1 RLP list prefix (0xc0+)", dataPath, firstByte));
         } catch (IOException e) {
             throw new BootstrapImportException("Error reading bootstrap data from " + dataPath, e);
         }

--- a/rskj-core/src/main/java/co/rsk/db/importer/BootstrapImporter.java
+++ b/rskj-core/src/main/java/co/rsk/db/importer/BootstrapImporter.java
@@ -48,7 +48,6 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 
-import static co.rsk.db.importer.BootstrapV2Format.MAGIC;
 import static co.rsk.db.importer.BootstrapV2Format.TAG_BLOCKS;
 import static co.rsk.db.importer.BootstrapV2Format.TAG_END;
 import static co.rsk.db.importer.BootstrapV2Format.TAG_NODES;
@@ -211,31 +210,11 @@ public class BootstrapImporter {
         SectionCounts counts = new SectionCounts();
         scanSections(dataPath, Set.of(TAG_BLOCKS, TAG_VALUES, TAG_NODES), (tag, chunk) -> {
             if (tag == TAG_BLOCKS) {
-                for (RLPElement element : RLP.decode2(chunk)) {
-                    saveBlockFromTuple(RLP.decodeList(element.getRLPData()));
-                    counts.blocks++;
-                }
+                counts.blocks += importBlocks(chunk);
             } else if (tag == TAG_VALUES) {
-                for (RLPElement element : RLP.decode2(chunk)) {
-                    byte[] value = element.getRLPData();
-                    if (value == null) {
-                        throw new BootstrapImportException("Bootstrap-data v2 values section contains an empty "
-                                + "element (a long value cannot be empty); the file is corrupt");
-                    }
-                    trieStore.saveValue(value);
-                    counts.values++;
-                }
+                counts.values += importValues(chunk);
             } else if (tag == TAG_NODES) {
-                for (RLPElement element : RLP.decode2(chunk)) {
-                    byte[] message = element.getRLPData();
-                    if (message == null) {
-                        throw new BootstrapImportException("Bootstrap-data v2 nodes section contains an empty "
-                                + "element (a state node cannot be empty); the file is corrupt");
-                    }
-                    Trie trie = Trie.fromMessage(message, trieStore);
-                    saveNode(trie);
-                    counts.nodes++;
-                }
+                counts.nodes += importNodes(chunk);
             }
         });
         if (counts.blocks == 0) {
@@ -248,6 +227,50 @@ public class BootstrapImporter {
         trieStore.flush();
         logger.info("Bootstrap-data v2 imported {} blocks, {} long values and {} state nodes in {} ms",
                 counts.blocks, counts.values, counts.nodes, System.currentTimeMillis() - start);
+    }
+
+    /** Decodes and saves every block tuple in a blocks-section chunk; returns how many were saved. */
+    private long importBlocks(byte[] chunk) {
+        long imported = 0;
+        for (RLPElement element : RLP.decode2(chunk)) {
+            saveBlockFromTuple(RLP.decodeList(element.getRLPData()));
+            imported++;
+        }
+        return imported;
+    }
+
+    /** Saves every long value in a values-section chunk into the destination store; returns how many. */
+    private long importValues(byte[] chunk) {
+        long imported = 0;
+        for (RLPElement element : RLP.decode2(chunk)) {
+            trieStore.saveValue(requireNonEmptyElement(element, "values"));
+            imported++;
+        }
+        return imported;
+    }
+
+    /** Reconstructs and saves every state node in a nodes-section chunk; returns how many were saved. */
+    private long importNodes(byte[] chunk) {
+        long imported = 0;
+        for (RLPElement element : RLP.decode2(chunk)) {
+            saveNode(Trie.fromMessage(requireNonEmptyElement(element, "nodes"), trieStore));
+            imported++;
+        }
+        return imported;
+    }
+
+    /**
+     * Returns the element's RLP data, rejecting an empty element. {@link RLPElement#getRLPData()} is
+     * {@code null} for an empty element; a value or node cannot be empty, so a {@code null} here means a
+     * corrupt section — surfaced as an actionable import error instead of a downstream NPE.
+     */
+    private static byte[] requireNonEmptyElement(RLPElement element, String section) {
+        byte[] data = element.getRLPData();
+        if (data == null) {
+            throw new BootstrapImportException("Bootstrap-data v2 " + section
+                    + " section contains an empty element; the file is corrupt");
+        }
+        return data;
     }
 
     /**
@@ -297,40 +320,11 @@ public class BootstrapImporter {
             boolean valuesSectionSeen = false;
             int tag = in.read();
             while (tag != -1 && tag != TAG_END) {
-                // The nodes section resolves each long value from the destination store at save time, so the
-                // values section must be co-located ahead of it (see BootstrapV2Format). Enforce that order
-                // structurally here — before any node is processed — so a mis-ordered file is rejected up
-                // front and deterministically, rather than failing later (and only) on the first node that
-                // happens to reference a long value. The check sees empty sections too (the tag byte is read
-                // even when a section carries no chunks), so an all-short-values snapshot still passes.
-                if (tag == TAG_VALUES) {
-                    valuesSectionSeen = true;
-                } else if (tag == TAG_NODES && !valuesSectionSeen) {
-                    throw new BootstrapImportException("Bootstrap-data v2 sections are out of order: the nodes "
-                            + "section appears before the values section, but long values must be co-located "
-                            + "before the nodes that reference them");
-                }
+                valuesSectionSeen = checkSectionOrder(tag, valuesSectionSeen);
                 // Unknown/unwanted section tags are skipped (their chunks are still length-validated), so
                 // an older reader tolerates optional sections a newer exporter may add.
                 boolean wanted = tagsOfInterest.contains(tag);
-                for (long len = in.readLong(); len != 0L; len = in.readLong()) {
-                    if (len < 0 || len > MAX_CHUNK_BYTES) {
-                        throw new BootstrapImportException("Bootstrap-data v2 chunk length out of range: " + len);
-                    }
-                    long remaining = fileSize - counter.getCount();
-                    if (len > remaining) {
-                        throw new BootstrapImportException("Bootstrap-data v2 chunk length " + len
-                                + " exceeds the " + remaining + " bytes remaining in the file; "
-                                + "the file is truncated or its length field is corrupt");
-                    }
-                    if (wanted) {
-                        byte[] chunk = new byte[(int) len];
-                        in.readFully(chunk);
-                        processor.process(tag, chunk);
-                    } else {
-                        skipFully(in, len);
-                    }
-                }
+                readSectionChunks(in, counter, fileSize, tag, wanted, processor);
                 tag = in.read();
             }
             if (tag == -1) {
@@ -345,6 +339,60 @@ public class BootstrapImporter {
             }
         } catch (IOException e) {
             throw new BootstrapImportException("Error reading bootstrap-data v2 from " + dataPath, e);
+        }
+    }
+
+    /**
+     * Enforces v2 section ordering: the values section must be co-located ahead of the nodes section, since
+     * each node resolves its long values from the destination store at save time. Rejecting a mis-ordered
+     * file here — at the section-tag level, before any node is processed — makes the failure deterministic
+     * rather than surfacing later only on the first node that references a long value. The check sees empty
+     * sections too (the tag byte is read even when a section carries no chunks), so an all-short-values
+     * snapshot still passes. Returns the updated "values section seen" flag.
+     */
+    private static boolean checkSectionOrder(int tag, boolean valuesSectionSeen) {
+        if (tag == TAG_VALUES) {
+            return true;
+        }
+        if (tag == TAG_NODES && !valuesSectionSeen) {
+            throw new BootstrapImportException("Bootstrap-data v2 sections are out of order: the nodes "
+                    + "section appears before the values section, but long values must be co-located "
+                    + "before the nodes that reference them");
+        }
+        return valuesSectionSeen;
+    }
+
+    /**
+     * Reads one section's chunks up to its end-of-section sentinel, handing each wanted chunk to
+     * {@code processor} and skipping the rest without allocating. Each declared length is bounded before
+     * any {@code byte[]} is allocated.
+     */
+    private void readSectionChunks(DataInputStream in, CountingInputStream counter, long fileSize,
+                                   int tag, boolean wanted, ChunkProcessor processor) throws IOException {
+        for (long len = in.readLong(); len != 0L; len = in.readLong()) {
+            validateChunkLength(len, fileSize - counter.getCount());
+            if (wanted) {
+                byte[] chunk = new byte[(int) len];
+                in.readFully(chunk);
+                processor.process(tag, chunk);
+            } else {
+                skipFully(in, len);
+            }
+        }
+    }
+
+    /**
+     * Bounds a declared chunk length against the per-chunk ceiling ({@code MAX_CHUNK_BYTES}) and the bytes
+     * actually remaining in the file, so a corrupt or oversized length is rejected before allocation.
+     */
+    private static void validateChunkLength(long len, long remaining) {
+        if (len < 0 || len > MAX_CHUNK_BYTES) {
+            throw new BootstrapImportException("Bootstrap-data v2 chunk length out of range: " + len);
+        }
+        if (len > remaining) {
+            throw new BootstrapImportException("Bootstrap-data v2 chunk length " + len
+                    + " exceeds the " + remaining + " bytes remaining in the file; "
+                    + "the file is truncated or its length field is corrupt");
         }
     }
 
@@ -374,9 +422,10 @@ public class BootstrapImporter {
     }
 
     private static void readAndVerifyHeader(DataInputStream in) throws IOException {
-        byte[] magic = new byte[MAGIC.length];
+        byte[] expectedMagic = BootstrapV2Format.magic();
+        byte[] magic = new byte[expectedMagic.length];
         in.readFully(magic);
-        if (!Arrays.equals(magic, MAGIC)) {
+        if (!Arrays.equals(magic, expectedMagic)) {
             throw new BootstrapImportException("Invalid bootstrap-data v2 magic");
         }
         int version = in.read();
@@ -422,8 +471,8 @@ public class BootstrapImporter {
 
     /** Per-section element tallies gathered during a v2 import (mutated from the streaming callback). */
     private static final class SectionCounts {
-        long blocks;
-        long values;
-        long nodes;
+        private long blocks;
+        private long values;
+        private long nodes;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/db/importer/BootstrapImporter.java
+++ b/rskj-core/src/main/java/co/rsk/db/importer/BootstrapImporter.java
@@ -62,8 +62,10 @@ public class BootstrapImporter {
     // A chunk is read into a single byte[], so per-chunk memory must stay bounded. The exporter flushes
     // once its buffer crosses CHUNK_MAX on an element boundary, so a well-formed chunk is at most
     // CHUNK_MAX plus one element; 2x CHUNK_MAX gives ample headroom while rejecting a corrupt length that
-    // would otherwise allocate up to a ~2 GiB byte[].
-    private static final long MAX_CHUNK_BYTES = 2 * BootstrapV2Format.CHUNK_MAX;
+    // would otherwise allocate up to a ~2 GiB byte[]. Held as an int (via toIntExact) so a validated length
+    // always fits the new byte[(int) len] allocation by construction; CHUNK_MAX is a documented tuning
+    // knob, and raising it past ~1 GiB fails fast at class-load here rather than overflowing the cast.
+    private static final int MAX_CHUNK_BYTES = Math.toIntExact(2 * BootstrapV2Format.CHUNK_MAX);
 
     private final BootstrapDataProvider bootstrapDataProvider;
     private final BlockStore blockStore;
@@ -233,7 +235,7 @@ public class BootstrapImporter {
     private long importBlocks(byte[] chunk) {
         long imported = 0;
         for (RLPElement element : RLP.decode2(chunk)) {
-            saveBlockFromTuple(RLP.decodeList(element.getRLPData()));
+            saveBlockFromTuple(RLP.decodeList(requireNonEmptyElement(element, "blocks")));
             imported++;
         }
         return imported;

--- a/rskj-core/src/main/java/co/rsk/db/importer/BootstrapImporter.java
+++ b/rskj-core/src/main/java/co/rsk/db/importer/BootstrapImporter.java
@@ -60,9 +60,11 @@ public class BootstrapImporter {
     private static final Logger logger = LoggerFactory.getLogger(BootstrapImporter.class);
 
     private static final int READ_BUFFER_SIZE = 64 * 1024;
-    // A chunk is read into a single byte[], so it must fit a Java array. CHUNK_MAX is the exporter's
-    // soft cap, but a single oversized element may exceed it; this is the hard ceiling either way.
-    private static final long MAX_CHUNK_BYTES = (long) Integer.MAX_VALUE - 8;
+    // A chunk is read into a single byte[], so per-chunk memory must stay bounded. The exporter flushes
+    // once its buffer crosses CHUNK_MAX on an element boundary, so a well-formed chunk is at most
+    // CHUNK_MAX plus one element; 2x CHUNK_MAX gives ample headroom while rejecting a corrupt length that
+    // would otherwise allocate up to a ~2 GiB byte[].
+    private static final long MAX_CHUNK_BYTES = 2 * BootstrapV2Format.CHUNK_MAX;
 
     private final BootstrapDataProvider bootstrapDataProvider;
     private final BlockStore blockStore;

--- a/rskj-core/src/main/java/co/rsk/db/importer/BootstrapImporter.java
+++ b/rskj-core/src/main/java/co/rsk/db/importer/BootstrapImporter.java
@@ -23,6 +23,7 @@ import co.rsk.db.importer.provider.BootstrapDataProvider;
 import co.rsk.trie.Trie;
 import co.rsk.trie.TrieStore;
 import co.rsk.trie.TrieStoreImpl;
+import com.google.common.io.ByteStreams;
 import com.google.common.io.CountingInputStream;
 import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
@@ -47,6 +48,7 @@ import java.util.LinkedList;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import static co.rsk.db.importer.BootstrapV2Format.TAG_BLOCKS;
 import static co.rsk.db.importer.BootstrapV2Format.TAG_END;
@@ -66,6 +68,10 @@ public class BootstrapImporter {
     // always fits the new byte[(int) len] allocation by construction; CHUNK_MAX is a documented tuning
     // knob, and raising it past ~1 GiB fails fast at class-load here rather than overflowing the cast.
     private static final int MAX_CHUNK_BYTES = Math.toIntExact(2 * BootstrapV2Format.CHUNK_MAX);
+
+    // The sections the v2 import consumes. Any other tag (e.g. a future manifest a newer exporter adds) is
+    // skipped without being read into memory, so an older reader tolerates optional sections.
+    private static final Set<Integer> DATA_TAGS = Set.of(TAG_BLOCKS, TAG_VALUES, TAG_NODES);
 
     private final BootstrapDataProvider bootstrapDataProvider;
     private final BlockStore blockStore;
@@ -210,13 +216,13 @@ public class BootstrapImporter {
         // fail fast on a file missing either section rather than "succeeding" with no state and only
         // crashing later at first state access.
         SectionCounts counts = new SectionCounts();
-        scanSections(dataPath, Set.of(TAG_BLOCKS, TAG_VALUES, TAG_NODES), (tag, chunk) -> {
+        scanSections(dataPath, (tag, chunk) -> {
             if (tag == TAG_BLOCKS) {
-                counts.blocks += importBlocks(chunk);
+                counts.blocks += importElements(chunk, "blocks", d -> saveBlockFromTuple(RLP.decodeList(d)));
             } else if (tag == TAG_VALUES) {
-                counts.values += importValues(chunk);
+                counts.values += importElements(chunk, "values", trieStore::saveValue);
             } else if (tag == TAG_NODES) {
-                counts.nodes += importNodes(chunk);
+                counts.nodes += importElements(chunk, "nodes", d -> saveNode(Trie.fromMessage(d, trieStore)));
             }
         });
         if (counts.blocks == 0) {
@@ -231,31 +237,15 @@ public class BootstrapImporter {
                 counts.blocks, counts.values, counts.nodes, System.currentTimeMillis() - start);
     }
 
-    /** Decodes and saves every block tuple in a blocks-section chunk; returns how many were saved. */
-    private long importBlocks(byte[] chunk) {
+    /**
+     * Applies {@code action} to every element of a section chunk (after rejecting empty elements) and
+     * returns how many were processed. The decode/count/empty-check invariant lives here for all sections;
+     * only the per-element action differs (save a block, a long value, or a state node).
+     */
+    private long importElements(byte[] chunk, String section, Consumer<byte[]> action) {
         long imported = 0;
         for (RLPElement element : RLP.decode2(chunk)) {
-            saveBlockFromTuple(RLP.decodeList(requireNonEmptyElement(element, "blocks")));
-            imported++;
-        }
-        return imported;
-    }
-
-    /** Saves every long value in a values-section chunk into the destination store; returns how many. */
-    private long importValues(byte[] chunk) {
-        long imported = 0;
-        for (RLPElement element : RLP.decode2(chunk)) {
-            trieStore.saveValue(requireNonEmptyElement(element, "values"));
-            imported++;
-        }
-        return imported;
-    }
-
-    /** Reconstructs and saves every state node in a nodes-section chunk; returns how many were saved. */
-    private long importNodes(byte[] chunk) {
-        long imported = 0;
-        for (RLPElement element : RLP.decode2(chunk)) {
-            saveNode(Trie.fromMessage(requireNonEmptyElement(element, "nodes"), trieStore));
+            action.accept(requireNonEmptyElement(element, section));
             imported++;
         }
         return imported;
@@ -293,19 +283,19 @@ public class BootstrapImporter {
     }
 
     /**
-     * Streams the v2 file, invoking {@code processor} once per chunk that belongs to a section in
-     * {@code tagsOfInterest}, in file order. Sections are dispatched by tag; the v2 import reads every
-     * section in a single pass (the exporter co-locates values before the nodes that reference them, so
-     * value/block/node chunks are processed as they stream past). That ordering is enforced structurally:
-     * a nodes section appearing before the values section is rejected up front. Chunks for tags outside
-     * {@code tagsOfInterest} are skipped without being read into memory or decoded — including tags this
-     * reader does not recognize, so a newer exporter can add optional sections (e.g. a metadata manifest)
-     * without breaking an older reader. Each wanted chunk is read into a bounded {@code byte[]}, handed
-     * off, then discarded. The full structural scan (header, chunk-length and end-of-section sentinels,
-     * end-of-sections marker) is validated regardless of which tags are of interest, and the file must end
-     * exactly at the end-of-sections marker — trailing bytes are rejected as non-canonical.
+     * Streams the v2 file, invoking {@code processor} once per chunk that belongs to a {@link #DATA_TAGS}
+     * section, in file order. Sections are dispatched by tag; the v2 import reads every section in a single
+     * pass (the exporter co-locates values before the nodes that reference them, so value/block/node chunks
+     * are processed as they stream past). That ordering is enforced structurally: a nodes section appearing
+     * before the values section is rejected up front. Chunks for tags outside {@link #DATA_TAGS} are skipped
+     * without being read into memory or decoded — including tags this reader does not recognize, so a newer
+     * exporter can add optional sections (e.g. a metadata manifest) without breaking an older reader. Each
+     * wanted chunk is read into a bounded {@code byte[]}, handed off, then discarded. The full structural
+     * scan (header, chunk-length and end-of-section sentinels, end-of-sections marker) is validated
+     * regardless of which tags are of interest, and the file must end exactly at the end-of-sections
+     * marker — trailing bytes are rejected as non-canonical.
      */
-    private void scanSections(Path dataPath, Set<Integer> tagsOfInterest, ChunkProcessor processor) {
+    private void scanSections(Path dataPath, ChunkProcessor processor) {
         long fileSize;
         try {
             fileSize = Files.size(dataPath);
@@ -325,7 +315,7 @@ public class BootstrapImporter {
                 valuesSectionSeen = checkSectionOrder(tag, valuesSectionSeen);
                 // Unknown/unwanted section tags are skipped (their chunks are still length-validated), so
                 // an older reader tolerates optional sections a newer exporter may add.
-                boolean wanted = tagsOfInterest.contains(tag);
+                boolean wanted = DATA_TAGS.contains(tag);
                 readSectionChunks(in, counter, fileSize, tag, wanted, processor);
                 tag = in.read();
             }
@@ -378,7 +368,8 @@ public class BootstrapImporter {
                 in.readFully(chunk);
                 processor.process(tag, chunk);
             } else {
-                skipFully(in, len);
+                // truncation surfaces as EOFException (an IOException), caught and wrapped by scanSections
+                ByteStreams.skipFully(in, len);
             }
         }
     }
@@ -395,31 +386,6 @@ public class BootstrapImporter {
             throw new BootstrapImportException("Bootstrap-data v2 chunk length " + len
                     + " exceeds the " + remaining + " bytes remaining in the file; "
                     + "the file is truncated or its length field is corrupt");
-        }
-    }
-
-    /**
-     * Skips exactly {@code n} bytes, falling back to reading-and-discarding when the underlying stream's
-     * {@code skip} cannot make progress, and detecting a chunk truncated below its declared length.
-     */
-    private static void skipFully(DataInputStream in, long n) throws IOException {
-        long remaining = n;
-        byte[] scratch = null;
-        while (remaining > 0) {
-            long skipped = in.skip(remaining);
-            if (skipped > 0) {
-                remaining -= skipped;
-                continue;
-            }
-            if (scratch == null) {
-                scratch = new byte[(int) Math.min(remaining, READ_BUFFER_SIZE)];
-            }
-            int read = in.read(scratch, 0, (int) Math.min(remaining, scratch.length));
-            if (read < 0) {
-                throw new BootstrapImportException(
-                        "Truncated bootstrap-data v2: section chunk shorter than its declared length");
-            }
-            remaining -= read;
         }
     }
 

--- a/rskj-core/src/main/java/co/rsk/db/importer/BootstrapImporter.java
+++ b/rskj-core/src/main/java/co/rsk/db/importer/BootstrapImporter.java
@@ -267,7 +267,8 @@ public class BootstrapImporter {
      * reader does not recognize, so a newer exporter can add optional sections (e.g. a metadata manifest)
      * without breaking an older reader. Each wanted chunk is read into a bounded {@code byte[]}, handed
      * off, then discarded. The full structural scan (header, chunk-length and end-of-section sentinels,
-     * end-of-sections marker) is validated regardless of which tags are of interest.
+     * end-of-sections marker) is validated regardless of which tags are of interest, and the file must end
+     * exactly at the end-of-sections marker — trailing bytes are rejected as non-canonical.
      */
     private void scanSections(Path dataPath, Set<Integer> tagsOfInterest, ChunkProcessor processor) {
         long fileSize;
@@ -324,6 +325,13 @@ public class BootstrapImporter {
             }
             if (tag == -1) {
                 throw new BootstrapImportException("Truncated bootstrap-data v2: missing end-of-sections marker");
+            }
+            // tag == TAG_END here. The v2 format is canonical: nothing may follow the end-of-sections
+            // marker. Reject trailing bytes (a tampered, truncated, or concatenated file) rather than
+            // silently ignoring them, matching the v1 path's whole-payload decode.
+            if (in.read() != -1) {
+                throw new BootstrapImportException("Bootstrap-data v2 has trailing bytes after the "
+                        + "end-of-sections marker; the file is corrupt or not canonical");
             }
         } catch (IOException e) {
             throw new BootstrapImportException("Error reading bootstrap-data v2 from " + dataPath, e);

--- a/rskj-core/src/main/java/co/rsk/db/importer/BootstrapV2Format.java
+++ b/rskj-core/src/main/java/co/rsk/db/importer/BootstrapV2Format.java
@@ -54,6 +54,8 @@ import java.nio.charset.StandardCharsets;
  * long value {@code RLP.encodeElement(value)}, each block {@code LIST[ELEMENT(block), ELEMENT(td)]});
  * only the container framing changes. This holder is shared by the rskj-core importer and is mirrored
  * by the bootstrap-exporter writer (separate repo, so the constants are restated there).
+ *
+ * <p>See {@code bootstrap-data-format.md} in this package for the full narrative specification (v1 + v2).
  */
 public final class BootstrapV2Format {
 

--- a/rskj-core/src/main/java/co/rsk/db/importer/BootstrapV2Format.java
+++ b/rskj-core/src/main/java/co/rsk/db/importer/BootstrapV2Format.java
@@ -59,8 +59,14 @@ import java.nio.charset.StandardCharsets;
  */
 public final class BootstrapV2Format {
 
-    /** First bytes of a v2 {@code bootstrap-data.bin}; the leading {@code 'R'} disambiguates from v1. */
-    public static final byte[] MAGIC = "RSKBOOT\n".getBytes(StandardCharsets.US_ASCII);
+    // First bytes of a v2 bootstrap-data.bin; the leading 'R' disambiguates from v1. Kept private (a
+    // mutable array must not be exposed as a public constant); callers use magic() for a fresh copy.
+    private static final byte[] MAGIC = "RSKBOOT\n".getBytes(StandardCharsets.US_ASCII);
+
+    /** The v2 file magic bytes (a fresh copy each call, so the internal array cannot be mutated). */
+    public static byte[] magic() {
+        return MAGIC.clone();
+    }
 
     public static final byte VERSION = 0x02;
 

--- a/rskj-core/src/main/java/co/rsk/db/importer/BootstrapV2Format.java
+++ b/rskj-core/src/main/java/co/rsk/db/importer/BootstrapV2Format.java
@@ -88,4 +88,9 @@ public final class BootstrapV2Format {
     public static boolean isV2(int firstByte) {
         return firstByte == (MAGIC[0] & 0xFF);
     }
+
+    /** Whether {@code firstByte} marks a legacy v1 file (a single top-level RLP list, prefix {@code 0xc0}+). */
+    public static boolean isV1(int firstByte) {
+        return firstByte >= 0xc0 && firstByte <= 0xff;
+    }
 }

--- a/rskj-core/src/main/java/co/rsk/db/importer/BootstrapV2Format.java
+++ b/rskj-core/src/main/java/co/rsk/db/importer/BootstrapV2Format.java
@@ -1,0 +1,89 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2026 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.db.importer;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * On-disk contract for the {@code bootstrap-data.bin} <b>v2</b> format: a self-describing, chunked,
+ * streamable layout with no total-size ceiling (it replaces the legacy single-nested-RLP-list format,
+ * whose {@code int} length fields capped the payload at {@code Integer.MAX_VALUE} ~ 2 GiB).
+ *
+ * <pre>
+ * HEADER
+ *   magic   = "RSKBOOT\n"   (8 bytes)
+ *   version = 0x02          (1 byte)
+ *
+ * SECTION blocks   (tag 0x01)
+ * SECTION values   (tag 0x03)   &lt;- co-located before nodes: values precede the nodes that reference
+ * SECTION nodes    (tag 0x02)      them, so the importer applies them in a single streaming pass
+ * SECTION end      (tag 0x00)   &lt;- terminator
+ *
+ * SECTION =
+ *   [1 byte  section tag]
+ *   zero or more chunks:
+ *       [8-byte big-endian chunk length L]   (0 &lt; L &le; CHUNK_MAX, plus the rare single oversized element)
+ *       [L bytes: a concatenation of whole canonical RLP elements]
+ *   [8-byte big-endian 0]                    &lt;- end-of-section sentinel
+ * </pre>
+ *
+ * <p>A chunk always holds a whole number of self-delimiting RLP elements, so the reader decodes each
+ * chunk with the existing {@code RLP} element machinery on a bounded {@code byte[]} and then discards it.
+ *
+ * <p><b>v1/v2 auto-detection:</b> a legacy v1 file always starts with an RLP list prefix byte
+ * ({@code 0xc0}+), which never collides with the ASCII {@code 'R'} ({@code 0x52}) that opens the v2
+ * magic. The importer dispatches on the first byte.
+ *
+ * <p>The leaf encoding is identical to v1 (each node {@code RLP.encodeElement(trie.toMessage())}, each
+ * long value {@code RLP.encodeElement(value)}, each block {@code LIST[ELEMENT(block), ELEMENT(td)]});
+ * only the container framing changes. This holder is shared by the rskj-core importer and is mirrored
+ * by the bootstrap-exporter writer (separate repo, so the constants are restated there).
+ */
+public final class BootstrapV2Format {
+
+    /** First bytes of a v2 {@code bootstrap-data.bin}; the leading {@code 'R'} disambiguates from v1. */
+    public static final byte[] MAGIC = "RSKBOOT\n".getBytes(StandardCharsets.US_ASCII);
+
+    public static final byte VERSION = 0x02;
+
+    public static final int TAG_END = 0x00;
+    public static final int TAG_BLOCKS = 0x01;
+    public static final int TAG_NODES = 0x02;
+    public static final int TAG_VALUES = 0x03;
+    /**
+     * Reserved for a future optional metadata/manifest section. Not written or read yet; the reader
+     * already skips unknown/unwanted section tags, so adding it later is a backward-compatible change.
+     */
+    public static final int TAG_MANIFEST = 0x04;
+
+    /**
+     * Soft cap on a chunk's payload. The exporter flushes a chunk once its buffer crosses this on an
+     * element boundary; a single element larger than this still becomes its own (oversized) chunk. Kept
+     * well under {@code Integer.MAX_VALUE} so a chunk always fits a bounded {@code byte[]}.
+     */
+    public static final long CHUNK_MAX = 256L * 1024 * 1024;
+
+    private BootstrapV2Format() {
+    }
+
+    /** Whether {@code firstByte} (the first byte of {@code bootstrap-data.bin}) marks a v2 file. */
+    public static boolean isV2(int firstByte) {
+        return firstByte == (MAGIC[0] & 0xFF);
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/db/importer/bootstrap-data-format.md
+++ b/rskj-core/src/main/java/co/rsk/db/importer/bootstrap-data-format.md
@@ -1,0 +1,164 @@
+# `bootstrap-data.bin` format
+
+Specification of the on-disk bootstrap snapshot payload consumed by `BootstrapImporter` and produced by
+the `bootstrap-exporter` tool (separate repo, which restates the same constants on its side). This
+document is the human-readable contract; the machine-readable constants live in
+[`BootstrapV2Format.java`](./BootstrapV2Format.java) and must stay in sync with it.
+
+Two versions exist. **v1** is the legacy format (still fully supported for already-published snapshots);
+**v2** is the current format. A reader auto-detects which one it is reading — there is no external version
+flag, because the bootstrap index entry carries none.
+
+## Motivation — why v2 exists
+
+The bootstrap snapshot is the supported fast-onboarding path: a node with `import.enabled` reconstructs
+its state from a signed `bootstrap-data.zip` (containing `bootstrap-data.bin`) instead of syncing from
+peers. A wrong reconstructed state root would silently fork the node, so this is a consensus-critical
+path.
+
+The v1 format cannot represent large state. It encodes the whole payload as one nested RLP list, and
+rskj's RLP length fields are signed 32-bit `int`, so the total payload is capped at `Integer.MAX_VALUE`
+(~2 GiB). The same ceiling appears on the import side three times over: v1 reads the whole `.bin` (and the
+whole `.zip` for hashing) into single `byte[]` arrays and decodes the entire payload into in-memory
+queues — so peak memory scales with total state size, and a payload past 2 GiB can be neither produced
+nor consumed.
+
+A network's serialized state grows over time and eventually exceeds the ~2 GiB ceiling; past that point a
+v1 snapshot for that network can be neither exported nor imported. Testnet, being ahead in state size,
+crossed it first — which is what forced v2.
+
+**v2** removes the ceiling and makes both export and import bounded-memory, independent of total state
+size, while keeping the leaf encoding byte-identical to v1 (only the container framing changes).
+
+## Version detection
+
+The importer dispatches on the **first byte** of `bootstrap-data.bin`:
+
+- A v1 file always starts with an RLP list prefix byte (`0xc0`+).
+- A v2 file starts with the ASCII `'R'` (`0x52`) of its magic.
+
+These never collide, so a single peeked byte is sufficient (`BootstrapV2Format.isV2(int)`).
+
+## v2 on-disk layout
+
+```
+HEADER
+  magic   = "RSKBOOT\n"   (8 bytes, ASCII)
+  version = 0x02          (1 byte)
+
+SECTION blocks   (tag 0x01)
+SECTION values   (tag 0x03)   <- co-located before nodes (see "Section ordering")
+SECTION nodes    (tag 0x02)
+SECTION end      (tag 0x00)   <- terminator (a bare tag byte, no chunks)
+
+SECTION =
+  [1 byte  section tag]
+  zero or more chunks:
+      [8-byte big-endian chunk length L]   (0 < L; normally L <= CHUNK_MAX)
+      [L bytes: a concatenation of whole canonical RLP elements]
+  [8-byte big-endian 0]                    <- end-of-section sentinel
+```
+
+All multi-byte integers are big-endian. All lengths are 8-byte (`long`) — this is what lifts the 2 GiB
+ceiling, since no single length field is a 32-bit `int` anymore.
+
+### Chunks
+
+A **chunk** holds a whole number of self-delimiting canonical RLP elements — an element never straddles a
+chunk boundary. The exporter accumulates encoded elements into a buffer and flushes a chunk once the
+buffer crosses `CHUNK_MAX` (256 MiB) *on an element boundary*. The one exception: a single element larger
+than `CHUNK_MAX` becomes its own oversized chunk (it cannot be split). Because a chunk is bounded, the
+reader loads it into one `byte[]`, decodes it with the ordinary `RLP` element machinery, processes it, and
+discards it — so import memory is bounded by roughly `CHUNK_MAX` plus one live `Trie` at a time.
+
+### Sections
+
+Each section is a tag byte, then a sequence of length-prefixed chunks, terminated by a zero-length
+sentinel. Three payload sections are defined:
+
+| Tag    | Name       | Contents (per element)                                             |
+|--------|------------|--------------------------------------------------------------------|
+| `0x01` | blocks     | `LIST[ELEMENT(block), ELEMENT(totalDifficulty)]`                   |
+| `0x03` | values     | `RLP.encodeElement(value)` — a trie node's long (non-embedded) value |
+| `0x02` | nodes      | `RLP.encodeElement(trie.toMessage())` — a state trie node          |
+| `0x00` | end        | terminator; carries no chunks                                      |
+| `0x04` | (manifest) | **reserved**, not yet written or read (see "Forward compatibility") |
+
+### Section ordering — the co-location invariant
+
+The **values section precedes the nodes section** deliberately. On import, a node is persisted with
+`TrieStore.save`, which resolves the node's long value lazily from the destination store *at save time* —
+including long values of embeddable children reached through parent recursion. So every long value a node
+can reference must already be in the store before that node is saved.
+
+Because the exporter co-locates all values ahead of the nodes, the importer satisfies this with a **single
+streaming pass**: it applies the `values` section (`TrieStore.saveValue`) before it reaches any node in
+the `nodes` section. No two-pass read and no temporary side store are needed.
+
+(The `blocks` section is independent and may come first.)
+
+### Leaf encoding is unchanged from v1
+
+The per-element encoding is identical to v1 — nodes, long values, and block/TD tuples all encode exactly
+as before. `Trie.fromMessage` and `BlockFactory.decodeBlock` are untouched. Only the *container* around
+the elements changed. This is intentional: rskj's RLP `int` length handling is consensus-adjacent, so v2
+sidesteps it by chunking under the ceiling rather than widening RLP.
+
+### Forward compatibility
+
+The reader **skips unknown or unwanted section tags** (their chunks are still length-validated, then
+discarded). This makes the format additively extensible: a newer exporter can emit an optional section an
+older reader does not recognize, and the older reader tolerates it. `TAG_MANIFEST = 0x04` is reserved for
+exactly this — a future optional metadata/manifest section (e.g. height, state root, and disk-size hints
+for pre-import validation) — but is not written or read today.
+
+### Robustness
+
+Chunk length fields are validated before any allocation: a length must be positive, must not exceed
+`2 * CHUNK_MAX` (headroom over the "CHUNK_MAX plus one oversized element" worst case while rejecting a
+corrupt length), and must not exceed the bytes actually remaining in the file (catches truncation and
+corrupt lengths). A missing end-of-sections marker (EOF before `TAG_END`) is rejected as truncated. The
+import also fails fast if the blocks or the nodes section is absent or empty, rather than "succeeding"
+with no state and only crashing later at first state access.
+
+## Constants
+
+Defined in [`BootstrapV2Format.java`](./BootstrapV2Format.java):
+
+| Constant       | Value            | Meaning                                             |
+|----------------|------------------|-----------------------------------------------------|
+| `MAGIC`        | `"RSKBOOT\n"`    | 8-byte ASCII header magic; leading `'R'` marks v2   |
+| `VERSION`      | `0x02`           | format version byte                                 |
+| `TAG_END`      | `0x00`           | end-of-sections terminator                          |
+| `TAG_BLOCKS`   | `0x01`           | blocks section                                      |
+| `TAG_NODES`    | `0x02`           | state trie nodes section                            |
+| `TAG_VALUES`   | `0x03`           | long trie values section                            |
+| `TAG_MANIFEST` | `0x04`           | reserved (unused)                                   |
+| `CHUNK_MAX`    | `256 MiB`        | soft chunk-flush threshold (tuning only)            |
+
+`CHUNK_MAX` is a tuning knob (peak memory vs. chunk count), not a hard limit — changing it does not break
+compatibility, since chunk lengths are self-describing.
+
+## v1 (legacy) format
+
+v1 remains supported for already-published snapshots and is selected automatically (see "Version
+detection"). The whole payload is a single nested RLP list:
+
+```
+LIST[
+  ELEMENT(blocks-list),   <- LIST of LIST[ELEMENT(block), ELEMENT(td)]
+  LIST[ nodes-list, values-list ]
+]
+```
+
+The importer reads the entire `.bin` into one `byte[]` and decodes it into in-memory queues, then builds
+the state. This is why v1 is memory-unbounded and 2 GiB-capped; it is kept only for backward compatibility
+and must not be changed.
+
+## Out of scope
+
+- **Widening rskj's RLP `int` length handling.** v2 chunks under the ceiling instead.
+- **The bootstrap index / signature scheme.** The sha256-over-`.zip` + signature are unchanged; v2 only
+  changes how the `.bin` inside the zip is framed. (The importer now computes the zip hash with a
+  streaming digest rather than reading the whole zip into memory, but the hash value and index logic are
+  identical.)

--- a/rskj-core/src/main/java/co/rsk/db/importer/provider/BootstrapDataProvider.java
+++ b/rskj-core/src/main/java/co/rsk/db/importer/provider/BootstrapDataProvider.java
@@ -24,6 +24,7 @@ import co.rsk.db.importer.provider.index.BootstrapIndexRetriever;
 import co.rsk.db.importer.provider.index.data.BootstrapDataEntry;
 import co.rsk.db.importer.provider.index.data.BootstrapDataIndex;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
@@ -81,6 +82,10 @@ public class BootstrapDataProvider {
 
     public byte[] getBootstrapData() {
         return bootstrapFileHandler.getBootstrapData();
+    }
+
+    public Path getBootstrapDataPath() {
+        return bootstrapFileHandler.getBootstrapDataPath();
     }
 
     public long getSelectedHeight() {

--- a/rskj-core/src/main/java/co/rsk/db/importer/provider/BootstrapFileHandler.java
+++ b/rskj-core/src/main/java/co/rsk/db/importer/provider/BootstrapFileHandler.java
@@ -31,6 +31,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.*;
 
@@ -39,6 +40,7 @@ public class BootstrapFileHandler {
     private static final Logger logger = LoggerFactory.getLogger(BootstrapFileHandler.class);
     private static final String BOOTSTRAP_DATA_NAME = "bootstrap-data.zip";
     private static final String EXTRACTED_PATH = "bootstrap-data.bin";
+    private static final int HASH_BUFFER_SIZE = 64 * 1024;
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private final BootstrapURLProvider bootstrapUrlProvider;
@@ -68,6 +70,15 @@ public class BootstrapFileHandler {
         }
     }
 
+    /**
+     * Path to the extracted {@code bootstrap-data.bin}. Exposed so the importer can stream it instead
+     * of loading the whole file into a single {@code byte[]} (the v2 format can exceed the
+     * {@code Integer.MAX_VALUE} array ceiling).
+     */
+    public Path getBootstrapDataPath() {
+        return tempPath.resolve(EXTRACTED_PATH);
+    }
+
     public void retrieveAndUnpack(Map<String, BootstrapDataEntry> selectedEntries) {
         Path zipPath = tempPath.resolve(BOOTSTRAP_DATA_NAME);
 
@@ -84,9 +95,15 @@ public class BootstrapFileHandler {
     }
 
     private void checkFileHash(Path databasePath, String expectedHash) {
-        try {
-            byte[] fileContent = Files.readAllBytes(databasePath);
-            byte[] hash = HashUtil.sha256(fileContent);
+        // Stream the digest so the (potentially > 2 GiB) zip is never loaded into a single byte[].
+        // The hash value is unchanged - same SHA-256 over the same bytes, just computed incrementally.
+        MessageDigest digest = HashUtil.makeMessageDigest();
+        try (InputStream is = new BufferedInputStream(Files.newInputStream(databasePath), HASH_BUFFER_SIZE)) {
+            byte[] buffer = new byte[HASH_BUFFER_SIZE];
+            for (int read = is.read(buffer); read >= 0; read = is.read(buffer)) {
+                digest.update(buffer, 0, read);
+            }
+            byte[] hash = digest.digest();
             if (!Arrays.equals(hash, Hex.decode(expectedHash))) {
                 throw new BootstrapImportException(String.format(
                         "File: %s does not match with expected hash: %s", databasePath, expectedHash));

--- a/rskj-core/src/main/java/co/rsk/trie/InOrderIterator.java
+++ b/rskj-core/src/main/java/co/rsk/trie/InOrderIterator.java
@@ -27,8 +27,20 @@ public class InOrderIterator implements Iterator<IterationElement> {
 
     private final Deque<IterationElement> visiting;
 
+    /**
+     * When {@code false}, child nodes are loaded without being memoized in their parent
+     * {@link NodeReference}. This keeps the retained set bounded to the current path (the visiting
+     * stack) instead of pinning the whole visited trie via the caller-held root.
+     */
+    private final boolean shouldCache;
+
     public InOrderIterator(Trie root) {
+        this(root, true);
+    }
+
+    public InOrderIterator(Trie root, boolean shouldCache) {
         Objects.requireNonNull(root);
+        this.shouldCache = shouldCache;
         TrieKeySlice traversedPath = root.getSharedPath();
         this.visiting = new LinkedList<>();
         // find the leftmost node, pushing all the intermediate nodes onto the visiting stack
@@ -46,7 +58,7 @@ public class InOrderIterator implements Iterator<IterationElement> {
         IterationElement visitingElement = visiting.pop();
         Trie node = visitingElement.getNode();
         // if the node has a right child, its leftmost node is next
-        Trie rightNode = node.retrieveNode((byte) 0x01);
+        Trie rightNode = node.retrieveNode((byte) 0x01, shouldCache);
         if (rightNode != null) {
             TrieKeySlice rightNodeKey = visitingElement.getNodeKey().rebuildSharedPath((byte) 0x01, rightNode.getSharedPath());
             visiting.push(new IterationElement(rightNodeKey, rightNode)); // push the right node
@@ -71,7 +83,7 @@ public class InOrderIterator implements Iterator<IterationElement> {
      */
     private void pushLeftmostNode(TrieKeySlice nodeKey, Trie node) {
         // find the leftmost node
-        Trie leftNode = node.retrieveNode((byte) 0x00);
+        Trie leftNode = node.retrieveNode((byte) 0x00, shouldCache);
         if (leftNode != null) {
             TrieKeySlice leftNodeKey = nodeKey.rebuildSharedPath((byte) 0x00, leftNode.getSharedPath());
             visiting.push(new IterationElement(leftNodeKey, leftNode)); // push the left node

--- a/rskj-core/src/main/java/co/rsk/trie/MultiTrieStore.java
+++ b/rskj-core/src/main/java/co/rsk/trie/MultiTrieStore.java
@@ -66,6 +66,11 @@ public class MultiTrieStore implements TrieStore {
         getCurrentStore().saveDTO(trieDTO);
     }
 
+    @Override
+    public void saveValue(byte[] value) {
+        getCurrentStore().saveValue(value);
+    }
+
     /**
      * It's not enough to just flush the current one b/c it may occur, if the epoch size doesn't match the flush size,
      * that some epoch may never get flushed

--- a/rskj-core/src/main/java/co/rsk/trie/NodeReference.java
+++ b/rskj-core/src/main/java/co/rsk/trie/NodeReference.java
@@ -85,6 +85,22 @@ public class NodeReference {
      * If the node could not be retrieved from the store, the Node is stopped using System.exit(1)
      */
     public Optional<Trie> getNode() {
+        return getNode(true);
+    }
+
+    /**
+     * The node or empty if this is an empty reference.
+     * If the node is not present but its hash is known, it will be retrieved from the store.
+     * If the node could not be retrieved from the store, the Node is stopped using System.exit(1)
+     *
+     * @param shouldCache when {@code true} the retrieved node is memoized in {@code lazyNode}
+     *                    (the default behaviour). When {@code false} the node is returned without
+     *                    being memoized, so it is not retained by this reference once the caller
+     *                    drops it. A non-memoizing traversal keeps memory bounded to the active
+     *                    path instead of retaining the whole visited sub-trie (see bootstrap state
+     *                    export, which would otherwise pin the entire trie via the held root).
+     */
+    public Optional<Trie> getNode(boolean shouldCache) {
         if (lazyNode != null) {
             return Optional.of(lazyNode);
         }
@@ -102,7 +118,9 @@ public class NodeReference {
             return Optional.empty();
         }
 
-        lazyNode = node.get();
+        if (shouldCache) {
+            lazyNode = node.get();
+        }
 
         return node;
     }

--- a/rskj-core/src/main/java/co/rsk/trie/Trie.java
+++ b/rskj-core/src/main/java/co/rsk/trie/Trie.java
@@ -739,7 +739,11 @@ public class Trie {
     }
 
     protected Trie retrieveNode(byte implicitByte) {
-        return getNodeReference(implicitByte).getNode().orElse(null);
+        return retrieveNode(implicitByte, true);
+    }
+
+    protected Trie retrieveNode(byte implicitByte, boolean shouldCache) {
+        return getNodeReference(implicitByte).getNode(shouldCache).orElse(null);
     }
 
     public NodeReference getNodeReference(byte implicitByte) {
@@ -1038,6 +1042,18 @@ public class Trie {
 
     public Iterator<IterationElement> getInOrderIterator() {
         return new InOrderIterator(this);
+    }
+
+    /**
+     * In-order iterator with control over node caching.
+     *
+     * @param shouldCache when {@code false}, traversed nodes are not memoized in their parent
+     *                    {@link NodeReference}, so memory stays bounded to the active path instead
+     *                    of retaining the whole visited trie via the held root. Use {@code false}
+     *                    for one-pass, memory-sensitive walks such as the bootstrap state export.
+     */
+    public Iterator<IterationElement> getInOrderIterator(boolean shouldCache) {
+        return new InOrderIterator(this, shouldCache);
     }
 
     public Iterator<IterationElement> getPreOrderIterator() {

--- a/rskj-core/src/main/java/co/rsk/trie/TrieStore.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieStore.java
@@ -32,6 +32,16 @@ public interface TrieStore {
     Optional<Trie> retrieve(byte[] hash);
     byte[] retrieveValue(byte[] hash);
 
+    /**
+     * Stores a long value, keyed by its keccak256 hash — the inverse of {@link #retrieveValue(byte[])}.
+     * The store computes the key, so the hash/value invariant is enforced in one place. Used to pre-stage
+     * long values ahead of the nodes that reference them (e.g. a co-located bootstrap import), so a node
+     * can be saved in a single pass without a separate value-staging store.
+     *
+     * @param value the long value bytes
+     */
+    void saveValue(byte[] value);
+
     void dispose();
 
     Optional<TrieDTO> retrieveDTO(byte[] hash);

--- a/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -219,6 +220,7 @@ public class TrieStoreImpl implements TrieStore {
 
     @Override
     public void saveValue(byte[] value) {
+        Objects.requireNonNull(value, "value must not be null");
         this.store.put(getValueHash(value), value);
     }
 

--- a/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
+++ b/rskj-core/src/main/java/co/rsk/trie/TrieStoreImpl.java
@@ -218,6 +218,11 @@ public class TrieStoreImpl implements TrieStore {
     }
 
     @Override
+    public void saveValue(byte[] value) {
+        this.store.put(getValueHash(value), value);
+    }
+
+    @Override
     public void dispose() {
         store.close();
     }

--- a/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -30,8 +29,8 @@ class BootstrapImporterTest {
         // using toURI() instead of getPath() prevent some errors on Windows
         // (https://stackoverflow.com/questions/38887853/java-nio-file-invalidpathexception-with-getpath/38888561)
         Path path = Paths.get(getClass().getClassLoader().getResource("import/bootstrap-data.bin").toURI());
-        byte[] oneBlockAndState = Files.readAllBytes(path);
-        when(bootstrapDataProvider.getBootstrapData()).thenReturn(oneBlockAndState);
+        when(bootstrapDataProvider.getBootstrapDataPath()).thenReturn(path);
+        when(bootstrapDataProvider.getBootstrapData()).thenReturn(java.nio.file.Files.readAllBytes(path));
         when(bootstrapDataProvider.getSelectedHeight()).thenReturn(1L);
 
         BootstrapImporter bootstrapImporter = new BootstrapImporter(blockStore, trieStore,

--- a/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -30,7 +31,7 @@ class BootstrapImporterTest {
         // (https://stackoverflow.com/questions/38887853/java-nio-file-invalidpathexception-with-getpath/38888561)
         Path path = Paths.get(getClass().getClassLoader().getResource("import/bootstrap-data.bin").toURI());
         when(bootstrapDataProvider.getBootstrapDataPath()).thenReturn(path);
-        when(bootstrapDataProvider.getBootstrapData()).thenReturn(java.nio.file.Files.readAllBytes(path));
+        when(bootstrapDataProvider.getBootstrapData()).thenReturn(Files.readAllBytes(path));
         when(bootstrapDataProvider.getSelectedHeight()).thenReturn(1L);
 
         BootstrapImporter bootstrapImporter = new BootstrapImporter(blockStore, trieStore,

--- a/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterV2Test.java
+++ b/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterV2Test.java
@@ -266,6 +266,35 @@ class BootstrapImporterV2Test {
         assertTrue(ex.getMessage().toLowerCase().contains("long value"), ex.getMessage());
     }
 
+    @Test
+    void rejectsV2WithNodesSectionBeforeValuesSection() throws IOException {
+        // A structurally malformed v2 file whose nodes section precedes its values section, violating the
+        // co-location invariant (values must come before the nodes that reference them). Node saving would
+        // otherwise fail deep inside the trie only for nodes that happen to reference a long value; the
+        // section-order guard rejects the mis-ordered file up front, deterministically, regardless of which
+        // nodes reference long values.
+        StateFixture fixture = buildState();
+        List<byte[]> blocks = syntheticBlockElements();
+        List<byte[]> values = collectValueElements(fixture.store, fixture.stateRoot);
+        List<byte[]> nodes = collectNodeElements(fixture.store, fixture.stateRoot);
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        out.write(BootstrapV2Format.MAGIC);
+        out.writeByte(BootstrapV2Format.VERSION);
+        writeSection(out, BootstrapV2Format.TAG_BLOCKS, blocks, 1024);
+        // deliberately mis-ordered: nodes written BEFORE values
+        writeSection(out, BootstrapV2Format.TAG_NODES, nodes, 1024);
+        writeSection(out, BootstrapV2Format.TAG_VALUES, values, 1024);
+        out.writeByte(BootstrapV2Format.TAG_END);
+        out.flush();
+
+        BootstrapImporter importer = newImporter(bos.toByteArray(), "nodes-before-values.bin");
+
+        BootstrapImportException ex = assertThrows(BootstrapImportException.class, importer::importData);
+        assertTrue(ex.getMessage().toLowerCase().contains("order"), ex.getMessage());
+    }
+
     /** An origin store plus the hash of a saved state trie that mixes short and long values. */
     private static final class StateFixture {
         final TrieStore store;

--- a/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterV2Test.java
+++ b/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterV2Test.java
@@ -298,6 +298,24 @@ class BootstrapImporterV2Test {
     }
 
     @Test
+    void failsWithActionableErrorWhenBlockElementIsEmpty() throws IOException {
+        // A corrupt blocks section carrying an empty element (getRLPData() == null) would otherwise surface
+        // as an IllegalArgumentException from RLP.decodeList. It must be an actionable import error, like the
+        // values and nodes sections.
+        StateFixture fixture = buildState();
+        List<byte[]> blocks = new ArrayList<>();
+        blocks.add(RLP.encodeElement(new byte[0])); // empty block element -> getRLPData() == null
+        byte[] v2 = assembleV2(1024, blocks,
+                collectNodeElements(fixture.store, fixture.stateRoot),
+                collectValueElements(fixture.store, fixture.stateRoot));
+
+        BootstrapImporter importer = newImporter(v2, "empty-block.bin");
+
+        BootstrapImportException ex = assertThrows(BootstrapImportException.class, importer::importData);
+        assertTrue(ex.getMessage().toLowerCase().contains("blocks"), ex.getMessage());
+    }
+
+    @Test
     void failsWithActionableErrorWhenValueElementIsEmpty() throws IOException {
         // RLPElement#getRLPData() returns null for an empty element; a corrupt values section carrying one
         // would otherwise NPE deep inside saveValue. It must surface as an actionable import error.

--- a/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterV2Test.java
+++ b/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterV2Test.java
@@ -132,7 +132,7 @@ class BootstrapImporterV2Test {
 
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         DataOutputStream out = new DataOutputStream(bos);
-        out.write(BootstrapV2Format.MAGIC);
+        out.write(BootstrapV2Format.magic());
         out.writeByte(BootstrapV2Format.VERSION);
         // a section tag this reader does not handle (reserved for a future manifest); must be skipped
         writeSection(out, BootstrapV2Format.TAG_MANIFEST,
@@ -239,7 +239,7 @@ class BootstrapImporterV2Test {
         // file instead of being eagerly allocated as a multi-hundred-MB byte[].
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         DataOutputStream out = new DataOutputStream(bos);
-        out.write(BootstrapV2Format.MAGIC);
+        out.write(BootstrapV2Format.magic());
         out.writeByte(BootstrapV2Format.VERSION);
         out.writeByte(BootstrapV2Format.TAG_BLOCKS);
         out.writeLong(10_000_000L); // corrupt length; no payload follows — the file ends here
@@ -282,7 +282,7 @@ class BootstrapImporterV2Test {
 
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         DataOutputStream out = new DataOutputStream(bos);
-        out.write(BootstrapV2Format.MAGIC);
+        out.write(BootstrapV2Format.magic());
         out.writeByte(BootstrapV2Format.VERSION);
         writeSection(out, BootstrapV2Format.TAG_BLOCKS, blocks, 1024);
         // deliberately mis-ordered: nodes written BEFORE values
@@ -421,7 +421,7 @@ class BootstrapImporterV2Test {
             throws IOException {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         DataOutputStream out = new DataOutputStream(bos);
-        out.write(BootstrapV2Format.MAGIC);
+        out.write(BootstrapV2Format.magic());
         out.writeByte(BootstrapV2Format.VERSION);
         if (blocks != null) {
             writeSection(out, BootstrapV2Format.TAG_BLOCKS, blocks, chunkMax);

--- a/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterV2Test.java
+++ b/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterV2Test.java
@@ -135,7 +135,8 @@ class BootstrapImporterV2Test {
         out.write(BootstrapV2Format.MAGIC);
         out.writeByte(BootstrapV2Format.VERSION);
         // a section tag this reader does not handle (reserved for a future manifest); must be skipped
-        writeSection(out, BootstrapV2Format.TAG_MANIFEST, List.of(RLP.encodeElement("future".getBytes())), 1024);
+        writeSection(out, BootstrapV2Format.TAG_MANIFEST,
+                List.of(RLP.encodeElement("future".getBytes(StandardCharsets.UTF_8))), 1024);
         writeSection(out, BootstrapV2Format.TAG_BLOCKS, blocks, 1024);
         writeSection(out, BootstrapV2Format.TAG_VALUES, values, 1024);
         writeSection(out, BootstrapV2Format.TAG_NODES, nodes, 1024);
@@ -294,6 +295,50 @@ class BootstrapImporterV2Test {
 
         BootstrapImportException ex = assertThrows(BootstrapImportException.class, importer::importData);
         assertTrue(ex.getMessage().toLowerCase().contains("order"), ex.getMessage());
+    }
+
+    @Test
+    void failsWithActionableErrorWhenValueElementIsEmpty() throws IOException {
+        // RLPElement#getRLPData() returns null for an empty element; a corrupt values section carrying one
+        // would otherwise NPE deep inside saveValue. It must surface as an actionable import error.
+        StateFixture fixture = buildState();
+        List<byte[]> values = new ArrayList<>();
+        values.add(RLP.encodeElement(new byte[0])); // empty value element -> getRLPData() == null
+        byte[] v2 = assembleV2(1024,
+                syntheticBlockElements(), collectNodeElements(fixture.store, fixture.stateRoot), values);
+
+        BootstrapImporter importer = newImporter(v2, "empty-value.bin");
+
+        BootstrapImportException ex = assertThrows(BootstrapImportException.class, importer::importData);
+        assertTrue(ex.getMessage().toLowerCase().contains("value"), ex.getMessage());
+    }
+
+    @Test
+    void failsWithActionableErrorWhenNodeElementIsEmpty() throws IOException {
+        // A corrupt nodes section carrying an empty element (getRLPData() == null) would otherwise pass null
+        // into Trie.fromMessage and surface as an unhelpful NPE/IAE. It must be an actionable import error.
+        StateFixture fixture = buildState();
+        List<byte[]> nodes = new ArrayList<>();
+        nodes.add(RLP.encodeElement(new byte[0])); // empty node element -> getRLPData() == null
+        byte[] v2 = assembleV2(1024,
+                syntheticBlockElements(), nodes, collectValueElements(fixture.store, fixture.stateRoot));
+
+        BootstrapImporter importer = newImporter(v2, "empty-node.bin");
+
+        BootstrapImportException ex = assertThrows(BootstrapImportException.class, importer::importData);
+        assertTrue(ex.getMessage().toLowerCase().contains("empty"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsUnrecognizedFirstByteAsNeitherV1NorV2() throws IOException {
+        // First byte is neither the v2 magic ('R') nor a v1 RLP list prefix (0xc0+): a corrupt or wrong file
+        // must be rejected up front with a clear error, not sent down the v1 path to fail with an opaque
+        // RLP error later.
+        byte[] bogus = new byte[]{0x42, 0x00, 0x01}; // 'B', not v2 magic and not a v1 list prefix
+        BootstrapImporter importer = newImporter(bogus, "bogus-format.bin");
+
+        BootstrapImportException ex = assertThrows(BootstrapImportException.class, importer::importData);
+        assertTrue(ex.getMessage().toLowerCase().contains("unrecognized"), ex.getMessage());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterV2Test.java
+++ b/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterV2Test.java
@@ -90,29 +90,17 @@ class BootstrapImporterV2Test {
 
         // tiny chunk size to force multi-chunk sections (chunk-spanning read path)
         byte[] v2 = writeV2(originStore, stateRoot, 96);
-        Path binPath = tempDir.resolve("bootstrap-data.bin");
-        Files.write(binPath, v2);
 
         // destination: real trie store (state assertions), mocked block plumbing (block decode/save).
-        TrieStore destinationStore = new TrieStoreImpl(new HashMapDB());
-        BlockStore blockStore = mock(BlockStore.class);
-        BlockFactory blockFactory = mock(BlockFactory.class);
-        when(blockFactory.decodeBlock(any())).thenReturn(mock(Block.class));
-
-        BootstrapDataProvider provider = mock(BootstrapDataProvider.class);
-        when(provider.getBootstrapDataPath()).thenReturn(binPath);
-
-        BootstrapImporter importer = new BootstrapImporter(
-                blockStore, destinationStore, blockFactory, provider);
-
-        importer.importData();
+        Wired wired = wire(v2, "bootstrap-data.bin");
+        wired.importer().importData();
 
         // blocks were decoded and saved
-        verify(blockFactory, atLeastOnce()).decodeBlock(any());
-        verify(blockStore, atLeastOnce()).saveBlock(any(), any(), anyBoolean());
+        verify(wired.blockFactory(), atLeastOnce()).decodeBlock(any());
+        verify(wired.blockStore(), atLeastOnce()).saveBlock(any(), any(), anyBoolean());
 
         // the state root is retrievable and every key/value round-trips intact
-        Trie reconstructed = destinationStore.retrieve(stateRoot)
+        Trie reconstructed = wired.destinationStore().retrieve(stateRoot)
                 .orElseThrow(() -> new AssertionError("state root missing after import"));
         assertArrayEquals(stateRoot, reconstructed.getHash().getBytes(), "state root mismatch");
         for (Map.Entry<byte[], byte[]> e : expected.entrySet()) {
@@ -143,19 +131,10 @@ class BootstrapImporterV2Test {
         out.writeByte(BootstrapV2Format.TAG_END);
         out.flush();
 
-        Path binPath = tempDir.resolve("with-unknown-section.bin");
-        Files.write(binPath, bos.toByteArray());
+        Wired wired = wire(bos.toByteArray(), "with-unknown-section.bin");
+        wired.importer().importData();
 
-        TrieStore destinationStore = new TrieStoreImpl(new HashMapDB());
-        BlockStore blockStore = mock(BlockStore.class);
-        BlockFactory blockFactory = mock(BlockFactory.class);
-        when(blockFactory.decodeBlock(any())).thenReturn(mock(Block.class));
-        BootstrapDataProvider provider = mock(BootstrapDataProvider.class);
-        when(provider.getBootstrapDataPath()).thenReturn(binPath);
-
-        new BootstrapImporter(blockStore, destinationStore, blockFactory, provider).importData();
-
-        Trie reconstructed = destinationStore.retrieve(fixture.stateRoot)
+        Trie reconstructed = wired.destinationStore().retrieve(fixture.stateRoot)
                 .orElseThrow(() -> new AssertionError("state root missing after import"));
         assertArrayEquals(fixture.stateRoot, reconstructed.getHash().getBytes());
     }
@@ -178,20 +157,11 @@ class BootstrapImporterV2Test {
         byte[] v2 = writeV2(originStore, stateRoot, 1024);
         // sanity: no long values were emitted
         assertTrue(collectValueElements(originStore, stateRoot).isEmpty(), "expected no long values");
-        Path binPath = tempDir.resolve("bootstrap-empty-values.bin");
-        Files.write(binPath, v2);
 
-        TrieStore destinationStore = new TrieStoreImpl(new HashMapDB());
-        BlockStore blockStore = mock(BlockStore.class);
-        BlockFactory blockFactory = mock(BlockFactory.class);
-        when(blockFactory.decodeBlock(any())).thenReturn(mock(Block.class));
-        BootstrapDataProvider provider = mock(BootstrapDataProvider.class);
-        when(provider.getBootstrapDataPath()).thenReturn(binPath);
+        Wired wired = wire(v2, "bootstrap-empty-values.bin");
+        wired.importer().importData();
 
-        new BootstrapImporter(blockStore, destinationStore, blockFactory, provider)
-                .importData();
-
-        Trie reconstructed = destinationStore.retrieve(stateRoot)
+        Trie reconstructed = wired.destinationStore().retrieve(stateRoot)
                 .orElseThrow(() -> new AssertionError("state root missing after import"));
         for (Map.Entry<byte[], byte[]> e : expected.entrySet()) {
             assertArrayEquals(e.getValue(), reconstructed.get(e.getKey()));
@@ -398,8 +368,13 @@ class BootstrapImporterV2Test {
         return new StateFixture(store, trie.getHash().getBytes());
     }
 
+    /** An importer wired over a temp v2 file, exposing the mocks/store the state-asserting tests inspect. */
+    private record Wired(BootstrapImporter importer, TrieStore destinationStore,
+                         BlockStore blockStore, BlockFactory blockFactory) {
+    }
+
     /** Writes {@code v2} to a temp file and wires an importer with mocked block plumbing over it. */
-    private BootstrapImporter newImporter(byte[] v2, String fileName) throws IOException {
+    private Wired wire(byte[] v2, String fileName) throws IOException {
         Path binPath = tempDir.resolve(fileName);
         Files.write(binPath, v2);
 
@@ -410,8 +385,14 @@ class BootstrapImporterV2Test {
         BootstrapDataProvider provider = mock(BootstrapDataProvider.class);
         when(provider.getBootstrapDataPath()).thenReturn(binPath);
 
-        return new BootstrapImporter(
+        BootstrapImporter importer = new BootstrapImporter(
                 blockStore, destinationStore, blockFactory, provider);
+        return new Wired(importer, destinationStore, blockStore, blockFactory);
+    }
+
+    /** Convenience for the fail-fast tests that only need the importer, not the wired store/mocks. */
+    private BootstrapImporter newImporter(byte[] v2, String fileName) throws IOException {
+        return wire(v2, fileName).importer();
     }
 
     private static byte[] longValue(int seed) {

--- a/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterV2Test.java
+++ b/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterV2Test.java
@@ -38,6 +38,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -293,6 +294,22 @@ class BootstrapImporterV2Test {
 
         BootstrapImportException ex = assertThrows(BootstrapImportException.class, importer::importData);
         assertTrue(ex.getMessage().toLowerCase().contains("order"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsV2WithTrailingBytesAfterEndMarker() throws IOException {
+        // A structurally complete v2 file with a stray byte appended after the end-of-sections marker. The
+        // v2 format is canonical — nothing may follow TAG_END — so trailing bytes (a tampered, truncated,
+        // or accidentally concatenated file) must be rejected, not silently ignored.
+        StateFixture fixture = buildState();
+        byte[] wellFormed = writeV2(fixture.store, fixture.stateRoot, 1024);
+        byte[] withTrailing = Arrays.copyOf(wellFormed, wellFormed.length + 1);
+        withTrailing[wellFormed.length] = 0x42; // stray trailing byte after TAG_END
+
+        BootstrapImporter importer = newImporter(withTrailing, "trailing-bytes.bin");
+
+        BootstrapImportException ex = assertThrows(BootstrapImportException.class, importer::importData);
+        assertTrue(ex.getMessage().toLowerCase().contains("trailing"), ex.getMessage());
     }
 
     /** An origin store plus the hash of a saved state trie that mixes short and long values. */

--- a/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterV2Test.java
+++ b/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterV2Test.java
@@ -232,9 +232,9 @@ class BootstrapImporterV2Test {
 
     @Test
     void rejectsChunkLengthExceedingFileSizeBeforeAllocating() throws IOException {
-        // A chunk whose declared length is far larger than the whole file, yet still under the ~2 GiB
-        // array ceiling (MAX_CHUNK_BYTES). It must be rejected against the bytes actually remaining in the
-        // file instead of being eagerly allocated as a multi-hundred-MB/GB byte[].
+        // A chunk whose declared length is far larger than the whole file, yet still under the per-chunk
+        // ceiling (MAX_CHUNK_BYTES). It must be rejected against the bytes actually remaining in the
+        // file instead of being eagerly allocated as a multi-hundred-MB byte[].
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         DataOutputStream out = new DataOutputStream(bos);
         out.write(BootstrapV2Format.MAGIC);

--- a/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterV2Test.java
+++ b/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterV2Test.java
@@ -1,0 +1,421 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2026 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.db.importer;
+
+import co.rsk.db.importer.provider.BootstrapDataProvider;
+import co.rsk.trie.IterationElement;
+import co.rsk.trie.Trie;
+import co.rsk.trie.TrieStore;
+import co.rsk.trie.TrieStoreImpl;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockFactory;
+import org.ethereum.datasource.HashMapDB;
+import org.ethereum.db.BlockStore;
+import org.ethereum.util.RLP;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Round-trips the v2 (chunked, streaming) {@code bootstrap-data.bin} format through the importer: a
+ * state trie (with short values, long values, and many nodes) is serialized into v2 bytes exactly the
+ * way the exporter does, then imported, and the reconstructed state is asserted byte-for-byte.
+ *
+ * <p>The v2 writer here mirrors {@code FileExporter} (separate repo) on purpose, so this test also pins
+ * the cross-repo format contract. A deliberately tiny chunk size forces multi-chunk sections, exercising
+ * the chunk-spanning read path.
+ */
+class BootstrapImporterV2Test {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void importsV2RoundTripReconstructingState() throws IOException {
+        // origin state with a mix of node shapes: short values (inlined) and long values (> 32 bytes,
+        // stored separately and referenced by hash) so both the nodes and values sections are non-trivial.
+        TrieStore originStore = new TrieStoreImpl(new HashMapDB());
+        Map<byte[], byte[]> expected = new LinkedHashMap<>();
+        Trie trie = new Trie(originStore);
+        for (int i = 0; i < 64; i++) {
+            byte[] key = ("account/" + i).getBytes(StandardCharsets.UTF_8);
+            // alternate short (<= 32B) and long (> 32B) values
+            byte[] value = (i % 2 == 0)
+                    ? ("v" + i).getBytes(StandardCharsets.UTF_8)
+                    : longValue(i);
+            trie = trie.put(key, value);
+            expected.put(key, value);
+        }
+        originStore.save(trie);
+        byte[] stateRoot = trie.getHash().getBytes();
+
+        // tiny chunk size to force multi-chunk sections (chunk-spanning read path)
+        byte[] v2 = writeV2(originStore, stateRoot, 96);
+        Path binPath = tempDir.resolve("bootstrap-data.bin");
+        Files.write(binPath, v2);
+
+        // destination: real trie store (state assertions), mocked block plumbing (block decode/save).
+        TrieStore destinationStore = new TrieStoreImpl(new HashMapDB());
+        BlockStore blockStore = mock(BlockStore.class);
+        BlockFactory blockFactory = mock(BlockFactory.class);
+        when(blockFactory.decodeBlock(any())).thenReturn(mock(Block.class));
+
+        BootstrapDataProvider provider = mock(BootstrapDataProvider.class);
+        when(provider.getBootstrapDataPath()).thenReturn(binPath);
+
+        BootstrapImporter importer = new BootstrapImporter(
+                blockStore, destinationStore, blockFactory, provider);
+
+        importer.importData();
+
+        // blocks were decoded and saved
+        verify(blockFactory, atLeastOnce()).decodeBlock(any());
+        verify(blockStore, atLeastOnce()).saveBlock(any(), any(), anyBoolean());
+
+        // the state root is retrievable and every key/value round-trips intact
+        Trie reconstructed = destinationStore.retrieve(stateRoot)
+                .orElseThrow(() -> new AssertionError("state root missing after import"));
+        assertArrayEquals(stateRoot, reconstructed.getHash().getBytes(), "state root mismatch");
+        for (Map.Entry<byte[], byte[]> e : expected.entrySet()) {
+            assertArrayEquals(e.getValue(), reconstructed.get(e.getKey()),
+                    "value mismatch for key " + new String(e.getKey(), StandardCharsets.UTF_8));
+        }
+    }
+
+    @Test
+    void importsV2SkippingAnUnknownSectionReconstructingState() throws IOException {
+        // a v2 file that carries an unknown/reserved section (a future optional section, e.g. a metadata
+        // manifest) ahead of the data sections: an older reader must skip it and still reconstruct state.
+        StateFixture fixture = buildState();
+        List<byte[]> blocks = syntheticBlockElements();
+        List<byte[]> values = collectValueElements(fixture.store, fixture.stateRoot);
+        List<byte[]> nodes = collectNodeElements(fixture.store, fixture.stateRoot);
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        out.write(BootstrapV2Format.MAGIC);
+        out.writeByte(BootstrapV2Format.VERSION);
+        // a section tag this reader does not handle (reserved for a future manifest); must be skipped
+        writeSection(out, BootstrapV2Format.TAG_MANIFEST, List.of(RLP.encodeElement("future".getBytes())), 1024);
+        writeSection(out, BootstrapV2Format.TAG_BLOCKS, blocks, 1024);
+        writeSection(out, BootstrapV2Format.TAG_VALUES, values, 1024);
+        writeSection(out, BootstrapV2Format.TAG_NODES, nodes, 1024);
+        out.writeByte(BootstrapV2Format.TAG_END);
+        out.flush();
+
+        Path binPath = tempDir.resolve("with-unknown-section.bin");
+        Files.write(binPath, bos.toByteArray());
+
+        TrieStore destinationStore = new TrieStoreImpl(new HashMapDB());
+        BlockStore blockStore = mock(BlockStore.class);
+        BlockFactory blockFactory = mock(BlockFactory.class);
+        when(blockFactory.decodeBlock(any())).thenReturn(mock(Block.class));
+        BootstrapDataProvider provider = mock(BootstrapDataProvider.class);
+        when(provider.getBootstrapDataPath()).thenReturn(binPath);
+
+        new BootstrapImporter(blockStore, destinationStore, blockFactory, provider).importData();
+
+        Trie reconstructed = destinationStore.retrieve(fixture.stateRoot)
+                .orElseThrow(() -> new AssertionError("state root missing after import"));
+        assertArrayEquals(fixture.stateRoot, reconstructed.getHash().getBytes());
+    }
+
+    @Test
+    void importsV2WithEmptyValuesSection() throws IOException {
+        // a state whose values are all short (<= 32B) → the values section is just the terminator.
+        TrieStore originStore = new TrieStoreImpl(new HashMapDB());
+        Trie trie = new Trie(originStore);
+        Map<byte[], byte[]> expected = new LinkedHashMap<>();
+        for (int i = 0; i < 16; i++) {
+            byte[] key = ("k" + i).getBytes(StandardCharsets.UTF_8);
+            byte[] value = ("short" + i).getBytes(StandardCharsets.UTF_8);
+            trie = trie.put(key, value);
+            expected.put(key, value);
+        }
+        originStore.save(trie);
+        byte[] stateRoot = trie.getHash().getBytes();
+
+        byte[] v2 = writeV2(originStore, stateRoot, 1024);
+        // sanity: no long values were emitted
+        assertTrue(collectValueElements(originStore, stateRoot).isEmpty(), "expected no long values");
+        Path binPath = tempDir.resolve("bootstrap-empty-values.bin");
+        Files.write(binPath, v2);
+
+        TrieStore destinationStore = new TrieStoreImpl(new HashMapDB());
+        BlockStore blockStore = mock(BlockStore.class);
+        BlockFactory blockFactory = mock(BlockFactory.class);
+        when(blockFactory.decodeBlock(any())).thenReturn(mock(Block.class));
+        BootstrapDataProvider provider = mock(BootstrapDataProvider.class);
+        when(provider.getBootstrapDataPath()).thenReturn(binPath);
+
+        new BootstrapImporter(blockStore, destinationStore, blockFactory, provider)
+                .importData();
+
+        Trie reconstructed = destinationStore.retrieve(stateRoot)
+                .orElseThrow(() -> new AssertionError("state root missing after import"));
+        for (Map.Entry<byte[], byte[]> e : expected.entrySet()) {
+            assertArrayEquals(e.getValue(), reconstructed.get(e.getKey()));
+        }
+    }
+
+    @Test
+    void detectsV2ByFirstByte() {
+        assertTrue(BootstrapV2Format.isV2('R'));
+        assertFalse(BootstrapV2Format.isV2(0xf8)); // a legacy v1 long-list prefix
+        assertFalse(BootstrapV2Format.isV2(0xc0));
+    }
+
+    @Test
+    void failsFastWhenNodesSectionMissing() throws IOException {
+        StateFixture fixture = buildState();
+        // blocks + values present, but the entire nodes section is omitted: a stateless snapshot must be
+        // rejected during import, not "succeed" and only blow up at first state access.
+        byte[] v2 = assembleV2(1024,
+                syntheticBlockElements(), null, collectValueElements(fixture.store, fixture.stateRoot));
+
+        BootstrapImporter importer = newImporter(v2, "missing-nodes.bin");
+
+        BootstrapImportException ex = assertThrows(BootstrapImportException.class, importer::importData);
+        assertTrue(ex.getMessage().toLowerCase().contains("state-nodes"), ex.getMessage());
+    }
+
+    @Test
+    void failsFastWhenBlocksSectionMissing() throws IOException {
+        StateFixture fixture = buildState();
+        byte[] v2 = assembleV2(1024,
+                null, collectNodeElements(fixture.store, fixture.stateRoot),
+                collectValueElements(fixture.store, fixture.stateRoot));
+
+        BootstrapImporter importer = newImporter(v2, "missing-blocks.bin");
+
+        BootstrapImportException ex = assertThrows(BootstrapImportException.class, importer::importData);
+        assertTrue(ex.getMessage().toLowerCase().contains("blocks"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsChunkLengthExceedingFileSizeBeforeAllocating() throws IOException {
+        // A chunk whose declared length is far larger than the whole file, yet still under the ~2 GiB
+        // array ceiling (MAX_CHUNK_BYTES). It must be rejected against the bytes actually remaining in the
+        // file instead of being eagerly allocated as a multi-hundred-MB/GB byte[].
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        out.write(BootstrapV2Format.MAGIC);
+        out.writeByte(BootstrapV2Format.VERSION);
+        out.writeByte(BootstrapV2Format.TAG_BLOCKS);
+        out.writeLong(10_000_000L); // corrupt length; no payload follows — the file ends here
+        out.flush();
+
+        BootstrapImporter importer = newImporter(bos.toByteArray(), "corrupt-length.bin");
+
+        BootstrapImportException ex = assertThrows(BootstrapImportException.class, importer::importData);
+        assertTrue(ex.getMessage().toLowerCase().contains("exceeds"), ex.getMessage());
+    }
+
+    @Test
+    void failsWithActionableErrorWhenNodeReferencesMissingLongValue() throws IOException {
+        StateFixture fixture = buildState();
+        assertFalse(collectValueElements(fixture.store, fixture.stateRoot).isEmpty(),
+                "fixture must contain at least one long value");
+        // nodes present (they reference long values by hash) but the values section is emitted empty, so
+        // every long value is absent from the staged store at node-save time. The opaque
+        // IllegalArgumentException from the trie must be translated into an actionable import error.
+        byte[] v2 = assembleV2(1024,
+                syntheticBlockElements(), collectNodeElements(fixture.store, fixture.stateRoot), new ArrayList<>());
+
+        BootstrapImporter importer = newImporter(v2, "missing-value.bin");
+
+        BootstrapImportException ex = assertThrows(BootstrapImportException.class, importer::importData);
+        assertTrue(ex.getMessage().toLowerCase().contains("long value"), ex.getMessage());
+    }
+
+    /** An origin store plus the hash of a saved state trie that mixes short and long values. */
+    private static final class StateFixture {
+        final TrieStore store;
+        final byte[] stateRoot;
+
+        StateFixture(TrieStore store, byte[] stateRoot) {
+            this.store = store;
+            this.stateRoot = stateRoot;
+        }
+    }
+
+    private static StateFixture buildState() {
+        TrieStore store = new TrieStoreImpl(new HashMapDB());
+        Trie trie = new Trie(store);
+        for (int i = 0; i < 32; i++) {
+            byte[] key = ("account/" + i).getBytes(StandardCharsets.UTF_8);
+            byte[] value = (i % 2 == 0) ? ("v" + i).getBytes(StandardCharsets.UTF_8) : longValue(i);
+            trie = trie.put(key, value);
+        }
+        store.save(trie);
+        return new StateFixture(store, trie.getHash().getBytes());
+    }
+
+    /** Writes {@code v2} to a temp file and wires an importer with mocked block plumbing over it. */
+    private BootstrapImporter newImporter(byte[] v2, String fileName) throws IOException {
+        Path binPath = tempDir.resolve(fileName);
+        Files.write(binPath, v2);
+
+        TrieStore destinationStore = new TrieStoreImpl(new HashMapDB());
+        BlockStore blockStore = mock(BlockStore.class);
+        BlockFactory blockFactory = mock(BlockFactory.class);
+        when(blockFactory.decodeBlock(any())).thenReturn(mock(Block.class));
+        BootstrapDataProvider provider = mock(BootstrapDataProvider.class);
+        when(provider.getBootstrapDataPath()).thenReturn(binPath);
+
+        return new BootstrapImporter(
+                blockStore, destinationStore, blockFactory, provider);
+    }
+
+    private static byte[] longValue(int seed) {
+        byte[] v = new byte[40 + (seed % 7)]; // always > 32 bytes
+        for (int i = 0; i < v.length; i++) {
+            v[i] = (byte) (seed * 31 + i);
+        }
+        return v;
+    }
+
+    // --- v2 writer mirroring FileExporter (bootstrap-exporter repo) ---
+
+    private static byte[] writeV2(TrieStore store, byte[] stateRoot, int chunkMax) throws IOException {
+        return assembleV2(chunkMax,
+                syntheticBlockElements(),
+                collectNodeElements(store, stateRoot),
+                collectValueElements(store, stateRoot));
+    }
+
+    /**
+     * Assembles a v2 file from explicit section contents; a {@code null} list omits that section entirely
+     * (so callers can build files that are structurally incomplete to exercise the fail-fast guards).
+     */
+    private static byte[] assembleV2(int chunkMax, List<byte[]> blocks, List<byte[]> nodes, List<byte[]> values)
+            throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        out.write(BootstrapV2Format.MAGIC);
+        out.writeByte(BootstrapV2Format.VERSION);
+        if (blocks != null) {
+            writeSection(out, BootstrapV2Format.TAG_BLOCKS, blocks, chunkMax);
+        }
+        // values are co-located BEFORE the nodes that reference them, so the importer can apply them in a
+        // single streaming pass (values into the destination store, then nodes resolve them at save time).
+        if (values != null) {
+            writeSection(out, BootstrapV2Format.TAG_VALUES, values, chunkMax);
+        }
+        if (nodes != null) {
+            writeSection(out, BootstrapV2Format.TAG_NODES, nodes, chunkMax);
+        }
+        out.writeByte(BootstrapV2Format.TAG_END);
+        out.flush();
+        return bos.toByteArray();
+    }
+
+    /** Writes a tagged section, flushing a chunk whenever the buffer crosses {@code chunkMax}. */
+    private static void writeSection(DataOutputStream out, int tag, List<byte[]> elements, int chunkMax) throws IOException {
+        out.writeByte(tag);
+        ByteArrayOutputStream chunk = new ByteArrayOutputStream();
+        for (byte[] element : elements) {
+            if (chunk.size() > 0 && chunk.size() + element.length > chunkMax) {
+                flushChunk(out, chunk);
+            }
+            chunk.write(element);
+        }
+        if (chunk.size() > 0) {
+            flushChunk(out, chunk);
+        }
+        out.writeLong(0L); // end-of-section sentinel
+    }
+
+    private static void flushChunk(DataOutputStream out, ByteArrayOutputStream chunk) throws IOException {
+        byte[] bytes = chunk.toByteArray();
+        out.writeLong(bytes.length);
+        out.write(bytes);
+        chunk.reset();
+    }
+
+    /**
+     * Mirrors {@code FileExporter#streamStateElements} node emission, reproducing the v1 wire order:
+     * the root element is written explicitly first (so it is emitted even when embeddable), then a full
+     * in-order traversal appends every non-embeddable node. For a non-embeddable root the traversal
+     * re-yields the root, so its element is emitted twice — a deliberate v1 byte-parity property that is
+     * harmless on import, where saving a node by its hash is idempotent.
+     */
+    private static List<byte[]> collectNodeElements(TrieStore store, byte[] stateRoot) {
+        Trie root = store.retrieve(stateRoot).orElseThrow(() -> new AssertionError("missing root"));
+        List<byte[]> nodes = new ArrayList<>();
+        nodes.add(RLP.encodeElement(root.toMessage())); // root first (even if embeddable)
+        Iterator<IterationElement> it = root.getInOrderIterator();
+        while (it.hasNext()) {
+            Trie node = it.next().getNode();
+            if (node.isEmbeddable()) {
+                continue;
+            }
+            // a non-embeddable root is re-emitted here (v1 parity); idempotent on import
+            nodes.add(RLP.encodeElement(node.toMessage()));
+        }
+        return nodes;
+    }
+
+    private static List<byte[]> collectValueElements(TrieStore store, byte[] stateRoot) {
+        Trie root = store.retrieve(stateRoot).orElseThrow(() -> new AssertionError("missing root"));
+        List<byte[]> values = new ArrayList<>();
+        Iterator<IterationElement> it = root.getInOrderIterator();
+        while (it.hasNext()) {
+            Trie node = it.next().getNode();
+            if (node.hasLongValue()) {
+                values.add(RLP.encodeElement(node.getValue()));
+            }
+        }
+        return values;
+    }
+
+    private static List<byte[]> syntheticBlockElements() {
+        // a block tuple is LIST[ ELEMENT(block), ELEMENT(td) ]; the importer hands element 0 to the
+        // (mocked) BlockFactory and element 1 to BlockDifficulty, so arbitrary non-empty bytes suffice.
+        List<byte[]> blocks = new ArrayList<>();
+        for (int i = 1; i <= 3; i++) {
+            byte[] blockBytes = ("block-" + i).getBytes(StandardCharsets.UTF_8);
+            byte[] tdBytes = new byte[]{(byte) i};
+            blocks.add(RLP.encodeList(RLP.encodeElement(blockBytes), RLP.encodeElement(tdBytes)));
+        }
+        return blocks;
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/trie/InOrderIteratorCachingTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/InOrderIteratorCachingTest.java
@@ -1,0 +1,137 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2026 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package co.rsk.trie;
+
+import co.rsk.crypto.Keccak256;
+import org.ethereum.crypto.Keccak256Helper;
+import org.ethereum.datasource.HashMapDB;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for the bootstrap state-export OOM (dominant sink).
+ *
+ * <p>The in-order iterator descends from a caller-held root through {@link Trie#retrieveNode}, which
+ * memoizes every loaded child into its parent {@link NodeReference#getNode()}. Because the root is
+ * pinned for the whole walk, the default (caching) traversal retains the entire visited trie in heap
+ * — O(state size), which OOMs the exporter on large state.
+ *
+ * <p>The non-caching traversal ({@code getInOrderIterator(false)}) must visit the <b>exact same</b>
+ * nodes in the <b>exact same</b> order (so the serialized export stays byte-identical) while NOT
+ * memoizing children into the held root (so the visited sub-trie is collectable and memory stays
+ * bounded to the active path).
+ */
+class InOrderIteratorCachingTest {
+
+    private TrieStore store;
+
+    @BeforeEach
+    void setUp() {
+        this.store = new TrieStoreImpl(new HashMapDB());
+    }
+
+    @Test
+    void nonCachingTraversalVisitsSameNodesInSameOrderAsCaching() {
+        Keccak256 rootHash = buildAndStoreTrie();
+
+        List<Keccak256> caching = collectVisitedHashes(retrieveRoot(rootHash).getInOrderIterator(true));
+        List<Keccak256> nonCaching = collectVisitedHashes(retrieveRoot(rootHash).getInOrderIterator(false));
+
+        assertTrue(caching.size() > 1, "test trie must have more than one node to be meaningful");
+        assertEquals(caching, nonCaching, "non-caching traversal must yield an identical node sequence");
+    }
+
+    @Test
+    void cachingTraversalPinsVisitedTrieToTheHeldRoot() {
+        Keccak256 rootHash = buildAndStoreTrie();
+        Trie root = retrieveRoot(rootHash);
+
+        // Precondition: a freshly retrieved root has non-embedded children that are not yet loaded,
+        // otherwise wasLoaded() below would not distinguish the two traversal modes.
+        assertFalse(root.getLeft().wasLoaded() && root.getRight().wasLoaded(),
+                "freshly retrieved root must have at least one lazy (non-embedded, unloaded) child");
+
+        drain(root.getInOrderIterator(true));
+
+        // The caching traversal memoizes the children back into the held root: the whole visited
+        // sub-trie is now reachable from (and pinned by) the root. This is the leak being fixed.
+        assertTrue(root.getLeft().wasLoaded() || root.getRight().wasLoaded(),
+                "caching traversal is expected to memoize loaded children into the held root");
+    }
+
+    @Test
+    void nonCachingTraversalDoesNotPinVisitedTrieToTheHeldRoot() {
+        Keccak256 rootHash = buildAndStoreTrie();
+        Trie root = retrieveRoot(rootHash);
+
+        assertFalse(root.getLeft().wasLoaded(), "left child must start unloaded");
+        assertFalse(root.getRight().wasLoaded(), "right child must start unloaded");
+
+        drain(root.getInOrderIterator(false));
+
+        // The fix: after a full non-caching walk, the held root never memoized its children, so the
+        // visited sub-trie is not retained through it and memory stays bounded to the active path.
+        assertFalse(root.getLeft().wasLoaded(),
+                "non-caching traversal must not memoize the left child into the held root");
+        assertFalse(root.getRight().wasLoaded(),
+                "non-caching traversal must not memoize the right child into the held root");
+    }
+
+    private Trie retrieveRoot(Keccak256 rootHash) {
+        return store.retrieve(rootHash.getBytes()).orElseThrow(AssertionError::new);
+    }
+
+    /**
+     * Builds a trie wide and deep enough that the root is a branch node whose left and right children
+     * are themselves non-embeddable stored nodes (so they are lazy references after a fresh retrieve).
+     */
+    private Keccak256 buildAndStoreTrie() {
+        Trie trie = new Trie(store);
+        for (int i = 0; i < 256; i++) {
+            byte[] key = Keccak256Helper.keccak256(new byte[]{(byte) i, (byte) (i >> 8)});
+            byte[] value = new byte[40]; // long value -> upper nodes stay non-embeddable
+            value[0] = (byte) i;
+            trie = trie.put(key, value);
+        }
+        store.save(trie);
+        return trie.getHash();
+    }
+
+    private static List<Keccak256> collectVisitedHashes(Iterator<IterationElement> it) {
+        List<Keccak256> hashes = new ArrayList<>();
+        while (it.hasNext()) {
+            hashes.add(it.next().getNode().getHash());
+        }
+        return hashes;
+    }
+
+    private static void drain(Iterator<IterationElement> it) {
+        while (it.hasNext()) {
+            it.next();
+        }
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/trie/TrieStoreImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieStoreImplTest.java
@@ -58,6 +58,14 @@ class TrieStoreImplTest {
     }
 
     @Test
+    void saveValue_rejectsNull() {
+        // new public API: a null value would NPE deep inside hashing; fail fast with a clear message.
+        NullPointerException ex = Assertions.assertThrows(NullPointerException.class, () -> store.saveValue(null));
+        assertTrue(ex.getMessage() != null && ex.getMessage().toLowerCase().contains("value"),
+                String.valueOf(ex.getMessage()));
+    }
+
+    @Test
     void saveTrieNode() {
         Trie trie = new Trie(store).put("foo", "bar".getBytes());
 

--- a/rskj-core/src/test/java/co/rsk/trie/TrieStoreImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/TrieStoreImplTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -43,6 +44,17 @@ class TrieStoreImplTest {
     void setUp() {
         this.map = spy(new HashMapDB());
         this.store = new TrieStoreImpl(map);
+    }
+
+    @Test
+    void saveValue_persistsValueRetrievableByItsHash() {
+        byte[] value = "a-long-value-over-thirty-two-bytes-xx".getBytes(StandardCharsets.UTF_8);
+        byte[] valueHash = Keccak256Helper.keccak256(value);
+
+        store.saveValue(value);
+
+        verify(map, times(1)).put(valueHash, value);
+        assertArrayEquals(value, store.retrieveValue(valueHash));
     }
 
     @Test


### PR DESCRIPTION
Adds a second, size-uncapped `bootstrap-data.bin` format (**v2**) to the import path and the bounded-memory trie traversal the exporter needs to produce it. Two logical parts:

**1. `Add non-caching option to in-order trie traversal`** — threads a `shouldCache` flag through the in-order iterator so a one-pass walk can load child nodes without memoizing them in their parent `NodeReference`. Without it, every visited node stays pinned via the caller-held root, so the retained set grows with the whole visited sub-trie; with caching disabled the retained set stays bounded to the active path (the visiting stack).
- New: `NodeReference#getNode(boolean)`, `Trie#retrieveNode(byte, boolean)`, `Trie#getInOrderIterator(boolean)`, `InOrderIterator(Trie, boolean)`.
- The no-arg methods delegate to the existing caching behaviour, so **current callers are unaffected**. The non-caching path's only consumer is the bootstrap state **export** (separate repo), which otherwise retains the entire trie while serializing it.

**2. `Add bootstrap-data v2 chunked format import`** — the new on-disk format and its streaming importer:
- `BootstrapV2Format` — the self-describing layout: magic `RSKBOOT\n`, version `0x02`, tagged sections (blocks / values / nodes / end), each a sequence of length-prefixed chunks of whole canonical RLP elements. Restated in the exporter (separate repo) so the contract is pinned on both sides. A narrative spec of the format (v1 + v2) is added alongside it as `bootstrap-data-format.md`.
- `BootstrapImporter` peeks the first byte of `bootstrap-data.bin` — `'R'` ⇒ v2, an RLP list prefix (`0xc0`+) ⇒ legacy **v1**. The v1 path is kept byte-for-byte intact (regression-safe for already-published snapshots).
- The v2 path streams the on-disk `.bin` in a **single pass**. The exporter co-locates the `values` section *before* the `nodes` section, so each long value is persisted to the destination store (new `TrieStore.saveValue`) before any node that references it; each node is then saved with `Trie.fromMessage(node, trieStore)` + `trieStore.save(...)`, resolving its long value from that same store at save time (including embeddable long-value children reached via parent recursion). Memory stays bounded regardless of total state size — **no second file scan and no temporary value-staging store** are needed. Per-chunk allocation is bounded to `2 * CHUNK_MAX` and validated against the bytes remaining in the file before any `byte[]` is allocated.
- `BootstrapFileHandler` gains `getBootstrapDataPath()` and now streams the zip SHA-256 (`DigestInputStream`) instead of reading the whole archive into a single `byte[]`, removing the `Integer.MAX_VALUE` ceilings from the signed-hash check. `BootstrapDataProvider` exposes the path.

## Motivation and Context

The exporter cannot produce a **testnet** snapshot: serialized testnet state exceeds the legacy `bootstrap-data.bin` 2 GiB ceiling (measured **2,270,959,945 B = 2.115 GiB** at block 7,780,000, over `Integer.MAX_VALUE`) — a limit baked into both the export framing (a single nested RLP list with `int` length fields) **and** the importer (which read the whole `.bin`/`.zip` into single `byte[]`s and decoded into in-memory queues). The v2 format is self-describing, chunked, streamable, size-uncapped, and bounded-memory on both sides.

## How Has This Been Tested?

**Unit (all green; Spotless + Checkstyle clean):**
- `BootstrapImporterV2Test` — real-`FileExporter`-shaped v2 bytes → importer reconstructs an identical state root; multi-chunk read path (tiny chunk size forcing chunk-spanning sections); empty-values section; first-byte v1/v2 detection; and the hardening guards: missing-nodes-section, missing-blocks-section, node-references-missing-long-value (actionable error), and chunk-length-exceeds-file (rejected before allocation). The new guard tests were written test-first (watched fail, then fixed).
- `BootstrapImporterTest` — v1 legacy path regression, unchanged.
- `InOrderIteratorCachingTest` — the non-caching traversal option (caching vs non-caching memoization behaviour).

**Empirical end-to-end (testnet large state, ~2.1 GiB):**
- **Export** — real `FileExporter` v2, `to=7780000`, `-Xmx5g`, **16,834,819 nodes**, peak RSS 2.62 GB, no OOM, **no 2 GiB ceiling** → `bootstrap-data.zip` 1.7 GB / uncompressed bin **2,270,959,945 B = 2.115 GiB** (> `Integer.MAX_VALUE`, which v1 cannot frame).
- **Import** — fresh node into an isolated DB → `eth_blockNumber` = 7,780,000, **stateRoot identical to origin** (`f9f0f6b9…5f55f480`), block range `[7776001..7780000]` correct, state trie navigable (balance/nonce resolve), node serves RPC.

**Independent local reproduction (byte-level determinism):**
- Re-ran the full export→import round-trip on real >2 GiB testnet state on a separate machine. The freshly-exported `bootstrap-data.bin` is **byte-identical** (SHA-256 `410e6e75…743bb1a3`) to the snapshot produced above from an independently-synced node, and re-imports to the same origin state root. Export peak RSS 1.77 GB, import peak RSS ≤ 4.82 GB (5 GB heap) — bounded on both halves. This confirms the pipeline is deterministic and lossless, not merely state-root-equivalent.

> The exporter half is a separate repo/PR; the cross-repo round-trip above exercises both together.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
  - v1 (legacy) format remains fully supported; format is auto-detected from the first byte, so existing published snapshots import unchanged.
  - A narrative format spec (`bootstrap-data-format.md`) is added next to `BootstrapV2Format`, documenting both v1 and v2.
  - The matching exporter change ships in a separate PR (`bootstrap-exporter`).

 Branches for RIT

`rskj:is/fix-bootstrap-exporter`
`fed:fed/vetiver-9.0.4-rc-do-not-inform`
`rit:VETIVER-9.0.3-rc`