### PR TITLE
test: cover IpUtils invalid-port edge cases and non-fatal list parsing

### DIFF
--- a/rskj-core/src/test/java/co/rsk/util/IpUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/util/IpUtilsTest.java
@@ -68,6 +68,53 @@ class IpUtilsTest {
     }
 
     @Test
+    void parsePortAtIntegerMax() {
+        // 2147483647 fits in an int but is far above the valid 0-65535 port range
+        InetSocketAddress result = IpUtils.parseAddress("localhost:2147483647");
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    void parsePortJustAboveIntegerMax() {
+        // 2147483648 = Integer.MAX_VALUE + 1, overflows Integer.valueOf
+        InetSocketAddress result = IpUtils.parseAddress("localhost:2147483648");
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    void parseNegativePort() {
+        InetSocketAddress result = IpUtils.parseAddress("localhost:-1");
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    void parsePortZero() {
+        InetSocketAddress result = IpUtils.parseAddress(IPV4_NO_PORT + ":0");
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(0, result.getPort());
+    }
+
+    @Test
+    void parseMaxValidPort() {
+        InetSocketAddress result = IpUtils.parseAddress(IPV4_NO_PORT + ":65535");
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(65535, result.getPort());
+    }
+
+    @Test
+    void parseAddressesSkipsInvalidEntriesWithoutFailing() {
+        // A single malformed entry must not abort parsing of the whole list
+        List<String> addresses = new ArrayList<>();
+        addresses.add(IPV4_WITH_PORT);                    // good
+        addresses.add("localhost:65536");                 // port out of range -> skipped
+        addresses.add(IPV6_WITH_PORT);                    // good
+        addresses.add("localhost:999999999999999999999"); // int overflow -> skipped
+        addresses.add("garbage-no-colon");                // malformed -> skipped
+        List<InetSocketAddress> result = IpUtils.parseAddresses(addresses);
+        Assertions.assertEquals(2, result.size());
+    }
+
+    @Test
     void parseAddresses() {
         List<String> addresses = new ArrayList<>();
         addresses.add(IPV6_WITH_PORT);


### PR DESCRIPTION
## Summary
Follow-up to the `IpUtils` invalid-port fix (#3611). Adds regression tests for `co.rsk.util.IpUtils`; no production code change.

## Why
`IpUtils.parseMatch` now guards against invalid ports, but coverage only exercised `65536` and a >Integer overflow value. A single malformed bootnode entry used to throw out of `parseAddresses`, aborting parsing of the entire list. These tests lock that behavior in.

## Tests added
- `parsePortAtIntegerMax` — `2147483647` (fits int, out of 0–65535 range) → null
- `parsePortJustAboveIntegerMax` — `2147483648` (overflows `Integer.valueOf`) → null
- `parseNegativePort` — `-1` rejected by regex → null
- `parsePortZero` — boundary valid port 0 → parsed
- `parseMaxValidPort` — boundary valid port 65535 → parsed
- `parseAddressesSkipsInvalidEntriesWithoutFailing` — one bad entry is skipped, good entries survive

## Verification
Compiled the real class + tests and ran via JUnit: all pass on current code; the port/list tests fail on the pre-fix `parseMatch`, confirming they exercise the real path.