### PR TITLE
RocksDB Compression Feature

### DIFF
--- a/docs/03-node-operators/04-setup/03-configuration/02-cli.md
+++ b/docs/03-node-operators/04-setup/03-configuration/02-cli.md
@@ -242,6 +242,34 @@ In this example, the current database will be migrated from leveldb to rocksdb.
 
 :::
 
+#### CompactRocksDb
+
+The `CompactRocksDb` command compacts every RocksDB data source under `database.dir`.
+
+**Usage:**
+
+`java -cp rsk.jar co.rsk.cli.tools.CompactRocksDb`
+
+**Options:**
+
+- `-c, --compressionType`: Compression type used for the compaction output files (`lz4`, `lz4hc`, `no_compression`, etc.). If omitted, it uses `database.rocksdb.compressionType`.
+
+**Example output:**
+
+```shell
+  INFO [clitool] [main]  CompactRocksDb started
+  INFO [clitool] [main]  Compacting RocksDB data source blocks
+  INFO [clitool] [main]  Compacting RocksDB data source stateRoots
+  INFO [clitool] [main]  Compaction completed for 6 data source(s)
+  INFO [clitool] [main]  CompactRocksDb finished
+```
+
+:::tip[Tip]
+
+This command only supports RocksDB. If your node is configured with another backend, the command exits with an error.
+
+:::
+
 ## Dev-related commands
 
 #### ShowStateInfo

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -135,6 +135,7 @@ import org.ethereum.vm.program.invoke.ProgramInvokeFactory;
 import org.ethereum.vm.program.invoke.ProgramInvokeFactoryImpl;
 import org.mapdb.DB;
 import org.mapdb.DBMaker;
+import org.rocksdb.CompressionType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1242,7 +1243,11 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         Path blocksDbPath = Paths.get(databaseDir, "blocks");
         DbKind currentDbKind = getDbKind(databaseDir);
-        KeyValueDataSource blocksDB = KeyValueDataSourceUtils.makeDataSource(blocksDbPath, currentDbKind);
+        KeyValueDataSource blocksDB = KeyValueDataSourceUtils.makeDataSource(
+                blocksDbPath,
+                currentDbKind,
+                getRocksDbCompressionType()
+        );
 
         return new IndexedBlockStore(getBlockFactory(), blocksDB, new MapDBBlocksIndex(indexDB));
     }
@@ -1361,7 +1366,11 @@ public class RskContext implements NodeContext, NodeBootstrapper {
         int bloomsCacheSize = getRskSystemProperties().getBloomsCacheSize();
         Path bloomsStorePath = Paths.get(getRskSystemProperties().databaseDir(), "blooms");
         DbKind currentDbKind = getDbKind(getRskSystemProperties().databaseDir());
-        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(bloomsStorePath, currentDbKind);
+        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(
+                bloomsStorePath,
+                currentDbKind,
+                getRocksDbCompressionType()
+        );
 
         if (bloomsCacheSize != 0) {
             CacheSnapshotHandler cacheSnapshotHandler = getRskSystemProperties().shouldPersistBloomsCacheSnapshot()
@@ -1444,7 +1453,11 @@ public class RskContext implements NodeContext, NodeBootstrapper {
         int receiptsCacheSize = rskSystemProperties.getReceiptsCacheSize();
         Path receiptsDbPath = Paths.get(rskSystemProperties.databaseDir(), "receipts");
         DbKind currentDbKind = getDbKind(getRskSystemProperties().databaseDir());
-        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(receiptsDbPath, currentDbKind);
+        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(
+                receiptsDbPath,
+                currentDbKind,
+                getRocksDbCompressionType()
+        );
 
         if (receiptsCacheSize != 0) {
             ds = new DataSourceWithCache(ds, receiptsCacheSize);
@@ -1486,7 +1499,11 @@ public class RskContext implements NodeContext, NodeBootstrapper {
         RskSystemProperties rskSystemProperties = getRskSystemProperties();
         int statesCacheSize = rskSystemProperties.getStatesCacheSize();
         DbKind currentDbKind = getDbKind(getRskSystemProperties().databaseDir());
-        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(trieStorePath, currentDbKind);
+        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(
+                trieStorePath,
+                currentDbKind,
+                getRocksDbCompressionType()
+        );
 
         if (statesCacheSize != 0) {
             CacheSnapshotHandler cacheSnapshotHandler = rskSystemProperties.shouldPersistStatesCacheSnapshot()
@@ -1517,7 +1534,11 @@ public class RskContext implements NodeContext, NodeBootstrapper {
         int stateRootsCacheSize = rskSystemProperties.getStateRootsCacheSize();
         Path stateRootsDbPath = Paths.get(rskSystemProperties.databaseDir(), "stateRoots");
         DbKind currentDbKind = getDbKind(getRskSystemProperties().databaseDir());
-        KeyValueDataSource stateRootsDB = KeyValueDataSourceUtils.makeDataSource(stateRootsDbPath, currentDbKind);
+        KeyValueDataSource stateRootsDB = KeyValueDataSourceUtils.makeDataSource(
+                stateRootsDbPath,
+                currentDbKind,
+                getRocksDbCompressionType()
+        );
 
         if (stateRootsCacheSize > 0) {
             stateRootsDB = new DataSourceWithCache(stateRootsDB, stateRootsCacheSize);
@@ -1575,7 +1596,11 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         Path walletDbPath = Paths.get(rskSystemProperties.databaseDir(), "wallet");
         DbKind currentDbKind = getDbKind(getRskSystemProperties().databaseDir());
-        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(walletDbPath, currentDbKind);
+        KeyValueDataSource ds = KeyValueDataSourceUtils.makeDataSource(
+                walletDbPath,
+                currentDbKind,
+                getRocksDbCompressionType()
+        );
 
         return new Wallet(ds);
     }
@@ -1593,6 +1618,10 @@ public class RskContext implements NodeContext, NodeBootstrapper {
         }
 
         return this.blocksBloomDataSource;
+    }
+
+    private CompressionType getRocksDbCompressionType() {
+        return RocksDbDataSource.parseCompressionType(getRskSystemProperties().databaseRocksDbCompressionType());
     }
 
     private TrieStore buildAbstractTrieStore(Path databasePath) {
@@ -1616,7 +1645,12 @@ public class RskContext implements NodeContext, NodeBootstrapper {
                 boolean gcWasEnabled = !multiTrieStorePaths.isEmpty();
                 if (gcWasEnabled) {
                     DbKind currentDbKind = getDbKind(getRskSystemProperties().databaseDir());
-                    KeyValueDataSourceUtils.mergeDataSources(trieStorePath, multiTrieStorePaths, currentDbKind);
+                    KeyValueDataSourceUtils.mergeDataSources(
+                            trieStorePath,
+                            multiTrieStorePaths,
+                            currentDbKind,
+                            getRocksDbCompressionType()
+                    );
                     // cleanup MultiTrieStore data sources
                     multiTrieStorePaths.stream()
                             .map(Path::toString)

--- a/rskj-core/src/main/java/co/rsk/cli/tools/CompactRocksDb.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/CompactRocksDb.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2026 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.cli.tools;
+
+import co.rsk.cli.PicoCliToolRskContextAware;
+import org.ethereum.datasource.DbKind;
+import org.ethereum.datasource.KeyValueDataSource;
+import org.ethereum.datasource.KeyValueDataSourceUtils;
+import org.ethereum.datasource.RocksDbDataSource;
+import org.rocksdb.CompressionType;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Stream;
+
+@CommandLine.Command(name = "compact-rocksdb", mixinStandardHelpOptions = true, version = "compact-rocksdb 1.0",
+        description = "Compacts all RocksDB data sources under database.dir.")
+public class CompactRocksDb extends PicoCliToolRskContextAware {
+
+    @CommandLine.Option(
+            names = {"-c", "--compressionType"},
+            description = "RocksDB compression type to use during compaction (for example: lz4, lz4hc, no_compression). Defaults to database.rocksdb.compressionType."
+    )
+    private String compressionTypeValue;
+
+    public static void main(String[] args) {
+        create(MethodHandles.lookup().lookupClass()).execute(args);
+    }
+
+    @Override
+    public Integer call() throws IOException {
+        String databaseDir = ctx.getRskSystemProperties().databaseDir();
+        DbKind dbKind = ctx.getDbKind(databaseDir);
+
+        if (dbKind != DbKind.ROCKS_DB) {
+            throw new IllegalStateException("compact-rocksdb only supports RocksDB-backed nodes");
+        }
+
+        Path databasePath = Paths.get(databaseDir);
+        String effectiveCompressionTypeValue = compressionTypeValue != null
+                ? compressionTypeValue
+                : ctx.getRskSystemProperties().databaseRocksDbCompressionType();
+        CompressionType compressionType = RocksDbDataSource.parseCompressionType(effectiveCompressionTypeValue);
+        printInfo("Using RocksDB compression type {}", compressionType.name());
+
+        List<Path> dataSourcePaths;
+        try (Stream<Path> databaseEntries = Files.list(databasePath)) {
+            dataSourcePaths = databaseEntries
+                    .filter(Files::isDirectory)
+                    .sorted()
+                    .toList();
+        }
+
+        if (dataSourcePaths.isEmpty()) {
+            printInfo("No RocksDB data sources found in {}", databasePath);
+            return 0;
+        }
+
+        for (Path dataSourcePath : dataSourcePaths) {
+            String dataSourceName = dataSourcePath.getFileName().toString();
+            printInfo("Compacting RocksDB data source {}", dataSourceName);
+
+            KeyValueDataSource dataSource = KeyValueDataSourceUtils.makeDataSource(dataSourcePath, dbKind, compressionType);
+            try {
+                ((RocksDbDataSource) dataSource).compactRange();
+            } finally {
+                dataSource.close();
+            }
+        }
+
+        printInfo("Compaction completed for {} data source(s)", dataSourcePaths.size());
+        return 0;
+    }
+}
+
+

--- a/rskj-core/src/main/java/co/rsk/cli/tools/DbMigrate.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/DbMigrate.java
@@ -22,7 +22,9 @@ import org.ethereum.datasource.DataSourceKeyIterator;
 import org.ethereum.datasource.DbKind;
 import org.ethereum.datasource.KeyValueDataSource;
 import org.ethereum.datasource.KeyValueDataSourceUtils;
+import org.ethereum.datasource.RocksDbDataSource;
 import org.ethereum.util.FileUtil;
+import org.rocksdb.CompressionType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -156,8 +158,19 @@ public class DbMigrate extends PicoCliToolRskContextAware {
     ) {
         logger.info("Preparing data sources for db: {}", dbName);
 
-        KeyValueDataSource sourceDataSource = KeyValueDataSourceUtils.makeDataSource(Paths.get(sourceDbDir, dbName), sourceDbKind);
-        KeyValueDataSource targetDataSource = KeyValueDataSourceUtils.makeDataSource(Paths.get(targetDbDir, dbName), targetDbKind);
+        CompressionType rocksDbCompressionType = RocksDbDataSource.parseCompressionType(
+                ctx.getRskSystemProperties().databaseRocksDbCompressionType()
+        );
+        KeyValueDataSource sourceDataSource = KeyValueDataSourceUtils.makeDataSource(
+                Paths.get(sourceDbDir, dbName),
+                sourceDbKind,
+                rocksDbCompressionType
+        );
+        KeyValueDataSource targetDataSource = KeyValueDataSourceUtils.makeDataSource(
+                Paths.get(targetDbDir, dbName),
+                targetDbKind,
+                rocksDbCompressionType
+        );
 
         logger.info("Data sources prepared successfully");
         logger.info("Preparing indexes for db: {}", dbName);

--- a/rskj-core/src/main/java/co/rsk/cli/tools/ImportState.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/ImportState.java
@@ -24,8 +24,10 @@ import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.crypto.Keccak256Helper;
 import org.ethereum.datasource.DbKind;
 import org.ethereum.datasource.KeyValueDataSource;
+import org.ethereum.datasource.RocksDbDataSource;
 import picocli.CommandLine;
 import org.ethereum.datasource.KeyValueDataSourceUtils;
+import org.rocksdb.CompressionType;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -58,7 +60,14 @@ public class ImportState extends PicoCliToolRskContextAware {
         Path unitrieDbPath = Paths.get(databaseDir, "unitrie");
         DbKind currentDbKind = ctx.getDbKind(databaseDir);
 
-        KeyValueDataSource trieDB = KeyValueDataSourceUtils.makeDataSource(unitrieDbPath, currentDbKind);
+        CompressionType rocksDbCompressionType = RocksDbDataSource.parseCompressionType(
+                rskSystemProperties.databaseRocksDbCompressionType()
+        );
+        KeyValueDataSource trieDB = KeyValueDataSourceUtils.makeDataSource(
+                unitrieDbPath,
+                currentDbKind,
+                rocksDbCompressionType
+        );
 
         try (BufferedReader reader = new BufferedReader(new FileReader(filePath))) {
             importState(reader, trieDB);

--- a/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/rskj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -82,6 +82,7 @@ public abstract class SystemProperties {
     public static final String PROPERTY_BASE_PATH = "database.dir";
     public static final String PROPERTY_DB_RESET = "database.reset";
     public static final String PROPERTY_DB_IMPORT = "database.import.enabled";
+    public static final String PROPERTY_DB_ROCKSDB_COMPRESSION_TYPE = "database.rocksdb.compressionType";
     // TODO review rpc properties
     public static final String PROPERTY_RPC_CORS = "rpc.providers.web.cors";
     public static final String PROPERTY_RPC_HTTP_SERVER_MAX_AGGREGATED_FRAME_SIZE = "rpc.providers.web.http.max_aggregated_frame_size";
@@ -360,6 +361,10 @@ public abstract class SystemProperties {
         return databaseDir == null ? configFromFiles.getString(PROPERTY_BASE_PATH) : databaseDir;
     }
 
+
+    public String databaseRocksDbCompressionType() {
+        return getString(PROPERTY_DB_ROCKSDB_COMPRESSION_TYPE, "no_compression");
+    }
     public Path getLastKnewPeersFilePath() {
         return Paths.get(databaseDir(), LAST_KNEW_PEERS_FILE);
     }

--- a/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/KeyValueDataSourceUtils.java
@@ -1,6 +1,7 @@
 package org.ethereum.datasource;
 
 import org.ethereum.db.ByteArrayWrapper;
+import org.rocksdb.CompressionType;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
@@ -20,6 +21,14 @@ public class KeyValueDataSourceUtils {
 
     @Nonnull
     public static KeyValueDataSource makeDataSource(@Nonnull Path datasourcePath, @Nonnull DbKind kind) {
+        return makeDataSource(datasourcePath, kind, CompressionType.NO_COMPRESSION);
+    }
+
+    @Nonnull
+    public static KeyValueDataSource makeDataSource(
+            @Nonnull Path datasourcePath,
+            @Nonnull DbKind kind,
+            @Nonnull CompressionType rocksDbCompressionType) {
         String name = datasourcePath.getFileName().toString();
         String databaseDir = datasourcePath.getParent().toString();
 
@@ -29,7 +38,7 @@ public class KeyValueDataSourceUtils {
                 ds = new LevelDbDataSource(name, databaseDir);
                 break;
             case ROCKS_DB:
-                ds = new RocksDbDataSource(name, databaseDir);
+                ds = new RocksDbDataSource(name, databaseDir, rocksDbCompressionType);
                 break;
             default:
                 throw new IllegalArgumentException("kind");
@@ -41,15 +50,23 @@ public class KeyValueDataSourceUtils {
     }
 
     public static void mergeDataSources(@Nonnull Path destinationPath, @Nonnull List<Path> originPaths, @Nonnull DbKind kind) {
+        mergeDataSources(destinationPath, originPaths, kind, CompressionType.NO_COMPRESSION);
+    }
+
+    public static void mergeDataSources(
+            @Nonnull Path destinationPath,
+            @Nonnull List<Path> originPaths,
+            @Nonnull DbKind kind,
+            @Nonnull CompressionType rocksDbCompressionType) {
         Map<ByteArrayWrapper, byte[]> mergedStores = new HashMap<>();
         for (Path originPath : originPaths) {
-            KeyValueDataSource singleOriginDataSource = makeDataSource(originPath, kind);
+            KeyValueDataSource singleOriginDataSource = makeDataSource(originPath, kind, rocksDbCompressionType);
             for (ByteArrayWrapper byteArrayWrapper : singleOriginDataSource.keys()) {
                 mergedStores.put(byteArrayWrapper, singleOriginDataSource.get(byteArrayWrapper.getData()));
             }
             singleOriginDataSource.close();
         }
-        KeyValueDataSource destinationDataSource = makeDataSource(destinationPath, kind);
+        KeyValueDataSource destinationDataSource = makeDataSource(destinationPath, kind, rocksDbCompressionType);
         destinationDataSource.updateBatch(mergedStores, Collections.emptySet());
         destinationDataSource.close();
     }

--- a/rskj-core/src/main/java/org/ethereum/datasource/RocksDbDataSource.java
+++ b/rskj-core/src/main/java/org/ethereum/datasource/RocksDbDataSource.java
@@ -53,7 +53,7 @@ public class RocksDbDataSource implements KeyValueDataSource {
     private final String databaseDir;
     private final String name;
 
-    private final Options options = createOptions();
+    private final Options options;
     private RocksDB db;
     private boolean alive;
 
@@ -66,9 +66,33 @@ public class RocksDbDataSource implements KeyValueDataSource {
     private final ReadWriteLock resetDbLock = new ReentrantReadWriteLock();
 
     public RocksDbDataSource(String name, String databaseDir) {
+        this(name, databaseDir, CompressionType.NO_COMPRESSION);
+    }
+
+    public RocksDbDataSource(String name, String databaseDir, CompressionType compressionType) {
         this.databaseDir = databaseDir;
         this.name = name;
+        this.options = createOptions(compressionType);
         logger.info("New RocksDbDataSource: {}", name);
+    }
+
+    public static CompressionType parseCompressionType(String compressionTypeValue) {
+        Objects.requireNonNull(compressionTypeValue, "compressionTypeValue cannot be null");
+
+        String normalizedValue = compressionTypeValue.trim().toUpperCase(Locale.ROOT).replace('-', '_');
+        String enumValue = normalizedValue.endsWith("_COMPRESSION")
+                ? normalizedValue
+                : normalizedValue + "_COMPRESSION";
+
+        try {
+            return CompressionType.valueOf(enumValue);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(String.format(
+                    "Invalid RocksDB compression type '%s'. Supported values: %s",
+                    compressionTypeValue,
+                    Arrays.toString(CompressionType.values())
+            ), e);
+        }
     }
 
     @Override
@@ -271,6 +295,32 @@ public class RocksDbDataSource implements KeyValueDataSource {
         return result;
     }
 
+    public void compactRange() {
+        Metric metric = profiler.start(MetricKind.DB_WRITE);
+        resetDbLock.writeLock().lock();
+
+        try {
+            if (logger.isTraceEnabled()) {
+                logger.trace("~> RocksDbDataSource.compactRange(): {}", name);
+            }
+
+            try (CompactRangeOptions compactRangeOptions = new CompactRangeOptions()) {
+                compactRangeOptions.setBottommostLevelCompaction(CompactRangeOptions.BottommostLevelCompaction.kForce);
+                db.compactRange(db.getDefaultColumnFamily(), null, null, compactRangeOptions);
+            }
+
+            if (logger.isTraceEnabled()) {
+                logger.trace("<~ RocksDbDataSource.compactRange(): {}", name);
+            }
+        } catch (RocksDBException e) {
+            logger.error("Exception compacting DB {}", name, e);
+            throw new RuntimeException(e);
+        } finally {
+            resetDbLock.writeLock().unlock();
+            profiler.stop(metric);
+        }
+    }
+
     private void updateBatchInternal(Map<ByteArrayWrapper, byte[]> rows, Set<ByteArrayWrapper> deleteKeys) {
         Metric metric = profiler.start(MetricKind.DB_WRITE);
         if (rows.containsKey(null) || rows.containsValue(null)) {
@@ -363,10 +413,11 @@ public class RocksDbDataSource implements KeyValueDataSource {
         // All is flushed immediately: there is no uncommittedCache to flush
     }
 
-    private static Options createOptions() {
+    private static Options createOptions(CompressionType compressionType) {
         Options options = new Options();
         options.setCreateIfMissing(true);
-        options.setCompressionType(CompressionType.NO_COMPRESSION);
+        options.setCompressionType(compressionType);
+        options.setBottommostCompressionType(compressionType);
         options.setArenaBlockSize(GENERAL_SIZE);
         options.setWriteBufferSize(GENERAL_SIZE);
         options.setParanoidChecks(true);

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -273,6 +273,20 @@ database {
         #url = ""
         trusted-keys = []
     }
+
+    rocksdb {
+        # Compression to use when keyvalue.datasource = rocksdb.
+        # Allowed values (case-insensitive):
+        # - no_compression
+        # - snappy_compression
+        # - zlib_compression
+        # - bzlib2_compression
+        # - lz4_compression
+        # - lz4hc_compression
+        # - xpress_compression
+        # - zstd_compression
+        compressionType = no_compression
+    }
 }
 
 # Interface to bind peer discovery and wire protocol

--- a/rskj-core/src/test/java/co/rsk/cli/tools/CompactRocksDbTest.java
+++ b/rskj-core/src/test/java/co/rsk/cli/tools/CompactRocksDbTest.java
@@ -1,0 +1,119 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2026 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.cli.tools;
+
+import co.rsk.RskContext;
+import co.rsk.config.RskSystemProperties;
+import co.rsk.util.NodeStopper;
+import org.ethereum.datasource.DbKind;
+import org.ethereum.datasource.KeyValueDataSource;
+import org.ethereum.datasource.KeyValueDataSourceUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class CompactRocksDbTest {
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void compactsEveryDataSourceInDatabaseDir() {
+        String databaseDir = tempDir.resolve("db").toString();
+
+        Path blocksPath = Paths.get(databaseDir, "blocks");
+        Path stateRootsPath = Paths.get(databaseDir, "stateRoots");
+
+        putEntry(
+                blocksPath,
+                "key-blocks".getBytes(StandardCharsets.UTF_8),
+                "value-blocks".getBytes(StandardCharsets.UTF_8)
+        );
+        putEntry(
+                stateRootsPath,
+                "key-state".getBytes(StandardCharsets.UTF_8),
+                "value-state".getBytes(StandardCharsets.UTF_8)
+        );
+
+        RskContext rskContext = mock(RskContext.class);
+        RskSystemProperties rskSystemProperties = mock(RskSystemProperties.class);
+        NodeStopper stopper = mock(NodeStopper.class);
+
+        doReturn(rskSystemProperties).when(rskContext).getRskSystemProperties();
+        doReturn(databaseDir).when(rskSystemProperties).databaseDir();
+        doReturn("no_compression").when(rskSystemProperties).databaseRocksDbCompressionType();
+        doReturn(DbKind.ROCKS_DB).when(rskSystemProperties).databaseKind();
+        doReturn(DbKind.ROCKS_DB).when(rskContext).getDbKind(databaseDir);
+
+        CompactRocksDb compactRocksDb = new CompactRocksDb();
+        compactRocksDb.execute(new String[]{"--compressionType", "lz4"}, () -> rskContext, stopper);
+
+        verify(stopper).stop(0);
+
+        assertArrayEquals(
+                "value-blocks".getBytes(StandardCharsets.UTF_8),
+                getEntry(blocksPath, "key-blocks".getBytes(StandardCharsets.UTF_8))
+        );
+        assertArrayEquals(
+                "value-state".getBytes(StandardCharsets.UTF_8),
+                getEntry(stateRootsPath, "key-state".getBytes(StandardCharsets.UTF_8))
+        );
+    }
+
+    @Test
+    void failsWhenCurrentDatabaseKindIsNotRocksDb() {
+        String databaseDir = tempDir.resolve("db").toString();
+
+        RskContext rskContext = mock(RskContext.class);
+        RskSystemProperties rskSystemProperties = mock(RskSystemProperties.class);
+        NodeStopper stopper = mock(NodeStopper.class);
+
+        doReturn(rskSystemProperties).when(rskContext).getRskSystemProperties();
+        doReturn(databaseDir).when(rskSystemProperties).databaseDir();
+        doReturn(DbKind.LEVEL_DB).when(rskSystemProperties).databaseKind();
+        doReturn(DbKind.LEVEL_DB).when(rskContext).getDbKind(databaseDir);
+
+        CompactRocksDb compactRocksDb = new CompactRocksDb();
+        compactRocksDb.execute(new String[]{}, () -> rskContext, stopper);
+
+        verify(stopper).stop(1);
+    }
+
+    private static void putEntry(Path dataSourcePath, byte[] key, byte[] value) {
+        KeyValueDataSource dataSource = KeyValueDataSourceUtils.makeDataSource(dataSourcePath, DbKind.ROCKS_DB);
+        dataSource.put(key, value);
+        dataSource.close();
+    }
+
+    private static byte[] getEntry(Path dataSourcePath, byte[] key) {
+        KeyValueDataSource dataSource = KeyValueDataSourceUtils.makeDataSource(dataSourcePath, DbKind.ROCKS_DB);
+        byte[] value = dataSource.get(key);
+        dataSource.close();
+        return value;
+    }
+}
+
+

--- a/rskj-core/src/test/java/org/ethereum/datasource/RocksDbDataSourceTest.java
+++ b/rskj-core/src/test/java/org/ethereum/datasource/RocksDbDataSourceTest.java
@@ -33,7 +33,10 @@ import org.mockito.MockedConstruction;
 import org.mockito.Mockito;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
+import org.rocksdb.CompressionType;
 import org.rocksdb.WriteBatch;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.CompactRangeOptions;
 
 import java.nio.file.Path;
 import java.time.Duration;
@@ -92,6 +95,47 @@ class RocksDbDataSourceTest {
         } catch (RocksDBException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Test
+    void parseCompressionTypeSupportsLowerSnakeCaseValues() {
+        CompressionType compressionType = RocksDbDataSource.parseCompressionType("no_compression");
+
+        assertEquals(CompressionType.NO_COMPRESSION, compressionType);
+    }
+
+    @Test
+    void parseCompressionTypeSupportsValuesWithoutCompressionSuffix() {
+        CompressionType compressionType = RocksDbDataSource.parseCompressionType("snappy");
+
+        assertEquals(CompressionType.SNAPPY_COMPRESSION, compressionType);
+    }
+
+    @Test
+    void parseCompressionTypeRejectsUnknownValues() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> RocksDbDataSource.parseCompressionType("unknown_compression")
+        );
+
+        assertTrue(exception.getMessage().contains("Invalid RocksDB compression type"));
+    }
+
+    @Test
+    void compactRangeCompactsWholeDataSource() throws RocksDBException {
+        RocksDB db = Mockito.mock(RocksDB.class);
+        ColumnFamilyHandle defaultColumnFamily = Mockito.mock(ColumnFamilyHandle.class);
+        Mockito.when(db.getDefaultColumnFamily()).thenReturn(defaultColumnFamily);
+        TestUtils.setInternalState(dataSource, "db", db);
+
+        dataSource.compactRange();
+
+        verify(db, times(1)).compactRange(
+                eq(defaultColumnFamily),
+                isNull(),
+                isNull(),
+                any(CompactRangeOptions.class)
+        );
     }
 
     @Test


### PR DESCRIPTION
# RocksDB Compression Feature

## PR Summary

This feature has a favorable effort/benefit ratio: adoption effort is low (property-based toggle plus optional compaction), while storage savings are meaningful on real data (~19.6% in this run) and potentially much higher for calldata-heavy/rollup-like workloads (up to ~80% in synthetic tests).

Compression is configurable via properties, defaults to `no_compression`, and can be enabled/disabled without an offline pre-conversion step, so current nodes are not affected unless operators opt in.

## Overview

This change introduces configurable RocksDB compression and a maintenance compaction flow to rewrite existing SST files with the selected codec.

The implementation includes:

- Configurable RocksDB compression type via node configuration.
- Compression propagation across runtime data sources and maintenance tools.
- Full-range RocksDB compaction support, including bottommost-level compaction.
- A CLI tool to compact all databases under `database.dir` with an optional compression override.

## Mainnet Results (up to ~9M blocks)

Compression/compaction was executed on a mainnet database snapshot up to approximately block 9,000,000.

| DB | Before | After | Reduction | Reduction % |
|---|---:|---:|---:|---:|
| `blocks` | 39G | 27G | 12G | 30.8% |
| `blooms` | 1.9G | 264M | 1.636G | 86.1% |
| `receipts` | 27G | 8.0G | 19G | 70.4% |
| `stateRoots` | 2.0G | 407M | 1.593G | 79.7% |
| `unitrie` | 130G | 125G | 5G | 3.8% |
| **Total** | **199.9G** | **160.671G** | **39.229G** | **19.6%** |

### Notes

- The overall reduction is significant (~19.6%), with the largest gains in `receipts`, `blocks`, `blooms`, and `stateRoots`.
- `unitrie` shows limited reduction, which is consistent with hash-heavy/high-entropy data (e.g., Keccak-oriented content) being less compressible.

## Synthetic Data Results

In synthetic data testing with calldata-heavy payloads (simulating rollup-like behavior), compression achieved approximately **80% size reduction**.

This indicates that compression effectiveness is strongly dependent on data characteristics, and calldata-dense workloads can benefit substantially more than hash-dominated state structures.

## Operational and Rollout Considerations

- This feature should be tested in more detail for performance before broad adoption, including CPU overhead, compaction duration, and read/write latency under realistic workloads.
- Compression is property-driven and can be enabled or disabled via configuration.
- The default behavior remains unchanged (`no_compression`), so current nodes are not impacted unless compression is explicitly enabled.
- Enabling compression should be treated as **experimental** in this stage.
- Enabling or disabling the option does not require an offline pre-conversion step; nodes can switch configuration and data is handled on the fly.

## Conclusion

The feature provides meaningful storage savings on real mainnet data and very strong gains for calldata-heavy synthetic workloads. It also offers operational flexibility through configurable codecs and explicit compaction tooling. The implementation is low effort to adopt, safe by default, and potentially high impact for rollup-oriented data profiles.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
