### PR TITLE
Feat/add max tx size integration

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Java & Gradle
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 #v5.2.0
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'gradle'
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1503,11 +1503,7 @@ public class BridgeSupport {
         }
 
         List<ReleaseRequestQueue.Entry> pegoutEntries = pegoutRequests.getEntries();
-        Coin totalPegoutRequestsValue = pegoutEntries
-            .stream()
-            .map(ReleaseRequestQueue.Entry::getAmount)
-            .reduce(Coin.ZERO, Coin::add);
-
+        Coin totalPegoutRequestsValue = sumPegoutValues(pegoutEntries);
         if (wallet.getBalance().isLessThan(totalPegoutRequestsValue)) {
             logger.warn(
                 "[processPegoutsInBatch] wallet balance {} is less than the totalPegoutValue {}",
@@ -1550,8 +1546,11 @@ public class BridgeSupport {
                 result.responseCode()
             );
 
+            Coin batchedPegoutRequestsValue = sumPegoutValues(pegoutEntries);
+            Coin pegoutValueToUse = activations.isActive(ConsensusRule.RSKIP378) ? batchedPegoutRequestsValue : totalPegoutRequestsValue;
+
             Keccak256 batchPegoutCreationTxHash = rskTx.getHash();
-            settleReleaseRequest(utxosToUse, pegoutsWaitingForConfirmations, batchPegoutTransaction, batchPegoutCreationTxHash, totalPegoutRequestsValue);
+            settleReleaseRequest(utxosToUse, pegoutsWaitingForConfirmations, batchPegoutTransaction, batchPegoutCreationTxHash, pegoutValueToUse);
 
             // Remove batched requests from the queue after successfully batching pegouts
             pegoutRequests.removeEntries(pegoutEntries);
@@ -1561,7 +1560,7 @@ public class BridgeSupport {
                 pegoutEntries.stream().map(ReleaseRequestQueue.Entry::getRskTxHash).toList()
             );
 
-            adjustBalancesIfChangeOutputWasDust(batchPegoutTransaction, totalPegoutRequestsValue, wallet);
+            adjustBalancesIfChangeOutputWasDust(batchPegoutTransaction, pegoutValueToUse, wallet);
         }
 
         // set the next pegout creation block number when there are no pending pegout requests to be processed,
@@ -1571,6 +1570,12 @@ public class BridgeSupport {
             provider.setNextPegoutHeight(nextPegoutHeight);
             logger.info("[processPegoutsInBatch] Next Pegout Height updated from {} to {}", currentBlockNumber, nextPegoutHeight);
         }
+    }
+
+    private static Coin sumPegoutValues(List<ReleaseRequestQueue.Entry> entries) {
+        return entries.stream()
+            .map(ReleaseRequestQueue.Entry::getAmount)
+            .reduce(Coin.ZERO, Coin::add);
     }
 
     /**

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -17,7 +17,7 @@
  */
 package co.rsk.peg;
 
-import static co.rsk.peg.BridgeUtils.calculatePegoutTxSize;
+import static co.rsk.peg.BridgeUtils.simulatePegoutTxSize;
 import static co.rsk.peg.BridgeUtils.getRegularPegoutTxSize;
 import static co.rsk.peg.PegUtils.*;
 import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
@@ -1225,7 +1225,7 @@ public class BridgeSupport {
     }
 
     private Coin calculateSvpSpendTxFees(Federation proposedFederation) {
-        int svpSpendTransactionSize = calculatePegoutTxSize(activations, proposedFederation, 2, 1);
+        int svpSpendTransactionSize = simulatePegoutTxSize(activations, proposedFederation, 2, 1);
         long svpSpendTransactionBackedUpSize = svpSpendTransactionSize * 12L / 10L; // just to be sure the fees sent will be enough
 
         return feePerKbSupport.getFeePerKb()
@@ -2629,20 +2629,21 @@ public class BridgeSupport {
     public Coin getEstimatedFeesForNextPegOutEvent() throws IOException {
         //  This method returns the fees of a peg-out transaction containing (N+2) outputs and 2 inputs,
         //  where N is the number of peg-outs requests waiting in the queue.
-
-        int pegoutRequestsCount = getQueuedPegoutsCount();
-
-        if (!activations.isActive(ConsensusRule.RSKIP385) &&
-            (!activations.isActive(ConsensusRule.RSKIP271) || pegoutRequestsCount == 0)) {
+        if (shouldReturnZeroEstimatedFees()) {
             return Coin.ZERO;
         }
 
-        if(!activations.isActive(RSKIP305)) {
+        if (!activations.isActive(RSKIP305)) {
             return getEstimatedFeesFromInputsAndOutputsCount();
         }
 
         return getEstimatedFeesFromPegoutTransactionSimulation();
+    }
 
+    private boolean shouldReturnZeroEstimatedFees() throws IOException {
+        int pegoutRequestsCount = getQueuedPegoutsCount();
+        return !activations.isActive(ConsensusRule.RSKIP385) &&
+            (!activations.isActive(ConsensusRule.RSKIP271) || pegoutRequestsCount == 0);
     }
 
     public Coin getEstimatedFeesForPegOutAmount(co.rsk.core.Coin pegoutAmountInWeis) throws IOException, BridgeIllegalArgumentException {
@@ -2658,11 +2659,10 @@ public class BridgeSupport {
     }
 
     private Coin getEstimatedFeesFromInputsAndOutputsCount() throws IOException {
-
         int outputsCount = getQueuedPegoutsCount() + 2;
         int inputsCount = 2;
 
-        int pegoutTxSize = BridgeUtils.calculatePegoutTxSize(activations, getActiveFederation(), inputsCount, outputsCount);
+        int pegoutTxSize = simulatePegoutTxSize(activations, getActiveFederation(), inputsCount, outputsCount);
 
         Coin feePerKB = getFeePerKb();
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1477,11 +1477,11 @@ public class BridgeSupport {
                 return false;
             }
 
-            BtcTransaction generatedTransaction = result.btcTx();
+            BtcTransaction pegoutTransaction = result.btcTx();
             Keccak256 pegoutCreationTxHash = pegoutRequest.getRskTxHash();
-            settleReleaseRequest(utxosToUse, pegoutsWaitingForConfirmations, generatedTransaction, pegoutCreationTxHash, pegoutRequest.getAmount());
+            settleReleaseRequest(utxosToUse, pegoutsWaitingForConfirmations, pegoutTransaction, pegoutCreationTxHash, pegoutRequest.getAmount());
 
-            adjustBalancesIfChangeOutputWasDust(generatedTransaction, pegoutRequest.getAmount(), wallet);
+            adjustBalancesIfChangeOutputWasDust(pegoutTransaction, pegoutRequest.getAmount(), wallet);
 
             return true;
         });
@@ -1659,26 +1659,26 @@ public class BridgeSupport {
     }
 
     /**
-     * If federation change output value had to be increased to be non-dust, the federation now has
-     * more BTC than it should. So, we burn some sBTC to make balances match.
+     * If federation change output value had to be increased to be non-dust, it will send less BTC
+     * than the received rBTC. So, we burn some rBTC to make balances match.
      *
-     * @param btcTx      The btc tx that was just completed
-     * @param sentByUser The number of sBTC originaly sent by the user
+     * @param pegoutTx      The pegout tx
+     * @param amountPeggedOut The pegged-out rBTC amount
      */
-    private void adjustBalancesIfChangeOutputWasDust(BtcTransaction btcTx, Coin sentByUser, Wallet wallet) {
-        if (btcTx.getOutputs().size() <= 1) {
+    private void adjustBalancesIfChangeOutputWasDust(BtcTransaction pegoutTx, Coin amountPeggedOut, Wallet wallet) {
+        if (pegoutTx.getOutputs().size() <= 1) {
             // If there is no change, do-nothing
             return;
         }
         Coin sumInputs = Coin.ZERO;
-        for (TransactionInput transactionInput : btcTx.getInputs()) {
+        for (TransactionInput transactionInput : pegoutTx.getInputs()) {
             sumInputs = sumInputs.add(transactionInput.getValue());
         }
 
-        Coin change = btcTx.getValueSentToMe(wallet);
+        Coin change = pegoutTx.getValueSentToMe(wallet);
         Coin spentByFederation = sumInputs.subtract(change);
-        if (spentByFederation.isLessThan(sentByUser)) {
-            Coin coinsToBurn = sentByUser.subtract(spentByFederation);
+        if (spentByFederation.isLessThan(amountPeggedOut)) {
+            Coin coinsToBurn = amountPeggedOut.subtract(spentByFederation);
             this.transferTo(BURN_ADDRESS, co.rsk.core.Coin.fromBitcoin(coinsToBurn));
         }
     }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1156,7 +1156,7 @@ public class BridgeSupport {
         ReleaseTransactionBuilder txBuilder = new ReleaseTransactionBuilder(
             btcContext.getParams(),
             activeFederationWallet,
-            activeFederation.getFormatVersion(),
+            activeFederation,
             activeFederation.getAddress(),
             getFeePerKb(),
             activations
@@ -1359,11 +1359,10 @@ public class BridgeSupport {
         }
 
         // Pegouts are attempted using the currently active federation.
-        int activeFederationFormatVersion = getActiveFederation().getFormatVersion();
         final ReleaseTransactionBuilder txBuilder = new ReleaseTransactionBuilder(
                 btcContext.getParams(),
                 activeFederationWallet,
-                activeFederationFormatVersion,
+                getActiveFederation(),
                 getActiveFederationAddress(),
                 getFeePerKb(),
                 activations
@@ -2687,7 +2686,7 @@ public class BridgeSupport {
         ReleaseTransactionBuilder txBuilder = new ReleaseTransactionBuilder(
             btcContext.getParams(),
             activeFederationWallet,
-            activeFederation.getFormatVersion(),
+            activeFederation,
             activeFederation.getAddress(),
             getFeePerKb(),
             activations
@@ -3073,7 +3072,7 @@ public class BridgeSupport {
             ReleaseTransactionBuilder txBuilder = new ReleaseTransactionBuilder(
                 networkParameters,
                 retiringFederationWallet,
-                retiringFederation.getFormatVersion(),
+                retiringFederation,
                 destinationAddress,
                 getFeePerKb(),
                 activations
@@ -3239,7 +3238,7 @@ public class BridgeSupport {
         ReleaseTransactionBuilder txBuilder = new ReleaseTransactionBuilder(
             btcContext.getParams(),
             wallet,
-            federation.getFormatVersion(),
+            federation,
             btcRefundAddress,
             getFeePerKb(),
             activations

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1506,7 +1506,7 @@ public class BridgeSupport {
         Coin totalPegoutRequestsValue = sumPegoutValues(pegoutEntries);
         if (wallet.getBalance().isLessThan(totalPegoutRequestsValue)) {
             logger.warn(
-                "[processPegoutsInBatch] wallet balance {} is less than the totalPegoutValue {}",
+                "[processPegoutsInBatch] Wallet balance {} is less than the total pegout requests value {}",
                 wallet.getBalance(),
                 totalPegoutRequestsValue
             );
@@ -1541,7 +1541,7 @@ public class BridgeSupport {
             BtcTransaction batchPegoutTransaction = result.btcTx();
             Sha256Hash batchPegoutTxHash = batchPegoutTransaction.getHash();
             logger.info(
-                "[processPegoutsInBatch] pegouts processed with btcTx hash {} and response code {}",
+                "[processPegoutsInBatch] Pegouts processed with btcTx hash {} and response code {}",
                 batchPegoutTxHash,
                 result.responseCode()
             );
@@ -1665,10 +1665,10 @@ public class BridgeSupport {
 
     /**
      * If federation change output value had to be increased to be non-dust, it will send less BTC
-     * than the received rBTC. So, we burn some rBTC to make balances match.
+     * than the received RBTC. So, we burn some RBTC to make balances match.
      *
      * @param pegoutTx      The pegout tx
-     * @param amountPeggedOut The pegged-out rBTC amount
+     * @param amountPeggedOut The pegged-out RBTC amount
      */
     private void adjustBalancesIfChangeOutputWasDust(BtcTransaction pegoutTx, Coin amountPeggedOut, Wallet wallet) {
         if (pegoutTx.getOutputs().size() <= 1) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1503,18 +1503,26 @@ public class BridgeSupport {
         }
 
         List<ReleaseRequestQueue.Entry> pegoutEntries = pegoutRequests.getEntries();
-        Coin totalPegoutValue = pegoutEntries
+        Coin totalPegoutRequestsValue = pegoutEntries
             .stream()
             .map(ReleaseRequestQueue.Entry::getAmount)
             .reduce(Coin.ZERO, Coin::add);
 
-        if (wallet.getBalance().isLessThan(totalPegoutValue)) {
-            logger.warn("[processPegoutsInBatch] wallet balance {} is less than the totalPegoutValue {}", wallet.getBalance(), totalPegoutValue);
+        if (wallet.getBalance().isLessThan(totalPegoutRequestsValue)) {
+            logger.warn(
+                "[processPegoutsInBatch] wallet balance {} is less than the totalPegoutValue {}",
+                wallet.getBalance(),
+                totalPegoutRequestsValue
+            );
             return;
         }
 
         if (!pegoutEntries.isEmpty()) {
-            logger.info("[processPegoutsInBatch] going to create a batched pegout transaction for {} requests, total amount {}", pegoutEntries.size(), totalPegoutValue);
+            logger.info(
+                "[processPegoutsInBatch] Going to create a batched pegout transaction for {} requests, total amount {}",
+                pegoutEntries.size(),
+                totalPegoutRequestsValue
+            );
             ReleaseTransactionBuilder.BuildResult result = txBuilder.buildBatchedPegouts(pegoutEntries);
 
             while (pegoutEntries.size() > 1 && result.responseCode() == ReleaseTransactionBuilder.Response.EXCEED_MAX_TRANSACTION_SIZE) {
@@ -1528,30 +1536,36 @@ public class BridgeSupport {
                 logger.warn(
                     "Couldn't build a pegout BTC tx for {} pending requests (total amount: {}), Reason: {}",
                     pegoutRequests.getEntries().size(),
-                    totalPegoutValue,
-                    result.responseCode());
+                    totalPegoutRequestsValue,
+                    result.responseCode()
+                );
                 return;
             }
 
+            BtcTransaction batchPegoutTransaction = result.btcTx();
+            Sha256Hash batchPegoutTxHash = batchPegoutTransaction.getHash();
             logger.info(
                 "[processPegoutsInBatch] pegouts processed with btcTx hash {} and response code {}",
-                result.btcTx().getHash(), result.responseCode());
+                batchPegoutTxHash,
+                result.responseCode()
+            );
 
-            BtcTransaction batchPegoutTransaction = result.btcTx();
             Keccak256 batchPegoutCreationTxHash = rskTx.getHash();
-
-            settleReleaseRequest(utxosToUse, pegoutsWaitingForConfirmations, batchPegoutTransaction, batchPegoutCreationTxHash, totalPegoutValue);
+            settleReleaseRequest(utxosToUse, pegoutsWaitingForConfirmations, batchPegoutTransaction, batchPegoutCreationTxHash, totalPegoutRequestsValue);
 
             // Remove batched requests from the queue after successfully batching pegouts
             pegoutRequests.removeEntries(pegoutEntries);
 
-            eventLogger.logBatchPegoutCreated(batchPegoutTransaction.getHash(),
-                pegoutEntries.stream().map(ReleaseRequestQueue.Entry::getRskTxHash).toList());
+            eventLogger.logBatchPegoutCreated(
+                batchPegoutTxHash,
+                pegoutEntries.stream().map(ReleaseRequestQueue.Entry::getRskTxHash).toList()
+            );
 
-            adjustBalancesIfChangeOutputWasDust(batchPegoutTransaction, totalPegoutValue, wallet);
+            adjustBalancesIfChangeOutputWasDust(batchPegoutTransaction, totalPegoutRequestsValue, wallet);
         }
 
-        // set the next pegout creation block number when there are no pending pegout requests to be processed or they have been already processed
+        // set the next pegout creation block number when there are no pending pegout requests to be processed,
+        // or they have been already processed
         if (pegoutRequests.getEntries().isEmpty()) {
             long nextPegoutHeight = currentBlockNumber + bridgeConstants.getNumberOfBlocksBetweenPegouts();
             provider.setNextPegoutHeight(nextPegoutHeight);
@@ -2694,7 +2708,7 @@ public class BridgeSupport {
 
         ReleaseTransactionBuilder.BuildResult buildResult = txBuilder.buildBatchedPegouts(releaseRequestListCopy);
 
-        if(buildResult.responseCode() != ReleaseTransactionBuilder.Response.SUCCESS) {
+        if (buildResult.responseCode() != ReleaseTransactionBuilder.Response.SUCCESS) {
             logger.debug(
                 "[getEstimatedFeesFromPegoutTransactionSimulation] Simulated pegout btc transaction failed to be created with response code: {}.",
                 buildResult.responseCode()

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -1525,6 +1525,7 @@ public class BridgeSupport {
                 logger.info("[processPegoutsInBatch] Max size exceeded, going to divide {} requests in half", pegoutEntries.size());
                 int firstHalfSize = pegoutEntries.size() / 2;
                 pegoutEntries = pegoutEntries.subList(0, firstHalfSize);
+                logger.info("[processPegoutsInBatch] Trying to process {} requests", pegoutEntries.size());
                 result = txBuilder.buildBatchedPegouts(pegoutEntries);
             }
 
@@ -1540,14 +1541,16 @@ public class BridgeSupport {
 
             BtcTransaction batchPegoutTransaction = result.btcTx();
             Sha256Hash batchPegoutTxHash = batchPegoutTransaction.getHash();
-            logger.info(
-                "[processPegoutsInBatch] Pegouts processed with btcTx hash {} and response code {}",
-                batchPegoutTxHash,
-                result.responseCode()
-            );
 
             Coin batchedPegoutRequestsValue = sumPegoutValues(pegoutEntries);
             Coin pegoutValueToUse = activations.isActive(ConsensusRule.RSKIP378) ? batchedPegoutRequestsValue : totalPegoutRequestsValue;
+
+            logger.info(
+                "[processPegoutsInBatch] Processing {} across {} requests in btcTx {}",
+                pegoutValueToUse.getValue(),
+                pegoutEntries.size(),
+                batchPegoutTxHash
+            );
 
             Keccak256 batchPegoutCreationTxHash = rskTx.getHash();
             settleReleaseRequest(utxosToUse, pegoutsWaitingForConfirmations, batchPegoutTransaction, batchPegoutCreationTxHash, pegoutValueToUse);

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -30,7 +30,6 @@ import co.rsk.core.RskAddress;
 import co.rsk.peg.bitcoin.RskAllowUnconfirmedCoinSelector;
 import co.rsk.peg.btcLockSender.BtcLockSender.TxSenderAddressType;
 import co.rsk.peg.federation.Federation;
-import co.rsk.peg.federation.FederationFormatVersion;
 import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.feeperkb.constants.FeePerKbConstants;
 import co.rsk.peg.flyover.FlyoverTxResponseCodes;
@@ -630,7 +629,7 @@ public final class BridgeUtils {
         final int INPUT_MULTIPLIER = 2;
         final int OUTPUT_MULTIPLIER = 2;
 
-        return calculatePegoutTxSize(
+        return simulatePegoutTxSize(
             activations,
             federation,
             INPUT_MULTIPLIER,
@@ -638,68 +637,67 @@ public final class BridgeUtils {
         );
     }
 
-    public static int calculatePegoutTxSize(ActivationConfig.ForBlock activations, Federation federation, int inputsCount, int outputsCount) {
-
+    public static int simulatePegoutTxSize(
+        ActivationConfig.ForBlock activations, 
+        Federation federation, 
+        int inputsCount, 
+        int outputsCount
+    ) {
         if (inputsCount < 1 || outputsCount < 1) {
-            throw new IllegalArgumentException("Inputs or outputs should be more than 1");
+            throw new IllegalArgumentException("Inputs and outputs should be at least 1");
         }
 
-        if (!activations.isActive(ConsensusRule.RSKIP271)) {
-            return BridgeUtilsLegacy.calculatePegoutTxSize(activations, federation, inputsCount, outputsCount);
+        if (!activations.isActive(ConsensusRule.RSKIP378)) {
+            return BridgeUtilsLegacy.simulatePegoutTxSize(activations, federation, inputsCount, outputsCount);
         }
 
-        boolean isSegwit = federation.getFormatVersion() == FederationFormatVersion.P2SH_P2WSH_ERP_FEDERATION.getFormatVersion();
-
-        return isSegwit
-            ? calculateSegwitTxSize(federation, inputsCount, outputsCount)
-            : calculateLegacyTxSize(federation, inputsCount, outputsCount);
+        return simulateSegwitPegoutVSize(federation, inputsCount, outputsCount);
     }
 
-    private static int calculateLegacyTxSize(Federation federation, int inputsCount, int outputsCount) {
+    private static int simulateSegwitPegoutVSize(Federation federation, int inputsCount, int outputsCount) {
         BtcTransaction tx = new BtcTransaction(federation.getBtcParams());
 
+        // add representative inputs to simulate calculation
+        Sha256Hash prevTxHash = Sha256Hash.ZERO_HASH;
+        int outputIndex = 0;
+        int segwitCompatibleScriptSigSize = 36;
+        Script segwitCompatibleScriptSig = new Script(new byte[segwitCompatibleScriptSigSize]);
         for (int i = 0; i < inputsCount; i++) {
-            tx.addInput(Sha256Hash.ZERO_HASH, 0, federation.getRedeemScript());
+            tx.addInput(prevTxHash, outputIndex, segwitCompatibleScriptSig);
         }
-
+        // add representative outputs to simulate calculation
         for (int i = 0; i < outputsCount; i++) {
             tx.addOutput(Coin.ZERO, federation.getAddress());
         }
 
-        int baseSize = calculateTxBaseSize(tx, inputsCount, false);
-        int signingSize = getSigningSize(federation.getNumberOfSignaturesRequired(), inputsCount);
-        return baseSize + signingSize;
+        return estimateUnsignedSegwitTxVSize(tx, federation);
     }
 
-    private static int calculateSegwitTxSize(Federation federation, int inputsCount, int outputsCount) {
-        BtcTransaction tx = new BtcTransaction(federation.getBtcParams());
-
-        for (int i = 0; i < outputsCount; i++) {
-            tx.addOutput(Coin.ZERO, federation.getAddress());
-        }
-
-        int baseSize = calculateTxBaseSize(tx, inputsCount, true);
-        int signingSize = getSigningSize(federation.getNumberOfSignaturesRequired(), inputsCount);
-        int totalSize = baseSize + signingSize + (inputsCount * federation.getRedeemScript().getProgram().length);
-        // As described in BIP141
-        int txWeight = totalSize + (3 * baseSize);
+    public static int estimateUnsignedSegwitTxVSize(BtcTransaction tx, Federation federation) {
+        int txWeight = estimateUnsignedSegwitTxWeight(tx, federation);
         return txWeight / 4;
     }
 
-    private static int getSigningSize(int numberOfSignaturesRequired, int inputsCount) {
-        int signatureSize = 72;
-        return numberOfSignaturesRequired * inputsCount * signatureSize;
+    private static int estimateUnsignedSegwitTxWeight(BtcTransaction tx, Federation federation) {
+        int inputsCount = tx.getInputs().size();
+        int signingSize = estimateSigningSize(federation.getNumberOfSignaturesRequired(), inputsCount);
+
+        // extra bytes per input: stack-item count (1b)
+        // + OP_0 (1b)
+        // + OP_NOTIF (1b)
+        // + redeemScript push-length prefix (~3b)
+        int extraBytes = 6;
+        int redeemScriptProgramLength = federation.getRedeemScript().getProgram().length;
+        int witnessData = inputsCount * (redeemScriptProgramLength + extraBytes);
+
+        int baseSize = BitcoinUtils.getTransactionWithoutWitness(tx).bitcoinSerialize().length;
+        int totalSize = baseSize + signingSize + witnessData;
+        // As described in BIP141
+        return totalSize + (3 * baseSize);
     }
 
-    private static int calculateTxBaseSize(BtcTransaction tx, int inputsCount, boolean isSegwit) {
-        int baseSize = tx.bitcoinSerialize().length;
-
-        if (isSegwit) {
-            final int SEGWIT_COMPATIBLE_SCRIPT_SIG_SIZE = 36;
-            baseSize += inputsCount * SEGWIT_COMPATIBLE_SCRIPT_SIG_SIZE;
-        }
-
-        return baseSize;
+    private static int estimateSigningSize(int numberOfSignaturesRequired, int inputsCount) {
+        int signatureSize = 73; // 72b upper bound signature length + 1b push-length prefix
+        return inputsCount * (numberOfSignaturesRequired * signatureSize);
     }
-
 }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -680,24 +680,44 @@ public final class BridgeUtils {
 
     private static int estimateUnsignedSegwitTxWeight(BtcTransaction tx, Federation federation) {
         int inputsCount = tx.getInputs().size();
-        int signingSize = estimateSigningSize(federation.getNumberOfSignaturesRequired(), inputsCount);
-
-        // extra bytes per input: stack-item count (1b)
-        // + OP_0 (1b)
-        // + OP_NOTIF (1b)
-        // + redeemScript push-length prefix (~3b)
-        int extraBytes = 6;
-        int redeemScriptProgramLength = federation.getRedeemScript().getProgram().length;
-        int witnessData = inputsCount * (redeemScriptProgramLength + extraBytes);
+        int signingSizePerInput = estimateSigningSizePerInput(federation);
+        int witnessData = inputsCount * signingSizePerInput;
 
         int baseSize = BitcoinUtils.getTransactionWithoutWitness(tx).bitcoinSerialize().length;
-        int totalSize = baseSize + signingSize + witnessData;
+        int totalSize = baseSize + witnessData;
         // As described in BIP141
         return totalSize + (3 * baseSize);
     }
 
-    private static int estimateSigningSize(int numberOfSignaturesRequired, int inputsCount) {
-        int signatureSize = 73; // 72b upper bound signature length + 1b push-length prefix
-        return inputsCount * (numberOfSignaturesRequired * signatureSize);
+    private static int estimateSigningSizePerInput(Federation federation) {
+        int numberOfSignaturesRequired = federation.getNumberOfSignaturesRequired();
+        // estimate the bytes of pushing the following stack in each input:
+        // [stack item count]
+        // [OP_0]
+        // [signature 1]
+        // ...
+        // [signature N]
+        // [OP_NOTIF]
+        // [redeem script]
+        long stackItemCount = 1L + numberOfSignaturesRequired + 1L + 1L; // OP_0 + N sigs pushes + OP_NOTIF + rs push
+        int stackItemCountSize = new VarInt(stackItemCount).getSizeInBytes();
+
+        int op0Size = 1;
+
+        int signatureLength = 72; // 72b is the upper bound signature length
+        int signaturePushPrefixSize = new VarInt(signatureLength).getSizeInBytes();
+        int signaturePushSize = signaturePushPrefixSize + signatureLength;
+
+        int opNotifSize = 1;
+
+        int redeemScriptLength = federation.getRedeemScript().getProgram().length;
+        int redeemScriptPushPrefixSize = new VarInt(redeemScriptLength).getSizeInBytes();
+        int redeemScriptPushSize = redeemScriptPushPrefixSize + redeemScriptLength;
+
+        return stackItemCountSize
+            + op0Size
+            + (signaturePushSize * numberOfSignaturesRequired)
+            + opNotifSize
+            + redeemScriptPushSize;
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -691,7 +691,7 @@ public final class BridgeUtils {
 
     private static int estimateSigningSizePerInput(Federation federation) {
         int numberOfSignaturesRequired = federation.getNumberOfSignaturesRequired();
-        // estimate the bytes of pushing the following stack in each input:
+        // the following stack will be pushed in each input:
         // [stack item count]
         // [OP_0]
         // [signature 1]
@@ -699,16 +699,20 @@ public final class BridgeUtils {
         // [signature N]
         // [OP_NOTIF]
         // [redeem script]
+        // witness stack per input (BIP144): item-count varint, then length-prefixed byte vectors.
+        // 1B empty (OP_CHECKMULTISIG) + N sig pushes + 1B empty (OP_NOTIF selector) + redeemScript push,
+        // so "op0"/"opNotif" are the empty elements' roles in script exec
+
         long stackItemCount = 1L + numberOfSignaturesRequired + 1L + 1L; // OP_0 + N sigs pushes + OP_NOTIF + rs push
         int stackItemCountSize = new VarInt(stackItemCount).getSizeInBytes();
 
-        int op0Size = 1;
+        int op0Size = 1; // empty element = single 0x00 length prefix
 
-        int signatureLength = 72; // 72b is the upper bound signature length
+        int signatureLength = 73; // 73b is the upper bound signature length -without low S, r and s each up to 33 bytes-
         int signaturePushPrefixSize = new VarInt(signatureLength).getSizeInBytes();
         int signaturePushSize = signaturePushPrefixSize + signatureLength;
 
-        int opNotifSize = 1;
+        int opNotifSize = 1; // empty element = single 0x00 length prefix
 
         int redeemScriptLength = federation.getRedeemScript().getProgram().length;
         int redeemScriptPushPrefixSize = new VarInt(redeemScriptLength).getSizeInBytes();

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtilsLegacy.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtilsLegacy.java
@@ -1,12 +1,8 @@
 package co.rsk.peg;
 
-import co.rsk.bitcoinj.core.Address;
-import co.rsk.bitcoinj.core.BtcTransaction;
-import co.rsk.bitcoinj.core.Coin;
-import co.rsk.bitcoinj.core.NetworkParameters;
-import co.rsk.bitcoinj.core.TransactionOutput;
-import co.rsk.bitcoinj.core.UTXO;
+import co.rsk.bitcoinj.core.*;
 import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationFormatVersion;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 
@@ -24,21 +20,30 @@ public class BridgeUtilsLegacy {
     }
 
     @Deprecated
-    protected static int calculatePegoutTxSize(ActivationConfig.ForBlock activations,
-                                               Federation federation,
-                                               int inputs,
-                                               int outputs) {
-
-        if (inputs < 1 || outputs < 1) {
-            throw new IllegalArgumentException("Inputs or outputs should be more than 1");
+    protected static int simulatePegoutTxSize(
+        ActivationConfig.ForBlock activations,
+        Federation federation,
+        int inputsCount,
+        int outputsCount
+    ) {
+        if (inputsCount < 1 || outputsCount < 1) {
+            throw new IllegalArgumentException("Inputs and outputs should be at least than 1");
         }
 
-        if (activations.isActive(ConsensusRule.RSKIP271)) {
+        if (activations.isActive(ConsensusRule.RSKIP378)) {
             throw new DeprecatedMethodCallException(
-                "Calling BridgeUtilsLegacy.calculatePegoutTxSize method after RSKIP271 activation"
+                "Calling BridgeUtilsLegacy.simulatePegoutTxSize method after RSKIP378 activation"
             );
         }
 
+        if (!activations.isActive(ConsensusRule.RSKIP271)) {
+            return simulatePegoutTxSizePreHOP(federation, inputsCount, outputsCount);
+        }
+
+        return simulatePegoutTxSizePreTBD100(federation, inputsCount, outputsCount);
+    }
+
+    private static int simulatePegoutTxSizePreHOP(Federation federation, int inputsCount, int outputsCount) {
         final int SIGNATURE_MULTIPLIER = 71;
         final int OUTPUT_SIZE = 25;
         // This data accounts for txid+vout+sequence
@@ -51,8 +56,63 @@ public class BridgeUtilsLegacy {
         final int scriptSigChunk = federation.getNumberOfSignaturesRequired() * (SIGNATURE_MULTIPLIER + 1) +
             federation.getRedeemScript().getProgram().length + 1;
         return TX_ADDITIONAL_DATA_SIZE +
-            (scriptSigChunk + INPUT_ADDITIONAL_DATA_SIZE) * inputs +
-            (OUTPUT_SIZE + 1 + OUTPUT_ADDITIONAL_DATA_SIZE) * outputs;
+            (scriptSigChunk + INPUT_ADDITIONAL_DATA_SIZE) * inputsCount +
+            (OUTPUT_SIZE + 1 + OUTPUT_ADDITIONAL_DATA_SIZE) * outputsCount;
+    }
+
+    private static int simulatePegoutTxSizePreTBD100(Federation federation, int inputsCount, int outputsCount) {
+        boolean isLegacyFed = federation.getFormatVersion() != FederationFormatVersion.P2SH_P2WSH_ERP_FEDERATION.getFormatVersion();
+
+        return isLegacyFed
+            ? simulateLegacyTxSizePreTBD100(federation, inputsCount, outputsCount)
+            : simulateSegwitTxSizePreTBD100(federation, inputsCount, outputsCount);
+    }
+
+    private static int simulateLegacyTxSizePreTBD100(Federation federation, int inputsCount, int outputsCount) {
+        BtcTransaction tx = new BtcTransaction(federation.getBtcParams());
+
+        for (int i = 0; i < inputsCount; i++) {
+            tx.addInput(Sha256Hash.ZERO_HASH, 0, federation.getRedeemScript());
+        }
+
+        for (int i = 0; i < outputsCount; i++) {
+            tx.addOutput(Coin.ZERO, federation.getAddress());
+        }
+
+        int baseSize = calculateTxBaseSize(tx, inputsCount, false);
+        int signingSize = getSigningSize(federation.getNumberOfSignaturesRequired(), inputsCount);
+        return baseSize + signingSize;
+    }
+
+    private static int simulateSegwitTxSizePreTBD100(Federation federation, int inputsCount, int outputsCount) {
+        BtcTransaction tx = new BtcTransaction(federation.getBtcParams());
+
+        for (int i = 0; i < outputsCount; i++) {
+            tx.addOutput(Coin.ZERO, federation.getAddress());
+        }
+
+        int baseSize = calculateTxBaseSize(tx, inputsCount, true);
+        int signingSize = getSigningSize(federation.getNumberOfSignaturesRequired(), inputsCount);
+        int totalSize = baseSize + signingSize + (inputsCount * federation.getRedeemScript().getProgram().length);
+        // As described in BIP141
+        int txWeight = totalSize + (3 * baseSize);
+        return txWeight / 4;
+    }
+
+    private static int calculateTxBaseSize(BtcTransaction tx, int inputsCount, boolean isSegwit) {
+        int baseSize = tx.bitcoinSerialize().length;
+
+        if (isSegwit) {
+            final int SEGWIT_COMPATIBLE_SCRIPT_SIG_SIZE = 36;
+            baseSize += inputsCount * SEGWIT_COMPATIBLE_SCRIPT_SIG_SIZE;
+        }
+
+        return baseSize;
+    }
+
+    private static int getSigningSize(int numberOfSignaturesRequired, int inputsCount) {
+        int signatureSize = 72;
+        return numberOfSignaturesRequired * inputsCount * signatureSize;
     }
 
     @Deprecated

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtilsLegacy.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtilsLegacy.java
@@ -27,7 +27,7 @@ public class BridgeUtilsLegacy {
         int outputsCount
     ) {
         if (inputsCount < 1 || outputsCount < 1) {
-            throw new IllegalArgumentException("Inputs and outputs should be at least than 1");
+            throw new IllegalArgumentException("Inputs and outputs should be at least 1");
         }
 
         if (activations.isActive(ConsensusRule.RSKIP378)) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtilsLegacy.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtilsLegacy.java
@@ -84,6 +84,8 @@ public class BridgeUtilsLegacy {
         return baseSize + signingSize;
     }
 
+    // this old calculation had a bug: it wasn't adding inputs to simulate the size,
+    // and in calculateTxBaseSize we were just adding the bytes from the script sig
     private static int simulateSegwitTxSizePreTBD100(Federation federation, int inputsCount, int outputsCount) {
         BtcTransaction tx = new BtcTransaction(federation.getBtcParams());
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtilsLegacy.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtilsLegacy.java
@@ -40,7 +40,7 @@ public class BridgeUtilsLegacy {
             return simulatePegoutTxSizePreHOP(federation, inputsCount, outputsCount);
         }
 
-        return simulatePegoutTxSizePreTBD100(federation, inputsCount, outputsCount);
+        return simulatePegoutTxSizePreTBD1000(federation, inputsCount, outputsCount);
     }
 
     private static int simulatePegoutTxSizePreHOP(Federation federation, int inputsCount, int outputsCount) {
@@ -60,15 +60,15 @@ public class BridgeUtilsLegacy {
             (OUTPUT_SIZE + 1 + OUTPUT_ADDITIONAL_DATA_SIZE) * outputsCount;
     }
 
-    private static int simulatePegoutTxSizePreTBD100(Federation federation, int inputsCount, int outputsCount) {
+    private static int simulatePegoutTxSizePreTBD1000(Federation federation, int inputsCount, int outputsCount) {
         boolean isLegacyFed = federation.getFormatVersion() != FederationFormatVersion.P2SH_P2WSH_ERP_FEDERATION.getFormatVersion();
 
         return isLegacyFed
-            ? simulateLegacyTxSizePreTBD100(federation, inputsCount, outputsCount)
-            : simulateSegwitTxSizePreTBD100(federation, inputsCount, outputsCount);
+            ? simulateLegacyTxSizePreTBD1000(federation, inputsCount, outputsCount)
+            : simulateSegwitTxSizePreTBD1000(federation, inputsCount, outputsCount);
     }
 
-    private static int simulateLegacyTxSizePreTBD100(Federation federation, int inputsCount, int outputsCount) {
+    private static int simulateLegacyTxSizePreTBD1000(Federation federation, int inputsCount, int outputsCount) {
         BtcTransaction tx = new BtcTransaction(federation.getBtcParams());
 
         for (int i = 0; i < inputsCount; i++) {
@@ -86,7 +86,7 @@ public class BridgeUtilsLegacy {
 
     // this old calculation had a bug: it wasn't adding inputs to simulate the size,
     // and in calculateTxBaseSize we were just adding the bytes from the script sig
-    private static int simulateSegwitTxSizePreTBD100(Federation federation, int inputsCount, int outputsCount) {
+    private static int simulateSegwitTxSizePreTBD1000(Federation federation, int inputsCount, int outputsCount) {
         BtcTransaction tx = new BtcTransaction(federation.getBtcParams());
 
         for (int i = 0; i < outputsCount; i++) {

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
@@ -104,7 +104,7 @@ public class ReleaseTransactionBuilder {
 
     public BuildResult buildBatchedPegouts(List<ReleaseRequestQueue.Entry> entries) {
         if (entries.isEmpty()) {
-            throw new IllegalStateException("cannot create batched pegouts tx when no existing requests");
+            throw new IllegalArgumentException("cannot create batched pegouts tx when no existing requests");
         }
 
         return buildWithConfiguration((SendRequest sr) -> {

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
@@ -40,7 +40,6 @@ import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.FederationFormatVersion;
 import java.util.List;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.slf4j.Logger;
@@ -61,7 +60,6 @@ public class ReleaseTransactionBuilder {
     private static final Logger logger = LoggerFactory.getLogger(ReleaseTransactionBuilder.class);
 
     private static final int MAX_STANDARD_TX_SIZE_SAFETY_MARGIN = 10_000;
-    @VisibleForTesting
     protected static final int MAX_STANDARD_TX_SIZE_ALLOWED = MAX_STANDARD_TX_SIZE - MAX_STANDARD_TX_SIZE_SAFETY_MARGIN;
 
     private final NetworkParameters params;

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
@@ -58,6 +58,9 @@ public class ReleaseTransactionBuilder {
 
     private static final Logger logger = LoggerFactory.getLogger(ReleaseTransactionBuilder.class);
 
+    private static final int MAX_STANDARD_TX_SIZE_SAFETY_MARGIN = 10_000;
+    private static final int MAX_STANDARD_TX_SIZE_ALLOWED = MAX_STANDARD_TX_SIZE - MAX_STANDARD_TX_SIZE_SAFETY_MARGIN;
+
     private final NetworkParameters params;
     private final Wallet wallet;
     private final Federation federation;
@@ -206,7 +209,7 @@ public class ReleaseTransactionBuilder {
             inputsCount,
             outputsCount
         );
-        if (btcTxVSize > MAX_STANDARD_TX_SIZE) {
+        if (btcTxVSize > MAX_STANDARD_TX_SIZE_ALLOWED) {
             throw new Wallet.ExceededMaxTransactionSize();
         }
     }

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
@@ -151,7 +151,7 @@ public class ReleaseTransactionBuilder {
 
         try {
             completeTx(sr);
-            checkTxVSize(btcTx);
+            validateTx(btcTx);
 
             // Disconnect input from output because we don't need the reference and it interferes serialization
             for (TransactionInput transactionInput : btcTx.getInputs()) {
@@ -192,22 +192,16 @@ public class ReleaseTransactionBuilder {
         }
     }
 
-    private void checkTxVSize(BtcTransaction btcTx) {
+    private void validateTx(BtcTransaction btcTx) {
         if (!activations.isActive(ConsensusRule.RSKIP378)) {
-            return;
-        }
-
-        int inputsCount = btcTx.getInputs().size();
-        int outputsCount = btcTx.getOutputs().size();
-        if (inputsCount == 0 || outputsCount == 0) {
             return;
         }
 
         int btcTxVSize = BridgeUtils.calculatePegoutTxSize(
             activations,
             federation,
-            inputsCount,
-            outputsCount
+            btcTx.getInputs().size(),
+            btcTx.getOutputs().size()
         );
         if (btcTxVSize > MAX_STANDARD_TX_SIZE_ALLOWED) {
             throw new Wallet.ExceededMaxTransactionSize();

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
@@ -39,6 +39,8 @@ import co.rsk.crypto.Keccak256;
 import co.rsk.peg.federation.Federation;
 import co.rsk.peg.federation.FederationFormatVersion;
 import java.util.List;
+
+import com.google.common.annotations.VisibleForTesting;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.slf4j.Logger;
@@ -59,7 +61,8 @@ public class ReleaseTransactionBuilder {
     private static final Logger logger = LoggerFactory.getLogger(ReleaseTransactionBuilder.class);
 
     private static final int MAX_STANDARD_TX_SIZE_SAFETY_MARGIN = 10_000;
-    private static final int MAX_STANDARD_TX_SIZE_ALLOWED = MAX_STANDARD_TX_SIZE - MAX_STANDARD_TX_SIZE_SAFETY_MARGIN;
+    @VisibleForTesting
+    protected static final int MAX_STANDARD_TX_SIZE_ALLOWED = MAX_STANDARD_TX_SIZE - MAX_STANDARD_TX_SIZE_SAFETY_MARGIN;
 
     private final NetworkParameters params;
     private final Wallet wallet;
@@ -102,6 +105,10 @@ public class ReleaseTransactionBuilder {
     }
 
     public BuildResult buildBatchedPegouts(List<ReleaseRequestQueue.Entry> entries) {
+        if (entries.isEmpty()) {
+            throw new IllegalStateException("cannot create batched pegouts tx when no existing requests");
+        }
+
         return buildWithConfiguration((SendRequest sr) -> {
             for (ReleaseRequestQueue.Entry entry : entries) {
                 sr.tx.addOutput(entry.getAmount(), entry.getDestination());
@@ -197,12 +204,7 @@ public class ReleaseTransactionBuilder {
             return;
         }
 
-        int btcTxVSize = BridgeUtils.calculatePegoutTxSize(
-            activations,
-            federation,
-            btcTx.getInputs().size(),
-            btcTx.getOutputs().size()
-        );
+        int btcTxVSize = BridgeUtils.estimateUnsignedSegwitTxVSize(btcTx, federation);
         if (btcTxVSize > MAX_STANDARD_TX_SIZE_ALLOWED) {
             throw new Wallet.ExceededMaxTransactionSize();
         }
@@ -247,10 +249,10 @@ public class ReleaseTransactionBuilder {
             return;
         }
 
-        signSegwitTxInputs(sr.tx);
+        addBaseScriptForSegwitTxInputs(sr.tx);
     }
 
-    private void signSegwitTxInputs(BtcTransaction tx) {
+    private void addBaseScriptForSegwitTxInputs(BtcTransaction tx) {
         for (int i = 0; i < tx.getInputs().size(); i++) {
             TransactionInput txInput = tx.getInput(i);
             RedeemData redeemData = txInput.getConnectedRedeemData(wallet);

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
@@ -18,10 +18,9 @@
 
 package co.rsk.peg;
 
+import static co.rsk.bitcoinj.core.BtcTransaction.MAX_STANDARD_TX_SIZE;
 import static co.rsk.peg.PegUtils.getFlyoverFederationAddress;
-import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_1;
-import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
-import static co.rsk.peg.bitcoin.BitcoinUtils.addSpendingFederationBaseScript;
+import static co.rsk.peg.bitcoin.BitcoinUtils.*;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import co.rsk.bitcoinj.core.Address;
@@ -61,7 +60,7 @@ public class ReleaseTransactionBuilder {
 
     private final NetworkParameters params;
     private final Wallet wallet;
-    private final int federationFormatVersion;
+    private final Federation federation;
     private final Address changeAddress;
     private final Coin feePerKb;
     private final ActivationConfig.ForBlock activations;
@@ -69,24 +68,24 @@ public class ReleaseTransactionBuilder {
     /**
      * Creates a release transaction builder.
      *
-     * @param params                        network params
-     * @param wallet                        wallet to be used to build the release tx
-     * @param federationFormatVersion       needed to correctly set the redeem input data (script sig for legacy fed, witness for segwit fed)
-     * @param changeAddress                 address to send change to
-     * @param feePerKb                      fee per kb
-     * @param activations                   activations
+     * @param params        network params
+     * @param wallet        wallet to be used to build the release tx
+     * @param federation    needed to correctly create the tx depending on fed format
+     * @param changeAddress address to send change to
+     * @param feePerKb      fee per kb
+     * @param activations   activations
      */
     public ReleaseTransactionBuilder(
         NetworkParameters params,
         Wallet wallet,
-        int federationFormatVersion,
+        Federation federation,
         Address changeAddress,
         Coin feePerKb,
         ActivationConfig.ForBlock activations
     ) {
         this.params = params;
         this.wallet = wallet;
-        this.federationFormatVersion = federationFormatVersion;
+        this.federation = federation;
         this.changeAddress = changeAddress;
         this.feePerKb = feePerKb;
         this.activations = activations;
@@ -149,6 +148,7 @@ public class ReleaseTransactionBuilder {
 
         try {
             completeTx(sr);
+            checkTxVSize(btcTx);
 
             // Disconnect input from output because we don't need the reference and it interferes serialization
             for (TransactionInput transactionInput : btcTx.getInputs()) {
@@ -189,6 +189,28 @@ public class ReleaseTransactionBuilder {
         }
     }
 
+    private void checkTxVSize(BtcTransaction btcTx) {
+        if (!activations.isActive(ConsensusRule.RSKIP378)) {
+            return;
+        }
+
+        int inputsCount = btcTx.getInputs().size();
+        int outputsCount = btcTx.getOutputs().size();
+        if (inputsCount == 0 || outputsCount == 0) {
+            return;
+        }
+
+        int btcTxVSize = BridgeUtils.calculatePegoutTxSize(
+            activations,
+            federation,
+            inputsCount,
+            outputsCount
+        );
+        if (btcTxVSize > MAX_STANDARD_TX_SIZE) {
+            throw new Wallet.ExceededMaxTransactionSize();
+        }
+    }
+
     private BtcTransaction setDefaultReleaseTxConfig() {
         // Build a tx and send request and configure it
         BtcTransaction btcTx = new BtcTransaction(params);
@@ -206,7 +228,7 @@ public class ReleaseTransactionBuilder {
         // Specific settings
         sendRequestConfigurator.configure(sr);
 
-        if (federationFormatVersion == FederationFormatVersion.P2SH_P2WSH_ERP_FEDERATION.getFormatVersion()) {
+        if (federation.getFormatVersion() == FederationFormatVersion.P2SH_P2WSH_ERP_FEDERATION.getFormatVersion()) {
             sr.signInputs = false;
             sr.isSegwitCompatible = true;
         }
@@ -238,7 +260,7 @@ public class ReleaseTransactionBuilder {
             checkNotNull(redeemData, "Transaction exists in wallet that we cannot redeem: %s", txInput.getOutpoint().getHash());
             Script redeemScript = redeemData.redeemScript;
 
-            addSpendingFederationBaseScript(tx, i, redeemScript, federationFormatVersion);
+            addSpendingFederationBaseScript(tx, i, redeemScript, federation.getFormatVersion());
         }
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
+++ b/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java
@@ -204,6 +204,7 @@ public class ReleaseTransactionBuilder {
 
         int btcTxVSize = BridgeUtils.estimateUnsignedSegwitTxVSize(btcTx, federation);
         if (btcTxVSize > MAX_STANDARD_TX_SIZE_ALLOWED) {
+            logger.warn("Btc tx {} vSize is {} which exceeds the max tx size allowed of {} vbytes", btcTx.getHash(), btcTxVSize, MAX_STANDARD_TX_SIZE_ALLOWED);
             throw new Wallet.ExceededMaxTransactionSize();
         }
     }

--- a/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/bitcoin/BitcoinUtils.java
@@ -19,7 +19,6 @@ import org.slf4j.LoggerFactory;
 public class BitcoinUtils {
     public static final int BTC_TX_VERSION_1 = 1;
     public static final int BTC_TX_VERSION_2 = 2;
-
     protected static final byte[] WITNESS_COMMITMENT_HEADER = Hex.decode("aa21a9ed");
     protected static final int WITNESS_COMMITMENT_LENGTH = WITNESS_COMMITMENT_HEADER.length + Sha256Hash.LENGTH;
 

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeConstants.java
@@ -43,8 +43,6 @@ public abstract class BridgeConstants {
 
     protected int updateBridgeExecutionPeriod;
 
-    protected int maxBtcHeadersPerRskBlock;
-
     protected Coin legacyMinimumPeginTxValue;
     protected Coin minimumPeginTxValue;
     protected Coin legacyMinimumPegoutTxValue;
@@ -95,8 +93,6 @@ public abstract class BridgeConstants {
     }
 
     public int getUpdateBridgeExecutionPeriod() { return updateBridgeExecutionPeriod; }
-
-    public int getMaxBtcHeadersPerRskBlock() { return maxBtcHeadersPerRskBlock; }
 
     public Coin getMinimumPeginTxValue(ActivationConfig.ForBlock activations) {
         return activations.isActive(ConsensusRule.RSKIP219) ? minimumPeginTxValue : legacyMinimumPeginTxValue;

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeMainNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeMainNetConstants.java
@@ -24,8 +24,6 @@ public class BridgeMainNetConstants extends BridgeConstants {
 
         updateBridgeExecutionPeriod = 3 * 60 * 1000; // 3 minutes
 
-        maxBtcHeadersPerRskBlock = 500;
-
         legacyMinimumPeginTxValue = Coin.valueOf(1_000_000);
         legacyMinimumPegoutTxValue = Coin.valueOf(800_000);
         minimumPeginTxValue = Coin.valueOf(500_000);

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeRegTestConstants.java
@@ -57,8 +57,6 @@ public class BridgeRegTestConstants extends BridgeConstants {
 
         updateBridgeExecutionPeriod = 15_000; //15 seconds in millis
 
-        maxBtcHeadersPerRskBlock = 500;
-
         legacyMinimumPeginTxValue = Coin.valueOf(1_000_000);
         minimumPeginTxValue = Coin.valueOf(500_000);
         legacyMinimumPegoutTxValue = Coin.valueOf(500_000);

--- a/rskj-core/src/main/java/co/rsk/peg/constants/BridgeTestNetConstants.java
+++ b/rskj-core/src/main/java/co/rsk/peg/constants/BridgeTestNetConstants.java
@@ -42,8 +42,6 @@ public class BridgeTestNetConstants extends BridgeConstants {
 
         updateBridgeExecutionPeriod = 3 * 60 * 1000; // 3 minutes
 
-        maxBtcHeadersPerRskBlock = 500;
-
         legacyMinimumPeginTxValue = Coin.valueOf(1_000_000);
         minimumPeginTxValue = Coin.valueOf(500_000);
         legacyMinimumPegoutTxValue = Coin.valueOf(500_000);

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -88,6 +88,7 @@ public enum ConsensusRule {
     RSKIP375("rskip375"),
     RSKIP376("rskip376"),
     RSKIP377("rskip377"),
+    RSKIP378("rskip378"), // Recalculate pegout value used when the batch is split
     RSKIP379("rskip379"),
     RSKIP383("rskip383"),
     RSKIP385("rskip385"),

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java
@@ -88,7 +88,7 @@ public enum ConsensusRule {
     RSKIP375("rskip375"),
     RSKIP376("rskip376"),
     RSKIP377("rskip377"),
-    RSKIP378("rskip378"), // Recalculate pegout value used when the batch is split
+    RSKIP378("rskip378"), // Enforce release transaction size limit
     RSKIP379("rskip379"),
     RSKIP383("rskip383"),
     RSKIP385("rskip385"),

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -93,6 +93,7 @@ blockchain = {
             rskip375 = <hardforkName>
             rskip376 = <hardforkName>
             rskip377 = <hardforkName>
+            rskip378 = <hardforkName>
             rskip379 = <hardforkName>
             rskip383 = <hardforkName>
             rskip385 = <hardforkName>

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -75,6 +75,7 @@ blockchain = {
             rskip375 = fingerroot500
             rskip376 = arrowhead600
             rskip377 = fingerroot500
+            rskip378 = tbd1000
             rskip379 = arrowhead600
             rskip383 = fingerroot500
             rskip385 = fingerroot500
@@ -103,7 +104,7 @@ blockchain = {
             rskip544 = vetiver900
             rskip551 = vetiver900
             rskip552 = vetiver900
-            rskip559 = tbd1000 
+            rskip559 = tbd1000
         }
     }
     gc = {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportGetEstimatedFeesTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportGetEstimatedFeesTest.java
@@ -45,6 +45,7 @@ class BridgeSupportGetEstimatedFeesTest {
     private static final ActivationConfig.ForBlock HOP400_ACTIVATIONS = ActivationConfigsForTest.hop400().forBlock(0L);
     private static final ActivationConfig.ForBlock FINGERROOT_ACTIVATIONS = ActivationConfigsForTest.fingerroot500().forBlock(0L);
     private static final ActivationConfig.ForBlock REED_ACTIVATIONS = ActivationConfigsForTest.reed800().forBlock(0L);
+    private static final ActivationConfig.ForBlock VETIVER_ACTIVATIONS = ActivationConfigsForTest.vetiver900().forBlock(0L);
     private static final ActivationConfig.ForBlock ALL_ACTIVATIONS = ActivationConfigsForTest.all().forBlock(0L);
 
     private static final Federation STANDARD_MULTISIG_FEDERATION = StandardMultiSigFederationBuilder.builder()
@@ -103,7 +104,7 @@ class BridgeSupportGetEstimatedFeesTest {
     private BridgeSupport bridgeSupport;
 
     @Nested
-    class PreHop400Activation {
+    class PreHop400Activations {
 
         @BeforeEach
         void setUp() {
@@ -429,26 +430,12 @@ class BridgeSupportGetEstimatedFeesTest {
     }
 
     @Nested
-    class PostVetiverActivation {
+    class PostVetiverPreTBD100Activations {
 
         @BeforeEach
         void setUp() {
-            setUpBridgeAndFederationSupport(ALL_ACTIVATIONS, FEE_PER_KB);
-            // After Reed activation, which is before Vetiver, the federation is P2SH-P2WSH ERP.
-            // Therefore, after Vetiver the federation is P2SH-P2WSH ERP.
+            setUpBridgeAndFederationSupport(VETIVER_ACTIVATIONS, FEE_PER_KB);
             federationStorageProvider.setNewFederation(P2SH_P2WSH_ERP_FEDERATION);
-        }
-
-        @Test
-        void getEstimatedFeesForNextPegOutEvent_withP2shP2wshErpFederation_withNoPegoutRequests_shouldEstimateFeesFromTransactionSimulation() throws IOException {
-            // Arrange
-            addUtxosToActiveFederation(TWO_P2SH_P2WSH_UTXOS_OF_EIGHT_BTCS);
-
-            // Act
-            Coin estimatedFeesForNextPegout = bridgeSupport.getEstimatedFeesForNextPegOutEvent();
-
-            // Assert
-            assertEquals(Coin.valueOf(4_536L), estimatedFeesForNextPegout);
         }
 
         @Test
@@ -470,6 +457,61 @@ class BridgeSupportGetEstimatedFeesTest {
 
             // Assert
             assertEquals(Coin.valueOf(7_920L), estimatedFeesForNextPegout);
+        }
+
+        @Test
+        void getEstimatedFeesForNextPegOutEvent_withP2shP2wshErpFederationHavingOneBTCAndMinPegoutValue_withPegoutRequestGreaterThanOneBtc_shouldFallBackToEstimateFeesFromInputAndOutputCount() throws IOException {
+            // Arrange
+            addUtxosToActiveFederation(TWO_P2SH_P2WSH_UTXOS_OF_ONE_BTC_AND_MIN_PEGOUT_VALUE);
+            addPegoutRequests(1, Coin.COIN.add(Coin.SATOSHI));
+
+            // Act
+            Coin estimatedFeesForNextPegout = bridgeSupport.getEstimatedFeesForNextPegOutEvent();
+
+            // Assert
+            assertEquals(Coin.valueOf(7_920L), estimatedFeesForNextPegout);
+        }
+    }
+
+    @Nested
+    class PostTBD100Activations {
+        @BeforeEach
+        void setUp() {
+            setUpBridgeAndFederationSupport(ALL_ACTIVATIONS, FEE_PER_KB);
+            federationStorageProvider.setNewFederation(P2SH_P2WSH_ERP_FEDERATION);
+        }
+
+        @Test
+        void getEstimatedFeesForNextPegOutEvent_withP2shP2wshErpFederation_withNoPegoutRequests_shouldEstimateFeesFromTransactionSimulation() throws IOException {
+            // Arrange
+            addUtxosToActiveFederation(TWO_P2SH_P2WSH_UTXOS_OF_EIGHT_BTCS);
+
+            // Act
+            Coin estimatedFeesForNextPegout = bridgeSupport.getEstimatedFeesForNextPegOutEvent();
+
+            // Assert
+            assertEquals(Coin.valueOf(4_536L), estimatedFeesForNextPegout);
+        }
+
+        @Test
+        void getEstimatedFeesForNextPegOutEvent_withP2shP2wshErpFederation_withNoUtxos_withNoPegoutRequests_shouldFallBackToEstimateFeesFromInputAndOutputCount() throws IOException {
+            // Act
+            Coin estimatedFeesForNextPegout = bridgeSupport.getEstimatedFeesForNextPegOutEvent();
+
+            // Assert
+            assertEquals(Coin.valueOf(8_384L), estimatedFeesForNextPegout);
+        }
+
+        @Test
+        void getEstimatedFeesForNextPegOutEvent_withP2shP2wshErpFederation_withNoUtxos_withOnePegoutRequest_shouldFallBackToEstimateFeesFromInputAndOutputCount() throws IOException {
+            // Arrange
+            addPegoutRequests(1, Coin.COIN);
+
+            // Act
+            Coin estimatedFeesForNextPegout = bridgeSupport.getEstimatedFeesForNextPegOutEvent();
+
+            // Assert
+            assertEquals(Coin.valueOf(8_640L), estimatedFeesForNextPegout);
         }
 
         @ParameterizedTest
@@ -540,7 +582,7 @@ class BridgeSupportGetEstimatedFeesTest {
             Coin estimatedFeesForNextPegout = bridgeSupport.getEstimatedFeesForNextPegOutEvent();
 
             // Assert
-            assertEquals(Coin.valueOf(7_920L), estimatedFeesForNextPegout);
+            assertEquals(Coin.valueOf(8_640L), estimatedFeesForNextPegout);
         }
 
         @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportGetEstimatedFeesTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportGetEstimatedFeesTest.java
@@ -430,7 +430,7 @@ class BridgeSupportGetEstimatedFeesTest {
     }
 
     @Nested
-    class PostVetiverPreTBD100Activations {
+    class PostVetiverPreTBD1000Activations {
 
         @BeforeEach
         void setUp() {
@@ -474,7 +474,7 @@ class BridgeSupportGetEstimatedFeesTest {
     }
 
     @Nested
-    class PostTBD100Activations {
+    class PostTBD1000Activations {
         @BeforeEach
         void setUp() {
             setUpBridgeAndFederationSupport(ALL_ACTIVATIONS, FEE_PER_KB);
@@ -499,7 +499,7 @@ class BridgeSupportGetEstimatedFeesTest {
             Coin estimatedFeesForNextPegout = bridgeSupport.getEstimatedFeesForNextPegOutEvent();
 
             // Assert
-            assertEquals(Coin.valueOf(8_384L), estimatedFeesForNextPegout);
+            assertEquals(Coin.valueOf(8_432L), estimatedFeesForNextPegout);
         }
 
         @Test
@@ -511,7 +511,7 @@ class BridgeSupportGetEstimatedFeesTest {
             Coin estimatedFeesForNextPegout = bridgeSupport.getEstimatedFeesForNextPegOutEvent();
 
             // Assert
-            assertEquals(Coin.valueOf(8_640L), estimatedFeesForNextPegout);
+            assertEquals(Coin.valueOf(8_688L), estimatedFeesForNextPegout);
         }
 
         @ParameterizedTest
@@ -582,7 +582,7 @@ class BridgeSupportGetEstimatedFeesTest {
             Coin estimatedFeesForNextPegout = bridgeSupport.getEstimatedFeesForNextPegOutEvent();
 
             // Assert
-            assertEquals(Coin.valueOf(8_640L), estimatedFeesForNextPegout);
+            assertEquals(Coin.valueOf(8_688L), estimatedFeesForNextPegout);
         }
 
         @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportPegoutTransactionCreatedEventTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportPegoutTransactionCreatedEventTest.java
@@ -5,27 +5,49 @@ import static co.rsk.peg.bitcoin.UtxoUtils.extractOutpointValues;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import co.rsk.bitcoinj.core.*;
+import co.rsk.RskTestUtils;
+import co.rsk.bitcoinj.core.BtcTransaction;
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.bitcoinj.core.Context;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.core.Sha256Hash;
+import co.rsk.bitcoinj.core.TransactionOutput;
+import co.rsk.bitcoinj.core.UTXO;
 import co.rsk.bitcoinj.wallet.Wallet;
 import co.rsk.blockchain.utils.BlockGenerator;
 import co.rsk.crypto.Keccak256;
 import co.rsk.peg.ReleaseRequestQueue.Entry;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.constants.BridgeMainNetConstants;
-import co.rsk.peg.federation.*;
+import co.rsk.peg.federation.ErpFederation;
+import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationArgs;
+import co.rsk.peg.federation.FederationFactory;
+import co.rsk.peg.federation.FederationStorageProvider;
+import co.rsk.peg.federation.FederationSupport;
+import co.rsk.peg.federation.FederationSupportImpl;
+import co.rsk.peg.federation.FederationTestUtils;
 import co.rsk.peg.federation.constants.FederationConstants;
-import co.rsk.peg.feeperkb.*;
+import co.rsk.peg.feeperkb.FeePerKbStorageProvider;
+import co.rsk.peg.feeperkb.FeePerKbSupport;
+import co.rsk.peg.feeperkb.FeePerKbSupportImpl;
 import co.rsk.peg.utils.BridgeEventLogger;
 import co.rsk.test.builders.BridgeSupportBuilder;
+import co.rsk.test.builders.UTXOBuilder;
 import java.io.IOException;
 import java.time.Instant;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.TreeMap;
 import java.util.stream.Stream;
-
-import co.rsk.test.builders.UTXOBuilder;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
@@ -76,7 +98,7 @@ class BridgeSupportPegoutTransactionCreatedEventTest {
         when(federationStorageProvider.getNewFederationBtcUTXOs(any(), any())).thenReturn(fedUTXOs);
         when(federationStorageProvider.getNewFederation(any(), any())).thenReturn(ERP_FEDERATION);
 
-        pegoutCreationRskTxHash = PegTestUtils.createHash3(1);
+        pegoutCreationRskTxHash = RskTestUtils.createHash(1);
         executionRskTx = mock(Transaction.class);
         when(executionRskTx.getHash()).thenReturn(pegoutCreationRskTxHash);
 
@@ -127,7 +149,7 @@ class BridgeSupportPegoutTransactionCreatedEventTest {
         BtcTransaction pegoutBatchTransaction = pegoutEntry.getBtcTransaction();
         Sha256Hash pegoutTxHash = pegoutBatchTransaction.getHash();
         List<Coin> outpointValues = extractOutpointValues(pegoutBatchTransaction);
-        List<Keccak256> pegoutRequestRskTxHashes = pegoutRequests.stream().map(Entry::getRskTxHash).collect(Collectors.toList());
+        List<Keccak256> pegoutRequestRskTxHashes = pegoutRequests.stream().map(Entry::getRskTxHash).toList();
         Coin totalTransactionAmount = pegoutRequests.stream().map(Entry::getAmount).reduce(Coin.ZERO, Coin::add);
 
         verify(eventLogger, times(1)).logBatchPegoutCreated(pegoutTxHash, pegoutRequestRskTxHashes);
@@ -282,7 +304,7 @@ class BridgeSupportPegoutTransactionCreatedEventTest {
             .build();
 
         Transaction rskTx = mock(Transaction.class);
-        when(rskTx.getHash()).thenReturn(PegTestUtils.createHash3(1));
+        when(rskTx.getHash()).thenReturn(RskTestUtils.createHash(1));
 
         // Act
         bridgeSupport.updateCollections(rskTx);
@@ -322,7 +344,7 @@ class BridgeSupportPegoutTransactionCreatedEventTest {
         Coin pegoutBatchTotalAmount = pegoutRequests.stream().map(Entry::getAmount).reduce(Coin.ZERO, Coin::add);
         List<Coin> pegoutBatchTxOutpointValues = extractOutpointValues(pegoutBatchTx);
 
-        List<Keccak256> pegoutRequestRskTxHashes = pegoutRequests.stream().map(Entry::getRskTxHash).collect(Collectors.toList());
+        List<Keccak256> pegoutRequestRskTxHashes = pegoutRequests.stream().map(Entry::getRskTxHash).toList();
 
         verify(eventLogger, times(1)).logBatchPegoutCreated(pegoutBatchBtcTxHash, pegoutRequestRskTxHashes);
         verify(eventLogger, times(1)).logReleaseBtcRequested(pegoutBatchCreationRskTxHash.getBytes(), pegoutBatchTx, pegoutBatchTotalAmount);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -1677,7 +1677,8 @@ class BridgeSupportReleaseBtcTest {
         private static final Coin DUST_CHANGE = DUST_THRESHOLD.subtract(Coin.SATOSHI);
         private static final Coin NON_DUST_CHANGE = DUST_THRESHOLD.add(Coin.SATOSHI);
         private static final Coin DUST_BUMP = DUST_THRESHOLD.subtract(DUST_CHANGE);
-        private static final Coin PEGOUT_REQUEST_VALUE = Coin.COIN.multiply(1_250);
+        private static final Coin PEGOUT_REQUEST_BASE_VALUE = Coin.COIN.multiply(1_250); // we will subtract dust/non-dust value from it
+        private static final int INPUTS_EXCEEDING_MAX_TX_SIZE = 2500;
 
         private List<LogInfo> logs;
         private Transaction rskTx;
@@ -1726,12 +1727,10 @@ class BridgeSupportReleaseBtcTest {
                 NETWORK_PARAMETERS
             );
 
-            // 2500 * 1 btc = 2500 btc
-            int numberOfUtxos = 2500;
             List<UTXO> utxos = UTXOBuilder.builder()
                 .withScriptPubKey(activeFederation.getP2SHScript())
                 .withValue(Coin.COIN)
-                .buildMany(numberOfUtxos, i -> createHash(i + 1));
+                .buildMany(INPUTS_EXCEEDING_MAX_TX_SIZE, i -> createHash(i + 1));
             federationStorageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, activations).addAll(utxos);
         }
 
@@ -1741,11 +1740,11 @@ class BridgeSupportReleaseBtcTest {
 
         @ParameterizedTest
         @MethodSource("activationsArgs")
-        void processPegoutsInBatch_noSplitting_shouldUseTotalPegoutRequestsValueRef(ActivationConfig.ForBlock activations) throws IOException {
+        void processPegoutsInBatch_noSplitting_withNonDustChange_shouldLogTotalPegoutRequestsValue_shouldNotBurn(ActivationConfig.ForBlock activations) throws IOException {
             // arrange
             setUp(activations);
-            int pegoutRequests = 10;
-            Coin pegoutRequestValue = Coin.COIN;
+            int pegoutRequests = 1;
+            Coin pegoutRequestValue = PEGOUT_REQUEST_BASE_VALUE.subtract(NON_DUST_CHANGE);
             setupRequests(pegoutRequests, pegoutRequestValue, activations);
 
             // act
@@ -1755,19 +1754,41 @@ class BridgeSupportReleaseBtcTest {
             int expectedRemainingRequests = 0;
             assertRemainingRequests(expectedRemainingRequests);
 
-            Coin originalRequestsValue = pegoutRequestValue.multiply(pegoutRequests);
-            assertReleaseRequested(originalRequestsValue);
+            Coin totalRequestsValue = pegoutRequestValue.multiply(pegoutRequests);
+            assertReleaseRequested(totalRequestsValue, activations);
 
             assertNoBurn();
         }
 
+        @ParameterizedTest
+        @MethodSource("activationsArgs")
+        void processPegoutsInBatch_noSplitting_withDustChange_shouldLogTotalPegoutRequestsValue_shouldBurnDustBump(ActivationConfig.ForBlock activations) throws IOException {
+            // arrange
+            setUp(activations);
+            int pegoutRequests = 1;
+            Coin pegoutRequestValue = PEGOUT_REQUEST_BASE_VALUE.subtract(DUST_CHANGE);
+            setupRequests(pegoutRequests, pegoutRequestValue, activations);
+
+            // act
+            bridgeSupport.updateCollections(rskTx);
+
+            // assert
+            int expectedRemainingRequests = 0;
+            assertRemainingRequests(expectedRemainingRequests);
+
+            Coin totalRequestsValue = pegoutRequestValue.multiply(pegoutRequests);
+            assertReleaseRequested(totalRequestsValue, activations);
+
+            assertAmountBurnt(DUST_BUMP);
+        }
+
         @Test
-        void processPegoutsInBatch_preRSKIP378_whenSplittingTotalRequests_withNonDustChange_shouldUseOriginalTotalPegoutRequestsValueRef_shouldBurnRemainingValue() throws IOException {
+        void processPegoutsInBatch_preRSKIP378_whenSplittingTotalRequests_withNonDustChange_shouldLogOriginalTotalPegoutRequestsValue_shouldBurnRemainingValue() throws IOException {
             // arrange
             setUp(VETIVER_ACTIVATIONS);
 
             int pegoutRequests = 2;
-            Coin pegoutRequestValue = PEGOUT_REQUEST_VALUE.subtract(NON_DUST_CHANGE);
+            Coin pegoutRequestValue = PEGOUT_REQUEST_BASE_VALUE.subtract(NON_DUST_CHANGE);
             setupRequests(pegoutRequests, pegoutRequestValue, VETIVER_ACTIVATIONS);
 
             // act
@@ -1777,8 +1798,8 @@ class BridgeSupportReleaseBtcTest {
             int expectedRemainingRequests = 1;
             assertRemainingRequests(expectedRemainingRequests);
 
-            Coin originalRequestsValue = pegoutRequestValue.multiply(pegoutRequests);
-            assertReleaseRequested(originalRequestsValue);
+            Coin totalRequestsValue = pegoutRequestValue.multiply(pegoutRequests);
+            assertReleaseRequested(totalRequestsValue, VETIVER_ACTIVATIONS);
 
             // pre-RSKIP378 burns the total value of the un-batched requests
             Coin expectedBurntAmount = pegoutRequestValue.multiply(expectedRemainingRequests);
@@ -1786,11 +1807,11 @@ class BridgeSupportReleaseBtcTest {
         }
 
         @Test
-        void processPegoutsInBatch_preRSKIP378_whenSplittingTotalRequests_withDustChange_shouldUseOriginalTotalPegoutRequestsValueRef_shouldBurnRemainingValuePlusDustBump() throws IOException {
+        void processPegoutsInBatch_preRSKIP378_whenSplittingTotalRequests_withDustChange_shouldLogOriginalTotalPegoutRequestsValue_shouldBurnRemainingValuePlusDustBump() throws IOException {
             // arrange
             setUp(VETIVER_ACTIVATIONS);
             int pegoutRequests = 2;
-            Coin pegoutRequestValue = PEGOUT_REQUEST_VALUE.subtract(DUST_CHANGE);
+            Coin pegoutRequestValue = PEGOUT_REQUEST_BASE_VALUE.subtract(DUST_CHANGE);
             setupRequests(pegoutRequests, pegoutRequestValue, VETIVER_ACTIVATIONS);
 
             // act
@@ -1800,8 +1821,8 @@ class BridgeSupportReleaseBtcTest {
             int expectedRemainingRequests = 1;
             assertRemainingRequests(expectedRemainingRequests);
 
-            Coin originalRequestsValue = pegoutRequestValue.multiply(pegoutRequests);
-            assertReleaseRequested(originalRequestsValue);
+            Coin totalRequestsValue = pegoutRequestValue.multiply(pegoutRequests);
+            assertReleaseRequested(totalRequestsValue, VETIVER_ACTIVATIONS);
 
             // pre-RSKIP378 burns the total value of the un-batched requests plus the dust bump the federation retained
             Coin expectedBurntAmount = pegoutRequestValue.multiply(expectedRemainingRequests).add(DUST_BUMP);
@@ -1809,11 +1830,11 @@ class BridgeSupportReleaseBtcTest {
         }
 
         @Test
-        void processPegoutsInBatch_postRSKIP378_whenSplittingTotalRequests_withNonDustChange_shouldUseSplitPegoutRequestsValueRef_shouldNotBurn() throws IOException {
+        void processPegoutsInBatch_postRSKIP378_whenSplittingTotalRequests_withNonDustChange_shouldLogSplitPegoutRequestsValue_shouldNotBurn() throws IOException {
             // arrange
             setUp(ACTIVATIONS_ALL);
             int pegoutRequests = 2;
-            Coin pegoutRequestValue = PEGOUT_REQUEST_VALUE.subtract(NON_DUST_CHANGE);
+            Coin pegoutRequestValue = PEGOUT_REQUEST_BASE_VALUE.subtract(NON_DUST_CHANGE);
             setupRequests(pegoutRequests, pegoutRequestValue, ACTIVATIONS_ALL);
 
             // act
@@ -1825,17 +1846,17 @@ class BridgeSupportReleaseBtcTest {
 
             int pegoutRequestsProcessed = pegoutRequests - expectedRemainingRequests;
             Coin expectedValueBeingPeggedOut = pegoutRequestValue.multiply(pegoutRequestsProcessed);
-            assertReleaseRequested(expectedValueBeingPeggedOut);
+            assertReleaseRequested(expectedValueBeingPeggedOut, ACTIVATIONS_ALL);
 
             assertNoBurn();
         }
 
         @Test
-        void processPegoutsInBatch_postRSKIP378_whenSplittingTotalRequests_withAmountToBurn_shouldUseSplitPegoutRequestsValueRef_shouldBurn() throws IOException {
+        void processPegoutsInBatch_postRSKIP378_whenSplittingTotalRequests_withDustChange_shouldLogSplitPegoutRequestsValue_shouldBurnDustBump() throws IOException {
             // arrange
             setUp(ACTIVATIONS_ALL);
             int pegoutRequests = 2;
-            Coin pegoutRequestValue = PEGOUT_REQUEST_VALUE.subtract(DUST_CHANGE);
+            Coin pegoutRequestValue = PEGOUT_REQUEST_BASE_VALUE.subtract(DUST_CHANGE);
             setupRequests(pegoutRequests, pegoutRequestValue, ACTIVATIONS_ALL);
 
             // act
@@ -1847,7 +1868,7 @@ class BridgeSupportReleaseBtcTest {
 
             int pegoutRequestsProcessed = pegoutRequests - expectedRemainingRequests;
             Coin expectedValueBeingPeggedOut = pegoutRequestValue.multiply(pegoutRequestsProcessed);
-            assertReleaseRequested(expectedValueBeingPeggedOut);
+            assertReleaseRequested(expectedValueBeingPeggedOut, ACTIVATIONS_ALL);
 
             assertAmountBurnt(DUST_BUMP);
         }
@@ -1858,9 +1879,9 @@ class BridgeSupportReleaseBtcTest {
             assertEquals(expectedRemainingRequests, remainingRequests);
         }
 
-        private void assertReleaseRequested(Coin expectedValue) throws IOException {
+        private void assertReleaseRequested(Coin expectedValue, ActivationConfig.ForBlock activations) throws IOException {
             PegoutsWaitingForConfirmations pegoutsWaitingForConfirmations = bridgeStorageProvider.getPegoutsWaitingForConfirmations();
-            Collection<PegoutsWaitingForConfirmations.Entry> pegoutsWFCEntries = pegoutsWaitingForConfirmations.getEntries(VETIVER_ACTIVATIONS);
+            Collection<PegoutsWaitingForConfirmations.Entry> pegoutsWFCEntries = pegoutsWaitingForConfirmations.getEntries(activations);
             assertEquals(1, pegoutsWFCEntries.size());
 
             BtcTransaction batchPegoutTransaction = pegoutsWFCEntries.iterator().next().getBtcTransaction();

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -17,8 +17,7 @@
  */
 package co.rsk.peg;
 
-import static co.rsk.peg.BridgeSupportTestUtil.addPegoutRequestsToQueue;
-import static co.rsk.peg.BridgeSupportTestUtil.assertLogReleaseRequested;
+import static co.rsk.peg.BridgeSupportTestUtil.*;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.createHash;
 import static org.junit.jupiter.api.Assertions.*;
@@ -1676,7 +1675,13 @@ class BridgeSupportReleaseBtcTest {
         private final Coin DUST_CHANGE = MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT.subtract(Coin.SATOSHI);
         private final Coin NON_DUST_CHANGE = MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT.add(Coin.SATOSHI);
         private final Coin DUST_BUMP = MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT.subtract(DUST_CHANGE);
-        private final Coin PEGOUT_REQUEST_BASE_VALUE = Coin.COIN.multiply(1_250); // we will subtract dust/non-dust value from it
+        private final int PEGOUT_REQUESTS_BASE_COUNT = 2;
+        private final Coin PEGOUT_REQUEST_BASE_VALUE_VETIVER = Coin.COIN
+            .multiply(P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE_VETIVER)
+            .div(PEGOUT_REQUESTS_BASE_COUNT); // we will subtract dust/non-dust value from it
+        private final Coin PEGOUT_REQUEST_BASE_VALUE = Coin.COIN
+            .multiply(P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE)
+            .div(PEGOUT_REQUESTS_BASE_COUNT); // we will subtract dust/non-dust value from it
 
         private List<LogInfo> logs;
         private Transaction rskTx;
@@ -1716,7 +1721,10 @@ class BridgeSupportReleaseBtcTest {
                 .build();
         }
 
-        private void setupRequests(int pegoutRequests, Coin pegoutRequestValue, ActivationConfig.ForBlock activations) throws IOException {
+        private void setupRequestsPreRSKIP378(
+            int pegoutRequests,
+            Coin pegoutRequestValue
+        ) throws IOException {
             ReleaseRequestQueue releaseRequestQueue = bridgeStorageProvider.getReleaseRequestQueue();
             addPegoutRequestsToQueue(
                 releaseRequestQueue,
@@ -1725,26 +1733,39 @@ class BridgeSupportReleaseBtcTest {
                 NETWORK_PARAMETERS
             );
 
-            int inputsExceedingMaxTxSize = 2500;
             List<UTXO> utxos = UTXOBuilder.builder()
                 .withScriptPubKey(activeFederation.getP2SHScript())
                 .withValue(Coin.COIN)
-                .buildMany(inputsExceedingMaxTxSize, i -> createHash(i + 1));
-            federationStorageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, activations).addAll(utxos);
+                .buildMany(P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE_VETIVER, i -> createHash(i + 1));
+            federationStorageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, VETIVER_ACTIVATIONS).addAll(utxos);
         }
 
-        private Stream<ActivationConfig.ForBlock> activationsArgs() {
-            return Stream.of(VETIVER_ACTIVATIONS, ACTIVATIONS_ALL);
+        private void setupRequests(
+            int pegoutRequests,
+            Coin pegoutRequestValue
+        ) throws IOException {
+            ReleaseRequestQueue releaseRequestQueue = bridgeStorageProvider.getReleaseRequestQueue();
+            addPegoutRequestsToQueue(
+                releaseRequestQueue,
+                pegoutRequests,
+                pegoutRequestValue,
+                NETWORK_PARAMETERS
+            );
+
+            List<UTXO> utxos = UTXOBuilder.builder()
+                .withScriptPubKey(activeFederation.getP2SHScript())
+                .withValue(Coin.COIN)
+                .buildMany(P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE, i -> createHash(i + 1));
+            federationStorageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, ACTIVATIONS_ALL).addAll(utxos);
         }
 
-        @ParameterizedTest
-        @MethodSource("activationsArgs")
-        void processPegoutsInBatch_noSplitting_withNonDustChange_shouldLogTotalPegoutRequestsValue_shouldNotBurn(ActivationConfig.ForBlock activations) throws IOException {
+        @Test
+        void processPegoutsInBatch_noSplitting_preRSKIP378_withNonDustChange_shouldLogTotalPegoutRequestsValue_shouldNotBurn() throws IOException {
             // arrange
-            setUp(activations);
+            setUp(VETIVER_ACTIVATIONS);
             int pegoutRequests = 1;
-            Coin pegoutRequestValue = PEGOUT_REQUEST_BASE_VALUE.subtract(NON_DUST_CHANGE);
-            setupRequests(pegoutRequests, pegoutRequestValue, activations);
+            Coin pegoutRequestValue = PEGOUT_REQUEST_BASE_VALUE_VETIVER.subtract(NON_DUST_CHANGE);
+            setupRequestsPreRSKIP378(pegoutRequests, pegoutRequestValue);
 
             // act
             bridgeSupport.updateCollections(rskTx);
@@ -1754,19 +1775,18 @@ class BridgeSupportReleaseBtcTest {
             assertRemainingRequests(expectedRemainingRequests);
 
             Coin totalRequestsValue = pegoutRequestValue.multiply(pegoutRequests);
-            assertReleaseRequested(totalRequestsValue, activations);
+            assertReleaseRequested(totalRequestsValue, VETIVER_ACTIVATIONS);
 
             assertNoBurn();
         }
 
-        @ParameterizedTest
-        @MethodSource("activationsArgs")
-        void processPegoutsInBatch_noSplitting_withDustChange_shouldLogTotalPegoutRequestsValue_shouldBurnDustBump(ActivationConfig.ForBlock activations) throws IOException {
+        @Test
+        void processPegoutsInBatch_noSplitting_withNonDustChange_shouldLogTotalPegoutRequestsValue_shouldNotBurn() throws IOException {
             // arrange
-            setUp(activations);
+            setUp(ACTIVATIONS_ALL);
             int pegoutRequests = 1;
-            Coin pegoutRequestValue = PEGOUT_REQUEST_BASE_VALUE.subtract(DUST_CHANGE);
-            setupRequests(pegoutRequests, pegoutRequestValue, activations);
+            Coin pegoutRequestValue = PEGOUT_REQUEST_BASE_VALUE.subtract(NON_DUST_CHANGE);
+            setupRequests(pegoutRequests, pegoutRequestValue);
 
             // act
             bridgeSupport.updateCollections(rskTx);
@@ -1776,7 +1796,49 @@ class BridgeSupportReleaseBtcTest {
             assertRemainingRequests(expectedRemainingRequests);
 
             Coin totalRequestsValue = pegoutRequestValue.multiply(pegoutRequests);
-            assertReleaseRequested(totalRequestsValue, activations);
+            assertReleaseRequested(totalRequestsValue, ACTIVATIONS_ALL);
+
+            assertNoBurn();
+        }
+
+        @Test
+        void processPegoutsInBatch_noSplitting_preRSKIP378_withDustChange_shouldLogTotalPegoutRequestsValue_shouldBurnDustBump() throws IOException {
+            // arrange
+            setUp(VETIVER_ACTIVATIONS);
+            int pegoutRequests = 1;
+            Coin pegoutRequestValue = PEGOUT_REQUEST_BASE_VALUE_VETIVER.subtract(DUST_CHANGE);
+            setupRequestsPreRSKIP378(pegoutRequests, pegoutRequestValue);
+
+            // act
+            bridgeSupport.updateCollections(rskTx);
+
+            // assert
+            int expectedRemainingRequests = 0;
+            assertRemainingRequests(expectedRemainingRequests);
+
+            Coin totalRequestsValue = pegoutRequestValue.multiply(pegoutRequests);
+            assertReleaseRequested(totalRequestsValue, VETIVER_ACTIVATIONS);
+
+            assertAmountBurnt(DUST_BUMP);
+        }
+
+        @Test
+        void processPegoutsInBatch_noSplitting_withDustChange_shouldLogTotalPegoutRequestsValue_shouldBurnDustBump() throws IOException {
+            // arrange
+            setUp(ACTIVATIONS_ALL);
+            int pegoutRequests = 1;
+            Coin pegoutRequestValue = PEGOUT_REQUEST_BASE_VALUE.subtract(DUST_CHANGE);
+            setupRequests(pegoutRequests, pegoutRequestValue);
+
+            // act
+            bridgeSupport.updateCollections(rskTx);
+
+            // assert
+            int expectedRemainingRequests = 0;
+            assertRemainingRequests(expectedRemainingRequests);
+
+            Coin totalRequestsValue = pegoutRequestValue.multiply(pegoutRequests);
+            assertReleaseRequested(totalRequestsValue, ACTIVATIONS_ALL);
 
             assertAmountBurnt(DUST_BUMP);
         }
@@ -1785,10 +1847,9 @@ class BridgeSupportReleaseBtcTest {
         void processPegoutsInBatch_preRSKIP378_whenSplittingTotalRequests_withNonDustChange_shouldLogOriginalTotalPegoutRequestsValue_shouldBurnRemainingValue() throws IOException {
             // arrange
             setUp(VETIVER_ACTIVATIONS);
-
             int pegoutRequests = 2;
-            Coin pegoutRequestValue = PEGOUT_REQUEST_BASE_VALUE.subtract(NON_DUST_CHANGE);
-            setupRequests(pegoutRequests, pegoutRequestValue, VETIVER_ACTIVATIONS);
+            Coin pegoutRequestValue = PEGOUT_REQUEST_BASE_VALUE_VETIVER.subtract(NON_DUST_CHANGE);
+            setupRequestsPreRSKIP378(pegoutRequests, pegoutRequestValue);
 
             // act
             bridgeSupport.updateCollections(rskTx);
@@ -1809,9 +1870,8 @@ class BridgeSupportReleaseBtcTest {
         void processPegoutsInBatch_preRSKIP378_whenSplittingTotalRequests_withDustChange_shouldLogOriginalTotalPegoutRequestsValue_shouldBurnRemainingValuePlusDustBump() throws IOException {
             // arrange
             setUp(VETIVER_ACTIVATIONS);
-            int pegoutRequests = 2;
-            Coin pegoutRequestValue = PEGOUT_REQUEST_BASE_VALUE.subtract(DUST_CHANGE);
-            setupRequests(pegoutRequests, pegoutRequestValue, VETIVER_ACTIVATIONS);
+            Coin pegoutRequestValue = PEGOUT_REQUEST_BASE_VALUE_VETIVER.subtract(DUST_CHANGE);
+            setupRequestsPreRSKIP378(PEGOUT_REQUESTS_BASE_COUNT, pegoutRequestValue);
 
             // act
             bridgeSupport.updateCollections(rskTx);
@@ -1820,7 +1880,7 @@ class BridgeSupportReleaseBtcTest {
             int expectedRemainingRequests = 1;
             assertRemainingRequests(expectedRemainingRequests);
 
-            Coin totalRequestsValue = pegoutRequestValue.multiply(pegoutRequests);
+            Coin totalRequestsValue = pegoutRequestValue.multiply(PEGOUT_REQUESTS_BASE_COUNT);
             assertReleaseRequested(totalRequestsValue, VETIVER_ACTIVATIONS);
 
             // pre-RSKIP378 burns the total value of the un-batched requests plus the dust bump the federation retained
@@ -1829,12 +1889,11 @@ class BridgeSupportReleaseBtcTest {
         }
 
         @Test
-        void processPegoutsInBatch_postRSKIP378_whenSplittingTotalRequests_withNonDustChange_shouldLogSplitPegoutRequestsValue_shouldNotBurn() throws IOException {
+        void processPegoutsInBatch_whenSplittingTotalRequests_withNonDustChange_shouldLogSplitPegoutRequestsValue_shouldNotBurn() throws IOException {
             // arrange
             setUp(ACTIVATIONS_ALL);
-            int pegoutRequests = 2;
             Coin pegoutRequestValue = PEGOUT_REQUEST_BASE_VALUE.subtract(NON_DUST_CHANGE);
-            setupRequests(pegoutRequests, pegoutRequestValue, ACTIVATIONS_ALL);
+            setupRequests(PEGOUT_REQUESTS_BASE_COUNT, pegoutRequestValue);
 
             // act
             bridgeSupport.updateCollections(rskTx);
@@ -1843,7 +1902,7 @@ class BridgeSupportReleaseBtcTest {
             int expectedRemainingRequests = 1;
             assertRemainingRequests(expectedRemainingRequests);
 
-            int pegoutRequestsProcessed = pegoutRequests - expectedRemainingRequests;
+            int pegoutRequestsProcessed = PEGOUT_REQUESTS_BASE_COUNT - expectedRemainingRequests;
             Coin expectedValueBeingPeggedOut = pegoutRequestValue.multiply(pegoutRequestsProcessed);
             assertReleaseRequested(expectedValueBeingPeggedOut, ACTIVATIONS_ALL);
 
@@ -1851,12 +1910,11 @@ class BridgeSupportReleaseBtcTest {
         }
 
         @Test
-        void processPegoutsInBatch_postRSKIP378_whenSplittingTotalRequests_withDustChange_shouldLogSplitPegoutRequestsValue_shouldBurnDustBump() throws IOException {
+        void processPegoutsInBatch_whenSplittingTotalRequests_withDustChange_shouldLogSplitPegoutRequestsValue_shouldBurnDustBump() throws IOException {
             // arrange
             setUp(ACTIVATIONS_ALL);
-            int pegoutRequests = 2;
             Coin pegoutRequestValue = PEGOUT_REQUEST_BASE_VALUE.subtract(DUST_CHANGE);
-            setupRequests(pegoutRequests, pegoutRequestValue, ACTIVATIONS_ALL);
+            setupRequests(PEGOUT_REQUESTS_BASE_COUNT, pegoutRequestValue);
 
             // act
             bridgeSupport.updateCollections(rskTx);
@@ -1865,7 +1923,7 @@ class BridgeSupportReleaseBtcTest {
             int expectedRemainingRequests = 1;
             assertRemainingRequests(expectedRemainingRequests);
 
-            int pegoutRequestsProcessed = pegoutRequests - expectedRemainingRequests;
+            int pegoutRequestsProcessed = PEGOUT_REQUESTS_BASE_COUNT - expectedRemainingRequests;
             Coin expectedValueBeingPeggedOut = pegoutRequestValue.multiply(pegoutRequestsProcessed);
             assertReleaseRequested(expectedValueBeingPeggedOut, ACTIVATIONS_ALL);
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -17,6 +17,8 @@
  */
 package co.rsk.peg;
 
+import static co.rsk.peg.BridgeSupportTestUtil.addPegoutRequestsToQueue;
+import static co.rsk.peg.BridgeSupportTestUtil.assertLogReleaseRequested;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.createHash;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -44,6 +46,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import co.rsk.test.builders.UTXOBuilder;
 import org.bouncycastle.util.encoders.Hex;
@@ -57,9 +60,9 @@ import org.ethereum.vm.LogInfo;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.InternalTransaction;
 import org.ethereum.vm.program.Program;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class BridgeSupportReleaseBtcTest {
     private static final BigInteger NONCE = new BigInteger("0");
@@ -1645,6 +1648,194 @@ class BridgeSupportReleaseBtcTest {
 
         BigInteger amount = (BigInteger) event.decodeEventData(firstLog.getData())[0];
         assertEquals(pegoutRequestValue.asBigInteger(), amount);
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class ProcessPegoutsInBatch {
+        // too many pegout requests can make the batched pegout exceed the max tx size.
+        // if this happens, it is split in half.
+        // pre-RSKIP378 the total pegout value is not recalculated after the split,
+        // so both the RELEASE_REQUESTED event and the RBTC burn
+        // use the value of ALL the original requests instead of only the batched ones.
+        //
+        // When the change will be dust (below 2700 sats), it is bumped up to reach a non-dust amount,
+        // so the federation keeps that 2700-change extra and that difference is burnt.
+        // The expected burnt amounts below are hardcoded to make tests deterministic, but derived as follows:
+        //   burnt = valuePeggedOut - spentByFederation
+        //     - valuePeggedOut    = full original total value (pre-RSKIP378) or actual batched value (post-RSKIP378)
+        //     - spentByFederation = sumInputs - change. Since recipients pay the fee, this equals the
+        //                           batched total when the change is NOT dust.
+        //   Hence:
+        //     - no split / no dust          -> burnt = 0
+        //     - split, change NOT dust      -> burnt = full - batched = total un-batched value (pre); 0 (post)
+        //     - split, change IS dust       -> add (2700 - real change) to the burn (pre and post)
+
+        private static final ActivationConfig.ForBlock VETIVER_ACTIVATIONS = ActivationConfigsForTest.vetiver900().forBlock(0L);
+
+        private static final Coin DUST_THRESHOLD = Coin.valueOf(2_700); // change outputs below this threshold are dust and get bumped up to it
+        private static final Coin DUST_CHANGE = DUST_THRESHOLD.subtract(Coin.SATOSHI);
+        private static final Coin NON_DUST_CHANGE = DUST_THRESHOLD.add(Coin.SATOSHI);
+        private static final Coin DUST_BUMP = DUST_THRESHOLD.subtract(DUST_CHANGE);
+        private static final Coin PEGOUT_REQUEST_VALUE = Coin.COIN.multiply(1_250);
+
+        private List<LogInfo> logs;
+        private Transaction rskTx;
+
+        void setUp(ActivationConfig.ForBlock activations) {
+            activeFederation = P2shP2wshErpFederationBuilder.builder().build();
+            repository = RskTestUtils.createRepository();
+
+            logs = new ArrayList<>();
+            rskTx = buildUpdateTx();
+
+            StorageAccessor bridgeStorageAccessor = new BridgeStorageAccessorImpl(repository);
+            federationStorageProvider = new FederationStorageProviderImpl(bridgeStorageAccessor);
+            federationStorageProvider.setNewFederation(activeFederation);
+            federationSupport = FederationSupportBuilder.builder()
+                .withFederationConstants(FEDERATION_CONSTANTS)
+                .withFederationStorageProvider(federationStorageProvider)
+                .build();
+            feePerKbSupport = mock(FeePerKbSupportImpl.class);
+            when(feePerKbSupport.getFeePerKb()).thenReturn(Coin.valueOf(5_000L));
+
+            eventLogger = new BridgeEventLoggerImpl(BRIDGE_CONSTANTS, activations, logs);
+            bridgeStorageProvider = new BridgeStorageProvider(
+                repository,
+                NETWORK_PARAMETERS,
+                activations
+            );
+            bridgeSupport = bridgeSupportBuilder
+                .withBridgeConstants(BRIDGE_CONSTANTS)
+                .withProvider(bridgeStorageProvider)
+                .withRepository(repository)
+                .withEventLogger(eventLogger)
+                .withActivations(activations)
+                .withSignatureCache(signatureCache)
+                .withFederationSupport(federationSupport)
+                .withFeePerKbSupport(feePerKbSupport)
+                .build();
+        }
+
+        private void setupRequests(int pegoutRequests, Coin pegoutRequestValue, ActivationConfig.ForBlock activations) throws IOException {
+            ReleaseRequestQueue releaseRequestQueue = bridgeStorageProvider.getReleaseRequestQueue();
+            addPegoutRequestsToQueue(
+                releaseRequestQueue,
+                pegoutRequests,
+                pegoutRequestValue,
+                NETWORK_PARAMETERS
+            );
+
+            // 2500 * 1 btc = 2500 btc
+            int numberOfUtxos = 2500;
+            List<UTXO> utxos = UTXOBuilder.builder()
+                .withScriptPubKey(activeFederation.getP2SHScript())
+                .withValue(Coin.COIN)
+                .buildMany(numberOfUtxos, i -> createHash(i + 1));
+            federationStorageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, activations).addAll(utxos);
+        }
+
+        private static Stream<ActivationConfig.ForBlock> activationsArgs() {
+            return Stream.of(VETIVER_ACTIVATIONS, ACTIVATIONS_ALL);
+        }
+
+        @ParameterizedTest
+        @MethodSource("activationsArgs")
+        void processPegoutsInBatch_noSplitting_shouldUseTotalPegoutRequestsValueRef(ActivationConfig.ForBlock activations) throws IOException {
+            // arrange
+            setUp(activations);
+            int pegoutRequests = 10;
+            Coin pegoutRequestValue = Coin.COIN;
+            setupRequests(pegoutRequests, pegoutRequestValue, activations);
+
+            // act
+            bridgeSupport.updateCollections(rskTx);
+
+            // assert
+            int expectedRemainingRequests = 0;
+            assertRemainingRequests(expectedRemainingRequests);
+
+            Coin originalRequestsValue = pegoutRequestValue.multiply(pegoutRequests);
+            assertReleaseRequested(originalRequestsValue);
+
+            assertNoBurn();
+        }
+
+        @Test
+        void processPegoutsInBatch_preRSKIP378_whenSplittingTotalRequests_withNonDustChange_shouldUseOriginalTotalPegoutRequestsValueRef_shouldBurnRemainingValue() throws IOException {
+            // arrange
+            setUp(VETIVER_ACTIVATIONS);
+
+            int pegoutRequests = 2;
+            Coin pegoutRequestValue = PEGOUT_REQUEST_VALUE.subtract(NON_DUST_CHANGE);
+            setupRequests(pegoutRequests, pegoutRequestValue, VETIVER_ACTIVATIONS);
+
+            // act
+            bridgeSupport.updateCollections(rskTx);
+
+            // assert
+            int expectedRemainingRequests = 1;
+            assertRemainingRequests(expectedRemainingRequests);
+
+            Coin originalRequestsValue = pegoutRequestValue.multiply(pegoutRequests);
+            assertReleaseRequested(originalRequestsValue);
+
+            // pre-RSKIP378 burns the total value of the un-batched requests
+            Coin expectedBurntAmount = pegoutRequestValue.multiply(expectedRemainingRequests);
+            assertAmountBurnt(expectedBurntAmount);
+        }
+
+        @Test
+        void processPegoutsInBatch_preRSKIP378_whenSplittingTotalRequests_withDustChange_shouldUseOriginalTotalPegoutRequestsValueRef_shouldBurnRemainingValuePlusDustBump() throws IOException {
+            // arrange
+            setUp(VETIVER_ACTIVATIONS);
+            int pegoutRequests = 2;
+            Coin pegoutRequestValue = PEGOUT_REQUEST_VALUE.subtract(DUST_CHANGE);
+            setupRequests(pegoutRequests, pegoutRequestValue, VETIVER_ACTIVATIONS);
+
+            // act
+            bridgeSupport.updateCollections(rskTx);
+
+            // assert
+            int expectedRemainingRequests = 1;
+            assertRemainingRequests(expectedRemainingRequests);
+
+            Coin originalRequestsValue = pegoutRequestValue.multiply(pegoutRequests);
+            assertReleaseRequested(originalRequestsValue);
+
+            // pre-RSKIP378 burns the total value of the un-batched requests plus the dust bump the federation retained
+            Coin expectedBurntAmount = pegoutRequestValue.multiply(expectedRemainingRequests).add(DUST_BUMP);
+            assertAmountBurnt(expectedBurntAmount);
+        }
+
+        private void assertRemainingRequests(int expectedRemainingRequests) throws IOException {
+            ReleaseRequestQueue releaseRequestQueue = bridgeStorageProvider.getReleaseRequestQueue();
+            int remainingRequests = releaseRequestQueue.getEntries().size();
+            assertEquals(expectedRemainingRequests, remainingRequests);
+        }
+
+        private void assertReleaseRequested(Coin expectedValue) throws IOException {
+            PegoutsWaitingForConfirmations pegoutsWaitingForConfirmations = bridgeStorageProvider.getPegoutsWaitingForConfirmations();
+            Collection<PegoutsWaitingForConfirmations.Entry> pegoutsWFCEntries = pegoutsWaitingForConfirmations.getEntries(VETIVER_ACTIVATIONS);
+            assertEquals(1, pegoutsWFCEntries.size());
+
+            BtcTransaction batchPegoutTransaction = pegoutsWFCEntries.iterator().next().getBtcTransaction();
+            assertLogReleaseRequested(
+                logs,
+                rskTx.getHash(),
+                batchPegoutTransaction.getHash(),
+                expectedValue
+            );
+        }
+
+        private void assertNoBurn() {
+            Coin expectedBurntAmount = Coin.valueOf(0L);
+            assertAmountBurnt(expectedBurntAmount);
+        }
+
+        private void assertAmountBurnt(Coin expectedBurntAmount) {
+            assertEquals(co.rsk.core.Coin.fromBitcoin(expectedBurntAmount), repository.getBalance(BridgeSupport.BURN_ADDRESS));
+        }
     }
 
     /**********************************

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -828,7 +828,7 @@ class BridgeSupportReleaseBtcTest {
     }
 
     @Test
-    void processPegoutsInBatch_after_hop_divide_transaction_when_max_size_exceeded() throws IOException {
+    void processPegoutsInBatch_whenMaxTxSizeExceeded_lovellActivations_dividesRequestsTwice() throws IOException {
         ActivationConfig.ForBlock lovellActivations = ActivationConfigsForTest.lovell700().forBlock(0L);
 
         int numberOfUtxos = 310;

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -613,7 +613,7 @@ class BridgeSupportReleaseBtcTest {
     @Test
     void release_verify_fee_below_fee_is_rejected() throws IOException {
         Coin value = BRIDGE_CONSTANTS.getMinimumPegoutTxValue().add(Coin.SATOSHI);
-        testPegoutMinimumWithFeeVerificationRejectedByFeeAboveValue(Coin.COIN, co.rsk.core.Coin.fromBitcoin(value));
+        testPegoutMinimumWithFeeVerificationRejectedByFeeAboveValue(Coin.COIN, co.rsk.core.Coin.fromBitcoin(value), ACTIVATIONS_ALL);
     }
 
     @Test
@@ -626,7 +626,7 @@ class BridgeSupportReleaseBtcTest {
             federationStorageProvider.getNewFederation(FEDERATION_CONSTANTS, irisActivations)
         );
         Coin value = feePerKB.div(1000).times(pegoutSize);
-        testPegoutMinimumWithFeeVerificationRejectedByFeeAboveValue(feePerKB, co.rsk.core.Coin.fromBitcoin(value));
+        testPegoutMinimumWithFeeVerificationRejectedByFeeAboveValue(feePerKB, co.rsk.core.Coin.fromBitcoin(value), irisActivations);
     }
 
     @Test
@@ -638,7 +638,7 @@ class BridgeSupportReleaseBtcTest {
             federationStorageProvider.getNewFederation(FEDERATION_CONSTANTS, ACTIVATIONS_ALL)
         );
         Coin value = feePerKB.div(1000).times(pegoutSize);
-        testPegoutMinimumWithFeeVerificationRejectedByFeeAboveValue(feePerKB, co.rsk.core.Coin.fromBitcoin(value));
+        testPegoutMinimumWithFeeVerificationRejectedByFeeAboveValue(feePerKB, co.rsk.core.Coin.fromBitcoin(value), ACTIVATIONS_ALL);
     }
 
     @Test
@@ -1288,20 +1288,21 @@ class BridgeSupportReleaseBtcTest {
 
     private void testPegoutMinimumWithFeeVerificationRejectedByFeeAboveValue(
         Coin feePerKB,
-        co.rsk.core.Coin pegoutRequestValue
+        co.rsk.core.Coin pegoutRequestValue,
+        ActivationConfig.ForBlock activations
     ) throws IOException {
         List<LogInfo> logInfo = new ArrayList<>();
         eventLogger = spy(new BridgeEventLoggerImpl(
             BRIDGE_CONSTANTS,
-            ACTIVATIONS_ALL,
+            activations,
             logInfo
         ));
-        bridgeSupport = initBridgeSupport(eventLogger, ACTIVATIONS_ALL);
+        bridgeSupport = initBridgeSupport(eventLogger, activations);
         when(feePerKbSupport.getFeePerKb()).thenReturn(feePerKB);
 
         int pegoutSize = BridgeUtils.getRegularPegoutTxSize(
-            ACTIVATIONS_ALL,
-            federationStorageProvider.getNewFederation(FEDERATION_CONSTANTS, ACTIVATIONS_ALL)
+            activations,
+            federationStorageProvider.getNewFederation(FEDERATION_CONSTANTS, activations)
         );
         Coin minValueAccordingToFee = feePerKbSupport.getFeePerKb().div(1000).times(pegoutSize);
         Coin minValueWithGapAboveFee = minValueAccordingToFee.add(minValueAccordingToFee.times(

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -45,7 +45,6 @@ import co.rsk.test.builders.FederationSupportBuilder;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.*;
-import java.util.stream.Stream;
 
 import co.rsk.test.builders.UTXOBuilder;
 import org.bouncycastle.util.encoders.Hex;
@@ -60,8 +59,6 @@ import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.InternalTransaction;
 import org.ethereum.vm.program.Program;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 
 class BridgeSupportReleaseBtcTest {
     private static final BigInteger NONCE = new BigInteger("0");
@@ -886,14 +883,14 @@ class BridgeSupportReleaseBtcTest {
 
         // First Half of the PegoutRequests 300 / 2 = 150 Is Batched For The First Time
         assertEquals(150, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
-        assertEquals(1, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertEquals(1, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(lovellActivations).size());
 
         rskTx = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx);
 
         // The Rest PegoutRequests 300 / 2 = 150 Is Batched The 2nd Time updateCollections Is Called
         assertEquals(0, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
-        assertEquals(2, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertEquals(2, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(lovellActivations).size());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -1808,6 +1808,50 @@ class BridgeSupportReleaseBtcTest {
             assertAmountBurnt(expectedBurntAmount);
         }
 
+        @Test
+        void processPegoutsInBatch_postRSKIP378_whenSplittingTotalRequests_withNonDustChange_shouldUseSplitPegoutRequestsValueRef_shouldNotBurn() throws IOException {
+            // arrange
+            setUp(ACTIVATIONS_ALL);
+            int pegoutRequests = 2;
+            Coin pegoutRequestValue = PEGOUT_REQUEST_VALUE.subtract(NON_DUST_CHANGE);
+            setupRequests(pegoutRequests, pegoutRequestValue, ACTIVATIONS_ALL);
+
+            // act
+            bridgeSupport.updateCollections(rskTx);
+
+            // assert
+            int expectedRemainingRequests = 1;
+            assertRemainingRequests(expectedRemainingRequests);
+
+            int pegoutRequestsProcessed = pegoutRequests - expectedRemainingRequests;
+            Coin expectedValueBeingPeggedOut = pegoutRequestValue.multiply(pegoutRequestsProcessed);
+            assertReleaseRequested(expectedValueBeingPeggedOut);
+
+            assertNoBurn();
+        }
+
+        @Test
+        void processPegoutsInBatch_postRSKIP378_whenSplittingTotalRequests_withAmountToBurn_shouldUseSplitPegoutRequestsValueRef_shouldBurn() throws IOException {
+            // arrange
+            setUp(ACTIVATIONS_ALL);
+            int pegoutRequests = 2;
+            Coin pegoutRequestValue = PEGOUT_REQUEST_VALUE.subtract(DUST_CHANGE);
+            setupRequests(pegoutRequests, pegoutRequestValue, ACTIVATIONS_ALL);
+
+            // act
+            bridgeSupport.updateCollections(rskTx);
+
+            // assert
+            int expectedRemainingRequests = 1;
+            assertRemainingRequests(expectedRemainingRequests);
+
+            int pegoutRequestsProcessed = pegoutRequests - expectedRemainingRequests;
+            Coin expectedValueBeingPeggedOut = pegoutRequestValue.multiply(pegoutRequestsProcessed);
+            assertReleaseRequested(expectedValueBeingPeggedOut);
+
+            assertAmountBurnt(DUST_BUMP);
+        }
+
         private void assertRemainingRequests(int expectedRemainingRequests) throws IOException {
             ReleaseRequestQueue releaseRequestQueue = bridgeStorageProvider.getReleaseRequestQueue();
             int remainingRequests = releaseRequestQueue.getEntries().size();

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -76,11 +76,12 @@ class BridgeSupportReleaseBtcTest {
     private Federation activeFederation;
     private Repository repository;
     private BridgeEventLogger eventLogger;
-    private BridgeStorageProvider provider;
+    private BridgeStorageProvider bridgeStorageProvider;
     private FederationStorageProvider federationStorageProvider;
     private BridgeSupport bridgeSupport;
     private Transaction releaseTx;
     private BridgeSupportBuilder bridgeSupportBuilder;
+    private FederationSupport federationSupport;
     private SignatureCache signatureCache;
     private FeePerKbSupport feePerKbSupport;
 
@@ -90,12 +91,34 @@ class BridgeSupportReleaseBtcTest {
         activeFederation = P2shErpFederationBuilder.builder().build();
         repository = spy(RskTestUtils.createRepository());
         eventLogger = mock(BridgeEventLogger.class);
-        provider = initProvider();
-        federationStorageProvider = initFederationStorageProvider();
+        bridgeStorageProvider = new BridgeStorageProvider(
+            repository,
+            NETWORK_PARAMETERS,
+            ACTIVATIONS_ALL
+        );
+        StorageAccessor bridgeStorageAccessor = new BridgeStorageAccessorImpl(repository);
+        federationStorageProvider = new FederationStorageProviderImpl(bridgeStorageAccessor);
+        federationStorageProvider.setNewFederation(activeFederation);
+        setUpUTXOs();
+
+        federationSupport = FederationSupportBuilder.builder()
+            .withFederationConstants(FEDERATION_CONSTANTS)
+            .withFederationStorageProvider(federationStorageProvider)
+            .build();
+
         bridgeSupportBuilder = BridgeSupportBuilder.builder();
         feePerKbSupport = mock(FeePerKbSupportImpl.class);
         when(feePerKbSupport.getFeePerKb()).thenReturn(Coin.valueOf(5_000L));
-        bridgeSupport = spy(initBridgeSupport(eventLogger, ACTIVATIONS_ALL));
+        bridgeSupport = spy(bridgeSupportBuilder
+            .withBridgeConstants(BRIDGE_CONSTANTS)
+            .withProvider(bridgeStorageProvider)
+            .withRepository(repository)
+            .withEventLogger(eventLogger)
+            .withActivations(ACTIVATIONS_ALL)
+            .withSignatureCache(signatureCache)
+            .withFederationSupport(federationSupport)
+            .withFeePerKbSupport(feePerKbSupport)
+            .build());
         releaseTx = buildReleaseRskTx(co.rsk.core.Coin.fromBitcoin(Coin.COIN));
     }
 
@@ -174,8 +197,8 @@ class BridgeSupportReleaseBtcTest {
         bridgeSupport.updateCollections(rskTx);
 
         verify(repository, never()).transfer(any(), any(), any());
-        assertEquals(1, provider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
-        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertEquals(0, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
 
         verify(eventLogger, never()).logReleaseBtcRequested(any(byte[].class), any(BtcTransaction.class), any(Coin.class));
         verify(eventLogger, never()).logReleaseBtcRequestReceived(any(), any(), any());
@@ -194,8 +217,8 @@ class BridgeSupportReleaseBtcTest {
         bridgeSupport.updateCollections(rskTx);
 
         verify(repository, never()).transfer(any(), any(), any());
-        assertEquals(1, provider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
-        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertEquals(0, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
         verify(eventLogger, times(1)).logReleaseBtcRequested(
             any(byte[].class),
             any(BtcTransaction.class),
@@ -218,15 +241,15 @@ class BridgeSupportReleaseBtcTest {
         assertTrue(value.isGreaterThan(BRIDGE_CONSTANTS.getMinimumPegoutTxValue()));
         bridgeSupport.releaseBtc(buildReleaseRskTx(co.rsk.core.Coin.fromBitcoin(value)));
 
-        assertEquals(1, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
 
         Transaction rskTx = buildUpdateTx();
         rskTx.sign(SENDER.getPrivKeyBytes());
         bridgeSupport.updateCollections(rskTx);
 
         verify(repository, never()).transfer(any(), any(), any());
-        assertEquals(1, provider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
-        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertEquals(0, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
 
         assertEquals(4, logInfo.size());
         verify(bridgeEventLogger, times(1)).logReleaseBtcRequested(
@@ -267,8 +290,8 @@ class BridgeSupportReleaseBtcTest {
 
         verify(repository, never()).transfer(any(), any(), any());
 
-        assertEquals(1, provider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
-        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertEquals(0, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
 
         assertEquals(4, logInfo.size());
         verify(bridgeEventLogger, times(1)).logReleaseBtcRequested(
@@ -308,8 +331,8 @@ class BridgeSupportReleaseBtcTest {
 
         verify(repository, never()).transfer(any(), any(), any());
 
-        assertEquals(1, provider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
-        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertEquals(0, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
 
         assertEquals(5, logInfo.size());
         verify(bridgeEventLogger, times(1)).logReleaseBtcRequested(
@@ -352,8 +375,8 @@ class BridgeSupportReleaseBtcTest {
 
         verify(repository, never()).transfer(any(), any(), any());
 
-        assertEquals(0, provider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
-        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertEquals(0, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
         verify(bridgeEventLogger, never()).logReleaseBtcRequestRejected(any(), any(), any());
 
         assertEquals(1, logInfo.size());
@@ -383,8 +406,8 @@ class BridgeSupportReleaseBtcTest {
             argThat(a -> a.equals(co.rsk.core.Coin.fromBitcoin(Coin.ZERO)))
         );
 
-        assertEquals(0, provider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
-        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertEquals(0, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
 
         assertEquals(2, logInfo.size());
         verify(bridgeEventLogger, never()).logReleaseBtcRequestReceived(any(), any(), any());
@@ -423,8 +446,8 @@ class BridgeSupportReleaseBtcTest {
             any(), any(), any()
         );
 
-        assertEquals(0, provider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
-        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertEquals(0, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
         verify(bridgeEventLogger, never()).logReleaseBtcRequestReceived(any(), any(), any());
         assertEquals(2, logInfo.size());
 
@@ -454,7 +477,7 @@ class BridgeSupportReleaseBtcTest {
 
         verify(repository, never()).transfer(any(), any(), any());
 
-        assertEquals(1, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
 
         assertEquals(1, logInfo.size());
         verify(bridgeEventLogger, times(1)).logReleaseBtcRequestReceived(any(), any(), any());
@@ -489,7 +512,7 @@ class BridgeSupportReleaseBtcTest {
         Transaction rskTx = buildUpdateTx();
         rskTx.sign(SENDER.getPrivKeyBytes());
 
-        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
 
         assertEquals(0, logInfo.size());
         verify(bridgeEventLogger, never()).logReleaseBtcRequestReceived(any(), any(), any());
@@ -515,7 +538,7 @@ class BridgeSupportReleaseBtcTest {
         Transaction rskTx = buildUpdateTx();
         rskTx.sign(SENDER.getPrivKeyBytes());
 
-        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
 
         assertEquals(0, logInfo.size());
         verify(bridgeEventLogger, never()).logReleaseBtcRequestReceived(any(), any(), any());
@@ -543,7 +566,7 @@ class BridgeSupportReleaseBtcTest {
 
         verify(repository, never()).transfer(any(), any(), any());
 
-        assertEquals(1, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
 
         assertEquals(1, logInfo.size());
         verify(bridgeEventLogger, times(1)).logReleaseBtcRequestReceived(any(), any(), any());
@@ -575,7 +598,7 @@ class BridgeSupportReleaseBtcTest {
 
         verify(repository, never()).transfer(any(), any(), any());
 
-        assertEquals(1, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
 
         assertEquals(1, logInfo.size());
         verify(bridgeEventLogger, times(1)).logReleaseBtcRequestReceived(any(), any(), any());
@@ -693,9 +716,9 @@ class BridgeSupportReleaseBtcTest {
         federationStorageProvider = mock(FederationStorageProvider.class);
         when(federationStorageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, ACTIVATIONS_ALL)).thenReturn(utxos);
 
-        provider = mock(BridgeStorageProvider.class);
-        when(provider.getReleaseRequestQueue()).thenReturn(pegoutRequests);
-        when(provider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
+        bridgeStorageProvider = mock(BridgeStorageProvider.class);
+        when(bridgeStorageProvider.getReleaseRequestQueue()).thenReturn(pegoutRequests);
+        when(bridgeStorageProvider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
 
         Coin totalValue = pegoutRequests.getEntries()
             .stream()
@@ -710,20 +733,20 @@ class BridgeSupportReleaseBtcTest {
         bridgeSupport = bridgeSupportBuilder
             .withActivations(ACTIVATIONS_ALL)
             .withBridgeConstants(BRIDGE_CONSTANTS)
-            .withProvider(provider)
+            .withProvider(bridgeStorageProvider)
             .withEventLogger(eventLogger)
             .build();
 
         Transaction rskTx = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx);
 
-        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
-        assertEquals(1, provider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertEquals(0, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
 
-        BtcTransaction generatedTransaction = provider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).iterator().next().getBtcTransaction();
+        BtcTransaction generatedTransaction = bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).iterator().next().getBtcTransaction();
 
-        verify(provider, times(1)).getNextPegoutHeight();
-        verify(provider, times(1)).setNextPegoutHeight(any(Long.class));
+        verify(bridgeStorageProvider, times(1)).getNextPegoutHeight();
+        verify(bridgeStorageProvider, times(1)).setNextPegoutHeight(any(Long.class));
 
         verify(eventLogger, times(1)).logBatchPegoutCreated(generatedTransaction.getHash(), rskHashesList);
         verify(eventLogger, times(1)).logReleaseBtcRequested(rskTx.getHash().getBytes(), generatedTransaction, totalValue);
@@ -736,17 +759,17 @@ class BridgeSupportReleaseBtcTest {
 
         long executionBlockNumber = executionBlock.getNumber();
 
-        provider = mock(BridgeStorageProvider.class);
-        when(provider.getNextPegoutHeight()).thenReturn(Optional.of(executionBlockNumber + BRIDGE_CONSTANTS.getNumberOfBlocksBetweenPegouts() - 1));
-        when(provider.getReleaseRequestQueue()).thenReturn(new ReleaseRequestQueue(Arrays.asList(
+        bridgeStorageProvider = mock(BridgeStorageProvider.class);
+        when(bridgeStorageProvider.getNextPegoutHeight()).thenReturn(Optional.of(executionBlockNumber + BRIDGE_CONSTANTS.getNumberOfBlocksBetweenPegouts() - 1));
+        when(bridgeStorageProvider.getReleaseRequestQueue()).thenReturn(new ReleaseRequestQueue(Arrays.asList(
             new ReleaseRequestQueue.Entry(BitcoinTestUtils.createP2PKHAddress(BRIDGE_CONSTANTS.getBtcParams(), "one"), Coin.MILLICOIN),
             new ReleaseRequestQueue.Entry(BitcoinTestUtils.createP2PKHAddress(BRIDGE_CONSTANTS.getBtcParams(), "two"), Coin.MILLICOIN)
         )));
-        when(provider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
+        when(bridgeStorageProvider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
 
         bridgeSupport = bridgeSupportBuilder
             .withBridgeConstants(BRIDGE_CONSTANTS)
-            .withProvider(provider)
+            .withProvider(bridgeStorageProvider)
             .withExecutionBlock(executionBlock)
             .withActivations(ACTIVATIONS_ALL)
             .build();
@@ -754,19 +777,19 @@ class BridgeSupportReleaseBtcTest {
         Transaction rskTx = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx);
 
-        verify(provider, times(1)).getNextPegoutHeight();
-        verify(provider, never()).setNextPegoutHeight(any(Long.class));
+        verify(bridgeStorageProvider, times(1)).getNextPegoutHeight();
+        verify(bridgeStorageProvider, never()).setNextPegoutHeight(any(Long.class));
 
-        assertEquals(2, provider.getReleaseRequestQueue().getEntries().size());
-        assertEquals(0, provider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertEquals(2, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
     }
 
     @Test
     void processPegoutsInBatch_hop_activation_no_requests_in_queue_updates_next_pegout_height() throws IOException {
-        provider = mock(BridgeStorageProvider.class);
-        when(provider.getNextPegoutHeight()).thenReturn(Optional.of(100L));
-        when(provider.getReleaseRequestQueue()).thenReturn(new ReleaseRequestQueue(Collections.emptyList()));
-        when(provider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
+        bridgeStorageProvider = mock(BridgeStorageProvider.class);
+        when(bridgeStorageProvider.getNextPegoutHeight()).thenReturn(Optional.of(100L));
+        when(bridgeStorageProvider.getReleaseRequestQueue()).thenReturn(new ReleaseRequestQueue(Collections.emptyList()));
+        when(bridgeStorageProvider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
 
         Block executionBlock = mock(Block.class);
         when(executionBlock.getNumber()).thenReturn(100L);
@@ -774,7 +797,7 @@ class BridgeSupportReleaseBtcTest {
         bridgeSupport = bridgeSupportBuilder
             .withActivations(ACTIVATIONS_ALL)
             .withBridgeConstants(BRIDGE_CONSTANTS)
-            .withProvider(provider)
+            .withProvider(bridgeStorageProvider)
             .withExecutionBlock(executionBlock)
             .build();
 
@@ -783,8 +806,8 @@ class BridgeSupportReleaseBtcTest {
 
         long nextPegoutHeight = executionBlock.getNumber() + BRIDGE_CONSTANTS.getNumberOfBlocksBetweenPegouts();
 
-        verify(provider, times(1)).getNextPegoutHeight();
-        verify(provider, times(1)).setNextPegoutHeight(nextPegoutHeight);
+        verify(bridgeStorageProvider, times(1)).getNextPegoutHeight();
+        verify(bridgeStorageProvider, times(1)).setNextPegoutHeight(nextPegoutHeight);
     }
 
     @Test
@@ -802,20 +825,20 @@ class BridgeSupportReleaseBtcTest {
         when(federationStorageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, ACTIVATIONS_ALL)).thenReturn(utxos);
         when(federationStorageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, ACTIVATIONS_ALL)).thenReturn(utxos);
 
-        provider = mock(BridgeStorageProvider.class);
-        when(provider.getReleaseRequestQueue()).thenReturn(new ReleaseRequestQueue(Arrays.asList(
+        bridgeStorageProvider = mock(BridgeStorageProvider.class);
+        when(bridgeStorageProvider.getReleaseRequestQueue()).thenReturn(new ReleaseRequestQueue(Arrays.asList(
             new ReleaseRequestQueue.Entry(BitcoinTestUtils.createP2PKHAddress(BRIDGE_CONSTANTS.getBtcParams(), "one"), Coin.COIN),
             new ReleaseRequestQueue.Entry(BitcoinTestUtils.createP2PKHAddress(BRIDGE_CONSTANTS.getBtcParams(), "two"), Coin.COIN),
             new ReleaseRequestQueue.Entry(BitcoinTestUtils.createP2PKHAddress(BRIDGE_CONSTANTS.getBtcParams(), "three"), Coin.COIN),
             new ReleaseRequestQueue.Entry(BitcoinTestUtils.createP2PKHAddress(BRIDGE_CONSTANTS.getBtcParams(), "four"), Coin.COIN),
             new ReleaseRequestQueue.Entry(BitcoinTestUtils.createP2PKHAddress(BRIDGE_CONSTANTS.getBtcParams(), "five"), Coin.COIN)
         )));
-        when(provider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
+        when(bridgeStorageProvider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
 
         bridgeSupport = bridgeSupportBuilder
             .withActivations(ACTIVATIONS_ALL)
             .withBridgeConstants(BRIDGE_CONSTANTS)
-            .withProvider(provider)
+            .withProvider(bridgeStorageProvider)
             .build();
 
         Transaction rskTx = buildUpdateTx();
@@ -823,8 +846,8 @@ class BridgeSupportReleaseBtcTest {
 
         // Insufficient_Money i.e 4 BTC UTXO Available For 5 BTC Transaction.
         // Pegout requests can't be processed and remains in the queue
-        assertEquals(5, provider.getReleaseRequestQueue().getEntries().size());
-        assertEquals(0, provider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertEquals(5, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
     }
 
     @Test
@@ -845,14 +868,14 @@ class BridgeSupportReleaseBtcTest {
             .withActivations(lovellActivations)
             .build();
 
-        provider = mock(BridgeStorageProvider.class);
-        when(provider.getReleaseRequestQueue()).thenReturn(new ReleaseRequestQueue(PegTestUtils.createReleaseRequestQueueEntries(300)));
-        when(provider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
+        bridgeStorageProvider = mock(BridgeStorageProvider.class);
+        when(bridgeStorageProvider.getReleaseRequestQueue()).thenReturn(new ReleaseRequestQueue(PegTestUtils.createReleaseRequestQueueEntries(300)));
+        when(bridgeStorageProvider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
 
         bridgeSupport = bridgeSupportBuilder
             .withActivations(lovellActivations)
             .withBridgeConstants(BRIDGE_CONSTANTS)
-            .withProvider(provider)
+            .withProvider(bridgeStorageProvider)
             .withFederationSupport(federationSupport)
             .build();
 
@@ -860,15 +883,15 @@ class BridgeSupportReleaseBtcTest {
         bridgeSupport.updateCollections(rskTx);
 
         // First Half of the PegoutRequests 300 / 2 = 150 Is Batched For The First Time
-        assertEquals(150, provider.getReleaseRequestQueue().getEntries().size());
-        assertEquals(1, provider.getPegoutsWaitingForConfirmations().getEntries(lovellActivations).size());
+        assertEquals(150, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
 
         rskTx = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx);
 
         // The Rest PegoutRequests 300 / 2 = 150 Is Batched The 2nd Time updateCollections Is Called
-        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
-        assertEquals(2, provider.getPegoutsWaitingForConfirmations().getEntries(lovellActivations).size());
+        assertEquals(0, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(2, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
     }
 
     @Test
@@ -881,23 +904,23 @@ class BridgeSupportReleaseBtcTest {
         federationStorageProvider = mock(FederationStorageProvider.class);
         when(federationStorageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, ACTIVATIONS_ALL)).thenReturn(utxos);
 
-        provider = mock(BridgeStorageProvider.class);
-        when(provider.getReleaseRequestQueue()).thenReturn(new ReleaseRequestQueue(Collections.singletonList(
+        bridgeStorageProvider = mock(BridgeStorageProvider.class);
+        when(bridgeStorageProvider.getReleaseRequestQueue()).thenReturn(new ReleaseRequestQueue(Collections.singletonList(
             new ReleaseRequestQueue.Entry(BitcoinTestUtils.createP2PKHAddress(BRIDGE_CONSTANTS.getBtcParams(), "one"), Coin.COIN.multiply(700))
         )));
-        when(provider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
+        when(bridgeStorageProvider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
 
         bridgeSupport = bridgeSupportBuilder
             .withActivations(ACTIVATIONS_ALL)
             .withBridgeConstants(BRIDGE_CONSTANTS)
-            .withProvider(provider)
+            .withProvider(bridgeStorageProvider)
             .build();
 
         Transaction rskTx = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx);
 
-        assertEquals(1, provider.getReleaseRequestQueue().getEntries().size());
-        assertEquals(0, provider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertEquals(1, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
     }
 
     @Test
@@ -910,24 +933,24 @@ class BridgeSupportReleaseBtcTest {
         federationStorageProvider = mock(FederationStorageProvider.class);
         when(federationStorageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, ACTIVATIONS_ALL)).thenReturn(utxos);
 
-        provider = mock(BridgeStorageProvider.class);
-        when(provider.getReleaseRequestQueue()).thenReturn(new ReleaseRequestQueue(Arrays.asList(
+        bridgeStorageProvider = mock(BridgeStorageProvider.class);
+        when(bridgeStorageProvider.getReleaseRequestQueue()).thenReturn(new ReleaseRequestQueue(Arrays.asList(
             new ReleaseRequestQueue.Entry(BitcoinTestUtils.createP2PKHAddress(BRIDGE_CONSTANTS.getBtcParams(), "one"), Coin.COIN.multiply(700)),
             new ReleaseRequestQueue.Entry(BitcoinTestUtils.createP2PKHAddress(BRIDGE_CONSTANTS.getBtcParams(), "two"), Coin.COIN.multiply(700))
         )));
-        when(provider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
+        when(bridgeStorageProvider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
 
         bridgeSupport = bridgeSupportBuilder
             .withActivations(ACTIVATIONS_ALL)
             .withBridgeConstants(BRIDGE_CONSTANTS)
-            .withProvider(provider)
+            .withProvider(bridgeStorageProvider)
             .build();
 
         Transaction rskTx = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx);
 
-        assertEquals(2, provider.getReleaseRequestQueue().getEntries().size());
-        assertEquals(0, provider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertEquals(2, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
     }
 
     @Test
@@ -958,21 +981,21 @@ class BridgeSupportReleaseBtcTest {
         federationStorageProvider = mock(FederationStorageProvider.class);
         when(federationStorageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, irisActivations)).thenReturn(utxos);
 
-        provider = mock(BridgeStorageProvider.class);
-        when(provider.getReleaseRequestQueue()).thenReturn(pegoutRequests);
-        when(provider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
+        bridgeStorageProvider = mock(BridgeStorageProvider.class);
+        when(bridgeStorageProvider.getReleaseRequestQueue()).thenReturn(pegoutRequests);
+        when(bridgeStorageProvider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
 
         bridgeSupport = bridgeSupportBuilder
             .withBridgeConstants(BRIDGE_CONSTANTS)
-            .withProvider(provider)
+            .withProvider(bridgeStorageProvider)
             .withActivations(irisActivations)
             .build();
 
         Transaction rskTx = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx);
 
-        assertEquals(originalPegoutRequests, provider.getReleaseRequestQueue());
-        assertEquals(0, provider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertEquals(originalPegoutRequests, bridgeStorageProvider.getReleaseRequestQueue());
+        assertEquals(0, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
     }
 
     @Test
@@ -1013,22 +1036,22 @@ class BridgeSupportReleaseBtcTest {
         federationStorageProvider = mock(FederationStorageProvider.class);
         when(federationStorageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, irisActivations)).thenReturn(utxos);
 
-        provider = mock(BridgeStorageProvider.class);
-        when(provider.getReleaseRequestQueue()).thenReturn(pegoutRequests);
-        when(provider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
+        bridgeStorageProvider = mock(BridgeStorageProvider.class);
+        when(bridgeStorageProvider.getReleaseRequestQueue()).thenReturn(pegoutRequests);
+        when(bridgeStorageProvider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
 
         bridgeSupport = bridgeSupportBuilder
             .withBridgeConstants(BRIDGE_CONSTANTS)
-            .withProvider(provider)
+            .withProvider(bridgeStorageProvider)
             .withActivations(irisActivations)
             .build();
 
         Transaction rskTx = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx);
 
-        assertNotEquals(originalPegoutRequests, provider.getReleaseRequestQueue());
-        assertEquals(expectedPegoutRequests, provider.getReleaseRequestQueue());
-        assertEquals(0, provider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertNotEquals(originalPegoutRequests, bridgeStorageProvider.getReleaseRequestQueue());
+        assertEquals(expectedPegoutRequests, bridgeStorageProvider.getReleaseRequestQueue());
+        assertEquals(0, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
     }
 
     @Test
@@ -1047,17 +1070,17 @@ class BridgeSupportReleaseBtcTest {
         federationStorageProvider = mock(FederationStorageProvider.class);
         when(federationStorageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, irisActivations)).thenReturn(utxos);
 
-        provider = mock(BridgeStorageProvider.class);
-        when(provider.getReleaseRequestQueue()).thenReturn(new ReleaseRequestQueue(Arrays.asList(
+        bridgeStorageProvider = mock(BridgeStorageProvider.class);
+        when(bridgeStorageProvider.getReleaseRequestQueue()).thenReturn(new ReleaseRequestQueue(Arrays.asList(
             new ReleaseRequestQueue.Entry(BitcoinTestUtils.createP2PKHAddress(BRIDGE_CONSTANTS.getBtcParams(), "one"), Coin.COIN.multiply(4)),
             new ReleaseRequestQueue.Entry(BitcoinTestUtils.createP2PKHAddress(BRIDGE_CONSTANTS.getBtcParams(), "two"), Coin.COIN.multiply(3)),
             new ReleaseRequestQueue.Entry(BitcoinTestUtils.createP2PKHAddress(BRIDGE_CONSTANTS.getBtcParams(), "three"), Coin.COIN.multiply(2))
         )));
-        when(provider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
+        when(bridgeStorageProvider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
 
         bridgeSupport = bridgeSupportBuilder
             .withBridgeConstants(BRIDGE_CONSTANTS)
-            .withProvider(provider)
+            .withProvider(bridgeStorageProvider)
             .withActivations(irisActivations)
             .build();
 
@@ -1065,8 +1088,8 @@ class BridgeSupportReleaseBtcTest {
         bridgeSupport.updateCollections(rskTx);
 
         // 2 remains in queue, 1 is processed to the transaction set
-        assertEquals(2, provider.getReleaseRequestQueue().getEntries().size());
-        assertEquals(1, provider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertEquals(2, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
     }
 
     @Test
@@ -1087,17 +1110,17 @@ class BridgeSupportReleaseBtcTest {
         federationStorageProvider = mock(FederationStorageProvider.class);
         when(federationStorageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, ACTIVATIONS_ALL)).thenReturn(utxos);
 
-        provider = mock(BridgeStorageProvider.class);
-        when(provider.getReleaseRequestQueue()).thenReturn(new ReleaseRequestQueue(Arrays.asList(
+        bridgeStorageProvider = mock(BridgeStorageProvider.class);
+        when(bridgeStorageProvider.getReleaseRequestQueue()).thenReturn(new ReleaseRequestQueue(Arrays.asList(
             new ReleaseRequestQueue.Entry(BitcoinTestUtils.createP2PKHAddress(BRIDGE_CONSTANTS.getBtcParams(), "one"), Coin.COIN.multiply(5)),
             new ReleaseRequestQueue.Entry(BitcoinTestUtils.createP2PKHAddress(BRIDGE_CONSTANTS.getBtcParams(), "two"), Coin.COIN.multiply(4)),
             new ReleaseRequestQueue.Entry(BitcoinTestUtils.createP2PKHAddress(BRIDGE_CONSTANTS.getBtcParams(), "three"), Coin.COIN.multiply(3))
         )));
-        when(provider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
+        when(bridgeStorageProvider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
 
         bridgeSupport = bridgeSupportBuilder
             .withBridgeConstants(BRIDGE_CONSTANTS)
-            .withProvider(provider)
+            .withProvider(bridgeStorageProvider)
             .withActivations(ACTIVATIONS_ALL)
             .withEventLogger(eventLogger)
             .build();
@@ -1105,11 +1128,11 @@ class BridgeSupportReleaseBtcTest {
         Transaction rskTx = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx);
 
-        assertEquals(3, provider.getReleaseRequestQueue().getEntries().size());
-        assertEquals(0, provider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertEquals(3, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
 
         verify(eventLogger, never()).logBatchPegoutCreated(any(), any());
-        verify(provider, never()).setNextPegoutHeight(any(Long.class));
+        verify(bridgeStorageProvider, never()).setNextPegoutHeight(any(Long.class));
     }
 
     @Test
@@ -1132,17 +1155,17 @@ class BridgeSupportReleaseBtcTest {
         when(federationStorageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, ACTIVATIONS_ALL)).thenReturn(utxos);
         when(federationStorageProvider.getNewFederation(FEDERATION_CONSTANTS, ACTIVATIONS_ALL)).thenReturn(activeFederation);
 
-        provider = mock(BridgeStorageProvider.class);
-        when(provider.getReleaseRequestQueue()).thenReturn(new ReleaseRequestQueue(Arrays.asList(
+        bridgeStorageProvider = mock(BridgeStorageProvider.class);
+        when(bridgeStorageProvider.getReleaseRequestQueue()).thenReturn(new ReleaseRequestQueue(Arrays.asList(
             new ReleaseRequestQueue.Entry(BitcoinTestUtils.createP2PKHAddress(BRIDGE_CONSTANTS.getBtcParams(), "one"), Coin.COIN.multiply(5)),
             new ReleaseRequestQueue.Entry(BitcoinTestUtils.createP2PKHAddress(BRIDGE_CONSTANTS.getBtcParams(), "two"), Coin.COIN.multiply(4)),
             new ReleaseRequestQueue.Entry(BitcoinTestUtils.createP2PKHAddress(BRIDGE_CONSTANTS.getBtcParams(), "three"), Coin.COIN.multiply(3))
         )));
-        when(provider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
+        when(bridgeStorageProvider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
 
         bridgeSupport = bridgeSupportBuilder
             .withBridgeConstants(BRIDGE_CONSTANTS)
-            .withProvider(provider)
+            .withProvider(bridgeStorageProvider)
             .withActivations(ACTIVATIONS_ALL)
             .withEventLogger(eventLogger)
             .build();
@@ -1151,11 +1174,11 @@ class BridgeSupportReleaseBtcTest {
         Transaction rskTx = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx);
 
-        assertEquals(3, provider.getReleaseRequestQueue().getEntries().size());
-        assertEquals(0, provider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertEquals(3, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
 
         verify(eventLogger, never()).logBatchPegoutCreated(any(), any());
-        verify(provider, never()).setNextPegoutHeight(any(Long.class));
+        verify(bridgeStorageProvider, never()).setNextPegoutHeight(any(Long.class));
 
         UTXO utxo = UTXOBuilder.builder()
             .withScriptPubKey(outputScript)
@@ -1171,7 +1194,7 @@ class BridgeSupportReleaseBtcTest {
 
         bridgeSupport = bridgeSupportBuilder
             .withBridgeConstants(BRIDGE_CONSTANTS)
-            .withProvider(provider)
+            .withProvider(bridgeStorageProvider)
             .withActivations(ACTIVATIONS_ALL)
             .withEventLogger(eventLogger)
             .withFederationSupport(federationSupport)
@@ -1181,11 +1204,11 @@ class BridgeSupportReleaseBtcTest {
         Transaction rskTx2 = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx2);
 
-        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
-        assertEquals(1, provider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertEquals(0, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, bridgeStorageProvider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
 
         verify(eventLogger, times(1)).logBatchPegoutCreated(any(), any());
-        verify(provider, times(1)).setNextPegoutHeight(any(Long.class));
+        verify(bridgeStorageProvider, times(1)).setNextPegoutHeight(any(Long.class));
     }
 
     private void testPegoutMinimumWithFeeVerificationPass(Coin feePerKB, co.rsk.core.Coin pegoutRequestedValue) throws IOException {
@@ -1217,7 +1240,7 @@ class BridgeSupportReleaseBtcTest {
 
         verify(repository, never()).transfer(any(), any(), any());
 
-        assertEquals(1, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(1, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
 
         assertEquals(1, logInfo.size());
         verify(eventLogger, times(1)).logReleaseBtcRequestReceived(any(), any(), any());
@@ -1253,7 +1276,7 @@ class BridgeSupportReleaseBtcTest {
         RskAddress senderAddress = new RskAddress(SENDER.getAddress());
 
         verify(repository, times(1)).transfer(BRIDGE_ADDRESS, senderAddress, pegoutRequestValue);
-        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
         assertEquals(1, logInfo.size());
 
         verify(eventLogger, never()).logReleaseBtcRequestReceived(any(), any(), any());
@@ -1300,7 +1323,7 @@ class BridgeSupportReleaseBtcTest {
             senderAddress,
             pegoutRequestValue
         );
-        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
         assertEquals(1, logInfo.size());
 
         verify(eventLogger, never()).logReleaseBtcRequestReceived(any(), any(), any());
@@ -1345,7 +1368,7 @@ class BridgeSupportReleaseBtcTest {
             expectedRefundValue
         );
 
-        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
 
         assertEquals(1, logInfo.size());
         verify(eventLogger, never()).logReleaseBtcRequestReceived(any(), any(), any());
@@ -1389,7 +1412,7 @@ class BridgeSupportReleaseBtcTest {
             pegoutRequestValue
         );
 
-        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
 
         assertEquals(1, logInfo.size());
         verify(eventLogger, never()).logReleaseBtcRequestReceived(any(), any(), any());
@@ -1435,7 +1458,7 @@ class BridgeSupportReleaseBtcTest {
         // No refund is made to a contract
         verify(repository, never()).transfer(any(), any(), any());
 
-        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
 
         assertEquals(1, logInfo.size());
         verify(eventLogger, never()).logReleaseBtcRequestReceived(any(), any(), any());
@@ -1482,7 +1505,7 @@ class BridgeSupportReleaseBtcTest {
         // No refund is made to a contract
         verify(repository, never()).transfer(any(), any(), any());
 
-        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
 
         assertEquals(1, logInfo.size());
         verify(eventLogger, never()).logReleaseBtcRequestReceived(any(), any(), any());
@@ -1545,7 +1568,7 @@ class BridgeSupportReleaseBtcTest {
             expectedRefundValue
         );
 
-        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
 
         assertEquals(1, logInfo.size());
         verify(eventLogger, never()).logReleaseBtcRequestReceived(any(), any(), any());
@@ -1606,7 +1629,7 @@ class BridgeSupportReleaseBtcTest {
             pegoutRequestValue
         );
 
-        assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
+        assertEquals(0, bridgeStorageProvider.getReleaseRequestQueue().getEntries().size());
 
         assertEquals(1, logInfo.size());
         verify(eventLogger, never()).logReleaseBtcRequestReceived(any(), any(), any());
@@ -1680,14 +1703,14 @@ class BridgeSupportReleaseBtcTest {
     }
 
     private BridgeSupport initBridgeSupport(BridgeEventLogger eventLogger, ActivationConfig.ForBlock activations) {
-        FederationSupport federationSupport = FederationSupportBuilder.builder()
+        federationSupport = FederationSupportBuilder.builder()
             .withFederationConstants(FEDERATION_CONSTANTS)
             .withFederationStorageProvider(federationStorageProvider)
             .build();
 
         return bridgeSupportBuilder
             .withBridgeConstants(BRIDGE_CONSTANTS)
-            .withProvider(provider)
+            .withProvider(bridgeStorageProvider)
             .withRepository(repository)
             .withEventLogger(eventLogger)
             .withActivations(activations)
@@ -1697,25 +1720,12 @@ class BridgeSupportReleaseBtcTest {
             .build();
     }
 
-    private BridgeStorageProvider initProvider() {
-        return new BridgeStorageProvider(
-            repository,
-            NETWORK_PARAMETERS,
-            ACTIVATIONS_ALL
-        );
-    }
-
-    private FederationStorageProvider initFederationStorageProvider() {
+    private void setUpUTXOs() {
         UTXO utxo = UTXOBuilder.builder()
             .withValue(Coin.COIN.multiply(2))
             .withBlockHeight(1)
             .withScriptPubKey(activeFederation.getP2SHScript())
             .build();
-        StorageAccessor bridgeStorageAccessor = new BridgeStorageAccessorImpl(repository);
-        FederationStorageProvider storageProvider = new FederationStorageProviderImpl(bridgeStorageAccessor);
-        storageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, ACTIVATIONS_ALL).add(utxo);
-        storageProvider.setNewFederation(activeFederation);
-
-        return storageProvider;
+        federationStorageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, ACTIVATIONS_ALL).add(utxo);
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -19,6 +19,7 @@ package co.rsk.peg;
 
 import static co.rsk.peg.BridgeSupportTestUtil.addPegoutRequestsToQueue;
 import static co.rsk.peg.BridgeSupportTestUtil.assertLogReleaseRequested;
+import static co.rsk.peg.bitcoin.BitcoinTestUtils.MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.createHash;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -45,7 +46,6 @@ import co.rsk.test.builders.FederationSupportBuilder;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.*;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import co.rsk.test.builders.UTXOBuilder;
@@ -675,7 +675,7 @@ class BridgeSupportReleaseBtcTest {
         federationStorageProvider = mock(FederationStorageProvider.class);
         when(federationStorageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, irisActivations)).thenReturn(utxos);
 
-        BridgeStorageProvider bridgeStorageProvider = mock(BridgeStorageProvider.class);
+        bridgeStorageProvider = mock(BridgeStorageProvider.class);
         when(bridgeStorageProvider.getReleaseRequestQueue()).thenReturn(new ReleaseRequestQueue(Arrays.asList(
             new ReleaseRequestQueue.Entry(BitcoinTestUtils.createP2PKHAddress(BRIDGE_CONSTANTS.getBtcParams(), "one"), Coin.COIN),
             new ReleaseRequestQueue.Entry(BitcoinTestUtils.createP2PKHAddress(BRIDGE_CONSTANTS.getBtcParams(), "two"), Coin.COIN))
@@ -731,7 +731,7 @@ class BridgeSupportReleaseBtcTest {
         List<Keccak256> rskHashesList = pegoutRequests.getEntries()
             .stream()
             .map(ReleaseRequestQueue.Entry::getRskTxHash)
-            .collect(Collectors.toList());
+            .toList();
 
         bridgeSupport = bridgeSupportBuilder
             .withActivations(ACTIVATIONS_ALL)
@@ -865,7 +865,7 @@ class BridgeSupportReleaseBtcTest {
         federationStorageProvider = mock(FederationStorageProvider.class);
         when(federationStorageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, lovellActivations)).thenReturn(utxos);
         when(federationStorageProvider.getNewFederation(FEDERATION_CONSTANTS, lovellActivations)).thenReturn(activeFederation);
-        FederationSupport federationSupport = FederationSupportBuilder.builder()
+        federationSupport = FederationSupportBuilder.builder()
             .withFederationConstants(FEDERATION_CONSTANTS)
             .withFederationStorageProvider(federationStorageProvider)
             .withActivations(lovellActivations)
@@ -1189,7 +1189,7 @@ class BridgeSupportReleaseBtcTest {
 
         utxos.add(utxo);
         when(federationStorageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, ACTIVATIONS_ALL)).thenReturn(utxos);
-        FederationSupport federationSupport = FederationSupportBuilder.builder()
+        federationSupport = FederationSupportBuilder.builder()
             .withFederationConstants(FEDERATION_CONSTANTS)
             .withFederationStorageProvider(federationStorageProvider)
             .withActivations(ACTIVATIONS_ALL)
@@ -1671,14 +1671,12 @@ class BridgeSupportReleaseBtcTest {
         //     - split, change NOT dust      -> burnt = full - batched = total un-batched value (pre); 0 (post)
         //     - split, change IS dust       -> add (2700 - real change) to the burn (pre and post)
 
-        private static final ActivationConfig.ForBlock VETIVER_ACTIVATIONS = ActivationConfigsForTest.vetiver900().forBlock(0L);
+        private final ActivationConfig.ForBlock VETIVER_ACTIVATIONS = ActivationConfigsForTest.vetiver900().forBlock(0L);
 
-        private static final Coin DUST_THRESHOLD = Coin.valueOf(2_700); // change outputs below this threshold are dust and get bumped up to it
-        private static final Coin DUST_CHANGE = DUST_THRESHOLD.subtract(Coin.SATOSHI);
-        private static final Coin NON_DUST_CHANGE = DUST_THRESHOLD.add(Coin.SATOSHI);
-        private static final Coin DUST_BUMP = DUST_THRESHOLD.subtract(DUST_CHANGE);
-        private static final Coin PEGOUT_REQUEST_BASE_VALUE = Coin.COIN.multiply(1_250); // we will subtract dust/non-dust value from it
-        private static final int INPUTS_EXCEEDING_MAX_TX_SIZE = 2500;
+        private final Coin DUST_CHANGE = MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT.subtract(Coin.SATOSHI);
+        private final Coin NON_DUST_CHANGE = MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT.add(Coin.SATOSHI);
+        private final Coin DUST_BUMP = MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT.subtract(DUST_CHANGE);
+        private final Coin PEGOUT_REQUEST_BASE_VALUE = Coin.COIN.multiply(1_250); // we will subtract dust/non-dust value from it
 
         private List<LogInfo> logs;
         private Transaction rskTx;
@@ -1727,14 +1725,15 @@ class BridgeSupportReleaseBtcTest {
                 NETWORK_PARAMETERS
             );
 
+            int inputsExceedingMaxTxSize = 2500;
             List<UTXO> utxos = UTXOBuilder.builder()
                 .withScriptPubKey(activeFederation.getP2SHScript())
                 .withValue(Coin.COIN)
-                .buildMany(INPUTS_EXCEEDING_MAX_TX_SIZE, i -> createHash(i + 1));
+                .buildMany(inputsExceedingMaxTxSize, i -> createHash(i + 1));
             federationStorageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, activations).addAll(utxos);
         }
 
-        private static Stream<ActivationConfig.ForBlock> activationsArgs() {
+        private Stream<ActivationConfig.ForBlock> activationsArgs() {
             return Stream.of(VETIVER_ACTIVATIONS, ACTIVATIONS_ALL);
         }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportReleaseBtcTest.java
@@ -829,18 +829,20 @@ class BridgeSupportReleaseBtcTest {
 
     @Test
     void processPegoutsInBatch_after_hop_divide_transaction_when_max_size_exceeded() throws IOException {
+        ActivationConfig.ForBlock lovellActivations = ActivationConfigsForTest.lovell700().forBlock(0L);
+
         int numberOfUtxos = 310;
         List<UTXO> utxos = UTXOBuilder.builder()
             .withScriptPubKey(activeFederation.getP2SHScript())
             .buildMany(numberOfUtxos, i -> createHash(i + 1));
 
         federationStorageProvider = mock(FederationStorageProvider.class);
-        when(federationStorageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, ACTIVATIONS_ALL)).thenReturn(utxos);
-        when(federationStorageProvider.getNewFederation(FEDERATION_CONSTANTS, ACTIVATIONS_ALL)).thenReturn(activeFederation);
+        when(federationStorageProvider.getNewFederationBtcUTXOs(NETWORK_PARAMETERS, lovellActivations)).thenReturn(utxos);
+        when(federationStorageProvider.getNewFederation(FEDERATION_CONSTANTS, lovellActivations)).thenReturn(activeFederation);
         FederationSupport federationSupport = FederationSupportBuilder.builder()
             .withFederationConstants(FEDERATION_CONSTANTS)
             .withFederationStorageProvider(federationStorageProvider)
-            .withActivations(ACTIVATIONS_ALL)
+            .withActivations(lovellActivations)
             .build();
 
         provider = mock(BridgeStorageProvider.class);
@@ -848,7 +850,7 @@ class BridgeSupportReleaseBtcTest {
         when(provider.getPegoutsWaitingForConfirmations()).thenReturn(new PegoutsWaitingForConfirmations(Collections.emptySet()));
 
         bridgeSupport = bridgeSupportBuilder
-            .withActivations(ACTIVATIONS_ALL)
+            .withActivations(lovellActivations)
             .withBridgeConstants(BRIDGE_CONSTANTS)
             .withProvider(provider)
             .withFederationSupport(federationSupport)
@@ -859,14 +861,14 @@ class BridgeSupportReleaseBtcTest {
 
         // First Half of the PegoutRequests 300 / 2 = 150 Is Batched For The First Time
         assertEquals(150, provider.getReleaseRequestQueue().getEntries().size());
-        assertEquals(1, provider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertEquals(1, provider.getPegoutsWaitingForConfirmations().getEntries(lovellActivations).size());
 
         rskTx = buildUpdateTx();
         bridgeSupport.updateCollections(rskTx);
 
         // The Rest PegoutRequests 300 / 2 = 150 Is Batched The 2nd Time updateCollections Is Called
         assertEquals(0, provider.getReleaseRequestQueue().getEntries().size());
-        assertEquals(2, provider.getPegoutsWaitingForConfirmations().getEntries(ACTIVATIONS_ALL).size());
+        assertEquals(2, provider.getPegoutsWaitingForConfirmations().getEntries(lovellActivations).size());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportSvpTest.java
@@ -5,7 +5,7 @@ import static co.rsk.RskTestUtils.createRskBlock;
 import static co.rsk.peg.BridgeEventsTestUtils.*;
 import static co.rsk.peg.BridgeStorageIndexKey.*;
 import static co.rsk.peg.BridgeSupportTestUtil.*;
-import static co.rsk.peg.BridgeUtils.calculatePegoutTxSize;
+import static co.rsk.peg.BridgeUtils.simulatePegoutTxSize;
 import static co.rsk.peg.PegUtils.getFlyoverFederationOutputScript;
 import static co.rsk.peg.PegUtils.getFlyoverFederationRedeemScript;
 import static co.rsk.peg.bitcoin.BitcoinUtils.BTC_TX_VERSION_2;
@@ -807,7 +807,7 @@ class BridgeSupportSvpTest {
             List<TransactionOutput> outputs = svpSpendTransaction.getOutputs();
             assertEquals(1, outputs.size());
 
-            long calculatedTransactionSize = calculatePegoutTxSize(allActivations, proposedFederation, 2, 1);
+            long calculatedTransactionSize = simulatePegoutTxSize(allActivations, proposedFederation, 2, 1);
             Coin fees = feePerKb
                 .multiply(calculatedTransactionSize * 12L / 10L) // back up calculation
                 .divide(1000);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestUtil.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestUtil.java
@@ -214,6 +214,19 @@ public final class BridgeSupportTestUtil {
         return activations.isActive(ConsensusRule.RSKIP459) && !activations.isActive(ConsensusRule.RSKIP551);
     }
 
+    public static ReleaseRequestQueue addPegoutRequestsToQueue(
+        ReleaseRequestQueue releaseRequestQueue,
+        int pegoutRequestCount,
+        Coin value,
+        NetworkParameters networkParameters
+    ) {
+        for (int i = 0; i < pegoutRequestCount; i++) {
+            Address receiver = BitcoinTestUtils.createP2PKHAddress(networkParameters, "receiver" + i);
+            releaseRequestQueue.add(receiver, value, PegTestUtils.createHash3(i));
+        }
+        return releaseRequestQueue;
+    }
+
     public static void assertWitnessAndScriptSigHaveExpectedInputRedeemData(TransactionWitness witness, TransactionInput input, Script expectedRedeemScript) {
         // assert last push has the redeem script
         int redeemScriptIndex = witness.getPushCount() - 1;

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestUtil.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestUtil.java
@@ -65,6 +65,16 @@ import org.ethereum.vm.LogInfo;
 import org.ethereum.vm.PrecompiledContracts;
 
 public final class BridgeSupportTestUtil {
+
+    public static final int STANDARD_MULTISIG_UTXO_COUNT_OVER_MAX_TX_SIZE = 277;
+    public static final int STANDARD_MULTISIG_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE = STANDARD_MULTISIG_UTXO_COUNT_OVER_MAX_TX_SIZE - 1;
+    public static final int P2SH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE = 196;
+    public static final int P2SH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE = P2SH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE - 1;
+    public static final int P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE_VETIVER = 2438;
+    public static final int P2SH_P2WSH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE_VETIVER = P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE_VETIVER - 1;
+    public static final int P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE = 204;
+    public static final int P2SH_P2WSH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE = P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE - 1;
+
     private static final ActivationConfig.ForBlock ACTIVATIONS_ALL = ActivationConfigsForTest.all().forBlock(0L);
 
     private BridgeSupportTestUtil() {}

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestUtil.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportTestUtil.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import co.rsk.RskTestUtils;
+import co.rsk.bitcoinj.core.Address;
 import co.rsk.bitcoinj.core.BtcBlock;
 import co.rsk.bitcoinj.core.BtcECKey;
 import co.rsk.bitcoinj.core.BtcTransaction;
@@ -222,7 +223,7 @@ public final class BridgeSupportTestUtil {
     ) {
         for (int i = 0; i < pegoutRequestCount; i++) {
             Address receiver = BitcoinTestUtils.createP2PKHAddress(networkParameters, "receiver" + i);
-            releaseRequestQueue.add(receiver, value, PegTestUtils.createHash3(i));
+            releaseRequestQueue.add(receiver, value, RskTestUtils.createHash(i));
         }
         return releaseRequestQueue;
     }

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsLegacyTest.java
@@ -13,6 +13,7 @@ import co.rsk.peg.federation.FederationMember;
 import co.rsk.test.builders.UTXOBuilder;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -475,7 +476,7 @@ class BridgeUtilsLegacyTest {
             Instant.now(), 0, btcParams);
         Federation federation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
-        int pegoutTxSize = BridgeUtilsLegacy.calculatePegoutTxSize(activations, federation, 2, 2);
+        int pegoutTxSize = BridgeUtilsLegacy.simulatePegoutTxSize(activations, federation, 2, 2);
 
         // The difference between the calculated size and a real tx size should be smaller than 2% in any direction
         int origTxSize = 2076; // Data for 2 inputs, 2 outputs From https://www.blockchain.com/btc/tx/e92cab54ecf738a00083fd8990515247aa3404df4f76ec358d9fe87d95102ae4
@@ -486,8 +487,8 @@ class BridgeUtilsLegacyTest {
     }
 
     @Test
-    void calculatePegoutTxSize_after_rskip_271() {
-        when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(true);
+    void calculatePegoutTxSize_afterRSKIP378() {
+        ActivationConfig.ForBlock activations = ActivationConfigsForTest.all().forBlock(0L);
         NetworkParameters btcParams = bridgeConstantsRegtest.getBtcParams();
 
         List<BtcECKey> keys = PegTestUtils.createRandomBtcECKeys(13);
@@ -496,7 +497,7 @@ class BridgeUtilsLegacyTest {
             Instant.now(), 0, btcParams);
         Federation federation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
-        Assertions.assertThrows(DeprecatedMethodCallException.class, () -> BridgeUtilsLegacy.calculatePegoutTxSize(activations, federation, 2, 2));
+        Assertions.assertThrows(DeprecatedMethodCallException.class, () -> BridgeUtilsLegacy.simulatePegoutTxSize(activations, federation, 2, 2));
     }
 
     @Test
@@ -509,7 +510,7 @@ class BridgeUtilsLegacyTest {
             Instant.now(), 0, btcParams);
         Federation federation = FederationFactory.buildStandardMultiSigFederation(federationArgs);
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> BridgeUtilsLegacy.calculatePegoutTxSize(activations, federation, 0, 0));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> BridgeUtilsLegacy.simulatePegoutTxSize(activations, federation, 0, 0));
     }
 
     private class SimpleBtcTransaction {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsLegacyTest.java
@@ -467,7 +467,7 @@ class BridgeUtilsLegacyTest {
     }
 
     @Test
-    void calculatePegoutTxSize_before_rskip_271() {
+    void simulatePegoutTxSize_before_rskip_271() {
         when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(false);
         NetworkParameters btcParams = bridgeConstantsRegtest.getBtcParams();
 
@@ -487,7 +487,7 @@ class BridgeUtilsLegacyTest {
     }
 
     @Test
-    void calculatePegoutTxSize_afterRSKIP378() {
+    void simulatePegoutTxSize_afterRSKIP378() {
         ActivationConfig.ForBlock activations = ActivationConfigsForTest.all().forBlock(0L);
         NetworkParameters btcParams = bridgeConstantsRegtest.getBtcParams();
 
@@ -501,7 +501,7 @@ class BridgeUtilsLegacyTest {
     }
 
     @Test
-    void calculatePegoutTxSize_ZeroInput_ZeroOutput() {
+    void simulatePegoutTxSize_ZeroInput_ZeroOutput() {
         when(activations.isActive(ConsensusRule.RSKIP271)).thenReturn(false);
         NetworkParameters btcParams = bridgeConstantsRegtest.getBtcParams();
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsLegacyTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsLegacyTest.java
@@ -488,7 +488,7 @@ class BridgeUtilsLegacyTest {
 
     @Test
     void simulatePegoutTxSize_afterRSKIP378() {
-        ActivationConfig.ForBlock activations = ActivationConfigsForTest.all().forBlock(0L);
+        activations = ActivationConfigsForTest.all().forBlock(0L);
         NetworkParameters btcParams = bridgeConstantsRegtest.getBtcParams();
 
         List<BtcECKey> keys = PegTestUtils.createRandomBtcECKeys(13);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -52,6 +52,8 @@ import org.ethereum.vm.PrecompiledContracts;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.math.BigInteger;
 import java.security.SecureRandom;
@@ -63,6 +65,7 @@ import java.util.List;
 
 import static co.rsk.RskTestUtils.createRepository;
 import static co.rsk.peg.PegUtils.getFlyoverFederationOutputScript;
+import static co.rsk.peg.ReleaseTransactionBuilder.MAX_STANDARD_TX_SIZE_ALLOWED;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.generateSignerEncodedSignatures;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.generateTransactionInputsSigHashes;
 import static co.rsk.peg.bitcoin.BitcoinUtils.*;
@@ -138,7 +141,7 @@ class BridgeUtilsTest {
         byte[] sign1 = new byte[]{0x79};
         byte[] sign2 = new byte[]{0x78};
 
-        BtcTransaction btcTx = createPegOutTx(Arrays.asList(sign1, sign2), 1);
+        BtcTransaction btcTx = createPegOutTxLegacy(Arrays.asList(sign1, sign2), 1);
         Assertions.assertTrue(BridgeUtils.hasEnoughSignatures(mock(Context.class), btcTx));
     }
 
@@ -147,13 +150,13 @@ class BridgeUtilsTest {
         // Create 2 signatures
         byte[] sign1 = new byte[]{0x79};
 
-        BtcTransaction btcTx = createPegOutTx(Arrays.asList(sign1, MISSING_SIGNATURE), 1);
+        BtcTransaction btcTx = createPegOutTxLegacy(Arrays.asList(sign1, MISSING_SIGNATURE), 1);
         Assertions.assertFalse(BridgeUtils.hasEnoughSignatures(mock(Context.class), btcTx));
     }
 
     @Test
     void hasEnoughSignatures_no_signatures() {
-        BtcTransaction btcTx = createPegOutTx(Collections.emptyList(), 1);
+        BtcTransaction btcTx = createPegOutTxLegacy(Collections.emptyList(), 1);
         Assertions.assertFalse(BridgeUtils.hasEnoughSignatures(mock(Context.class), btcTx));
     }
 
@@ -163,7 +166,7 @@ class BridgeUtilsTest {
         byte[] sign1 = new byte[]{0x79};
         byte[] sign2 = new byte[]{0x78};
 
-        BtcTransaction btcTx = createPegOutTx(Arrays.asList(sign1, sign2), 3);
+        BtcTransaction btcTx = createPegOutTxLegacy(Arrays.asList(sign1, sign2), 3);
         Assertions.assertTrue(BridgeUtils.hasEnoughSignatures(mock(Context.class), btcTx));
     }
 
@@ -174,7 +177,7 @@ class BridgeUtilsTest {
         byte[] sign2 = new byte[]{0x78};
 
         ErpFederation nonStandardErpFederation = createNonStandardErpFederation();
-        BtcTransaction btcTx = createPegOutTx(
+        BtcTransaction btcTx = createPegOutTxLegacy(
             Arrays.asList(sign1, sign2),
             3,
             nonStandardErpFederation,
@@ -220,7 +223,7 @@ class BridgeUtilsTest {
         // Create 1 signature
         byte[] sign1 = new byte[]{0x79};
 
-        BtcTransaction btcTx = createPegOutTx(Arrays.asList(sign1, MISSING_SIGNATURE), 3);
+        BtcTransaction btcTx = createPegOutTxLegacy(Arrays.asList(sign1, MISSING_SIGNATURE), 3);
         Assertions.assertFalse(BridgeUtils.hasEnoughSignatures(mock(Context.class), btcTx));
     }
 
@@ -230,7 +233,7 @@ class BridgeUtilsTest {
         byte[] sign1 = new byte[]{0x79};
         byte[] sign2 = new byte[]{0x78};
 
-        BtcTransaction btcTx = createPegOutTx(Arrays.asList(sign1, sign2), 1);
+        BtcTransaction btcTx = createPegOutTxLegacy(Arrays.asList(sign1, sign2), 1);
         Assertions.assertEquals(0, BridgeUtils.countMissingSignatures(mock(Context.class), btcTx));
     }
 
@@ -239,14 +242,14 @@ class BridgeUtilsTest {
         // Add 1 signature
         byte[] sign1 = new byte[]{0x79};
 
-        BtcTransaction btcTx = createPegOutTx(Arrays.asList(sign1, MISSING_SIGNATURE), 1);
+        BtcTransaction btcTx = createPegOutTxLegacy(Arrays.asList(sign1, MISSING_SIGNATURE), 1);
         Assertions.assertEquals(1, BridgeUtils.countMissingSignatures(mock(Context.class), btcTx));
     }
 
     @Test
     void countMissingSignatures_no_signatures() {
         // As no signature was added, missing signatures is 2
-        BtcTransaction btcTx = createPegOutTx(Collections.emptyList(), 1);
+        BtcTransaction btcTx = createPegOutTxLegacy(Collections.emptyList(), 1);
         Assertions.assertEquals(2, BridgeUtils.countMissingSignatures(mock(Context.class), btcTx));
     }
 
@@ -256,7 +259,7 @@ class BridgeUtilsTest {
         byte[] sign1 = new byte[]{0x79};
         byte[] sign2 = new byte[]{0x78};
 
-        BtcTransaction btcTx = createPegOutTx(Arrays.asList(sign1, sign2), 3);
+        BtcTransaction btcTx = createPegOutTxLegacy(Arrays.asList(sign1, sign2), 3);
         Assertions.assertEquals(0, BridgeUtils.countMissingSignatures(mock(Context.class), btcTx));
     }
 
@@ -267,7 +270,7 @@ class BridgeUtilsTest {
         byte[] sign2 = new byte[]{0x78};
 
         ErpFederation nonStandardErpFederation = createNonStandardErpFederation();
-        BtcTransaction btcTx = createPegOutTx(
+        BtcTransaction btcTx = createPegOutTxLegacy(
             Arrays.asList(sign1, sign2),
             3,
             nonStandardErpFederation,
@@ -313,7 +316,7 @@ class BridgeUtilsTest {
         // Create 1 signature
         byte[] sign1 = new byte[]{0x79};
 
-        BtcTransaction btcTx = createPegOutTx(Arrays.asList(sign1, MISSING_SIGNATURE), 3);
+        BtcTransaction btcTx = createPegOutTxLegacy(Arrays.asList(sign1, MISSING_SIGNATURE), 3);
         Assertions.assertEquals(1, BridgeUtils.countMissingSignatures(mock(Context.class), btcTx));
     }
 
@@ -979,7 +982,7 @@ class BridgeUtilsTest {
             federationArgs
         );
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> BridgeUtils.calculatePegoutTxSize(activations, federation, 0, 0));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> BridgeUtils.simulatePegoutTxSize(activations, federation, 0, 0));
     }
 
     @Test
@@ -999,7 +1002,7 @@ class BridgeUtilsTest {
 
         int inputSize = 2;
         int outputSize = 2;
-        int pegoutTxSize = BridgeUtils.calculatePegoutTxSize(activations, federation, inputSize, outputSize);
+        int pegoutTxSize = BridgeUtils.simulatePegoutTxSize(activations, federation, inputSize, outputSize);
 
         assertEquals(2058, pegoutTxSize);
 
@@ -1014,7 +1017,7 @@ class BridgeUtilsTest {
             .withMembersBtcPublicKeys(keys)
             .build();
 
-        int pegoutTxSizeSegwit = BridgeUtils.calculatePegoutTxSize(activations, p2shP2wshFederation, inputSize, outputSize);
+        int pegoutTxSizeSegwit = BridgeUtils.simulatePegoutTxSize(activations, p2shP2wshFederation, inputSize, outputSize);
 
         assertEquals(694, pegoutTxSizeSegwit);
 
@@ -1041,7 +1044,7 @@ class BridgeUtilsTest {
 
         int inputSize = 9;
         int outputSize = 2;
-        int pegoutTxSize = BridgeUtils.calculatePegoutTxSize(activations, federation, inputSize, outputSize);
+        int pegoutTxSize = BridgeUtils.simulatePegoutTxSize(activations, federation, inputSize, outputSize);
 
         assertEquals(9002, pegoutTxSize);
 
@@ -1056,7 +1059,7 @@ class BridgeUtilsTest {
             .withMembersBtcPublicKeys(keys)
             .build();
 
-        int pegoutTxSizeSegwit = BridgeUtils.calculatePegoutTxSize(activations, p2shP2wshFederation, inputSize, outputSize);
+        int pegoutTxSizeSegwit = BridgeUtils.simulatePegoutTxSize(activations, p2shP2wshFederation, inputSize, outputSize);
 
         assertEquals(2866, pegoutTxSizeSegwit);
 
@@ -1085,9 +1088,9 @@ class BridgeUtilsTest {
         // Create a pegout tx with 10 inputs and 20 outputs
         int inputSize = 10;
         int outputSize = 20;
-        BtcTransaction pegoutTx = createPegOutTx(inputSize, outputSize, federation, keys);
+        BtcTransaction pegoutTx = createPegOutTxLegacy(inputSize, outputSize, federation, keys);
 
-        int pegoutTxSize = BridgeUtils.calculatePegoutTxSize(activations, federation, inputSize, outputSize);
+        int pegoutTxSize = BridgeUtils.simulatePegoutTxSize(activations, federation, inputSize, outputSize);
 
         assertEquals(10570, pegoutTxSize);
 
@@ -1102,7 +1105,7 @@ class BridgeUtilsTest {
             .withMembersBtcPublicKeys(keys)
             .build();
 
-        int pegoutTxSizeSegwit = BridgeUtils.calculatePegoutTxSize(activations, p2shP2wshFederation, inputSize, outputSize);
+        int pegoutTxSizeSegwit = BridgeUtils.simulatePegoutTxSize(activations, p2shP2wshFederation, inputSize, outputSize);
 
         assertEquals(3752, pegoutTxSizeSegwit);
 
@@ -1130,9 +1133,9 @@ class BridgeUtilsTest {
         // Create a pegout tx with 50 inputs and 200 outputs
         int inputSize = 50;
         int outputSize = 200;
-        BtcTransaction pegoutTx = createPegOutTx(inputSize, outputSize, federation, keys);
+        BtcTransaction pegoutTx = createPegOutTxLegacy(inputSize, outputSize, federation, keys);
 
-        int pegoutTxSize = BridgeUtils.calculatePegoutTxSize(activations, federation, inputSize, outputSize);
+        int pegoutTxSize = BridgeUtils.simulatePegoutTxSize(activations, federation, inputSize, outputSize);
 
         assertEquals(56010, pegoutTxSize);
 
@@ -1147,7 +1150,7 @@ class BridgeUtilsTest {
             .withMembersBtcPublicKeys(keys)
             .build();
 
-        int pegoutTxSizeSegwit = BridgeUtils.calculatePegoutTxSize(activations, p2shP2wshFederation, inputSize, outputSize);
+        int pegoutTxSizeSegwit = BridgeUtils.simulatePegoutTxSize(activations, p2shP2wshFederation, inputSize, outputSize);
 
         assertEquals(21922, pegoutTxSizeSegwit);
 
@@ -1187,9 +1190,9 @@ class BridgeUtilsTest {
         // Create a pegout tx with 50 inputs and 200 outputs
         int inputSize = 50;
         int outputSize = 200;
-        BtcTransaction pegoutTx = createPegOutTx(inputSize, outputSize, nonStandardErpFederation, defaultFederationKeys);
+        BtcTransaction pegoutTx = createPegOutTxLegacy(inputSize, outputSize, nonStandardErpFederation, defaultFederationKeys);
 
-        int pegoutTxSize = BridgeUtils.calculatePegoutTxSize(activations, nonStandardErpFederation, inputSize, outputSize);
+        int pegoutTxSize = BridgeUtils.simulatePegoutTxSize(activations, nonStandardErpFederation, inputSize, outputSize);
 
         assertEquals(26510, pegoutTxSize);
 
@@ -1204,13 +1207,65 @@ class BridgeUtilsTest {
             .withMembersBtcPublicKeys(defaultFederationKeys)
             .build();
 
-        int pegoutTxSizeSegwit = BridgeUtils.calculatePegoutTxSize(activations, p2shP2wshFederation, inputSize, outputSize);
+        int pegoutTxSizeSegwit = BridgeUtils.simulatePegoutTxSize(activations, p2shP2wshFederation, inputSize, outputSize);
 
         assertEquals(13172, pegoutTxSizeSegwit);
 
         double segWitSavingPercentage = (100 - ((double) pegoutTxSizeSegwit / pegoutTxSize * 100));
 
         assertTrue(segWitSavingPercentage >= 49);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "184, 14",
+        "183, 28",
+        "182, 42",
+        "181, 57"
+    })
+    void estimateUnsignedSegwitTxVSize_forRecreatedTx_almostExceedingMaxTxSizeAllowed_shouldReturnLessThanMaximumAllowed(int inputsCount, int outputsCount) {
+        // arrange
+        Federation federation = P2shP2wshErpFederationBuilder.builder().build();
+
+        BtcTransaction pegoutTx = PegTestUtils.createUnsignedPegOutTx(
+            networkParameters,
+            inputsCount,
+            outputsCount,
+            federation
+        );
+
+        // act & assert
+        int pegoutTxSize = BridgeUtils.estimateUnsignedSegwitTxVSize(pegoutTx, federation);
+        assertTrue(pegoutTxSize < MAX_STANDARD_TX_SIZE_ALLOWED);
+    }
+
+    @Test
+    void estimateUnsignedSegwitTxVSize_forRealTx_200inputs50outputs() {
+        // https://mempool.space/testnet/tx/ada9a76e0da39a2ad49c07dfaf9bab51fe696a92c95177f54cc7b68ad50fb7cb
+        // arrange
+        int realVSize = 98690;
+        Federation federation = P2shP2wshErpFederationBuilder.builder().build();
+
+        int inputsCount = 200;
+        int outputsCount = 50;
+        BtcTransaction pegoutTx = PegTestUtils.createUnsignedPegOutTx(
+            networkParameters,
+            inputsCount,
+            outputsCount,
+            federation
+        );
+
+        // act
+        int calculatedPegoutTxSize = BridgeUtils.estimateUnsignedSegwitTxVSize(pegoutTx, federation);
+
+        // assert
+        int expectedCalculatedPegoutTxSize = 98960;
+        assertEquals(expectedCalculatedPegoutTxSize, calculatedPegoutTxSize);
+        // we expect calculated size to be greater than real one
+        assertTrue(calculatedPegoutTxSize > realVSize);
+        double diff = calculatedPegoutTxSize - realVSize;
+        // and the diff to be very small
+        assertTrue(diff < realVSize * 0.01);
     }
 
     @Test
@@ -1243,9 +1298,9 @@ class BridgeUtilsTest {
         // Create a pegout tx with 100 inputs and 50 outputs
         int inputSize = 100;
         int outputSize = 50;
-        BtcTransaction pegoutTx = createPegOutTx(inputSize, outputSize, nonStandardErpFederation, defaultFederationKeys);
+        BtcTransaction pegoutTx = createPegOutTxLegacy(inputSize, outputSize, nonStandardErpFederation, defaultFederationKeys);
 
-        int pegoutTxSize = BridgeUtils.calculatePegoutTxSize(activations, nonStandardErpFederation, inputSize, outputSize);
+        int pegoutTxSize = BridgeUtils.simulatePegoutTxSize(activations, nonStandardErpFederation, inputSize, outputSize);
 
         assertEquals(41810, pegoutTxSize);
 
@@ -1260,7 +1315,7 @@ class BridgeUtilsTest {
             .withMembersBtcPublicKeys(defaultFederationKeys)
             .build();
 
-        int pegoutTxSizeSegwit = BridgeUtils.calculatePegoutTxSize(activations, p2shP2wshFederation, inputSize, outputSize);
+        int pegoutTxSizeSegwit = BridgeUtils.simulatePegoutTxSize(activations, p2shP2wshFederation, inputSize, outputSize);
 
         assertEquals(15135, pegoutTxSizeSegwit);
 
@@ -1290,7 +1345,7 @@ class BridgeUtilsTest {
 
         // Create a pegout tx with two inputs and two outputs
         int inputs = 2;
-        BtcTransaction pegoutTx = createPegOutTx(Collections.emptyList(), inputs, fed, false);
+        BtcTransaction pegoutTx = createPegOutTxLegacy(Collections.emptyList(), inputs, fed, false);
 
         for (int inputIndex = 0; inputIndex < inputs; inputIndex++) {
             Script inputScript = pegoutTx.getInput(inputIndex).getScriptSig();
@@ -1604,7 +1659,7 @@ class BridgeUtilsTest {
         return FederationFactory.buildNonStandardErpFederation(genesisFederationArgs, erpPubKeys, activationDelay, activations);
     }
 
-    private BtcTransaction createPegOutTx(
+    private BtcTransaction createPegOutTxLegacy(
         List<byte[]> signatures,
         int inputsToAdd,
         Federation federation,
@@ -1680,7 +1735,7 @@ class BridgeUtilsTest {
         return btcTx;
     }
 
-    private BtcTransaction createPegOutTx(int inputSize, int outputSize, Federation federation, List<BtcECKey> keys) {
+    private BtcTransaction createPegOutTxLegacy(int inputSize, int outputSize, Federation federation, List<BtcECKey> keys) {
         Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
 
         BtcTransaction btcTx = new BtcTransaction(networkParameters);
@@ -1707,12 +1762,12 @@ class BridgeUtilsTest {
         return btcTx;
     }
 
-    private BtcTransaction createPegOutTx(List<byte[]> signatures, int inputsToAdd) {
-        return createPegOutTx(signatures, inputsToAdd, null, false);
+    private BtcTransaction createPegOutTxLegacy(List<byte[]> signatures, int inputsToAdd) {
+        return createPegOutTxLegacy(signatures, inputsToAdd, null, false);
     }
 
     private BtcTransaction createPegOutTxForFlyover(List<byte[]> signatures, int inputsToAdd, Federation federation) {
-        return createPegOutTx(signatures, inputsToAdd, federation, true);
+        return createPegOutTxLegacy(signatures, inputsToAdd, federation, true);
     }
 
     private byte[] generatePrivKey() {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -1264,7 +1264,7 @@ class BridgeUtilsTest {
         // we expect calculated size to be greater than real one
         assertTrue(calculatedPegoutTxSize > realVSize);
         double diff = calculatedPegoutTxSize - realVSize;
-        // and the diff to be very small
+        // and the diff to be less than 1%
         assertTrue(diff < realVSize * 0.01);
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -37,6 +37,7 @@ import co.rsk.crypto.Keccak256;
 import co.rsk.peg.bitcoin.RskAllowUnconfirmedCoinSelector;
 import co.rsk.peg.federation.*;
 import co.rsk.peg.flyover.FlyoverTxResponseCodes;
+import co.rsk.test.builders.PegoutTransactionBuilder;
 import co.rsk.test.builders.UTXOBuilder;
 import co.rsk.trie.TrieStore;
 import co.rsk.trie.TrieStoreImpl;
@@ -1227,12 +1228,18 @@ class BridgeUtilsTest {
         // arrange
         Federation federation = P2shP2wshErpFederationBuilder.builder().build();
 
-        BtcTransaction pegoutTx = PegTestUtils.createUnsignedPegOutTx(
-            networkParameters,
-            inputsCount,
-            outputsCount,
-            federation
-        );
+        PegoutTransactionBuilder pegoutTxBuilder = PegoutTransactionBuilder.builder()
+            .withActiveFederation(federation);
+        Sha256Hash prevTxHash = Sha256Hash.ZERO_HASH;
+        for (int i = 0; i < inputsCount; i++) {
+            pegoutTxBuilder.withInput(prevTxHash, i, Coin.COIN);
+        }
+        for (int i = 0; i < outputsCount; i++) {
+            Address userAddress = BitcoinTestUtils.createP2PKHAddress(networkParameters, String.valueOf(i));
+            pegoutTxBuilder.withOutput(Coin.COIN, userAddress);
+        }
+
+        BtcTransaction pegoutTx = pegoutTxBuilder.build();
 
         // act & assert
         int pegoutTxSize = BridgeUtils.estimateUnsignedSegwitTxVSize(pegoutTx, federation);
@@ -1246,20 +1253,31 @@ class BridgeUtilsTest {
         int realVSize = 98690;
         Federation federation = P2shP2wshErpFederationBuilder.builder().build();
 
+        PegoutTransactionBuilder pegoutTxBuilder = PegoutTransactionBuilder.builder()
+            .withActiveFederation(federation);
         int inputsCount = 200;
-        int outputsCount = 50;
-        BtcTransaction pegoutTx = PegTestUtils.createUnsignedPegOutTx(
-            networkParameters,
-            inputsCount,
-            outputsCount,
-            federation
-        );
+        Sha256Hash prevTxHash = Sha256Hash.ZERO_HASH;
+        for (int i = 0; i < inputsCount; i++) {
+            pegoutTxBuilder.withInput(prevTxHash, i, Coin.COIN);
+        }
+
+        int outputsCount = 49;
+        for (int i = 0; i < outputsCount; i++) {
+            Address userAddress = BitcoinTestUtils.createP2PKHAddress(networkParameters, String.valueOf(i));
+            pegoutTxBuilder.withOutput(Coin.COIN, userAddress);
+        }
+
+        BtcTransaction pegoutTx = pegoutTxBuilder.build();
 
         // act
         int calculatedPegoutTxSize = BridgeUtils.estimateUnsignedSegwitTxVSize(pegoutTx, federation);
 
         // assert
-        int expectedCalculatedPegoutTxSize = 98960;
+        assertEquals(inputsCount, pegoutTx.getInputs().size());
+        int expectedOutputsCount = 50; // builder always adds a change output
+        assertEquals(expectedOutputsCount, pegoutTx.getOutputs().size());
+
+        int expectedCalculatedPegoutTxSize = 98958;
         assertEquals(expectedCalculatedPegoutTxSize, calculatedPegoutTxSize);
         // we expect calculated size to be greater than real one
         assertTrue(calculatedPegoutTxSize > realVSize);

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -1219,24 +1219,27 @@ class BridgeUtilsTest {
 
     @ParameterizedTest
     @CsvSource({
-        "184, 14",
-        "183, 28",
-        "182, 42",
-        "181, 57"
+        "183, 14",
+        "182, 29",
+        "181, 43",
+        "180, 57"
     })
     void estimateUnsignedSegwitTxVSize_forRecreatedTx_almostExceedingMaxTxSizeAllowed_shouldReturnLessThanMaximumAllowed(int inputsCount, int outputsCount) {
         // arrange
         Federation federation = P2shP2wshErpFederationBuilder.builder().build();
 
         PegoutTransactionBuilder pegoutTxBuilder = PegoutTransactionBuilder.builder()
-            .withActiveFederation(federation);
+            .withActiveFederation(federation)
+            .withoutChange();
         Sha256Hash prevTxHash = Sha256Hash.ZERO_HASH;
+        Coin inputValue = Coin.COIN;
         for (int i = 0; i < inputsCount; i++) {
-            pegoutTxBuilder.withInput(prevTxHash, i, Coin.COIN);
+            pegoutTxBuilder.withInput(prevTxHash, i, inputValue);
         }
+        Coin outputValue = Coin.COIN;
         for (int i = 0; i < outputsCount; i++) {
             Address userAddress = BitcoinTestUtils.createP2PKHAddress(networkParameters, String.valueOf(i));
-            pegoutTxBuilder.withOutput(Coin.COIN, userAddress);
+            pegoutTxBuilder.withOutput(outputValue, userAddress);
         }
 
         BtcTransaction pegoutTx = pegoutTxBuilder.build();
@@ -1248,23 +1251,26 @@ class BridgeUtilsTest {
 
     @Test
     void estimateUnsignedSegwitTxVSize_forRealTx_200inputs50outputs() {
-        // https://mempool.space/testnet/tx/ada9a76e0da39a2ad49c07dfaf9bab51fe696a92c95177f54cc7b68ad50fb7cb
+        // https://mempool.space/testnet/tx/aa46df617eeabd5a0c1f82dde9d7a9383f698b4ef3bf15141aefd2add562c750
         // arrange
-        int realVSize = 98690;
+        int realVSize = 96980;
         Federation federation = P2shP2wshErpFederationBuilder.builder().build();
 
         PegoutTransactionBuilder pegoutTxBuilder = PegoutTransactionBuilder.builder()
-            .withActiveFederation(federation);
+            .withActiveFederation(federation)
+            .withoutChange();
         int inputsCount = 200;
         Sha256Hash prevTxHash = Sha256Hash.ZERO_HASH;
+        Coin inputValue  = Coin.valueOf(5_000);
         for (int i = 0; i < inputsCount; i++) {
-            pegoutTxBuilder.withInput(prevTxHash, i, Coin.COIN);
+            pegoutTxBuilder.withInput(prevTxHash, i, inputValue);
         }
 
-        int outputsCount = 49;
+        int outputsCount = 50;
+        Coin outputValue = Coin.valueOf(20_000);
         for (int i = 0; i < outputsCount; i++) {
-            Address userAddress = BitcoinTestUtils.createP2PKHAddress(networkParameters, String.valueOf(i));
-            pegoutTxBuilder.withOutput(Coin.COIN, userAddress);
+            Address userAddress = Address.fromBase58(networkParameters, "mi2KEWHb9WUBLBm4LCTUx75jWCSr68uxRr");
+            pegoutTxBuilder.withOutput(outputValue, userAddress);
         }
 
         BtcTransaction pegoutTx = pegoutTxBuilder.build();
@@ -1274,16 +1280,15 @@ class BridgeUtilsTest {
 
         // assert
         assertEquals(inputsCount, pegoutTx.getInputs().size());
-        int expectedOutputsCount = 50; // builder always adds a change output
-        assertEquals(expectedOutputsCount, pegoutTx.getOutputs().size());
+        assertEquals(outputsCount, pegoutTx.getOutputs().size());
 
-        int expectedCalculatedPegoutTxSize = 98958;
+        int expectedCalculatedPegoutTxSize = 99510;
         assertEquals(expectedCalculatedPegoutTxSize, calculatedPegoutTxSize);
         // we expect calculated size to be greater than real one
         assertTrue(calculatedPegoutTxSize > realVSize);
         double diff = calculatedPegoutTxSize - realVSize;
-        // and the diff to be less than 1%
-        assertTrue(diff < realVSize * 0.01);
+        // and the diff to be less than 3%
+        assertTrue(diff < realVSize * 0.03);
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -18,12 +18,7 @@
 
 package co.rsk.peg;
 
-import co.rsk.bitcoinj.core.Address;
-import co.rsk.bitcoinj.core.BtcECKey;
-import co.rsk.bitcoinj.core.Coin;
-import co.rsk.bitcoinj.core.NetworkParameters;
-import co.rsk.bitcoinj.core.Sha256Hash;
-import co.rsk.bitcoinj.core.TransactionOutput;
+import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.params.RegTestParams;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
@@ -48,6 +43,8 @@ import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.Keccak256Helper;
+
+import static co.rsk.peg.bitcoin.BitcoinUtils.addSpendingFederationBaseScript;
 
 public final class PegTestUtils {
 
@@ -330,5 +327,33 @@ public final class PegTestUtils {
             valuesToSend,
             address
         );
+    }
+
+    public static BtcTransaction createUnsignedPegOutTx(
+        NetworkParameters networkParameters,
+        int inputsCount,
+        int outputsCount,
+        Federation federation
+    ) {
+        BtcTransaction btcTx = new BtcTransaction(networkParameters);
+
+        // Add inputs
+        Script redeemScript = federation.getRedeemScript();
+        for (int i = 0; i < inputsCount; i++) {
+            btcTx.addInput(
+                Sha256Hash.ZERO_HASH,
+                i,
+                new Script(new byte[]{})
+            );
+            addSpendingFederationBaseScript(btcTx, i, redeemScript, federation.getFormatVersion());
+        }
+
+        // Add outputs
+        Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
+        for (int i = 0; i < outputsCount; i++) {
+            btcTx.addOutput(Coin.COIN, randomAddress);
+        }
+
+        return btcTx;
     }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -328,32 +328,4 @@ public final class PegTestUtils {
             address
         );
     }
-
-    public static BtcTransaction createUnsignedPegOutTx(
-        NetworkParameters networkParameters,
-        int inputsCount,
-        int outputsCount,
-        Federation federation
-    ) {
-        BtcTransaction btcTx = new BtcTransaction(networkParameters);
-
-        // Add inputs
-        Script redeemScript = federation.getRedeemScript();
-        for (int i = 0; i < inputsCount; i++) {
-            btcTx.addInput(
-                Sha256Hash.ZERO_HASH,
-                i,
-                new Script(new byte[]{})
-            );
-            addSpendingFederationBaseScript(btcTx, i, redeemScript, federation.getFormatVersion());
-        }
-
-        // Add outputs
-        Address randomAddress = PegTestUtils.createRandomP2PKHBtcAddress(networkParameters);
-        for (int i = 0; i < outputsCount; i++) {
-            btcTx.addOutput(Coin.COIN, randomAddress);
-        }
-
-        return btcTx;
-    }
 }

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -18,34 +18,38 @@
 
 package co.rsk.peg;
 
-import co.rsk.bitcoinj.core.*;
+import co.rsk.bitcoinj.core.Address;
+import co.rsk.bitcoinj.core.BtcECKey;
+import co.rsk.bitcoinj.core.Coin;
+import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.core.Sha256Hash;
+import co.rsk.bitcoinj.core.TransactionOutput;
 import co.rsk.bitcoinj.params.RegTestParams;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.script.ScriptBuilder;
-import co.rsk.peg.bitcoin.FlyoverRedeemScriptBuilderImpl;
-import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
-import co.rsk.peg.federation.*;
+import co.rsk.peg.bitcoin.FlyoverRedeemScriptBuilderImpl;
+import co.rsk.peg.constants.BridgeConstants;
+import co.rsk.peg.federation.Federation;
+import co.rsk.peg.federation.FederationArgs;
+import co.rsk.peg.federation.FederationFactory;
+import co.rsk.peg.federation.FederationMember;
+import co.rsk.peg.federation.FederationTestUtils;
 import co.rsk.peg.simples.SimpleRskTransaction;
-import org.bouncycastle.util.encoders.Hex;
-import org.ethereum.core.Transaction;
-import org.ethereum.crypto.ECKey;
-import org.ethereum.crypto.Keccak256Helper;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.core.Transaction;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.crypto.Keccak256Helper;
 
-/**
- * Created by oscar on 05/08/2016.
- */
 public final class PegTestUtils {
 
-    public static final int BTC_TX_LEGACY_VERSION = 1;
     private static int nhash = 0;
 
     /**
@@ -56,6 +60,10 @@ public final class PegTestUtils {
         return createHash3(nhash++);
     }
 
+    /**
+     * @deprecated Use co.rsk.RskTestUtils.createHash(int) instead
+     */
+    @Deprecated
     public static Keccak256 createHash3(int nHash) {
         byte[] bytes = new byte[32];
         bytes[0] = (byte) (nHash & 0xFF);
@@ -74,6 +82,7 @@ public final class PegTestUtils {
     /**
      * @deprecated Use co.rsk.peg.bitcoin.BitcoinTestUtils#createHash(int) instead.
      */
+    @Deprecated
     public static Sha256Hash createHash(int nHash) {
         byte[] bytes = new byte[32];
         bytes[0] = (byte) (0xFF & nHash);
@@ -219,6 +228,11 @@ public final class PegTestUtils {
         return key.toAddress(networkParameters);
     }
 
+    /**
+     * @deprecated Use co.rsk.peg.bitcoin.BitcoinTestUtils#getBtcEcKeys(int amount) instead.
+     * Avoid using random values in tests
+     */
+    @Deprecated
     public static List<BtcECKey> createRandomBtcECKeys(int keysCount) {
         List<BtcECKey> keys = new ArrayList<>();
         for (int i = 0; i < keysCount; i++) {
@@ -227,6 +241,11 @@ public final class PegTestUtils {
         return keys;
     }
 
+    /**
+     * @deprecated Use co.rsk.RskTestUtils#generateAddress(String seed) instead.
+     * Avoid using random values in tests
+     */
+    @Deprecated
     public static RskAddress createRandomRskAddress() {
         ECKey key = new ECKey();
         return new RskAddress(key.getAddress());

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -43,6 +43,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;

--- a/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegTestUtils.java
@@ -44,8 +44,6 @@ import org.ethereum.core.Transaction;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.Keccak256Helper;
 
-import static co.rsk.peg.bitcoin.BitcoinUtils.addSpendingFederationBaseScript;
-
 public final class PegTestUtils {
 
     private static int nhash = 0;

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -111,14 +111,6 @@ class ReleaseTransactionBuilderTest {
     private static final Coin THOUSAND_SATOSHIS = Coin.valueOf(1000);
 
     private static final int EXPECTED_NUMBER_OF_CHANGE_OUTPUTS = 1;
-    private static final int STANDARD_MULTISIG_UTXO_COUNT_OVER_MAX_TX_SIZE = 277;
-    private static final int STANDARD_MULTISIG_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE = STANDARD_MULTISIG_UTXO_COUNT_OVER_MAX_TX_SIZE - 1;
-    private static final int P2SH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE = 196;
-    private static final int P2SH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE = P2SH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE - 1;
-    private static final int P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE_VETIVER = 2438;
-    private static final int P2SH_P2WSH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE_VETIVER = P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE_VETIVER - 1;
-    private static final int P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE = 204;
-    private static final int P2SH_P2WSH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE = P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE - 1;
 
     private static final Keccak256 FLYOVER_DERIVATION_HASH = BRIDGE_MAINNET_CONSTANTS.getProposedFederationFlyoverPrefix();
     private static final Sha256Hash BTC_TX_HASH_FLYOVER_UTXO = createHash(10_000);

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -3187,8 +3187,9 @@ class ReleaseTransactionBuilderTest {
             }
 
             @Test
-            void buildBatchedPegouts_whenNoPegoutRequests_returnsAnEmptyTransaction() {
+            void buildBatchedPegouts_preRSKIP378_whenNoPegoutRequests_returnsAnEmptyTransaction() {
                 // Arrange
+                activations = ActivationConfigsForTest.vetiver900().forBlock(0L);
                 ReleaseTransactionBuilder releaseTransactionBuilder = createReleaseTransactionBuilder();
 
                 // Act & Assert
@@ -3198,6 +3199,15 @@ class ReleaseTransactionBuilderTest {
                 BtcTransaction batchedPegoutsTx = batchedPegoutsResult.btcTx();
                 assertTrue(batchedPegoutsTx.getOutputs().isEmpty());
                 assertTrue(batchedPegoutsTx.getInputs().isEmpty());
+            }
+
+            @Test
+            void buildBatchedPegouts_whenNoPegoutRequests_throwsIllegalArgumentException() {
+                // Arrange
+                ReleaseTransactionBuilder releaseTransactionBuilder = createReleaseTransactionBuilder();
+
+                // Act & Assert
+                assertThrows(IllegalArgumentException.class, () -> releaseTransactionBuilder.buildBatchedPegouts(NO_PEGOUT_REQUESTS));
             }
 
             @Test

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -111,6 +111,14 @@ class ReleaseTransactionBuilderTest {
     private static final Coin THOUSAND_SATOSHIS = Coin.valueOf(1000);
 
     private static final int EXPECTED_NUMBER_OF_CHANGE_OUTPUTS = 1;
+    private static final int STANDARD_MULTISIG_UTXO_COUNT_OVER_MAX_TX_SIZE = 277;
+    private static final int STANDARD_MULTISIG_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE = STANDARD_MULTISIG_UTXO_COUNT_OVER_MAX_TX_SIZE - 1;
+    private static final int P2SH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE = 196;
+    private static final int P2SH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE = P2SH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE - 1;
+    private static final int P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE_VETIVER = 2438;
+    private static final int P2SH_P2WSH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE_VETIVER = P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE_VETIVER - 1;
+    private static final int P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE_WHEN_ONE_OUTPUT = 186;
+    private static final int P2SH_P2WSH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE_WHEN_ONE_OUTPUT = P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE_WHEN_ONE_OUTPUT - 1;
 
     private static final Keccak256 FLYOVER_DERIVATION_HASH = BRIDGE_MAINNET_CONSTANTS.getProposedFederationFlyoverPrefix();
     private static final Sha256Hash BTC_TX_HASH_FLYOVER_UTXO = createHash(10_000);
@@ -872,7 +880,7 @@ class ReleaseTransactionBuilderTest {
         }
 
         @Test
-        void buildAmountTo_whenTxExceedsMaxTxSize_shouldReturnExceedMaxTransactionSize() {
+        void buildAmountTo_whenTxExceedsMaxTxSizeAllowed_shouldReturnExceedMaxTransactionSize() {
             // Arrange
             federationUTXOs = UTXOBuilder.builder()
                 .withScriptPubKey(federationOutputScript)
@@ -889,7 +897,7 @@ class ReleaseTransactionBuilderTest {
         }
 
         @Test
-        void buildAmountTo_whenTxIsAlmostExceedingMaxTxSize_shouldCreatePegoutTx() {
+        void buildAmountTo_whenTxIsAlmostExceedingMaxTxSizeAllowed_shouldCreatePegoutTx() {
             // Arrange
             federationUTXOs = UTXOBuilder.builder()
                 .withScriptPubKey(federationOutputScript)
@@ -1272,7 +1280,7 @@ class ReleaseTransactionBuilderTest {
             }
 
             @Test
-            void buildEmptyWalletTo_whenTxExceedsMaxTxSize_shouldReturnExceedMaxTransactionSize() {
+            void buildEmptyWalletTo_whenTxExceedsMaxTxSizeAllowed_shouldReturnExceedMaxTransactionSize() {
                 // Arrange
                 federationUTXOs = UTXOBuilder.builder()
                     .withScriptPubKey(federationOutputScript)
@@ -1439,7 +1447,7 @@ class ReleaseTransactionBuilderTest {
             }
 
             @Test
-            void buildEmptyWalletTo_whenTxExceedsMaxTxSize_shouldReturnExceedMaxTransactionSize() {
+            void buildEmptyWalletTo_whenTxExceedsMaxTxSizeAllowed_shouldReturnExceedMaxTransactionSize() {
                 // Arrange
                 federationUTXOs = UTXOBuilder.builder()
                     .withScriptPubKey(federationOutputScript)
@@ -1606,7 +1614,7 @@ class ReleaseTransactionBuilderTest {
             }
 
             @Test
-            void buildEmptyWalletTo_whenTxExceedsMaxTxSize_shouldReturnExceedMaxTransactionSize() {
+            void buildEmptyWalletTo_whenTxExceedsMaxTxSizeAllowed_shouldReturnExceedMaxTransactionSize() {
                 // Arrange
                 federationUTXOs = UTXOBuilder.builder()
                     .withScriptPubKey(federationOutputScript)
@@ -2003,7 +2011,7 @@ class ReleaseTransactionBuilderTest {
             }
 
             @Test
-            void buildMigrationTransaction_whenTxExceedMaxTxSize_shouldReturnExceedMaxTransactionSize() {
+            void buildMigrationTransaction_whenTxExceedMaxTxSizeAllowed_shouldReturnExceedMaxTransactionSize() {
                 // Arrange
                 retiringFederationUTXOs = UTXOBuilder.builder()
                     .withScriptPubKey(retiringFederationOutputScript)
@@ -2021,7 +2029,7 @@ class ReleaseTransactionBuilderTest {
             }
 
             @Test
-            void buildMigrationTransaction_whenTxIsAlmostExceedingMaxTxSize_shouldCreateMigrationTx() {
+            void buildMigrationTransaction_whenTxIsAlmostExceedingMaxTxSizeAllowed_shouldCreateMigrationTx() {
                 // Arrange
                 retiringFederationUTXOs = UTXOBuilder.builder()
                     .withScriptPubKey(retiringFederationOutputScript)
@@ -2355,7 +2363,7 @@ class ReleaseTransactionBuilderTest {
             }
 
             @Test
-            void buildMigrationTransaction_whenTxExceedMaxTxSize_shouldReturnExceedMaxTransactionSize() {
+            void buildMigrationTransaction_whenTxExceedMaxTxSizeAllowed_shouldReturnExceedMaxTransactionSize() {
                 // Arrange
                 retiringFederationUTXOs = UTXOBuilder.builder()
                     .withScriptPubKey(retiringFederationOutputScript)
@@ -2373,7 +2381,7 @@ class ReleaseTransactionBuilderTest {
             }
 
             @Test
-            void buildMigrationTransaction_whenTxIsAlmostExceedingMaxTxSize_shouldCreateMigrationTx() {
+            void buildMigrationTransaction_whenTxIsAlmostExceedingMaxTxSizeAllowed_shouldCreateMigrationTx() {
                 // Arrange
                 retiringFederationUTXOs = UTXOBuilder.builder()
                     .withScriptPubKey(retiringFederationOutputScript)
@@ -2673,7 +2681,7 @@ class ReleaseTransactionBuilderTest {
             }
 
             @Test
-            void buildMigrationTransaction_whenTxExceedMaxTxSize_preRSKIP378_shouldReturnExceedMaxTransactionSize() {
+            void buildMigrationTransaction_whenTxExceedMaxTxSizeAllowed_preRSKIP378_shouldReturnExceedMaxTransactionSize() {
                 // Arrange
                 setUp(VETIVER_ACTIVATIONS);
                 retiringFederationUTXOs = UTXOBuilder.builder()
@@ -2692,12 +2700,12 @@ class ReleaseTransactionBuilderTest {
             }
 
             @Test
-            void buildMigrationTransaction_whenTxExceedMaxTxSize_shouldReturnExceedMaxTransactionSize() {
+            void buildMigrationTransaction_whenTxExceedMaxTxSizeAllowed_shouldReturnExceedMaxTransactionSize() {
                 // Arrange
                 retiringFederationUTXOs = UTXOBuilder.builder()
                     .withScriptPubKey(retiringFederationOutputScript)
                     .withValue(Coin.COIN)
-                    .buildMany(P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE, i -> createHash(i + 1));
+                    .buildMany(P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE_WHEN_ONE_OUTPUT, i -> createHash(i + 1));
                 ReleaseTransactionBuilder releaseTransactionBuilder = setupWalletAndCreateReleaseTransactionBuilder(retiringFederationUTXOs);
                 Coin migrationValue = wallet.getBalance();
 
@@ -2710,7 +2718,7 @@ class ReleaseTransactionBuilderTest {
             }
 
             @Test
-            void buildMigrationTransaction_whenTxIsAlmostExceedingMaxTxSize_preRSKIP378_shouldCreateMigrationTx() {
+            void buildMigrationTransaction_whenTxIsAlmostExceedingMaxTxSizeAllowed_preRSKIP378_shouldCreateMigrationTx() {
                 // Arrange
                 setUp(VETIVER_ACTIVATIONS);
                 retiringFederationUTXOs = UTXOBuilder.builder()
@@ -2746,12 +2754,12 @@ class ReleaseTransactionBuilderTest {
             }
 
             @Test
-            void buildMigrationTransaction_whenTxIsAlmostExceedingMaxTxSize_shouldCreateMigrationTx() {
+            void buildMigrationTransaction_whenTxIsAlmostExceedingMaxTxSizeAllowed_shouldCreateMigrationTx() {
                 // Arrange
                 retiringFederationUTXOs = UTXOBuilder.builder()
                     .withScriptPubKey(retiringFederationOutputScript)
                     .withValue(Coin.COIN)
-                    .buildMany(P2SH_P2WSH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE, i -> createHash(i + 1));
+                    .buildMany(P2SH_P2WSH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE_WHEN_ONE_OUTPUT, i -> createHash(i + 1));
                 ReleaseTransactionBuilder releaseTransactionBuilder = setupWalletAndCreateReleaseTransactionBuilder(retiringFederationUTXOs);
                 Coin migrationValue = wallet.getBalance();
 
@@ -3155,7 +3163,7 @@ class ReleaseTransactionBuilderTest {
                 "196, 1",
                 "195, 15",
             })
-            void buildBatchedPegouts_whenTxExceedsMaxTxSize_shouldReturnExceedMaxTransactionSize(int numberOfUtxos, int numberOfPegoutRequests) {
+            void buildBatchedPegouts_whenTxExceedsMaxTxSizeAllowed_shouldReturnExceedMaxTransactionSize(int numberOfUtxos, int numberOfPegoutRequests) {
                 // Arrange
                 federationUTXOs = UTXOBuilder.builder()
                     .withScriptPubKey(federationOutputScript)
@@ -3181,7 +3189,7 @@ class ReleaseTransactionBuilderTest {
                 "195, 14",
                 "194, 15",
             })
-            void buildBatchedPegouts_whenTxIsAlmostExceedingMaxTxSize_shouldCreateBatchedPegoutsTx(int expectedNumberOfUtxos, int numberOfPegoutRequests) {
+            void buildBatchedPegouts_whenTxIsAlmostExceedingMaxTxSizeAllowed_shouldCreateBatchedPegoutsTx(int expectedNumberOfUtxos, int numberOfPegoutRequests) {
                 // Arrange
                 federationUTXOs = UTXOBuilder.builder()
                     .withScriptPubKey(federationOutputScript)
@@ -3244,27 +3252,12 @@ class ReleaseTransactionBuilderTest {
             }
 
             @Test
-            void buildBatchedPegouts_preRSKIP378_whenNoPegoutRequests_returnsAnEmptyTransaction() {
-                // Arrange
-                setUp(VETIVER_ACTIVATIONS);
-                ReleaseTransactionBuilder releaseTransactionBuilder = createReleaseTransactionBuilder();
-
-                // Act & Assert
-                BuildResult batchedPegoutsResult = releaseTransactionBuilder.buildBatchedPegouts(NO_PEGOUT_REQUESTS);
-                assertSuccessBuildResult(batchedPegoutsResult);
-
-                BtcTransaction batchedPegoutsTx = batchedPegoutsResult.btcTx();
-                assertTrue(batchedPegoutsTx.getOutputs().isEmpty());
-                assertTrue(batchedPegoutsTx.getInputs().isEmpty());
-            }
-
-            @Test
-            void buildBatchedPegouts_whenNoPegoutRequests_throwsIllegalArgumentException() {
+            void buildBatchedPegouts_whenNoPegoutRequests_throwsIllegalStateException() {
                 // Arrange
                 ReleaseTransactionBuilder releaseTransactionBuilder = createReleaseTransactionBuilder();
 
                 // Act & Assert
-                assertThrows(IllegalArgumentException.class, () -> releaseTransactionBuilder.buildBatchedPegouts(NO_PEGOUT_REQUESTS));
+                assertThrows(IllegalStateException.class, () -> releaseTransactionBuilder.buildBatchedPegouts(NO_PEGOUT_REQUESTS));
             }
 
             @Test
@@ -3545,7 +3538,7 @@ class ReleaseTransactionBuilderTest {
                 "2437, 2",
                 "2436, 3"
             })
-            void buildBatchedPegouts_whenTxExceedsMaxTxSize_preRSKIP378_shouldReturnExceedMaxTransactionSize(int numberOfUtxos, int numberOfPegoutRequests) {
+            void buildBatchedPegouts_whenTxExceedsMaxTxSizeAllowed_preRSKIP378_shouldReturnExceedMaxTransactionSize(int numberOfUtxos, int numberOfPegoutRequests) {
                 // Arrange
                 setUp(VETIVER_ACTIVATIONS);
                 federationUTXOs = UTXOBuilder.builder()
@@ -3567,11 +3560,13 @@ class ReleaseTransactionBuilderTest {
 
             @ParameterizedTest
             @CsvSource({
-                "202, 22",
-                "203, 8",
-                "204, 1"
+                "185, 1",
+                "184, 15",
+                "183, 29",
+                "182, 43",
+                "181, 58"
             })
-            void buildBatchedPegouts_whenTxExceedsMaxTxSize_shouldReturnExceedMaxTransactionSize(int numberOfUtxos, int numberOfPegoutRequests) {
+            void buildBatchedPegouts_whenTxExceedsMaxTxSizeAllowed_shouldReturnExceedMaxTransactionSize(int numberOfUtxos, int numberOfPegoutRequests) {
                 // Arrange
                 federationUTXOs = UTXOBuilder.builder()
                     .withScriptPubKey(federationOutputScript)
@@ -3597,7 +3592,7 @@ class ReleaseTransactionBuilderTest {
                 "2436, 2",
                 "2435, 3"
             })
-            void buildBatchedPegouts_whenTxIsAlmostExceedingMaxTxSize_preRSKIP378_shouldCreateBatchedPegoutsTx(
+            void buildBatchedPegouts_whenTxIsAlmostExceedingMaxTxSizeAllowed_preRSKIP378_shouldCreateBatchedPegoutsTx(
                 int expectedNumberOfUtxos,
                 int numberOfPegoutRequests
             ) {
@@ -3634,11 +3629,12 @@ class ReleaseTransactionBuilderTest {
 
             @ParameterizedTest
             @CsvSource({
-                "201, 34",
-                "202, 21",
-                "203, 7",
+                "184, 14",
+                "183, 28",
+                "182, 42",
+                "181, 57"
             })
-            void buildBatchedPegouts_whenTxIsAlmostExceedingMaxTxSize_shouldCreateBatchedPegoutsTx(
+            void buildBatchedPegouts_whenTxIsAlmostExceedingMaxTxSizeAllowed_shouldCreateBatchedPegoutsTx(
                 int expectedNumberOfUtxos,
                 int numberOfPegoutRequests
             ) {

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -2879,13 +2879,13 @@ class ReleaseTransactionBuilderTest {
             }
 
             @Test
-            void buildBatchedPegouts_whenNoPegoutRequests_shouldThrowIllegalStateException() {
+            void buildBatchedPegouts_whenNoPegoutRequests_shouldThrowIllegalArgumentException() {
                 // Arrange
                 ReleaseTransactionBuilder releaseTransactionBuilder = setupWalletAndCreateReleaseTransactionBuilder(
                     federationUTXOs);
 
                 // Act & Assert
-                assertThrows(IllegalStateException.class,
+                assertThrows(IllegalArgumentException.class,
                     () -> releaseTransactionBuilder.buildBatchedPegouts(NO_PEGOUT_REQUESTS));
             }
 
@@ -3252,12 +3252,12 @@ class ReleaseTransactionBuilderTest {
             }
 
             @Test
-            void buildBatchedPegouts_whenNoPegoutRequests_throwsIllegalStateException() {
+            void buildBatchedPegouts_whenNoPegoutRequests_throwsIllegalArgumentException() {
                 // Arrange
                 ReleaseTransactionBuilder releaseTransactionBuilder = createReleaseTransactionBuilder();
 
                 // Act & Assert
-                assertThrows(IllegalStateException.class, () -> releaseTransactionBuilder.buildBatchedPegouts(NO_PEGOUT_REQUESTS));
+                assertThrows(IllegalArgumentException.class, () -> releaseTransactionBuilder.buildBatchedPegouts(NO_PEGOUT_REQUESTS));
             }
 
             @Test

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -113,7 +113,7 @@ class ReleaseTransactionBuilderTest {
     private static final int STANDARD_MULTISIG_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE = STANDARD_MULTISIG_UTXO_COUNT_OVER_MAX_TX_SIZE - 1;
     private static final int P2SH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE = 196;
     private static final int P2SH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE = P2SH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE - 1;
-    private static final int P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE = 227;
+    private static final int P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE = 204;
     private static final int P2SH_P2WSH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE = P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE - 1;
 
     private static final Keccak256 FLYOVER_DERIVATION_HASH = BRIDGE_MAINNET_CONSTANTS.getProposedFederationFlyoverPrefix();
@@ -931,7 +931,7 @@ class ReleaseTransactionBuilderTest {
                 federationArgs,
                 BRIDGE_MAINNET_CONSTANTS.getFederationConstants().getErpFedPubKeysList(),
                 BRIDGE_MAINNET_CONSTANTS.getFederationConstants().getErpFedActivationDelay(),
-                ALL_ACTIVATIONS
+                hopActivations
             );
 
             int numberOfUtxos = 2;
@@ -954,7 +954,7 @@ class ReleaseTransactionBuilderTest {
                 nonStandardErpFederation,
                 nonStandardErpFederationAddress,
                 FEE_PER_KB_1000_SATOSHIS,
-                ALL_ACTIVATIONS
+                hopActivations
             );
 
             Address pegoutRecipient = BitcoinTestUtils.createP2PKHAddress(BTC_MAINNET_PARAMS, "destinationAddress");
@@ -3500,9 +3500,9 @@ class ReleaseTransactionBuilderTest {
 
             @ParameterizedTest
             @CsvSource({
-                "224, 29",
-                "225, 15",
-                "226, 2",
+                "201, 34",
+                "202, 21",
+                "203, 7",
             })
             void buildBatchedPegouts_whenTxIsAlmostExceedingMaxTxSize_shouldCreateBatchedPegoutsTx(
                 int expectedNumberOfUtxos,

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -117,7 +117,7 @@ class ReleaseTransactionBuilderTest {
     private static final int P2SH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE = P2SH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE - 1;
     private static final int P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE_VETIVER = 2438;
     private static final int P2SH_P2WSH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE_VETIVER = P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE_VETIVER - 1;
-    private static final int P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE_WHEN_ONE_OUTPUT = 186;
+    private static final int P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE_WHEN_ONE_OUTPUT = 184;
     private static final int P2SH_P2WSH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE_WHEN_ONE_OUTPUT = P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE_WHEN_ONE_OUTPUT - 1;
 
     private static final Keccak256 FLYOVER_DERIVATION_HASH = BRIDGE_MAINNET_CONSTANTS.getProposedFederationFlyoverPrefix();
@@ -3560,11 +3560,11 @@ class ReleaseTransactionBuilderTest {
 
             @ParameterizedTest
             @CsvSource({
-                "185, 1",
-                "184, 15",
-                "183, 29",
-                "182, 43",
-                "181, 58"
+                "184, 1",
+                "183, 14",
+                "182, 29",
+                "181, 43",
+                "180, 58"
             })
             void buildBatchedPegouts_whenTxExceedsMaxTxSizeAllowed_shouldReturnExceedMaxTransactionSize(int numberOfUtxos, int numberOfPegoutRequests) {
                 // Arrange
@@ -3629,10 +3629,10 @@ class ReleaseTransactionBuilderTest {
 
             @ParameterizedTest
             @CsvSource({
-                "184, 14",
-                "183, 28",
-                "182, 42",
-                "181, 57"
+                "183, 13",
+                "182, 28",
+                "181, 42",
+                "180, 57"
             })
             void buildBatchedPegouts_whenTxIsAlmostExceedingMaxTxSizeAllowed_shouldCreateBatchedPegoutsTx(
                 int expectedNumberOfUtxos,
@@ -3651,8 +3651,7 @@ class ReleaseTransactionBuilderTest {
                 List<ReleaseRequestQueue.Entry> pegoutRequests = createPegoutRequests(numberOfPegoutRequests, pegoutRequestAmount);
 
                 // Act
-                BuildResult batchedPegoutsResult = releaseTransactionBuilder.buildBatchedPegouts(
-                    pegoutRequests);
+                BuildResult batchedPegoutsResult = releaseTransactionBuilder.buildBatchedPegouts(pegoutRequests);
 
                 // Assert
                 assertSuccessBuildResult(batchedPegoutsResult);

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -19,7 +19,7 @@
 package co.rsk.peg;
 
 import static co.rsk.RskTestUtils.createRepository;
-import static co.rsk.peg.BridgeSupportTestUtil.setUpFlyoverUtxoInStorage;
+import static co.rsk.peg.BridgeSupportTestUtil.*;
 import static co.rsk.peg.ReleaseTransactionAssertions.assertBtcTxVersionIs1;
 import static co.rsk.peg.ReleaseTransactionAssertions.assertBtcTxVersionIs2;
 import static co.rsk.peg.ReleaseTransactionAssertions.assertDestinationAddress;
@@ -76,6 +76,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.core.Repository;
@@ -92,7 +93,8 @@ class ReleaseTransactionBuilderTest {
     private static final Context BTC_MAINNET_CONTEXT = new Context(BTC_MAINNET_PARAMS);
 
     private static final ActivationConfig.ForBlock ALL_ACTIVATIONS = ActivationConfigsForTest.all().forBlock(0);
-    private static final ActivationConfig.ForBlock LOVELL_ACTIVATIONS = ActivationConfigsForTest.lovell700().forBlock(0L);
+    private static final ActivationConfig.ForBlock VETIVER_ACTIVATIONS = ActivationConfigsForTest.vetiver900().forBlock(0);
+    private static final ActivationConfig.ForBlock LOVELL_ACTIVATIONS = ActivationConfigsForTest.lovell700().forBlock(0);
     private static final ActivationConfig.ForBlock FINGERROOT_ACTIVATIONS = ActivationConfigsForTest.fingerroot500().forBlock(0);
     private static final ActivationConfig.ForBlock IRIS_ACTIVATIONS = ActivationConfigsForTest.iris300().forBlock(0);
     private static final ActivationConfig.ForBlock PAPYRUS_ACTIVATIONS = ActivationConfigsForTest.papyrus200().forBlock(0);
@@ -113,6 +115,8 @@ class ReleaseTransactionBuilderTest {
     private static final int STANDARD_MULTISIG_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE = STANDARD_MULTISIG_UTXO_COUNT_OVER_MAX_TX_SIZE - 1;
     private static final int P2SH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE = 196;
     private static final int P2SH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE = P2SH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE - 1;
+    private static final int P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE_VETIVER = 2438;
+    private static final int P2SH_P2WSH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE_VETIVER = P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE_VETIVER - 1;
     private static final int P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE = 204;
     private static final int P2SH_P2WSH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE = P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE - 1;
 
@@ -139,6 +143,11 @@ class ReleaseTransactionBuilderTest {
         for (UTXO flyoverUtxo : flyoverUtxos) {
             setUpFlyoverUtxoInStorage(flyoverUtxo, flyoverOutputScript, federation, provider, FLYOVER_DERIVATION_HASH);
         }
+    }
+
+    @BeforeEach
+    void setUpDefaultFeePerKb() {
+        setUpFeePerKb(BtcTransaction.DEFAULT_TX_FEE);
     }
 
     /**
@@ -551,9 +560,12 @@ class ReleaseTransactionBuilderTest {
         private UTXO flyoverUtxo;
 
         @BeforeEach
-        void setup() {
-            setUpActivations(IRIS_ACTIVATIONS);
-            setUpFeePerKb(BtcTransaction.DEFAULT_TX_FEE);
+        void setUp() {
+            setUp(IRIS_ACTIVATIONS);
+        }
+
+        void setUp(ActivationConfig.ForBlock activations) {
+            setUpActivations(activations);
             federation = StandardMultiSigFederationBuilder.builder().build();
             federationAddress = federation.getAddress();
             federationOutputScript = federation.getP2SHScript();
@@ -594,7 +606,7 @@ class ReleaseTransactionBuilderTest {
         @Test
         void buildAmountTo_whenRSKIP201IsNotActive_shouldCreatePegoutTxWithBtcVersion1() {
             // Arrange
-            setUpActivations(PAPYRUS_ACTIVATIONS);
+            setUp(PAPYRUS_ACTIVATIONS);
             int numberOfUtxos = 10;
             Coin minimumPeginTxValue = BRIDGE_MAINNET_CONSTANTS.getMinimumPeginTxValue(PAPYRUS_ACTIVATIONS);
             federationUTXOs = UTXOBuilder.builder()
@@ -1122,7 +1134,6 @@ class ReleaseTransactionBuilderTest {
         private static final int P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX = 2438;
 
         private Federation federation;
-        private int federationFormatVersion;
         private Address federationAddress;
         private List<UTXO> federationUTXOs;
         private Script federationOutputScript;
@@ -1130,19 +1141,17 @@ class ReleaseTransactionBuilderTest {
         private Wallet wallet;
         private BridgeStorageProvider bridgeStorageProvider;
 
-        @BeforeEach
-        void setUp() {
-            setUpActivations(ALL_ACTIVATIONS);
-            setUpFeePerKb(BtcTransaction.DEFAULT_TX_FEE);
-        }
-
         @Nested
         class StandardMultiSigFederationTest {
 
             @BeforeEach
-            void setup() {
+            void setUp() {
+                setUp(IRIS_ACTIVATIONS);
+            }
+
+            void setUp(ActivationConfig.ForBlock activations) {
+                setUpActivations(activations);
                 federation = StandardMultiSigFederationBuilder.builder().build();
-                federationFormatVersion = federation.getFormatVersion();
                 federationAddress = federation.getAddress();
                 federationOutputScript = federation.getP2SHScript();
                 federationRedeemScript = federation.getRedeemScript();
@@ -1183,7 +1192,7 @@ class ReleaseTransactionBuilderTest {
             @Test
             void buildEmptyWalletTo_whenRSKIP201IsNotActive_shouldCreateRefundTxWithBtcVersion1() {
                 // Arrange
-                setUpActivations(PAPYRUS_ACTIVATIONS);
+                setUp(PAPYRUS_ACTIVATIONS);
                 ReleaseTransactionBuilder releaseTransactionBuilder = setupWalletAndCreateReleaseTransactionBuilder(federationUTXOs);
 
                 // Act
@@ -1331,9 +1340,9 @@ class ReleaseTransactionBuilderTest {
         class P2shFederationTest {
 
             @BeforeEach
-            void setup() {
+            void setUp() {
+                setUpActivations(LOVELL_ACTIVATIONS);
                 federation = P2shErpFederationBuilder.builder().build();
-                federationFormatVersion = federation.getFormatVersion();
                 federationAddress = federation.getAddress();
                 federationOutputScript = federation.getP2SHScript();
                 federationRedeemScript = federation.getRedeemScript();
@@ -1498,9 +1507,9 @@ class ReleaseTransactionBuilderTest {
         class P2shP2wshFederationTest {
 
             @BeforeEach
-            void setup() {
+            void setUp() {
+                setUpActivations(ALL_ACTIVATIONS);
                 federation = P2shP2wshErpFederationBuilder.builder().build();
-                federationFormatVersion = federation.getFormatVersion();
                 federationAddress = federation.getAddress();
                 federationOutputScript = federation.getP2SHScript();
                 federationRedeemScript = federation.getRedeemScript();
@@ -1736,18 +1745,13 @@ class ReleaseTransactionBuilderTest {
         private Script retiringFederationRedeemScript;
         protected Wallet wallet;
 
-        private Coin feePerKb;
         private Address newFederationAddress;
         private BridgeStorageProvider bridgeStorageProvider;
         private UTXO flyoverUtxo;
 
-        @BeforeEach
-        void setUp() {
-            setUpFeePerKb(BtcTransaction.DEFAULT_TX_FEE);
-        }
-
         @Nested
         class StandardMultiSigFederationTests {
+
             @BeforeEach
             void setUp() {
                 setUpActivations(IRIS_ACTIVATIONS);
@@ -2059,9 +2063,14 @@ class ReleaseTransactionBuilderTest {
 
         @Nested
         class P2shErpFederationTests {
+
             @BeforeEach
             void setUp() {
-                setUpActivations(LOVELL_ACTIVATIONS);
+                setUp(LOVELL_ACTIVATIONS);
+            }
+
+            void setUp(ActivationConfig.ForBlock activations) {
+                setUpActivations(activations);
                 retiringFederation = P2shErpFederationBuilder.builder().build();
                 retiringFederationFormatVersion = retiringFederation.getFormatVersion();
                 retiringFederationAddress = retiringFederation.getAddress();
@@ -2109,7 +2118,7 @@ class ReleaseTransactionBuilderTest {
             @Test
             void buildMigrationTransaction_whenRSKIP376IsNotActive_shouldCreateMigrationTxWithBtcVersion1() {
                 // Arrange
-                setUpActivations(FINGERROOT_ACTIVATIONS);
+                setUp(FINGERROOT_ACTIVATIONS);
                 int numberOfUtxos = 10;
                 retiringFederationUTXOs = UTXOBuilder.builder()
                     .withScriptPubKey(retiringFederationOutputScript)
@@ -2406,9 +2415,14 @@ class ReleaseTransactionBuilderTest {
 
         @Nested
         class P2shP2wshErpFederationTests {
+
             @BeforeEach
             void setUp() {
-                setUpActivations(ALL_ACTIVATIONS);
+                setUp(ALL_ACTIVATIONS);
+            }
+
+            void setUp(ActivationConfig.ForBlock activations) {
+                setUpActivations(activations);
                 retiringFederation = P2shP2wshErpFederationBuilder.builder().build();
                 retiringFederationFormatVersion = retiringFederation.getFormatVersion();
                 retiringFederationAddress = retiringFederation.getAddress();
@@ -2667,6 +2681,25 @@ class ReleaseTransactionBuilderTest {
             }
 
             @Test
+            void buildMigrationTransaction_whenTxExceedMaxTxSize_preRSKIP378_shouldReturnExceedMaxTransactionSize() {
+                // Arrange
+                setUp(VETIVER_ACTIVATIONS);
+                retiringFederationUTXOs = UTXOBuilder.builder()
+                    .withScriptPubKey(retiringFederationOutputScript)
+                    .withValue(Coin.COIN)
+                    .buildMany(P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE_VETIVER, i -> createHash(i + 1));
+                ReleaseTransactionBuilder releaseTransactionBuilder = setupWalletAndCreateReleaseTransactionBuilder(retiringFederationUTXOs);
+                Coin migrationValue = wallet.getBalance();
+
+                // Act
+                BuildResult migrationTransactionResult = releaseTransactionBuilder.buildMigrationTransaction(
+                    migrationValue, newFederationAddress);
+
+                // Assert
+                assertFailedBuildResult(EXCEED_MAX_TRANSACTION_SIZE, migrationTransactionResult);
+            }
+
+            @Test
             void buildMigrationTransaction_whenTxExceedMaxTxSize_shouldReturnExceedMaxTransactionSize() {
                 // Arrange
                 retiringFederationUTXOs = UTXOBuilder.builder()
@@ -2682,6 +2715,42 @@ class ReleaseTransactionBuilderTest {
 
                 // Assert
                 assertFailedBuildResult(EXCEED_MAX_TRANSACTION_SIZE, migrationTransactionResult);
+            }
+
+            @Test
+            void buildMigrationTransaction_whenTxIsAlmostExceedingMaxTxSize_preRSKIP378_shouldCreateMigrationTx() {
+                // Arrange
+                setUp(VETIVER_ACTIVATIONS);
+                retiringFederationUTXOs = UTXOBuilder.builder()
+                    .withScriptPubKey(retiringFederationOutputScript)
+                    .withValue(Coin.COIN)
+                    .buildMany(P2SH_P2WSH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE_VETIVER, i -> createHash(i + 1));
+                ReleaseTransactionBuilder releaseTransactionBuilder = setupWalletAndCreateReleaseTransactionBuilder(retiringFederationUTXOs);
+                Coin migrationValue = wallet.getBalance();
+
+                // Act
+                BuildResult migrationTransactionResult = releaseTransactionBuilder.buildMigrationTransaction(
+                    migrationValue,
+                    newFederationAddress
+                );
+
+                // Assert
+                assertSuccessBuildResult(migrationTransactionResult);
+                BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
+                assertBtcTxVersionIs2(migrationTransaction);
+
+                assertMigrationReleaseTxInputsP2shP2wshErp(
+                    migrationTransaction,
+                    retiringFederationRedeemScript,
+                    retiringFederationUTXOs,
+                    migrationTransactionResult.selectedUTXOs());
+
+                assertMigrationTxWithOnlyMigrationOutputs(
+                    migrationTransaction,
+                    migrationValue,
+                    newFederationAddress,
+                    BTC_MAINNET_PARAMS
+                );
             }
 
             @Test
@@ -2736,10 +2805,6 @@ class ReleaseTransactionBuilderTest {
             assertMigrationTransactionIsMigratingMoreThanRequestedValue(migrationValueRequested, migrationTransaction);
         }
 
-        private void setUpFeePerKb(Coin transactionFeePerKb) {
-            this.feePerKb = transactionFeePerKb;
-        }
-
         private static void assertMigrationTransactionIsMigratingMoreThanRequestedValue(Coin migrationValueRequested, BtcTransaction migrationTransaction) {
             Coin migratedValue = getMigrationTransactionValueSent(migrationTransaction);
             Coin fee = migrationTransaction.getFee();
@@ -2787,16 +2852,11 @@ class ReleaseTransactionBuilderTest {
         private Script federationRedeemScript;
         private BridgeStorageProvider bridgeStorageProvider;
 
-        @BeforeEach
-        void setUp() {
-            setUpActivations(ALL_ACTIVATIONS);
-            setUpFeePerKb(BtcTransaction.DEFAULT_TX_FEE);
-        }
-
         @Nested
         class P2shErpFederationTests {
+
             @BeforeEach
-            void setup() {
+            void setUp() {
                 setUpActivations(LOVELL_ACTIVATIONS);
                 federation = P2shErpFederationBuilder.builder().build();
                 federationFormatVersion = federation.getFormatVersion();
@@ -3165,7 +3225,12 @@ class ReleaseTransactionBuilderTest {
         class P2shP2wshErpFederationTests {
 
             @BeforeEach
-            void setup() {
+            void setUp() {
+                setUp(ALL_ACTIVATIONS);
+            }
+
+            void setUp(ActivationConfig.ForBlock activations) {
+                setUpActivations(activations);
                 federation = P2shP2wshErpFederationBuilder.builder().build();
                 federationFormatVersion = federation.getFormatVersion();
                 federationAddress = federation.getAddress();
@@ -3189,7 +3254,7 @@ class ReleaseTransactionBuilderTest {
             @Test
             void buildBatchedPegouts_preRSKIP378_whenNoPegoutRequests_returnsAnEmptyTransaction() {
                 // Arrange
-                activations = ActivationConfigsForTest.vetiver900().forBlock(0L);
+                setUp(VETIVER_ACTIVATIONS);
                 ReleaseTransactionBuilder releaseTransactionBuilder = createReleaseTransactionBuilder();
 
                 // Act & Assert
@@ -3484,9 +3549,35 @@ class ReleaseTransactionBuilderTest {
 
             @ParameterizedTest
             @CsvSource({
-                "224, 30",
-                "225, 16",
-                "226, 3"
+                "2438, 1",
+                "2437, 2",
+                "2436, 3"
+            })
+            void buildBatchedPegouts_whenTxExceedsMaxTxSize_preRSKIP378_shouldReturnExceedMaxTransactionSize(int numberOfUtxos, int numberOfPegoutRequests) {
+                // Arrange
+                setUp(VETIVER_ACTIVATIONS);
+                federationUTXOs = UTXOBuilder.builder()
+                    .withScriptPubKey(federationOutputScript)
+                    .withValue(Coin.COIN)
+                    .buildMany(numberOfUtxos, i -> createHash(i + 1));
+                ReleaseTransactionBuilder releaseTransactionBuilder = setupWalletAndCreateReleaseTransactionBuilder(federationUTXOs);
+
+                Coin utxosTotalAmount = Coin.COIN.multiply(numberOfUtxos);
+                Coin pegoutRequestAmount = utxosTotalAmount.divide(numberOfPegoutRequests).subtract(THOUSAND_SATOSHIS);
+                List<ReleaseRequestQueue.Entry> pegoutRequests = createPegoutRequests(numberOfPegoutRequests, pegoutRequestAmount);
+
+                // Act
+                BuildResult batchedPegoutsResult = releaseTransactionBuilder.buildBatchedPegouts(pegoutRequests);
+
+                // Assert
+                assertFailedBuildResult(EXCEED_MAX_TRANSACTION_SIZE, batchedPegoutsResult);
+            }
+
+            @ParameterizedTest
+            @CsvSource({
+                "202, 22",
+                "203, 8",
+                "204, 1"
             })
             void buildBatchedPegouts_whenTxExceedsMaxTxSize_shouldReturnExceedMaxTransactionSize(int numberOfUtxos, int numberOfPegoutRequests) {
                 // Arrange
@@ -3506,6 +3597,47 @@ class ReleaseTransactionBuilderTest {
 
                 // Assert
                 assertFailedBuildResult(EXCEED_MAX_TRANSACTION_SIZE, batchedPegoutsResult);
+            }
+
+            @ParameterizedTest
+            @CsvSource({
+                "2437, 1",
+                "2436, 2",
+                "2435, 3"
+            })
+            void buildBatchedPegouts_whenTxIsAlmostExceedingMaxTxSize_preRSKIP378_shouldCreateBatchedPegoutsTx(
+                int expectedNumberOfUtxos,
+                int numberOfPegoutRequests
+            ) {
+                // Arrange
+                setUp(VETIVER_ACTIVATIONS);
+                federationUTXOs = UTXOBuilder.builder()
+                    .withScriptPubKey(federationOutputScript)
+                    .withValue(Coin.COIN)
+                    .buildMany(expectedNumberOfUtxos, i -> createHash(i + 1));
+                ReleaseTransactionBuilder releaseTransactionBuilder = setupWalletAndCreateReleaseTransactionBuilder(federationUTXOs);
+
+                Coin utxosTotalAmount = Coin.COIN.multiply(expectedNumberOfUtxos);
+                Coin pegoutRequestAmount = utxosTotalAmount.divide(numberOfPegoutRequests).subtract(MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT);
+
+                List<ReleaseRequestQueue.Entry> pegoutRequests = createPegoutRequests(numberOfPegoutRequests, pegoutRequestAmount);
+
+                // Act
+                BuildResult batchedPegoutsResult = releaseTransactionBuilder.buildBatchedPegouts(pegoutRequests);
+
+                // Assert
+                assertSuccessBuildResult(batchedPegoutsResult);
+                BtcTransaction batchedPegoutsTransaction = batchedPegoutsResult.btcTx();
+
+                assertBtcTxVersionIs2(batchedPegoutsTransaction);
+                assertReleaseTxInputsP2shP2wshErp(
+                    batchedPegoutsTransaction,
+                    federationRedeemScript,
+                    federationUTXOs,
+                    batchedPegoutsResult.selectedUTXOs(),
+                    expectedNumberOfUtxos
+                );
+                assertOutputsWithNonDustChange(batchedPegoutsTransaction, pegoutRequests);
             }
 
             @ParameterizedTest

--- a/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/ReleaseTransactionBuilderTest.java
@@ -92,11 +92,10 @@ class ReleaseTransactionBuilderTest {
     private static final Context BTC_MAINNET_CONTEXT = new Context(BTC_MAINNET_PARAMS);
 
     private static final ActivationConfig.ForBlock ALL_ACTIVATIONS = ActivationConfigsForTest.all().forBlock(0);
-    private static final ActivationConfig.ForBlock FINGERROOT_ACTIVATIONS =
-        ActivationConfigsForTest.fingerroot500().forBlock(0);
+    private static final ActivationConfig.ForBlock LOVELL_ACTIVATIONS = ActivationConfigsForTest.lovell700().forBlock(0L);
+    private static final ActivationConfig.ForBlock FINGERROOT_ACTIVATIONS = ActivationConfigsForTest.fingerroot500().forBlock(0);
     private static final ActivationConfig.ForBlock IRIS_ACTIVATIONS = ActivationConfigsForTest.iris300().forBlock(0);
-    private static final ActivationConfig.ForBlock PAPYRUS_ACTIVATIONS =
-        ActivationConfigsForTest.papyrus200().forBlock(0);
+    private static final ActivationConfig.ForBlock PAPYRUS_ACTIVATIONS = ActivationConfigsForTest.papyrus200().forBlock(0);
 
     private static final Coin DUST_VALUE = MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT.minus(Coin.SATOSHI);
     private static final Coin FEE_PER_KB_1000_SATOSHIS = Coin.SATOSHI.multiply(1000);
@@ -111,15 +110,20 @@ class ReleaseTransactionBuilderTest {
 
     private static final int EXPECTED_NUMBER_OF_CHANGE_OUTPUTS = 1;
     private static final int STANDARD_MULTISIG_UTXO_COUNT_OVER_MAX_TX_SIZE = 277;
-    private static final int UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE = 276;
+    private static final int STANDARD_MULTISIG_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE = STANDARD_MULTISIG_UTXO_COUNT_OVER_MAX_TX_SIZE - 1;
+    private static final int P2SH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE = 196;
+    private static final int P2SH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE = P2SH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE - 1;
+    private static final int P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE = 227;
+    private static final int P2SH_P2WSH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE = P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE - 1;
+
     private static final Keccak256 FLYOVER_DERIVATION_HASH = BRIDGE_MAINNET_CONSTANTS.getProposedFederationFlyoverPrefix();
     private static final Sha256Hash BTC_TX_HASH_FLYOVER_UTXO = createHash(10_000);
 
     private ActivationConfig.ForBlock activations;
     private Coin feePerKb;
 
-    private void setUpActivations(ActivationConfig.ForBlock activations) {
-        this.activations = activations;
+    private void setUpActivations(ActivationConfig.ForBlock activationConfig) {
+        this.activations = activationConfig;
     }
 
     private void setUpFeePerKb(Coin feePerKb) {
@@ -525,7 +529,7 @@ class ReleaseTransactionBuilderTest {
             return new ReleaseTransactionBuilder(
                 BTC_MAINNET_PARAMS,
                 thisWallet,
-                activeFederation.getFormatVersion(),
+                activeFederation,
                 activeFederation.getAddress(),
                 MOCK_FEE_PER_KB,
                 ALL_ACTIVATIONS
@@ -535,11 +539,9 @@ class ReleaseTransactionBuilderTest {
 
     @Nested
     class BuildAmountToTest {
-
         private static final Address RECIPIENT_ADDRESS = ReleaseTransactionBuilderTest.recipientAddressFromPrivateKeyOffset(2100);
 
         private Federation federation;
-        private int federationFormatVersion;
         private Address federationAddress;
         private List<UTXO> federationUTXOs;
         private Script federationOutputScript;
@@ -553,7 +555,6 @@ class ReleaseTransactionBuilderTest {
             setUpActivations(IRIS_ACTIVATIONS);
             setUpFeePerKb(BtcTransaction.DEFAULT_TX_FEE);
             federation = StandardMultiSigFederationBuilder.builder().build();
-            federationFormatVersion = federation.getFormatVersion();
             federationAddress = federation.getAddress();
             federationOutputScript = federation.getP2SHScript();
             federationRedeemScript = federation.getRedeemScript();
@@ -889,7 +890,7 @@ class ReleaseTransactionBuilderTest {
             federationUTXOs = UTXOBuilder.builder()
                 .withScriptPubKey(federationOutputScript)
                 .withValue(Coin.COIN)
-                .buildMany(UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE, i -> createHash(i + 1));
+                .buildMany(STANDARD_MULTISIG_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE, i -> createHash(i + 1));
             ReleaseTransactionBuilder releaseTransactionBuilder = setupWalletAndCreateReleaseTransactionBuilder();
             Coin requestedAmount = wallet.getBalance().subtract(MIN_NON_DUST_VALUE_FOR_P2SH_OUTPUT_SCRIPT);
 
@@ -913,6 +914,8 @@ class ReleaseTransactionBuilderTest {
          */
         @Test
         void buildAmountTo_whenNonStandardErpFederation_shouldCreatePegoutTx() {
+            ActivationConfig.ForBlock hopActivations = ActivationConfigsForTest.hop400().forBlock(0L);
+            setUpActivations(hopActivations);
             List<FederationMember> members = FederationMember.getFederationMembersFromKeys(
                 Arrays.asList(
                     new BtcECKey(),
@@ -948,7 +951,7 @@ class ReleaseTransactionBuilderTest {
             ReleaseTransactionBuilder releaseTransactionBuilder = new ReleaseTransactionBuilder(
                 BTC_MAINNET_PARAMS,
                 spendWallet,
-                nonStandardErpFederation.getFormatVersion(),
+                nonStandardErpFederation,
                 nonStandardErpFederationAddress,
                 FEE_PER_KB_1000_SATOSHIS,
                 ALL_ACTIVATIONS
@@ -975,7 +978,7 @@ class ReleaseTransactionBuilderTest {
             return new ReleaseTransactionBuilder(
                 BTC_MAINNET_PARAMS,
                 wallet,
-                federationFormatVersion,
+                federation,
                 federationAddress,
                 feePerKb,
                 activations
@@ -1689,7 +1692,7 @@ class ReleaseTransactionBuilderTest {
             return new ReleaseTransactionBuilder(
                 BTC_MAINNET_PARAMS,
                 wallet,
-                federationFormatVersion,
+                federation,
                 federationAddress,
                 feePerKb,
                 activations
@@ -1733,7 +1736,6 @@ class ReleaseTransactionBuilderTest {
         private Script retiringFederationRedeemScript;
         protected Wallet wallet;
 
-        private ActivationConfig.ForBlock activations;
         private Coin feePerKb;
         private Address newFederationAddress;
         private BridgeStorageProvider bridgeStorageProvider;
@@ -1741,15 +1743,14 @@ class ReleaseTransactionBuilderTest {
 
         @BeforeEach
         void setUp() {
-            setUpActivationConfig(ALL_ACTIVATIONS);
             setUpFeePerKb(BtcTransaction.DEFAULT_TX_FEE);
         }
 
         @Nested
         class StandardMultiSigFederationTests {
-
             @BeforeEach
             void setUp() {
+                setUpActivations(IRIS_ACTIVATIONS);
                 retiringFederation = StandardMultiSigFederationBuilder.builder().build();
                 retiringFederationFormatVersion = retiringFederation.getFormatVersion();
                 retiringFederationAddress = retiringFederation.getAddress();
@@ -1795,41 +1796,6 @@ class ReleaseTransactionBuilderTest {
             }
 
             @Test
-            void buildMigrationTransaction_whenRSKIP376IsNotActive_shouldCreateMigrationTxWithBtcVersion1() {
-                // Arrange
-                setUpActivationConfig(FINGERROOT_ACTIVATIONS);
-                int numberOfUtxos = 10;
-                retiringFederationUTXOs = UTXOBuilder.builder()
-                    .withScriptPubKey(retiringFederationOutputScript)
-                    .withValue(MINIMUM_PEGIN_TX_VALUE_WITH_ALL_ACTIVATIONS)
-                    .buildMany(numberOfUtxos, i -> createHash(i + 1));
-                ReleaseTransactionBuilder releaseTransactionBuilder = setupWalletAndCreateReleaseTransactionBuilder(
-                    retiringFederationUTXOs);
-                Coin migrationValue = wallet.getBalance();
-
-                // Act
-                BuildResult migrationTransactionResult = releaseTransactionBuilder.buildMigrationTransaction(
-                    migrationValue, newFederationAddress);
-
-                // Assert
-                assertSuccessBuildResult(migrationTransactionResult);
-                BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
-                assertBtcTxVersionIs1(migrationTransaction);
-
-                assertMigrationReleaseTxInputsStandardMultisig(
-                    migrationTransaction,
-                    retiringFederationRedeemScript,
-                    retiringFederationUTXOs,
-                    migrationTransactionResult.selectedUTXOs());
-                assertMigrationTxWithOnlyMigrationOutputs(
-                    migrationTransaction,
-                    migrationValue,
-                    newFederationAddress,
-                    BTC_MAINNET_PARAMS
-                );
-            }
-
-            @Test
             void buildMigrationTransaction_whenSingleUTXOToMigrate_shouldCreateMigrationTx() {
                 // Arrange
                 retiringFederationUTXOs = List.of(
@@ -1849,7 +1815,7 @@ class ReleaseTransactionBuilderTest {
                 // Assert
                 assertSuccessBuildResult(migrationTransactionResult);
                 BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
-                assertBtcTxVersionIs2(migrationTransaction);
+                assertBtcTxVersionIs1(migrationTransaction);
 
                 assertMigrationReleaseTxInputsStandardMultisig(
                     migrationTransaction,
@@ -1883,7 +1849,7 @@ class ReleaseTransactionBuilderTest {
                 // Assert
                 assertSuccessBuildResult(migrationTransactionResult);
                 BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
-                assertBtcTxVersionIs2(migrationTransaction);
+                assertBtcTxVersionIs1(migrationTransaction);
 
                 assertMigrationReleaseTxInputsStandardMultisig(
                     migrationTransaction,
@@ -1943,7 +1909,7 @@ class ReleaseTransactionBuilderTest {
                 // Assert
                 assertSuccessBuildResult(migrationTransactionResult);
                 BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
-                assertBtcTxVersionIs2(migrationTransaction);
+                assertBtcTxVersionIs1(migrationTransaction);
 
                 assertMigrationReleaseTxInputsStandardMultisig(
                     migrationTransaction,
@@ -2009,7 +1975,7 @@ class ReleaseTransactionBuilderTest {
                 // Assert
                 assertSuccessBuildResult(migrationTransactionResult);
                 BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
-                assertBtcTxVersionIs2(migrationTransaction);
+                assertBtcTxVersionIs1(migrationTransaction);
 
                 assertMigrationReleaseTxInputsStandardMultisig(
                     migrationTransaction,
@@ -2061,11 +2027,10 @@ class ReleaseTransactionBuilderTest {
             @Test
             void buildMigrationTransaction_whenTxIsAlmostExceedingMaxTxSize_shouldCreateMigrationTx() {
                 // Arrange
-                int numberOfUtxos = 276;
                 retiringFederationUTXOs = UTXOBuilder.builder()
                     .withScriptPubKey(retiringFederationOutputScript)
                     .withValue(Coin.COIN)
-                    .buildMany(numberOfUtxos, i -> createHash(i + 1));
+                    .buildMany(STANDARD_MULTISIG_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE, i -> createHash(i + 1));
                 ReleaseTransactionBuilder releaseTransactionBuilder = setupWalletAndCreateReleaseTransactionBuilder(retiringFederationUTXOs);
                 Coin migrationValue = wallet.getBalance();
 
@@ -2076,7 +2041,7 @@ class ReleaseTransactionBuilderTest {
                 // Assert
                 assertSuccessBuildResult(migrationTransactionResult);
                 BtcTransaction migrationTransaction = migrationTransactionResult.btcTx();
-                assertBtcTxVersionIs2(migrationTransaction);
+                assertBtcTxVersionIs1(migrationTransaction);
 
                 assertMigrationReleaseTxInputsStandardMultisig(
                     migrationTransaction,
@@ -2094,9 +2059,9 @@ class ReleaseTransactionBuilderTest {
 
         @Nested
         class P2shErpFederationTests {
-
             @BeforeEach
             void setUp() {
+                setUpActivations(LOVELL_ACTIVATIONS);
                 retiringFederation = P2shErpFederationBuilder.builder().build();
                 retiringFederationFormatVersion = retiringFederation.getFormatVersion();
                 retiringFederationAddress = retiringFederation.getAddress();
@@ -2144,7 +2109,7 @@ class ReleaseTransactionBuilderTest {
             @Test
             void buildMigrationTransaction_whenRSKIP376IsNotActive_shouldCreateMigrationTxWithBtcVersion1() {
                 // Arrange
-                setUpActivationConfig(FINGERROOT_ACTIVATIONS);
+                setUpActivations(FINGERROOT_ACTIVATIONS);
                 int numberOfUtxos = 10;
                 retiringFederationUTXOs = UTXOBuilder.builder()
                     .withScriptPubKey(retiringFederationOutputScript)
@@ -2391,11 +2356,10 @@ class ReleaseTransactionBuilderTest {
             @Test
             void buildMigrationTransaction_whenTxExceedMaxTxSize_shouldReturnExceedMaxTransactionSize() {
                 // Arrange
-                int numberOfUtxos = 196;
                 retiringFederationUTXOs = UTXOBuilder.builder()
                     .withScriptPubKey(retiringFederationOutputScript)
                     .withValue(Coin.COIN)
-                    .buildMany(numberOfUtxos, i -> createHash(i + 1));
+                    .buildMany(P2SH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE, i -> createHash(i + 1));
                 ReleaseTransactionBuilder releaseTransactionBuilder = setupWalletAndCreateReleaseTransactionBuilder(retiringFederationUTXOs);
                 Coin migrationValue = wallet.getBalance();
 
@@ -2410,11 +2374,10 @@ class ReleaseTransactionBuilderTest {
             @Test
             void buildMigrationTransaction_whenTxIsAlmostExceedingMaxTxSize_shouldCreateMigrationTx() {
                 // Arrange
-                int numberOfUtxos = 195;
                 retiringFederationUTXOs = UTXOBuilder.builder()
                     .withScriptPubKey(retiringFederationOutputScript)
                     .withValue(Coin.COIN)
-                    .buildMany(numberOfUtxos, i -> createHash(i + 1));
+                    .buildMany(P2SH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE, i -> createHash(i + 1));
                 ReleaseTransactionBuilder releaseTransactionBuilder = setupWalletAndCreateReleaseTransactionBuilder(retiringFederationUTXOs);
                 Coin migrationValue = wallet.getBalance();
 
@@ -2443,9 +2406,9 @@ class ReleaseTransactionBuilderTest {
 
         @Nested
         class P2shP2wshErpFederationTests {
-
             @BeforeEach
             void setUp() {
+                setUpActivations(ALL_ACTIVATIONS);
                 retiringFederation = P2shP2wshErpFederationBuilder.builder().build();
                 retiringFederationFormatVersion = retiringFederation.getFormatVersion();
                 retiringFederationAddress = retiringFederation.getAddress();
@@ -2706,11 +2669,10 @@ class ReleaseTransactionBuilderTest {
             @Test
             void buildMigrationTransaction_whenTxExceedMaxTxSize_shouldReturnExceedMaxTransactionSize() {
                 // Arrange
-                int numberOfUtxos = 2438;
                 retiringFederationUTXOs = UTXOBuilder.builder()
                     .withScriptPubKey(retiringFederationOutputScript)
                     .withValue(Coin.COIN)
-                    .buildMany(numberOfUtxos, i -> createHash(i + 1));
+                    .buildMany(P2SH_P2WSH_ERP_UTXO_COUNT_OVER_MAX_TX_SIZE, i -> createHash(i + 1));
                 ReleaseTransactionBuilder releaseTransactionBuilder = setupWalletAndCreateReleaseTransactionBuilder(retiringFederationUTXOs);
                 Coin migrationValue = wallet.getBalance();
 
@@ -2725,17 +2687,18 @@ class ReleaseTransactionBuilderTest {
             @Test
             void buildMigrationTransaction_whenTxIsAlmostExceedingMaxTxSize_shouldCreateMigrationTx() {
                 // Arrange
-                int numberOfUtxos = 2437;
                 retiringFederationUTXOs = UTXOBuilder.builder()
                     .withScriptPubKey(retiringFederationOutputScript)
                     .withValue(Coin.COIN)
-                    .buildMany(numberOfUtxos, i -> createHash(i + 1));
+                    .buildMany(P2SH_P2WSH_ERP_UTXO_COUNT_JUST_UNDER_MAX_STANDARD_TX_SIZE, i -> createHash(i + 1));
                 ReleaseTransactionBuilder releaseTransactionBuilder = setupWalletAndCreateReleaseTransactionBuilder(retiringFederationUTXOs);
                 Coin migrationValue = wallet.getBalance();
 
                 // Act
                 BuildResult migrationTransactionResult = releaseTransactionBuilder.buildMigrationTransaction(
-                    migrationValue, newFederationAddress);
+                    migrationValue,
+                    newFederationAddress
+                );
 
                 // Assert
                 assertSuccessBuildResult(migrationTransactionResult);
@@ -2773,10 +2736,6 @@ class ReleaseTransactionBuilderTest {
             assertMigrationTransactionIsMigratingMoreThanRequestedValue(migrationValueRequested, migrationTransaction);
         }
 
-        private void setUpActivationConfig(ActivationConfig.ForBlock activationConfig) {
-            this.activations = activationConfig;
-        }
-
         private void setUpFeePerKb(Coin transactionFeePerKb) {
             this.feePerKb = transactionFeePerKb;
         }
@@ -2803,7 +2762,7 @@ class ReleaseTransactionBuilderTest {
             return new ReleaseTransactionBuilder(
                 BTC_MAINNET_PARAMS,
                 wallet,
-                retiringFederationFormatVersion,
+                retiringFederation,
                 retiringFederationAddress,
                 feePerKb,
                 activations
@@ -2816,7 +2775,6 @@ class ReleaseTransactionBuilderTest {
      */
     @Nested
     class BuildBatchedPegoutsTest {
-
         private static final List<ReleaseRequestQueue.Entry> NO_PEGOUT_REQUESTS = Collections.emptyList();
 
         protected Federation federation;
@@ -2837,9 +2795,9 @@ class ReleaseTransactionBuilderTest {
 
         @Nested
         class P2shErpFederationTests {
-
             @BeforeEach
             void setup() {
+                setUpActivations(LOVELL_ACTIVATIONS);
                 federation = P2shErpFederationBuilder.builder().build();
                 federationFormatVersion = federation.getFormatVersion();
                 federationAddress = federation.getAddress();
@@ -3234,8 +3192,7 @@ class ReleaseTransactionBuilderTest {
                 ReleaseTransactionBuilder releaseTransactionBuilder = createReleaseTransactionBuilder();
 
                 // Act & Assert
-                BuildResult batchedPegoutsResult = releaseTransactionBuilder.buildBatchedPegouts(
-                    NO_PEGOUT_REQUESTS);
+                BuildResult batchedPegoutsResult = releaseTransactionBuilder.buildBatchedPegouts(NO_PEGOUT_REQUESTS);
                 assertSuccessBuildResult(batchedPegoutsResult);
 
                 BtcTransaction batchedPegoutsTx = batchedPegoutsResult.btcTx();
@@ -3517,9 +3474,9 @@ class ReleaseTransactionBuilderTest {
 
             @ParameterizedTest
             @CsvSource({
-                "2438, 1",
-                "2437, 2",
-                "2436, 3"
+                "224, 30",
+                "225, 16",
+                "226, 3"
             })
             void buildBatchedPegouts_whenTxExceedsMaxTxSize_shouldReturnExceedMaxTransactionSize(int numberOfUtxos, int numberOfPegoutRequests) {
                 // Arrange
@@ -3543,12 +3500,14 @@ class ReleaseTransactionBuilderTest {
 
             @ParameterizedTest
             @CsvSource({
-                "2437, 1",
-                "2436, 2",
-                "2435, 3",
+                "224, 29",
+                "225, 15",
+                "226, 2",
             })
             void buildBatchedPegouts_whenTxIsAlmostExceedingMaxTxSize_shouldCreateBatchedPegoutsTx(
-                int expectedNumberOfUtxos, int numberOfPegoutRequests) {
+                int expectedNumberOfUtxos,
+                int numberOfPegoutRequests
+            ) {
                 // Arrange
                 federationUTXOs = UTXOBuilder.builder()
                     .withScriptPubKey(federationOutputScript)
@@ -3616,7 +3575,7 @@ class ReleaseTransactionBuilderTest {
             return new ReleaseTransactionBuilder(
                 BTC_MAINNET_PARAMS,
                 wallet,
-                federationFormatVersion,
+                federation,
                 federationAddress,
                 feePerKb,
                 activations

--- a/rskj-core/src/test/java/co/rsk/test/builders/PegoutTransactionBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/test/builders/PegoutTransactionBuilder.java
@@ -18,6 +18,7 @@ public class PegoutTransactionBuilder {
     private final List<TransactionOutput> outputs;
 
     private Coin changeAmount;
+    private boolean withChange;
     private boolean signTransaction;
 
     private PegoutTransactionBuilder() {
@@ -28,6 +29,7 @@ public class PegoutTransactionBuilder {
         this.signingKeys = defaultKeys;
 
         this.networkParameters = NetworkParameters.fromID(NetworkParameters.ID_MAINNET);
+        this.withChange = true;
         this.changeAmount = Coin.COIN.div(2);
         this.signTransaction = false;
 
@@ -73,6 +75,11 @@ public class PegoutTransactionBuilder {
         return this;
     }
 
+    public PegoutTransactionBuilder withoutChange() {
+        this.withChange = false;
+        return this;
+    }
+
     public PegoutTransactionBuilder withSignatures() {
         signTransaction = true;
         return this;
@@ -89,7 +96,9 @@ public class PegoutTransactionBuilder {
 
         addInputsToTransaction(pegoutTransaction);
         addOutputsToTransaction(pegoutTransaction);
-        addChangeOutput(pegoutTransaction);
+        if (withChange) {
+            addChangeOutput(pegoutTransaction);
+        }
         signInputs(pegoutTransaction);
 
         return pegoutTransaction;

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -129,6 +129,7 @@ class ActivationConfigTest {
         "    rskip375: fingerroot500",
         "    rskip376: arrowhead600",
         "    rskip377: fingerroot500",
+        "    rskip378: tbd1000",
         "    rskip379: arrowhead600",
         "    rskip383: fingerroot500",
         "    rskip385: fingerroot500",

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
@@ -218,6 +218,7 @@ public class ActivationConfigsForTest {
 
     private static List<ConsensusRule> getTbd1000Rskips() {
         return new ArrayList<>(List.of(
+            ConsensusRule.RSKIP378,
             ConsensusRule.RSKIP559
         ));
     }


### PR DESCRIPTION
This pull request refactors and improves the pegout transaction size estimation logic, updates how federation information is passed to transaction builders, and makes several code quality improvements in the `BridgeSupport` and `BridgeUtils` classes. The main goal is to provide a more accurate and maintainable way to simulate pegout transaction sizes, especially for SegWit transactions, and to simplify related code paths.

**Pegout Transaction Size Simulation and Refactoring:**

* The method for estimating pegout transaction size is renamed from `calculatePegoutTxSize` to `simulatePegoutTxSize`, and its logic is improved to better simulate unsigned SegWit transaction sizes. Legacy and SegWit estimation logic is now separated and clarified, with new helper methods for SegWit size simulation.
* All usages of `calculatePegoutTxSize` are replaced with `simulatePegoutTxSize` throughout the codebase for consistency and accuracy. [[1]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L20-R20) [[2]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L1228-R1228) [[3]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L2643-R2665)

**Federation Handling Improvements:**

* The `ReleaseTransactionBuilder` now receives the entire `Federation` object instead of just the federation format version, allowing for more flexible and future-proof federation handling. All relevant builder invocations are updated accordingly. [[1]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L1159-R1159) [[2]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L1362-R1365) [[3]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L2690-R2708) [[4]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L3076-R3094) [[5]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L3242-R3260)

**Batch Pegout Processing Enhancements:**

* The logic for summing and logging pegout values in batch processing is improved for clarity, with a new helper method `sumPegoutValues` and clearer variable naming and logging. The value used for balance adjustment now depends on whether RSKIP378 is active. [[1]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L1507-R1521) [[2]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L1532-R1580)

**Fee Estimation and Code Cleanup:**

* The logic for returning zero estimated fees is extracted into a dedicated method, improving readability and maintainability. [[1]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L2614-R2632) [[2]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685R2641-R2646)
* Minor code cleanups and naming improvements are made for better clarity and consistency, such as variable renaming in pegout processing and improved documentation. [[1]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L1481-R1484) [[2]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L1649-R1686)

**Legacy Utilities and Imports:**

* Imports in `BridgeUtilsLegacy` are consolidated for brevity, and legacy simulation logic is updated to match the new naming conventions.

These changes collectively improve the accuracy, maintainability, and clarity of the pegout transaction simulation and related bridge logic.

---

**Pegout Transaction Size Simulation:**
- Refactored `calculatePegoutTxSize` to `simulatePegoutTxSize` with improved SegWit transaction size simulation and new helper methods for unsigned SegWit transaction vsize estimation.
- Updated all usages of the old estimation method to the new `simulatePegoutTxSize`. [[1]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L20-R20) [[2]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L1228-R1228) [[3]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L2643-R2665)

**Federation Handling:**
- Changed `ReleaseTransactionBuilder` constructors to accept the full `Federation` object, updating all call sites. [[1]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L1159-R1159) [[2]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L1362-R1365) [[3]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L2690-R2708) [[4]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L3076-R3094) [[5]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L3242-R3260)

**Batch Pegout Processing:**
- Improved batch pegout value calculation and logging, with a new `sumPegoutValues` helper and conditional logic for RSKIP378. [[1]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L1507-R1521) [[2]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L1532-R1580)

**Fee Estimation and Cleanup:**
- Extracted zero-fee logic to a dedicated method and improved related code clarity. [[1]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L2614-R2632) [[2]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685R2641-R2646)
- Enhanced documentation and variable naming in pegout processing and balance adjustment. [[1]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L1481-R1484) [[2]](diffhunk://#diff-61e5c53e59bedc5790b677df9fb9db0fbe260d86030c6caa00fb9b12a6afc685L1649-R1686)

**Legacy and Imports:**
- Consolidated imports in `BridgeUtilsLegacy` and updated legacy simulation method names.