### PR TITLE
fix: allowing type4 transactions to be gas bumped

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
@@ -264,16 +264,18 @@ public class TransactionPoolImpl implements TransactionPool {
         }
         PendingState pendingState = getPendingState(currentRepository);
 
-        Optional<TransactionPoolAddResult> delegatedAccountResult = rejectIfDelegatedAccountCannotBeAccepted(tx, tx.getSender(signatureCache), currentRepository, pendingState);
+        Keccak256 hash = tx.getHash();
+        logger.trace("add transaction {} {}", toBI(tx.getNonce()), tx.getHash());
+
+        Optional<Transaction> replacedTx = pendingTransactions.getTransactionsWithSender(tx.getSender(signatureCache)).stream().filter(t -> t.getNonceAsInteger().equals(tx.getNonceAsInteger())).findFirst();
+
+        Optional<TransactionPoolAddResult> delegatedAccountResult = rejectIfDelegatedAccountCannotBeAccepted
+                (tx, tx.getSender(signatureCache), currentRepository, pendingState, replacedTx.isPresent());
 
         if (delegatedAccountResult.isPresent()) {
             return delegatedAccountResult.get();
         }
 
-        Keccak256 hash = tx.getHash();
-        logger.trace("add transaction {} {}", toBI(tx.getNonce()), tx.getHash());
-
-        Optional<Transaction> replacedTx = pendingTransactions.getTransactionsWithSender(tx.getSender(signatureCache)).stream().filter(t -> t.getNonceAsInteger().equals(tx.getNonceAsInteger())).findFirst();
         if (replacedTx.isPresent() && !isBumpingGasPriceForSameNonceTx(tx, replacedTx.get())) {
             return TransactionPoolAddResult.withError("gas price not enough to bump transaction");
         }
@@ -533,11 +535,19 @@ public class TransactionPoolImpl implements TransactionPool {
             Transaction tx,
             RskAddress sender,
             RepositorySnapshot repository,
-            PendingState pendingState
+            PendingState pendingState,
+            boolean isSameNonceReplacement
     ) {
         byte[] code = repository.getCode(sender);
 
         if (!DelegationCodeResolver.isDelegatedCode(code)) {
+            return Optional.empty();
+        }
+
+        // EIP-7702 delegated accounts are intentionally limited to one transaction
+        // in the pool. Same-nonce replacements are allowed to preserve the normal
+        // replace-by-fee flow without increasing the number of occupied txpool slots.
+        if (isSameNonceReplacement) {
             return Optional.empty();
         }
 

--- a/rskj-core/src/test/java/co/rsk/core/bc/TransactionPoolImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/TransactionPoolImplTest.java
@@ -1017,25 +1017,6 @@ class TransactionPoolImplTest {
     }
 
     @Test
-    void delegatedAccount_replacementTransactionRejectedWhenAlreadyHasPendingTransaction() {
-        createTestAccounts(2,  Coin.valueOf(1000000));
-        makeAccountDelegated(1,2);
-
-        Transaction tx1 = createSampleTransactionWithGasPrice(1, 2, 1000, 0, 1);
-        Transaction tx2 = createSampleTransactionWithGasPrice(1, 2, 2000, 0, 2);
-
-        Assertions.assertTrue(transactionPool.addTransaction(tx1).transactionsWereAdded());
-
-        TransactionPoolAddResult result = transactionPool.addTransaction(tx2);
-
-        Assertions.assertFalse(result.transactionsWereAdded());
-        Assertions.assertEquals("delegated account already has a transaction in the pool", result.getErrorMessage());
-        Assertions.assertEquals(1, transactionPool.getPendingTransactions().size());
-        Assertions.assertTrue(transactionPool.getPendingTransactions().contains(tx1));
-        Assertions.assertEquals(0, transactionPool.getQueuedTransactions().size());
-    }
-
-    @Test
     void delegatedAccounts_eachAccountCanHaveOneTransaction() {
         createTestAccounts(3, Coin.valueOf(1000000));
 
@@ -1067,6 +1048,90 @@ class TransactionPoolImplTest {
         Assertions.assertTrue(transactionPool.getPendingTransactions().isEmpty());
         Assertions.assertEquals(1, transactionPool.getQueuedTransactions().size());
         Assertions.assertTrue(transactionPool.getQueuedTransactions().contains(tx));
+    }
+
+    @Test
+    void delegatedAccount_replacementTransactionWithValidGasBumpAcceptedAndOnlyOneTransactionRemainsInPool() {
+        createTestAccounts(2, Coin.valueOf(1000000));
+        makeAccountDelegated(1, 2);
+
+        Transaction tx1 = createSampleTransactionWithGasPrice(1, 2, 1000, 0, 1);
+        Transaction tx2 = createSampleTransactionWithGasPrice(1, 2, 2000, 0, 2);
+
+        TransactionPoolAddResult result1 = transactionPool.addTransaction(tx1);
+        TransactionPoolAddResult result2 = transactionPool.addTransaction(tx2);
+
+        Assertions.assertTrue(result1.transactionsWereAdded());
+        Assertions.assertTrue(result2.transactionsWereAdded());
+
+        Assertions.assertEquals(1, transactionPool.getPendingTransactions().size());
+        Assertions.assertTrue(transactionPool.getPendingTransactions().contains(tx2));
+        Assertions.assertFalse(transactionPool.getPendingTransactions().contains(tx1));
+        Assertions.assertTrue(transactionPool.getQueuedTransactions().isEmpty());
+    }
+
+    @Test
+    void delegatedAccount_replacementTransactionWithInsufficientGasBumpRejected() {
+        createTestAccounts(2, Coin.valueOf(1000000));
+        makeAccountDelegated(1, 2);
+
+        Transaction tx1 = createSampleTransactionWithGasPrice(1, 2, 1000, 0, 10);
+        Transaction tx2 = createSampleTransactionWithGasPrice(1, 2, 2000, 0, 10);
+
+        Assertions.assertTrue(transactionPool.addTransaction(tx1).transactionsWereAdded());
+
+        TransactionPoolAddResult result = transactionPool.addTransaction(tx2);
+
+        Assertions.assertFalse(result.transactionsWereAdded());
+        Assertions.assertEquals("gas price not enough to bump transaction", result.getErrorMessage());
+        Assertions.assertEquals(1, transactionPool.getPendingTransactions().size());
+        Assertions.assertTrue(transactionPool.getPendingTransactions().contains(tx1));
+        Assertions.assertFalse(transactionPool.getPendingTransactions().contains(tx2));
+        Assertions.assertTrue(transactionPool.getQueuedTransactions().isEmpty());
+    }
+
+    @Test
+    void delegatedAccount_replacementAcceptedButDifferentNonceStillRejected() {
+        createTestAccounts(2, Coin.valueOf(1000000));
+        makeAccountDelegated(1, 2);
+
+        Transaction tx1 = createSampleTransactionWithGasPrice(1, 2, 1000, 0, 1);
+        Transaction tx1Replacement = createSampleTransactionWithGasPrice(1, 2, 2000, 0, 2);
+        Transaction tx2 = createSampleTransactionWithGasPrice(1, 2, 3000, 1, 3);
+
+        Assertions.assertTrue(transactionPool.addTransaction(tx1).transactionsWereAdded());
+        Assertions.assertTrue(transactionPool.addTransaction(tx1Replacement).transactionsWereAdded());
+
+        TransactionPoolAddResult result = transactionPool.addTransaction(tx2);
+
+        Assertions.assertFalse(result.transactionsWereAdded());
+        Assertions.assertEquals("delegated account already has a transaction in the pool", result.getErrorMessage());
+
+        Assertions.assertEquals(1, transactionPool.getPendingTransactions().size());
+        Assertions.assertTrue(transactionPool.getPendingTransactions().contains(tx1Replacement));
+        Assertions.assertFalse(transactionPool.getPendingTransactions().contains(tx1));
+        Assertions.assertFalse(transactionPool.getPendingTransactions().contains(tx2));
+        Assertions.assertTrue(transactionPool.getQueuedTransactions().isEmpty());
+    }
+
+    @Test
+    void delegatedAccount_replacementTransactionChecksQuotaAsReplacement() {
+        createTestAccounts(2, Coin.valueOf(1000000));
+        makeAccountDelegated(1, 2);
+
+        Transaction tx1 = createSampleTransactionWithGasPrice(1, 2, 1000, 0, 1);
+        Transaction tx2 = createSampleTransactionWithGasPrice(1, 2, 2000, 0, 2);
+
+        Assertions.assertTrue(transactionPool.addTransaction(tx1).transactionsWereAdded());
+        Assertions.assertTrue(transactionPool.addTransaction(tx2).transactionsWereAdded());
+
+        verify(quotaChecker).acceptTx(eq(tx1), isNull(), any());
+        verify(quotaChecker).acceptTx(eq(tx2), eq(tx1), any());
+
+        Assertions.assertEquals(1, transactionPool.getPendingTransactions().size());
+        Assertions.assertTrue(transactionPool.getPendingTransactions().contains(tx2));
+        Assertions.assertFalse(transactionPool.getPendingTransactions().contains(tx1));
+        Assertions.assertTrue(transactionPool.getQueuedTransactions().isEmpty());
     }
 
     private void makeAccountDelegated(int senderAccountId, int delegateAccountId) {


### PR DESCRIPTION
## Description
This PR fixes the EIP-7702 delegated-account transaction pool validation so that same-nonce replace-by-fee transactions are allowed.

Delegated accounts are still limited to one transaction in the pool, but a replacement transaction with the same nonce and a sufficient gas price bump can now replace the existing transaction instead of being rejected before the gas-bump validation runs.

## Motivation and Context
Previously, once a delegated account had a transaction in the pool, any second transaction from that account was rejected with:

`delegated account already has a transaction in the pool`

This also rejected valid same-nonce replacement transactions before they reached the existing isBumpingGasPriceForSameNonceTx logic.

As a result, if a delegated account transaction got stuck below the market gas price, the user had no way to bump it.

This change preserves the one-transaction limit for delegated accounts while allowing normal replace-by-fee behavior within that single txpool slot.

## How Has This Been Tested?
Added unit tests covering:

- a delegated account can replace an existing transaction with the same nonce and a valid gas price bump;
- only one transaction remains in the pool after the replacement;
- the original transaction is removed from the pool;
- a delegated account still cannot add a second transaction with a different nonce;
- insufficient gas bumps are still rejected with the normal gas-bump error;
- quota validation receives the replaced transaction when processing a replacement.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)

