### PR TITLE
Fix invalid port handling in IpUtils

### DIFF
--- a/rskj-core/src/main/java/co/rsk/util/IpUtils.java
+++ b/rskj-core/src/main/java/co/rsk/util/IpUtils.java
@@ -53,6 +53,10 @@ public class IpUtils {
     }
 
     private static InetSocketAddress parseMatch(Matcher matcher) {
-        return new InetSocketAddress(matcher.group(1), Integer.valueOf(matcher.group(2)));
+        try {
+            return new InetSocketAddress(matcher.group(1), Integer.valueOf(matcher.group(2)));
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 }

--- a/rskj-core/src/main/java/co/rsk/util/IpUtils.java
+++ b/rskj-core/src/main/java/co/rsk/util/IpUtils.java
@@ -56,6 +56,12 @@ public class IpUtils {
         try {
             return new InetSocketAddress(matcher.group(1), Integer.valueOf(matcher.group(2)));
         } catch (IllegalArgumentException e) {
+            logger.warn(
+                    "Invalid address with host '{}' and port '{}': {}",
+                    matcher.group(1),
+                    matcher.group(2),
+                    e.getMessage()
+            );
             return null;
         }
     }

--- a/rskj-core/src/test/java/co/rsk/util/IpUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/util/IpUtilsTest.java
@@ -56,6 +56,18 @@ class IpUtilsTest {
     }
 
     @Test
+    void parsePortAboveMaximum() {
+        InetSocketAddress result = IpUtils.parseAddress("localhost:65536");
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    void parsePortLargerThanInteger() {
+        InetSocketAddress result = IpUtils.parseAddress("localhost:999999999999999999999");
+        Assertions.assertNull(result);
+    }
+
+    @Test
     void parseAddresses() {
         List<String> addresses = new ArrayList<>();
         addresses.add(IPV6_WITH_PORT);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Make `IpUtils.parseAddress` return `null` for invalid numeric ports instead of propagating an `IllegalArgumentException`.
- Add regression tests for ports above `65535` and values exceeding the integer range.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


`parseAddress` already uses `null` to represent invalid address formats, and `parseAddresses` skips those entries. However, numeric port strings pass the regular expression and can still throw when the port is out of range or cannot be represented as an integer.

This change keeps invalid-address handling consistent and prevents a malformed boot node entry from interrupting peer discovery initialization.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- `IpUtilsTest`: 9 tests passed
- Added coverage for:
  - a port above the maximum valid value
  - a numeric port larger than the integer range

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
