### PR TITLE
fix: decode access list for Type 4 transactions in TransactionResultDTO

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
@@ -144,6 +144,7 @@ public class TransactionResultDTO {
             }
         } else if (txType == TransactionType.TYPE_4) {
             chainId = HexUtils.toQuantityJsonHex(tx.getChainId() & 0xFF);
+            accessList = decodeAccessList(tx.getAccessListBytes());
             yParity = HexUtils.toQuantityJsonHex(tx.getEncodedV() & 0xFF);
             Coin maxP = tx.getMaxPriorityFeePerGas();
             Coin maxF = tx.getMaxFeePerGas();

--- a/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionResultDTOTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionResultDTOTest.java
@@ -237,6 +237,7 @@ class TransactionResultDTOTest {
         Assertions.assertNotNull(dto.getAuthorizationList());
         Assertions.assertEquals(3, dto.getAuthorizationList().size());
         Assertions.assertEquals(delegate.toJsonString(), dto.getAuthorizationList().get(0).getAddress());
+        Assertions.assertNotNull(dto.getAccessList(), "accessList must be present for Type 4 tx");
         Assertions.assertNotNull(dto.getMaxFeePerGas());
         Assertions.assertNotNull(dto.getMaxPriorityFeePerGas());
         Assertions.assertNotNull(dto.getChainId());
@@ -244,6 +245,7 @@ class TransactionResultDTOTest {
         JsonNode json = new ObjectMapper().valueToTree(dto);
         Assertions.assertTrue(json.has("authorizationList"));
         Assertions.assertEquals(3, json.get("authorizationList").size());
+        Assertions.assertTrue(json.has("accessList"), "accessList must appear in JSON for Type 4");
     }
 
     @Test
@@ -315,6 +317,36 @@ class TransactionResultDTOTest {
         TransactionResultDTO dto = new TransactionResultDTO(mock(Block.class), 0, tx, false,
                 new BlockTxSignatureCache(new ReceivedTxSignatureCache()));
 
+        Assertions.assertEquals(1, dto.getAccessList().size());
+        TransactionResultDTO.AccessListEntryDTO entry = dto.getAccessList().get(0);
+        Assertions.assertTrue(entry.getAddress().startsWith("0x"));
+        Assertions.assertEquals(1, entry.getStorageKeys().size());
+        Assertions.assertTrue(entry.getStorageKeys().get(0).startsWith("0x"));
+    }
+
+    @Test
+    void type4Transaction_decodesNonemptyAccessList() {
+        byte[] address = new RskAddress("0x095e7baea6a6c7c4c2dfeb977efac326af552d87").getBytes();
+        byte[] storageKey = new byte[32];
+        storageKey[31] = 0x01;
+        byte[] accessList = RLP.encodeList(
+                RLP.encodeList(
+                        RLP.encodeElement(address),
+                        RLP.encodeList(RLP.encodeElement(storageKey))
+                )
+        );
+        Transaction tx = Rskip545TestSupport.unsignedType4(
+                new RskAddress("0x095e7baea6a6c7c4c2dfeb977efac326af552d87"),
+                Coin.valueOf(10L),
+                Coin.valueOf(100L),
+                new byte[0],
+                accessList);
+        tx.sign(new byte[]{});
+
+        TransactionResultDTO dto = new TransactionResultDTO(mock(Block.class), 0, tx, false,
+                new BlockTxSignatureCache(new ReceivedTxSignatureCache()));
+
+        Assertions.assertEquals("0x4", dto.getType());
         Assertions.assertEquals(1, dto.getAccessList().size());
         TransactionResultDTO.AccessListEntryDTO entry = dto.getAccessList().get(0);
         Assertions.assertTrue(entry.getAddress().startsWith("0x"));


### PR DESCRIPTION
## Description
When building RPC transaction objects, the Type-4 (RSKIP-545) branch of TransactionResultDTO now calls decodeAccessList(tx.getAccessListBytes()), matching the Type-1 and Type-2 path.

## Motivation and Context
Type-4 transactions include an access list in their wire encoding. Clients that re-read the transaction for re-simulation, fee estimation, or display need that list back in the JSON-RPC response.

## How Has This Been Tested?
It has been tested with updated and new unit tests.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
