### PR TITLE
fix: Fixed max fee fields decoding for Type2 and Type4 transaction parsers

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/core/transaction/parser/Type2RawTransactionParser.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/parser/Type2RawTransactionParser.java
@@ -31,7 +31,6 @@ import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 
 import java.math.BigInteger;
-import java.util.Objects;
 
 import static org.ethereum.rpc.exception.RskJsonRpcRequestException.invalidParamError;
 
@@ -62,8 +61,8 @@ public class Type2RawTransactionParser implements RawTransactionTypeParser<Parse
         Coin value = CommonParsingUtils.defaultValue(RLP.parseCoinNullZero(txFields.get(VALUE_INDEX).getRLPData()));
         byte[] data = CommonParsingUtils.nullToEmpty(txFields.get(DATA_INDEX).getRLPData());
         byte[] accessListBytes = AccessListCodec.defaultAccessListBytes(txFields.get(ACCESS_LIST_INDEX).getRLPRawData());
-        Coin maxPriorityFeePerGas = Objects.requireNonNull(RLP.parseCoinNonNullZero(txFields.get(MAX_PRIORITY_FEE_PER_GAS_INDEX).getRLPData()), "Type 2 maxPriorityFeePerGas");
-        Coin maxFeePerGas = Objects.requireNonNull(RLP.parseCoinNonNullZero(txFields.get(MAX_FEE_PER_GAS_INDEX).getRLPData()), "Type 2 maxFeePerGas");
+        Coin maxPriorityFeePerGas = CommonParsingUtils.defaultValue(RLP.parseCoinNonNullZero(txFields.get(MAX_PRIORITY_FEE_PER_GAS_INDEX).getRLPData()));
+        Coin maxFeePerGas = CommonParsingUtils.defaultValue(RLP.parseCoinNonNullZero(txFields.get(MAX_FEE_PER_GAS_INDEX).getRLPData()));
 
         validateFeeCapRelationship(maxPriorityFeePerGas, maxFeePerGas);
         CommonParsingUtils.requireTypedScalarFields(nonce, gasLimit, value, maxPriorityFeePerGas, maxFeePerGas);

--- a/rskj-core/src/main/java/org/ethereum/core/transaction/parser/Type4RawTransactionParser.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/parser/Type4RawTransactionParser.java
@@ -33,7 +33,6 @@ import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 
 import java.math.BigInteger;
-import java.util.Objects;
 
 import static org.ethereum.rpc.exception.RskJsonRpcRequestException.invalidParamError;
 
@@ -77,8 +76,8 @@ public class Type4RawTransactionParser implements RawTransactionTypeParser<Parse
                 txFields.get(AUTHORIZATION_LIST_INDEX).getRLPRawData());
         var authorizationList = AuthorizationListCodec.decodeListUnchecked(authorizationListBytes);
         // max priority fee per gas and max fee per gas
-        Coin maxPriorityFeePerGas = Objects.requireNonNull(RLP.parseCoinNonNullZero(txFields.get(MAX_PRIORITY_FEE_PER_GAS_INDEX).getRLPData()), "Type 4 maxPriorityFeePerGas");
-        Coin maxFeePerGas = Objects.requireNonNull(RLP.parseCoinNonNullZero(txFields.get(MAX_FEE_PER_GAS_INDEX).getRLPData()), "Type 4 maxFeePerGas");
+        Coin maxPriorityFeePerGas = CommonParsingUtils.defaultValue(RLP.parseCoinNonNullZero(txFields.get(MAX_PRIORITY_FEE_PER_GAS_INDEX).getRLPData()));
+        Coin maxFeePerGas = CommonParsingUtils.defaultValue(RLP.parseCoinNonNullZero(txFields.get(MAX_FEE_PER_GAS_INDEX).getRLPData()));
         validateFeeCapRelationship(maxPriorityFeePerGas, maxFeePerGas);
         CommonParsingUtils.requireTypedScalarFields(nonce, gasLimit, value, maxPriorityFeePerGas, maxFeePerGas);
 

--- a/rskj-core/src/test/java/org/ethereum/core/TypedTransactionIntegrationTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/TypedTransactionIntegrationTest.java
@@ -28,6 +28,7 @@ import co.rsk.test.builders.BlockBuilder;
 import com.typesafe.config.ConfigValueFactory;
 import org.ethereum.core.transaction.TransactionType;
 import org.ethereum.db.TransactionInfo;
+import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,7 +39,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Integration tests for typed transactions (RSKIP-543/546) covering transport encoding,
@@ -209,6 +214,38 @@ class TypedTransactionIntegrationTest {
                 "Standard Type 2 must NOT be RSK namespace");
         assertArrayEquals(type2.getHash().getBytes(), decodedTx.getHash().getBytes(),
                 "Type 2 tx hash must be identical after TransactionsMessage encode/decode");
+    }
+
+    @Test
+    void type2CanonicalZeroFees_decodesViaTransactionsMessageP2pPath() {
+        byte[][] fields = new byte[][] {
+                RLP.encodeByte(CHAIN_ID),
+                RLP.encodeElement(ByteUtil.EMPTY_BYTE_ARRAY),
+                RLP.encodeElement(null),
+                RLP.encodeElement(null),
+                RLP.encodeElement(org.bouncycastle.util.BigIntegers.asUnsignedByteArray(BigInteger.valueOf(21_000))),
+                RLP.encodeElement(receiver.getAddress().getBytes()),
+                RLP.encodeElement(ByteUtil.EMPTY_BYTE_ARRAY),
+                RLP.encodeElement(ByteUtil.EMPTY_BYTE_ARRAY),
+                Rskip546TestSupport.EMPTY_ACCESS_LIST,
+                RLP.encodeByte((byte) 0),
+                RLP.encodeElement(new byte[32]),
+                RLP.encodeElement(new byte[32])
+        };
+        byte[] raw = ByteUtil.merge(
+                new byte[] { TransactionType.TYPE_2.getByteCode() },
+                RLP.encodeList(fields)
+        );
+
+        TransactionsMessage original = new TransactionsMessage(List.of(new ImmutableTransaction(raw)));
+        BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+        RLPList paramsList = (RLPList) RLP.decode2(original.getEncoded()).get(0);
+        TransactionsMessage decoded = (TransactionsMessage) Message.create(blockFactory, paramsList);
+
+        assertEquals(1, decoded.getTransactions().size());
+        Transaction decodedTx = decoded.getTransactions().get(0);
+        assertEquals(Coin.ZERO, decodedTx.getMaxPriorityFeePerGas());
+        assertEquals(Coin.ZERO, decodedTx.getMaxFeePerGas());
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/core/TypedTransactionIntegrationTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/TypedTransactionIntegrationTest.java
@@ -21,12 +21,14 @@ import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.bc.BlockHashesHelper;
 import co.rsk.net.messages.Message;
+import co.rsk.net.messages.MessageType;
 import co.rsk.net.messages.TransactionsMessage;
 import co.rsk.test.World;
 import co.rsk.test.builders.AccountBuilder;
 import co.rsk.test.builders.BlockBuilder;
 import com.typesafe.config.ConfigValueFactory;
 import org.ethereum.core.transaction.TransactionType;
+import org.ethereum.core.transaction.parser.util.AuthorizationListCodec;
 import org.ethereum.db.TransactionInfo;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
@@ -43,6 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -246,6 +249,66 @@ class TypedTransactionIntegrationTest {
         Transaction decodedTx = decoded.getTransactions().get(0);
         assertEquals(Coin.ZERO, decodedTx.getMaxPriorityFeePerGas());
         assertEquals(Coin.ZERO, decodedTx.getMaxFeePerGas());
+    }
+
+    @Test
+    void type4CanonicalZeroFees_decodesViaTransactionsMessageP2pPath() {
+        byte[] authList = AuthorizationListCodec.encodeList(
+                List.of(Rskip545TestSupport.minimalAuthorization(CHAIN_ID)));
+        byte[][] fields = new byte[][] {
+                RLP.encodeByte(CHAIN_ID),
+                RLP.encodeElement(new byte[]{0x01}),
+                RLP.encodeElement(null),
+                RLP.encodeElement(null),
+                RLP.encodeElement(org.bouncycastle.util.BigIntegers.asUnsignedByteArray(BigInteger.valueOf(21_000))),
+                RLP.encodeElement(receiver.getAddress().getBytes()),
+                RLP.encodeElement(ByteUtil.EMPTY_BYTE_ARRAY),
+                RLP.encodeElement(ByteUtil.EMPTY_BYTE_ARRAY),
+                Rskip545TestSupport.EMPTY_ACCESS_LIST,
+                authList,
+                RLP.encodeElement(null),
+                RLP.encodeElement(null),
+                RLP.encodeElement(null)
+        };
+        byte[] raw = ByteUtil.merge(
+                new byte[] { TransactionType.TYPE_4.getByteCode() },
+                RLP.encodeList(fields)
+        );
+
+        TransactionsMessage original = new TransactionsMessage(List.of(new ImmutableTransaction(raw)));
+        BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+        RLPList paramsList = (RLPList) RLP.decode2(original.getEncoded()).get(0);
+        TransactionsMessage decoded = (TransactionsMessage) Message.create(blockFactory, paramsList);
+
+        assertEquals(1, decoded.getTransactions().size());
+        Transaction decodedTx = decoded.getTransactions().get(0);
+        assertEquals(TransactionType.TYPE_4, decodedTx.getType());
+        assertEquals(Coin.ZERO, decodedTx.getMaxPriorityFeePerGas());
+        assertEquals(Coin.ZERO, decodedTx.getMaxFeePerGas());
+    }
+
+    @Test
+    void malformedType4_isRejectedViaTransactionsMessageP2pPath() {
+        byte[] invalidRaw = ByteUtil.merge(
+                new byte[] { TransactionType.TYPE_4.getByteCode() },
+                RLP.encodeList(
+                        RLP.encodeByte(CHAIN_ID),
+                        RLP.encodeElement(ByteUtil.EMPTY_BYTE_ARRAY),
+                        RLP.encodeElement(null),
+                        RLP.encodeElement(null)
+                )
+        );
+        byte[] body = RLP.encodeList(RLP.encodeElement(invalidRaw));
+        byte[] encoded = RLP.encodeList(
+                RLP.encodeByte(MessageType.TRANSACTIONS.getTypeAsByte()),
+                RLP.encodeElement(body)
+        );
+
+        BlockFactory blockFactory = new BlockFactory(config.getActivationConfig());
+        RLPList paramsList = (RLPList) RLP.decode2(encoded).get(0);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> Message.create(blockFactory, paramsList));
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/core/TypedTransactionTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/TypedTransactionTest.java
@@ -452,6 +452,22 @@ class TypedTransactionTest {
                 "Parsing Type 2 tx with maxPriorityFeePerGas > maxFeePerGas must throw per EIP-1559");
     }
 
+    @Test
+    void type2_decodeAcceptsCanonicalRlpZeroFees() {
+        byte[][] fields = defaultType2ShapeFields();
+        fields[2] = RLP.encodeElement(null);
+        fields[3] = RLP.encodeElement(null);
+        byte[] raw = ByteUtil.merge(
+                new byte[] { TransactionType.TYPE_2.getByteCode() },
+                RLP.encodeList(fields)
+        );
+
+        Transaction tx = new ImmutableTransaction(raw);
+
+        assertEquals(Coin.ZERO, tx.getMaxPriorityFeePerGas());
+        assertEquals(Coin.ZERO, tx.getMaxFeePerGas());
+    }
+
     // ========================================================================
     // Legacy decode-time field validation
     // ========================================================================

--- a/rskj-core/src/test/java/org/ethereum/core/transaction/parser/Type4RawTransactionParserTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/transaction/parser/Type4RawTransactionParserTest.java
@@ -332,6 +332,33 @@ class Type4RawTransactionParserTest {
     }
 
     @Test
+    void parse_rlp_canonicalRlpZeroFees_accepted() {
+        byte[] authList = AuthorizationListCodec.encodeList(
+                List.of(Rskip545TestSupport.minimalAuthorization(REGTEST_CHAIN_ID)));
+        byte[][] fields = new byte[][]{
+                RLP.encodeByte(REGTEST_CHAIN_ID),
+                RLP.encodeElement(new byte[]{0x01}),
+                RLP.encodeElement(null),
+                RLP.encodeElement(null),
+                RLP.encodeBigInteger(BigInteger.valueOf(21_000)),
+                RLP.encodeRskAddress(RECEIVER),
+                RLP.encodeBigInteger(BigInteger.ZERO),
+                RLP.encodeElement(new byte[0]),
+                RLP.encodeList(),
+                authList,
+                RLP.encodeElement(null),
+                RLP.encodeElement(null),
+                RLP.encodeElement(null),
+        };
+        RLPList payload = RLP.decodeList(RLP.encodeList(fields));
+
+        ParsedType4Transaction parsed = parser.parse(TransactionTypePrefix.typed(TransactionType.TYPE_4), payload);
+
+        assertEquals(Coin.ZERO, parsed.maxPriorityFeePerGas());
+        assertEquals(Coin.ZERO, parsed.maxFeePerGas());
+    }
+
+    @Test
     void parse_rlp_truncatedAccessList_throws() {
         byte[][] base = Rskip545TestSupport.defaultSignedType4Fields(RECEIVER, Rskip545TestSupport.defaultAuthListBytes());
         base[8] = new byte[]{(byte) 0xC4, 0x01};


### PR DESCRIPTION
## Description
Decode zero maxPriorityFeePerGas / maxFeePerGas as Coin.ZERO when wallets encode them as RLP 0x80, aligning Type-2/Type-4 with Type-0/Type-1 and avoiding NPE on raw-tx decode.

## Motivation and Context
Type-2 and Type-4 parsers used Objects.requireNonNull(RLP.parseCoinNonNullZero(...)) for maxPriorityFeePerGas and maxFeePerGas. When those fields are encoded as the canonical RLP empty string (0x80) parseCoinNonNullZero returns null and decoding throws an uncaught NullPointerException.

## How Has This Been Tested?
The unit tests cover canonical zero-fee (0x80) decoding for Type-2 and Type-4 on the raw RLP decode path, plus an integration test for Type-2 over the P2P TransactionsMessage wire path.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)
