### PR TITLE
fix: Fix EIP-7702 nonce encoding and verification for delegated EOAs

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/core/SetCodeAuthorizationTransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/SetCodeAuthorizationTransactionExecutor.java
@@ -26,7 +26,6 @@ import org.ethereum.vm.GasCost;
 
 import java.math.BigInteger;
 import java.security.SignatureException;
-import java.util.Arrays;
 
 
 public class SetCodeAuthorizationTransactionExecutor {
@@ -40,10 +39,10 @@ public class SetCodeAuthorizationTransactionExecutor {
         RskAddress authority = checkRecoveredAuthority(authorization);
 
         byte[] code = repository.getCode(authority);
-        byte[] currentNonce  = repository.getNonce(authority).toByteArray();
+        BigInteger currentNonce  = repository.getNonce(authority);
 
         verifyAuthorityCode(code);
-        verifyAuthorityNonce(authorization.getNonce(), currentNonce);
+        verifyAuthorityNonce(authorization.getNonceAsInteger(), currentNonce);
 
         long refund = calculateRefund(code);
 
@@ -103,8 +102,8 @@ public class SetCodeAuthorizationTransactionExecutor {
     }
 
 
-    private void verifyAuthorityNonce(byte[] expectedNonce, byte[] currentNonce) {
-        if (!Arrays.equals(currentNonce, expectedNonce)) {
+    private void verifyAuthorityNonce(BigInteger expectedNonce, BigInteger currentNonce) {
+        if (!currentNonce.equals(expectedNonce)) {
             throw new IllegalStateException("Authority nonce mismatch");
         }
     }

--- a/rskj-core/src/main/java/org/ethereum/core/transaction/SetCodeAuthorization.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/SetCodeAuthorization.java
@@ -18,11 +18,12 @@
 package org.ethereum.core.transaction;
 
 import co.rsk.core.RskAddress;
+import org.bouncycastle.util.BigIntegers;
 import org.ethereum.config.Constants;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.crypto.signature.ECDSASignature;
 import org.ethereum.util.RLP;
-import org.spongycastle.util.BigIntegers;
+
 
 import java.math.BigInteger;
 import java.util.Arrays;

--- a/rskj-core/src/main/java/org/ethereum/core/transaction/SetCodeAuthorization.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/SetCodeAuthorization.java
@@ -22,6 +22,7 @@ import org.ethereum.config.Constants;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.crypto.signature.ECDSASignature;
 import org.ethereum.util.RLP;
+import org.spongycastle.util.BigIntegers;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -53,7 +54,7 @@ public class SetCodeAuthorization {
         return address;
     }
 
-    public byte[] getNonce() {
+    public byte[] getNonceBytes() {
         return  nonce.clone();
     }
 
@@ -76,13 +77,13 @@ public class SetCodeAuthorization {
     }
 
     public void verifyNonceRange() {
-        if (nonce.length == 0) {
-            throw new IllegalStateException("Nonce is empty");
-        }
-        BigInteger nonceValue = new BigInteger(1, nonce);
-        if (nonceValue.compareTo(MAX_NONCE) >= 0) {
+        if (getNonceAsInteger().compareTo(MAX_NONCE) >= 0) {
             throw new IllegalStateException("Nonce must be < 2^64 - 1");
         }
+    }
+
+    public BigInteger getNonceAsInteger() {
+        return BigIntegers.fromUnsignedByteArray(nonce);
     }
 
     public void verifyLowS() {

--- a/rskj-core/src/main/java/org/ethereum/core/transaction/parser/util/AuthorizationListCodec.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/parser/util/AuthorizationListCodec.java
@@ -98,7 +98,7 @@ public final class AuthorizationListCodec {
         return RLP.encodeList(
                 RLP.encodeBigInteger(auth.getChainId()),
                 RLP.encodeRskAddress(auth.getAddress()),
-                RLP.encodeElement(auth.getNonce()),
+                RLP.encodeElement(auth.getNonceBytes()),
                 RLP.encodeByte(yParity),
                 RLP.encodeElement(BigIntegers.asUnsignedByteArray(auth.getSignature().getR())),
                 RLP.encodeElement(BigIntegers.asUnsignedByteArray(auth.getSignature().getS()))
@@ -262,7 +262,7 @@ public final class AuthorizationListCodec {
         if (auth.getChainId().signum() < 0 || auth.getChainId().compareTo(MAX_CHAIN_ID) >= 0) {
             throw new IllegalArgumentException("Authorization chain_id must be non-negative and less than 2^256");
         }
-        validateNonceValue(decodeNonce(auth.getNonce()));
+        validateNonceValue(decodeNonce(auth.getNonceBytes()));
 
         ECDSASignature signature = auth.getSignature();
         BigInteger r = signature.getR();

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
@@ -167,7 +167,7 @@ public class TransactionResultDTO {
             result.add(new AuthorizationListEntryDTO(
                     HexUtils.toQuantityJsonHex(auth.getChainId()),
                     auth.getAddress().toJsonString(),
-                    HexUtils.toQuantityJsonHex(auth.getNonce()),
+                    HexUtils.toQuantityJsonHex(auth.getNonceBytes()),
                     HexUtils.toQuantityJsonHex((long) signature.getV() - Transaction.LOWER_REAL_V),
                     HexUtils.toQuantityJsonHex(signature.getR()),
                     HexUtils.toQuantityJsonHex(signature.getS())

--- a/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/SetCodeSetCodeAuthorizationTransactionExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/SetCodeSetCodeAuthorizationTransactionExecutorTest.java
@@ -39,6 +39,7 @@ import static java.math.BigInteger.ZERO;
 import static org.ethereum.config.Constants.MAINNET_CHAIN_ID;
 import static org.ethereum.config.Constants.REGTEST_CHAIN_ID;
 import static org.ethereum.config.Constants.TESTNET_CHAIN_ID;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -99,24 +100,6 @@ import static org.mockito.Mockito.when;
 
         assertFalse(DelegationCodeResolver.isDelegatedCode(code));
     }
-
-    @Test
-    void processAuthorizationTuple_shouldThrow_whenNonceIsEmpty() {
-       var tuple = new SetCodeAuthorization(
-                        ZERO_CHAIN_ID,
-                        randomAddress(),
-                        new byte[0],
-                        mock(ECDSASignature.class)
-                );
-
-        IllegalStateException ex = assertThrows(
-                IllegalStateException.class,
-                () -> executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple)
-        );
-
-        assertEquals("Nonce is empty", ex.getMessage());
-    }
-
 
     @Test
     void processAuthorizationTuple_shouldThrow_whenNonceExceedsLimit() {
@@ -364,7 +347,7 @@ import static org.mockito.Mockito.when;
     }
 
     @Test
-    void processAuthorizationTuple_shouldRejectWrongNonce() {
+    void processAuthorizationTuple_shouldTreatLeadingZeroByteAsSameNonce() {
         ECKey authorityKey = new ECKey();
         RskAddress authority = new RskAddress(authorityKey.getAddress());
 
@@ -380,15 +363,39 @@ import static org.mockito.Mockito.when;
         when(repository.getCode(authority)).thenReturn(null);
         when(repository.getNonce(authority)).thenReturn(ONE);
 
-        IllegalStateException ex = assertThrows(
-                IllegalStateException.class,
-                () -> executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple)
-        );
 
-        assertEquals("Authority nonce mismatch", ex.getMessage());
-        verify(repository, never()).saveCode(any(), any());
-        verify(repository, never()).increaseNonce(any());
+        assertDoesNotThrow(() -> executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple));
+
+        verify(repository).saveCode(eq(authority), any());
+        verify(repository).increaseNonce(authority);
     }
+
+     @Test
+     void processAuthorizationTuple_shouldRejectMismatchedNonce() {
+         ECKey authorityKey = new ECKey();
+         RskAddress authority = new RskAddress(authorityKey.getAddress());
+
+         byte[] authorizationNonce = new byte[]{0x02};
+
+         var tuple = createValidAuthorizationTuple(
+                 RskAddress.ZERO_ADDRESS,
+                 authorizationNonce,
+                 ZERO_CHAIN_ID,
+                 authorityKey
+         );
+
+         when(repository.getCode(authority)).thenReturn(null);
+         when(repository.getNonce(authority)).thenReturn(ONE);
+
+         IllegalStateException ex = assertThrows(
+                 IllegalStateException.class,
+                 () -> executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple)
+         );
+
+         assertEquals("Authority nonce mismatch", ex.getMessage());
+         verify(repository, never()).saveCode(any(), any());
+         verify(repository, never()).increaseNonce(any());
+     }
 
     @Test
     void processAuthorizationTuple_shouldClearCode_whenDelegatedAddressIsNullAddress() {
@@ -536,6 +543,96 @@ import static org.mockito.Mockito.when;
         verify(repository).saveCode(eq(authority), aryEq(createDelegatedCode(delegated)));
         verify(repository).increaseNonce(eq(authority));
     }
+
+     @Test
+     void verifyAuthorityNonceShouldAcceptSameNumericNonceWithDifferentByteRepresentations() {
+         BigInteger expectedNonce = new BigInteger(1, new byte[] {(byte) 0x80});
+         ECKey authorityKey = new ECKey();
+         RskAddress authority = new RskAddress(authorityKey.getAddress());
+         RskAddress delegated = randomAddress();
+
+         var tuple = createValidAuthorizationTuple(delegated, new byte[] {0x00, (byte) 0x80}, ZERO_CHAIN_ID, authorityKey);
+
+         when(repository.getCode(authority)).thenReturn(null);
+         when(repository.getNonce(authority)).thenReturn(expectedNonce);
+
+         executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple);
+         verify(repository).saveCode(eq(authority), aryEq(createDelegatedCode(delegated)));
+         verify(repository).increaseNonce(eq(authority));
+     }
+
+     @Test
+     void processAuthorizationTuple_shouldAcceptFreshAuthorityWithEmptyNonceAsZero() {
+         ECKey authorityKey = new ECKey();
+         RskAddress authority = new RskAddress(authorityKey.getAddress());
+         RskAddress delegated = randomAddress();
+
+         var tuple = createValidAuthorizationTuple(
+                 delegated,
+                 new byte[0],
+                 ZERO_CHAIN_ID,
+                 authorityKey
+         );
+
+         when(repository.getCode(authority)).thenReturn(null);
+         when(repository.getNonce(authority)).thenReturn(ZERO);
+
+         long refund = executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple);
+
+         assertEquals(0L, refund);
+         verify(repository).saveCode(eq(authority), aryEq(createDelegatedCode(delegated)));
+         verify(repository).increaseNonce(authority);
+     }
+
+     @Test
+     void processAuthorizationTuple_shouldAcceptNonce128WhenAuthorizationUsesMinimalUnsignedBytes() {
+         ECKey authorityKey = new ECKey();
+         RskAddress authority = new RskAddress(authorityKey.getAddress());
+         RskAddress delegated = randomAddress();
+
+         byte[] authorizationNonce = new byte[] {(byte) 0x80};
+
+         var tuple = createValidAuthorizationTuple(
+                 delegated,
+                 authorizationNonce,
+                 ZERO_CHAIN_ID,
+                 authorityKey
+         );
+
+         when(repository.getCode(authority)).thenReturn(null);
+         when(repository.getNonce(authority)).thenReturn(BigInteger.valueOf(128));
+
+         long refund = executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple);
+
+         assertEquals(0L, refund);
+         verify(repository).saveCode(eq(authority), aryEq(createDelegatedCode(delegated)));
+         verify(repository).increaseNonce(authority);
+     }
+
+     @Test
+     void processAuthorizationTuple_shouldAcceptNonce255WhenAuthorizationUsesMinimalUnsignedBytes() {
+         ECKey authorityKey = new ECKey();
+         RskAddress authority = new RskAddress(authorityKey.getAddress());
+         RskAddress delegated = randomAddress();
+
+         byte[] authorizationNonce = new byte[] {(byte) 0xff};
+
+         var tuple = createValidAuthorizationTuple(
+                 delegated,
+                 authorizationNonce,
+                 ZERO_CHAIN_ID,
+                 authorityKey
+         );
+
+         when(repository.getCode(authority)).thenReturn(null);
+         when(repository.getNonce(authority)).thenReturn(BigInteger.valueOf(255));
+
+         long refund = executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple);
+
+         assertEquals(0L, refund);
+         verify(repository).saveCode(eq(authority), aryEq(createDelegatedCode(delegated)));
+         verify(repository).increaseNonce(authority);
+     }
 
     private SetCodeAuthorization createValidAuthorizationTuple(
             RskAddress delegatedAddress,

--- a/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/SetCodeSetCodeAuthorizationTransactionExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/SetCodeSetCodeAuthorizationTransactionExecutorTest.java
@@ -370,32 +370,31 @@ import static org.mockito.Mockito.when;
         verify(repository).increaseNonce(authority);
     }
 
-     @Test
-     void processAuthorizationTuple_shouldRejectMismatchedNonce() {
-         ECKey authorityKey = new ECKey();
-         RskAddress authority = new RskAddress(authorityKey.getAddress());
+    @Test
+    void processAuthorizationTuple_shouldRejectMismatchedNonce() {
+        ECKey authorityKey = new ECKey();
+        RskAddress authority = new RskAddress(authorityKey.getAddress());
 
-         byte[] authorizationNonce = new byte[]{0x02};
+        byte[] authorizationNonce = new byte[]{0x02};
 
-         var tuple = createValidAuthorizationTuple(
+        var tuple = createValidAuthorizationTuple(
                  RskAddress.ZERO_ADDRESS,
                  authorizationNonce,
                  ZERO_CHAIN_ID,
                  authorityKey
-         );
+        );
 
-         when(repository.getCode(authority)).thenReturn(null);
-         when(repository.getNonce(authority)).thenReturn(ONE);
-
-         IllegalStateException ex = assertThrows(
+        when(repository.getCode(authority)).thenReturn(null);
+        when(repository.getNonce(authority)).thenReturn(ONE);
+        IllegalStateException ex = assertThrows(
                  IllegalStateException.class,
                  () -> executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple)
-         );
+        );
 
-         assertEquals("Authority nonce mismatch", ex.getMessage());
-         verify(repository, never()).saveCode(any(), any());
-         verify(repository, never()).increaseNonce(any());
-     }
+        assertEquals("Authority nonce mismatch", ex.getMessage());
+        verify(repository, never()).saveCode(any(), any());
+        verify(repository, never()).increaseNonce(any());
+    }
 
     @Test
     void processAuthorizationTuple_shouldClearCode_whenDelegatedAddressIsNullAddress() {
@@ -544,94 +543,94 @@ import static org.mockito.Mockito.when;
         verify(repository).increaseNonce(eq(authority));
     }
 
-     @Test
-     void verifyAuthorityNonceShouldAcceptSameNumericNonceWithDifferentByteRepresentations() {
-         BigInteger expectedNonce = new BigInteger(1, new byte[] {(byte) 0x80});
-         ECKey authorityKey = new ECKey();
-         RskAddress authority = new RskAddress(authorityKey.getAddress());
-         RskAddress delegated = randomAddress();
+    @Test
+    void verifyAuthorityNonceShouldAcceptSameNumericNonceWithDifferentByteRepresentations() {
+        BigInteger expectedNonce = new BigInteger(1, new byte[] {(byte) 0x80});
+        ECKey authorityKey = new ECKey();
+        RskAddress authority = new RskAddress(authorityKey.getAddress());
+        RskAddress delegated = randomAddress();
 
-         var tuple = createValidAuthorizationTuple(delegated, new byte[] {0x00, (byte) 0x80}, ZERO_CHAIN_ID, authorityKey);
+        var tuple = createValidAuthorizationTuple(delegated, new byte[] {0x00, (byte) 0x80}, ZERO_CHAIN_ID, authorityKey);
 
-         when(repository.getCode(authority)).thenReturn(null);
-         when(repository.getNonce(authority)).thenReturn(expectedNonce);
+        when(repository.getCode(authority)).thenReturn(null);
+        when(repository.getNonce(authority)).thenReturn(expectedNonce);
 
-         executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple);
-         verify(repository).saveCode(eq(authority), aryEq(createDelegatedCode(delegated)));
-         verify(repository).increaseNonce(eq(authority));
+        executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple);
+        verify(repository).saveCode(eq(authority), aryEq(createDelegatedCode(delegated)));
+        verify(repository).increaseNonce(eq(authority));
      }
 
      @Test
      void processAuthorizationTuple_shouldAcceptFreshAuthorityWithEmptyNonceAsZero() {
-         ECKey authorityKey = new ECKey();
-         RskAddress authority = new RskAddress(authorityKey.getAddress());
-         RskAddress delegated = randomAddress();
+        ECKey authorityKey = new ECKey();
+        RskAddress authority = new RskAddress(authorityKey.getAddress());
+        RskAddress delegated = randomAddress();
 
-         var tuple = createValidAuthorizationTuple(
+        var tuple = createValidAuthorizationTuple(
                  delegated,
                  new byte[0],
                  ZERO_CHAIN_ID,
                  authorityKey
          );
 
-         when(repository.getCode(authority)).thenReturn(null);
-         when(repository.getNonce(authority)).thenReturn(ZERO);
+        when(repository.getCode(authority)).thenReturn(null);
+        when(repository.getNonce(authority)).thenReturn(ZERO);
 
-         long refund = executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple);
+        long refund = executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple);
 
-         assertEquals(0L, refund);
-         verify(repository).saveCode(eq(authority), aryEq(createDelegatedCode(delegated)));
-         verify(repository).increaseNonce(authority);
+        assertEquals(0L, refund);
+        verify(repository).saveCode(eq(authority), aryEq(createDelegatedCode(delegated)));
+        verify(repository).increaseNonce(authority);
      }
 
      @Test
      void processAuthorizationTuple_shouldAcceptNonce128WhenAuthorizationUsesMinimalUnsignedBytes() {
-         ECKey authorityKey = new ECKey();
-         RskAddress authority = new RskAddress(authorityKey.getAddress());
-         RskAddress delegated = randomAddress();
+        ECKey authorityKey = new ECKey();
+        RskAddress authority = new RskAddress(authorityKey.getAddress());
+        RskAddress delegated = randomAddress();
 
-         byte[] authorizationNonce = new byte[] {(byte) 0x80};
+        byte[] authorizationNonce = new byte[] {(byte) 0x80};
 
-         var tuple = createValidAuthorizationTuple(
+        var tuple = createValidAuthorizationTuple(
                  delegated,
                  authorizationNonce,
                  ZERO_CHAIN_ID,
                  authorityKey
          );
 
-         when(repository.getCode(authority)).thenReturn(null);
-         when(repository.getNonce(authority)).thenReturn(BigInteger.valueOf(128));
+        when(repository.getCode(authority)).thenReturn(null);
+        when(repository.getNonce(authority)).thenReturn(BigInteger.valueOf(128));
 
-         long refund = executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple);
+        long refund = executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple);
 
-         assertEquals(0L, refund);
-         verify(repository).saveCode(eq(authority), aryEq(createDelegatedCode(delegated)));
-         verify(repository).increaseNonce(authority);
+        assertEquals(0L, refund);
+        verify(repository).saveCode(eq(authority), aryEq(createDelegatedCode(delegated)));
+        verify(repository).increaseNonce(authority);
      }
 
      @Test
      void processAuthorizationTuple_shouldAcceptNonce255WhenAuthorizationUsesMinimalUnsignedBytes() {
-         ECKey authorityKey = new ECKey();
-         RskAddress authority = new RskAddress(authorityKey.getAddress());
-         RskAddress delegated = randomAddress();
+        ECKey authorityKey = new ECKey();
+        RskAddress authority = new RskAddress(authorityKey.getAddress());
+        RskAddress delegated = randomAddress();
 
-         byte[] authorizationNonce = new byte[] {(byte) 0xff};
+        byte[] authorizationNonce = new byte[] {(byte) 0xff};
 
-         var tuple = createValidAuthorizationTuple(
+        var tuple = createValidAuthorizationTuple(
                  delegated,
                  authorizationNonce,
                  ZERO_CHAIN_ID,
                  authorityKey
-         );
+        );
 
-         when(repository.getCode(authority)).thenReturn(null);
-         when(repository.getNonce(authority)).thenReturn(BigInteger.valueOf(255));
+        when(repository.getCode(authority)).thenReturn(null);
+        when(repository.getNonce(authority)).thenReturn(BigInteger.valueOf(255));
 
-         long refund = executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple);
+        long refund = executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple);
 
-         assertEquals(0L, refund);
-         verify(repository).saveCode(eq(authority), aryEq(createDelegatedCode(delegated)));
-         verify(repository).increaseNonce(authority);
+        assertEquals(0L, refund);
+        verify(repository).saveCode(eq(authority), aryEq(createDelegatedCode(delegated)));
+        verify(repository).increaseNonce(authority);
      }
 
     private SetCodeAuthorization createValidAuthorizationTuple(

--- a/rskj-core/src/test/java/org/ethereum/core/Rskip545DeepDslTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/Rskip545DeepDslTest.java
@@ -480,7 +480,7 @@ class Rskip545DeepDslTest {
         SetCodeAuthorization second = tx.getAuthorizationList().get(1);
         assertEquals(first.getChainId(), second.getChainId());
         assertEquals(first.getAddress(), second.getAddress());
-        assertArrayEquals(first.getNonce(), second.getNonce());
+        assertArrayEquals(first.getNonceBytes(), second.getNonceBytes());
         assertEquals(first.getSignature().getR(), second.getSignature().getR());
         assertEquals(first.getSignature().getS(), second.getSignature().getS());
     }

--- a/rskj-core/src/test/java/org/ethereum/core/Rskip545TestSupport.java
+++ b/rskj-core/src/test/java/org/ethereum/core/Rskip545TestSupport.java
@@ -105,7 +105,7 @@ public final class Rskip545TestSupport {
         return new SetCodeAuthorization(
                 chainId,
                 base.getAddress(),
-                base.getNonce(),
+                base.getNonceBytes(),
                 base.getSignature());
     }
 
@@ -241,7 +241,7 @@ public final class Rskip545TestSupport {
                 org.bouncycastle.util.BigIntegers.asUnsignedByteArray(highS),
                 valid.getSignature().getV()
         );
-        return new SetCodeAuthorization(valid.getChainId(), valid.getAddress(), valid.getNonce(), highSig);
+        return new SetCodeAuthorization(valid.getChainId(), valid.getAddress(), valid.getNonceBytes(), highSig);
     }
 
     /**

--- a/rskj-core/src/test/java/org/ethereum/core/SetCodeAuthorizationTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/SetCodeAuthorizationTest.java
@@ -32,7 +32,7 @@ class SetCodeAuthorizationTest {
     }
 
     @Test
-     void getNonceShouldReturnDefensiveCopy() {
+    void getNonceShouldReturnDefensiveCopy() {
         SetCodeAuthorization authorization = new SetCodeAuthorization(CHAIN_ID, ADDRESS, NONCE, validSignature());
         byte[] returnedNonce = authorization.getNonceBytes();
         returnedNonce[0] = 0x02;

--- a/rskj-core/src/test/java/org/ethereum/core/SetCodeAuthorizationTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/SetCodeAuthorizationTest.java
@@ -9,6 +9,7 @@ import java.math.BigInteger;
 
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -16,14 +17,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.ethereum.config.Constants;
 import org.ethereum.crypto.signature.ECDSASignature;
 
-public class SetCodeAuthorizationTest {
+class SetCodeAuthorizationTest {
 
     private static final BigInteger CHAIN_ID = BigInteger.valueOf(31);
     private static final RskAddress ADDRESS = new RskAddress("0000000000000000000000000000000000000001");
     private static final byte[] NONCE = new byte[] {0x01};
 
     @Test
-    public void constructorShouldRejectNullValues() {
+    void constructorShouldRejectNullValues() {
         assertThrows(NullPointerException.class, () -> new SetCodeAuthorization(null, ADDRESS, NONCE, validSignature()));
         assertThrows(NullPointerException.class, () -> new SetCodeAuthorization(CHAIN_ID, null, NONCE, validSignature()));
         assertThrows(NullPointerException.class, () -> new SetCodeAuthorization(CHAIN_ID, ADDRESS, null, validSignature()));
@@ -31,23 +32,23 @@ public class SetCodeAuthorizationTest {
     }
 
     @Test
-    public void getNonceShouldReturnDefensiveCopy() {
+     void getNonceShouldReturnDefensiveCopy() {
         SetCodeAuthorization authorization = new SetCodeAuthorization(CHAIN_ID, ADDRESS, NONCE, validSignature());
-        byte[] returnedNonce = authorization.getNonce();
+        byte[] returnedNonce = authorization.getNonceBytes();
         returnedNonce[0] = 0x02;
-        assertArrayEquals(NONCE, authorization.getNonce());
+        assertArrayEquals(NONCE, authorization.getNonceBytes());
     }
 
     @Test
-    public void constructorShouldDefensivelyCopyNonce() {
+     void constructorShouldDefensivelyCopyNonce() {
         byte[] nonce = new byte[] {0x01};
         SetCodeAuthorization authorization = new SetCodeAuthorization(CHAIN_ID, ADDRESS, nonce, validSignature());
         nonce[0] = 0x02;
-        assertArrayEquals(new byte[] {0x01}, authorization.getNonce());
+        assertArrayEquals(new byte[] {0x01}, authorization.getNonceBytes());
     }
 
     @Test
-    public void getSigningHashShouldReturnExpectedHash() {
+     void getSigningHashShouldReturnExpectedHash() {
         SetCodeAuthorization authorization = new SetCodeAuthorization(CHAIN_ID, ADDRESS, NONCE, validSignature());
 
         byte[] rlpEncoded = RLP.encodeList(
@@ -66,20 +67,13 @@ public class SetCodeAuthorizationTest {
     }
 
     @Test
-    public void verifyNonceRangeShouldAcceptValidNonce() {
+     void verifyNonceRangeShouldAcceptValidNonce() {
         SetCodeAuthorization authorization = new SetCodeAuthorization(CHAIN_ID, ADDRESS, new byte[] {0x01}, validSignature());
         authorization.verifyNonceRange();
     }
 
     @Test
-    public void verifyNonceRangeShouldRejectEmptyNonce() {
-        SetCodeAuthorization authorization = new SetCodeAuthorization(CHAIN_ID, ADDRESS, new byte[0], validSignature());
-        IllegalStateException exception = assertThrows(IllegalStateException.class, authorization::verifyNonceRange);
-        assertEquals("Nonce is empty", exception.getMessage());
-    }
-
-    @Test
-    public void verifyNonceRangeShouldRejectNonceGreaterThanOrEqualToMaxNonce() {
+    void verifyNonceRangeShouldRejectNonceGreaterThanOrEqualToMaxNonce() {
         byte[] maxNonce = new BigInteger("FFFFFFFFFFFFFFFF", 16).toByteArray();
 
         SetCodeAuthorization authorization = new SetCodeAuthorization(CHAIN_ID, ADDRESS, maxNonce, validSignature());
@@ -89,7 +83,7 @@ public class SetCodeAuthorizationTest {
     }
 
     @Test
-    public void verifyNonceRangeShouldAcceptMaxAllowedNonce() {
+    void verifyNonceRangeShouldAcceptMaxAllowedNonce() {
         byte[] maxAllowedNonce = new BigInteger("FFFFFFFFFFFFFFFE", 16).toByteArray();
 
         SetCodeAuthorization authorization = new SetCodeAuthorization(
@@ -103,7 +97,7 @@ public class SetCodeAuthorizationTest {
     }
 
     @Test
-    public void verifyLowSShouldAcceptLowS() {
+    void verifyLowSShouldAcceptLowS() {
         SetCodeAuthorization authorization = new SetCodeAuthorization(
                 CHAIN_ID,
                 ADDRESS,
@@ -115,7 +109,7 @@ public class SetCodeAuthorizationTest {
     }
 
     @Test
-    public void verifyLowSShouldAcceptHalfCurveOrderS() {
+    void verifyLowSShouldAcceptHalfCurveOrderS() {
         BigInteger halfCurveOrder = Constants.getSECP256K1N().divide(BigInteger.valueOf(2));
 
         SetCodeAuthorization authorization = new SetCodeAuthorization(
@@ -129,7 +123,7 @@ public class SetCodeAuthorizationTest {
     }
 
     @Test
-    public void verifyLowSShouldRejectHighS() {
+    void verifyLowSShouldRejectHighS() {
         BigInteger highS = Constants.getSECP256K1N().divide(BigInteger.valueOf(2)).add(BigInteger.ONE);
 
         SetCodeAuthorization authorization = new SetCodeAuthorization(
@@ -148,7 +142,7 @@ public class SetCodeAuthorizationTest {
     }
 
     @Test
-    public void equalsShouldReturnTrueForSameValues() {
+     void equalsShouldReturnTrueForSameValues() {
         ECDSASignature signature = validSignature();
 
         SetCodeAuthorization first = new SetCodeAuthorization(CHAIN_ID, ADDRESS, NONCE, signature);
@@ -159,12 +153,115 @@ public class SetCodeAuthorizationTest {
     }
 
     @Test
-    public void equalsShouldReturnFalseForDifferentNonce() {
+    void equalsShouldReturnFalseForDifferentNonce() {
         SetCodeAuthorization first = new SetCodeAuthorization(CHAIN_ID, ADDRESS, new byte[] {0x01}, validSignature());
         SetCodeAuthorization second = new SetCodeAuthorization(CHAIN_ID, ADDRESS, new byte[] {0x02}, validSignature());
-
         assertNotEquals(first, second);
     }
+
+    @Test
+    void getNonceAsIntegerShouldTreatEmptyNonceAsZero() {
+        SetCodeAuthorization authorization = new SetCodeAuthorization(CHAIN_ID, ADDRESS, new byte[0], validSignature());
+        assertEquals(BigInteger.ZERO, authorization.getNonceAsInteger());
+    }
+    @Test
+    void verifyNonceRangeShouldAcceptEmptyNonceAsZero() {
+        SetCodeAuthorization authorization = new SetCodeAuthorization(CHAIN_ID, ADDRESS, new byte[0], validSignature());
+        assertDoesNotThrow(authorization::verifyNonceRange);
+    }
+
+    @Test
+    void getNonceAsIntegerShouldDecodeUnsignedNonceWithTopBitSet() {
+        SetCodeAuthorization authorization =
+                new SetCodeAuthorization(CHAIN_ID, ADDRESS, new byte[] {(byte) 0x80}, validSignature());
+
+        assertEquals(BigInteger.valueOf(128), authorization.getNonceAsInteger());
+    }
+
+    @Test
+    void verifyNonceRangeShouldAcceptNonce128() {
+        SetCodeAuthorization authorization =
+                new SetCodeAuthorization(CHAIN_ID, ADDRESS, new byte[] {(byte) 0x80}, validSignature());
+        authorization.verifyNonceRange();
+    }
+
+    @Test
+    void verifyNonceRangeShouldAcceptNonce255() {
+        SetCodeAuthorization authorization = new SetCodeAuthorization(CHAIN_ID, ADDRESS, new byte[] {(byte) 0xff}, validSignature());
+        authorization.verifyNonceRange();
+    }
+
+    @Test
+    void verifyNonceRangeShouldAcceptNonce256() {
+        SetCodeAuthorization authorization =
+                new SetCodeAuthorization(CHAIN_ID, ADDRESS, new byte[] {0x01, 0x00}, validSignature());
+
+        assertDoesNotThrow(authorization::verifyNonceRange);
+    }
+
+    @Test
+    void verifyNonceRangeShouldRejectMaxNonce() {
+        byte[] maxNonce = new byte[] {
+                (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
+                (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff
+        };
+
+        SetCodeAuthorization authorization = new SetCodeAuthorization(CHAIN_ID, ADDRESS, maxNonce, validSignature());
+        IllegalStateException exception = assertThrows(IllegalStateException.class, authorization::verifyNonceRange);
+        assertEquals("Nonce must be < 2^64 - 1", exception.getMessage());
+    }
+
+    @Test
+    void verifyNonceRangeShouldRejectNonceLargerThanMaxNonce() {
+        byte[] tooLargeNonce = new byte[] {
+                0x01,
+                0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00
+        };
+
+        SetCodeAuthorization authorization =
+                new SetCodeAuthorization(CHAIN_ID, ADDRESS, tooLargeNonce, validSignature());
+
+        IllegalStateException ex =
+                assertThrows(IllegalStateException.class, authorization::verifyNonceRange);
+
+        assertEquals("Nonce must be < 2^64 - 1", ex.getMessage());
+    }
+
+    @Test
+    void getNonceAsIntegerShouldTreatZeroByteAndEmptyByteArrayAsZero() {
+        SetCodeAuthorization empty =
+                new SetCodeAuthorization(CHAIN_ID, ADDRESS, new byte[0], validSignature());
+
+        SetCodeAuthorization zeroByte =
+                new SetCodeAuthorization(CHAIN_ID, ADDRESS, new byte[] {0x00}, validSignature());
+
+        assertEquals(BigInteger.ZERO, empty.getNonceAsInteger());
+        assertEquals(BigInteger.ZERO, zeroByte.getNonceAsInteger());
+    }
+
+    @Test
+    void verifyNonceRangeShouldAcceptMaxAllowedNonceUsingByteArray() {
+        byte[] maxAllowedNonce = new byte[] {
+                (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
+                (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xfe
+        };
+
+        SetCodeAuthorization authorization =
+                new SetCodeAuthorization(CHAIN_ID, ADDRESS, maxAllowedNonce, validSignature());
+
+        authorization.verifyNonceRange();
+    }
+    @Test
+    void getNonceAsIntegerShouldIgnoreLeadingZeroBytes() {
+        SetCodeAuthorization authorization =
+                new SetCodeAuthorization(CHAIN_ID, ADDRESS, new byte[] {0x00, 0x00, 0x01}, validSignature());
+
+        assertEquals(BigInteger.ONE, authorization.getNonceAsInteger());
+    }
+
+
+
 
     private static ECDSASignature validSignature() {
         return signatureWithS(BigInteger.ONE);

--- a/rskj-core/src/test/java/org/ethereum/core/transaction/parser/util/AuthorizationListCodecTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/transaction/parser/util/AuthorizationListCodecTest.java
@@ -151,7 +151,7 @@ class AuthorizationListCodecTest {
 
         assertEquals(BigInteger.valueOf(33), auth.getChainId());
         assertEquals(reference.getAddress(), auth.getAddress());
-        assertEquals(BigInteger.ONE, new BigInteger(1, auth.getNonce()));
+        assertEquals(BigInteger.ONE, new BigInteger(1, auth.getNonceBytes()));
     }
 
     @Test
@@ -324,7 +324,7 @@ class AuthorizationListCodecTest {
         byte[] tuple = rebuildTupleField(reference, 2, RLP.encodeBigInteger(maxAllowed));
 
         SetCodeAuthorization decoded = decodeSingleTuple(tuple);
-        assertEquals(maxAllowed, new BigInteger(1, decoded.getNonce()));
+        assertEquals(maxAllowed, new BigInteger(1, decoded.getNonceBytes()));
     }
 
     @Test
@@ -418,7 +418,7 @@ class AuthorizationListCodecTest {
         SetCodeAuthorization bad = new SetCodeAuthorization(
                 auth.getChainId(),
                 auth.getAddress(),
-                auth.getNonce(),
+                auth.getNonceBytes(),
                 ECDSASignature.fromComponents(
                         BigIntegers.asUnsignedByteArray(auth.getSignature().getR()),
                         BigIntegers.asUnsignedByteArray(highS),
@@ -435,7 +435,7 @@ class AuthorizationListCodecTest {
 
         SetCodeAuthorization decoded = decodeSingleTuple(tuple);
 
-        assertEquals(BigInteger.ZERO, new BigInteger(1, decoded.getNonce()));
+        assertEquals(BigInteger.ZERO, new BigInteger(1, decoded.getNonceBytes()));
     }
 
     @Test
@@ -457,7 +457,7 @@ class AuthorizationListCodecTest {
 
         SetCodeAuthorization auth = AuthorizationListCodec.parseFromCallArguments(List.of(entry)).get(0);
 
-        assertEquals(BigInteger.ZERO, new BigInteger(1, auth.getNonce()));
+        assertEquals(BigInteger.ZERO, new BigInteger(1, auth.getNonceBytes()));
     }
 
     @Test
@@ -505,7 +505,7 @@ class AuthorizationListCodecTest {
 
             SetCodeAuthorization auth = (SetCodeAuthorization) parseEntry.invoke(null, entry, 0);
 
-            assertEquals(BigInteger.ZERO, new BigInteger(1, auth.getNonce()));
+            assertEquals(BigInteger.ZERO, new BigInteger(1, auth.getNonceBytes()));
         }
     }
 
@@ -548,7 +548,7 @@ class AuthorizationListCodecTest {
 
         SetCodeAuthorization auth = Mockito.mock(SetCodeAuthorization.class);
         Mockito.when(auth.getChainId()).thenReturn(BigInteger.ONE.shiftLeft(256));
-        Mockito.when(auth.getNonce()).thenReturn(new byte[]{0x01});
+        Mockito.when(auth.getNonceBytes()).thenReturn(new byte[]{0x01});
 
         InvocationTargetException ex = assertThrows(InvocationTargetException.class,
                 () -> validate.invoke(null, auth));
@@ -564,7 +564,7 @@ class AuthorizationListCodecTest {
         SetCodeAuthorization auth = Mockito.mock(SetCodeAuthorization.class);
         ECDSASignature signature = Mockito.mock(ECDSASignature.class);
         Mockito.when(auth.getChainId()).thenReturn(BigInteger.ZERO);
-        Mockito.when(auth.getNonce()).thenReturn(new byte[]{0x01});
+        Mockito.when(auth.getNonceBytes()).thenReturn(new byte[]{0x01});
         Mockito.when(auth.getSignature()).thenReturn(signature);
         Mockito.when(signature.validateComponentsWithoutV()).thenReturn(true);
         Mockito.when(signature.getR()).thenReturn(BigInteger.ONE.shiftLeft(256));
@@ -583,7 +583,7 @@ class AuthorizationListCodecTest {
         SetCodeAuthorization bad = new SetCodeAuthorization(
                 auth.getChainId(),
                 auth.getAddress(),
-                auth.getNonce(),
+                auth.getNonceBytes(),
                 ECDSASignature.fromComponents(
                         oversized,
                         BigIntegers.asUnsignedByteArray(auth.getSignature().getS()),


### PR DESCRIPTION
## Description
This fixes two issues in nonce encoding/verification:

- Fresh EOAs (nonce 0) could not delegate code because RLP decoding produced an empty byte array, which was incorrectly rejected as an empty nonce.
- Accounts with nonces requiring a leading sign byte (e.g. 128–255) could fail nonce verification because BigInteger.toByteArray() output was compared directly against the minimally encoded authorization nonce.

## Motivation and Context
The change normalizes nonce handling to correctly support nonce 0 and avoid encoding-related mismatches.

## How Has This Been Tested?
Uupdate the tests, which previously asserted the incorrect behavior by expecting empty nonces to be rejected and add new ones. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)