### PR TITLE
test(bootstrap-v2): cover chunk-length ceiling, streamed hash, framing negatives, MultiTrieStore.saveValue

### DIFF
--- a/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterV2Test.java
+++ b/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterV2Test.java
@@ -345,6 +345,115 @@ class BootstrapImporterV2Test {
         assertTrue(ex.getMessage().toLowerCase().contains("trailing"), ex.getMessage());
     }
 
+    @Test
+    void rejectsChunkLengthAbovePerChunkCeilingBeforeAllocating() throws IOException {
+        // A declared chunk length above the absolute per-chunk ceiling (MAX_CHUNK_BYTES = 2 * CHUNK_MAX =
+        // 512 MiB). validateChunkLength checks this range guard BEFORE the remaining-bytes guard, so a
+        // corrupt length that would otherwise allocate a > 512 MiB byte[] is rejected in a tiny file without
+        // any allocation. This is the absolute-ceiling branch, distinct from the remaining-bytes branch that
+        // rejectsChunkLengthExceedingFileSize exercises.
+        long overCeiling = 2L * BootstrapV2Format.CHUNK_MAX + 1; // 512 MiB + 1, > MAX_CHUNK_BYTES
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        out.write(BootstrapV2Format.magic());
+        out.writeByte(BootstrapV2Format.VERSION);
+        out.writeByte(BootstrapV2Format.TAG_BLOCKS);
+        out.writeLong(overCeiling); // corrupt length above the per-chunk ceiling; no payload follows
+        out.flush();
+
+        BootstrapImporter importer = newImporter(bos.toByteArray(), "over-ceiling-length.bin");
+
+        BootstrapImportException ex = assertThrows(BootstrapImportException.class, importer::importData);
+        assertTrue(ex.getMessage().toLowerCase().contains("out of range"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsNegativeChunkLengthBeforeAllocating() throws IOException {
+        // A negative declared chunk length must be rejected up front by the range guard: it could never be
+        // used as a byte[] size, and the check precedes any allocation or remaining-bytes comparison.
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        out.write(BootstrapV2Format.magic());
+        out.writeByte(BootstrapV2Format.VERSION);
+        out.writeByte(BootstrapV2Format.TAG_BLOCKS);
+        out.writeLong(-1L); // negative declared length
+        out.flush();
+
+        BootstrapImporter importer = newImporter(bos.toByteArray(), "negative-length.bin");
+
+        BootstrapImportException ex = assertThrows(BootstrapImportException.class, importer::importData);
+        assertTrue(ex.getMessage().toLowerCase().contains("out of range"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsEmptyFile() throws IOException {
+        // A zero-length bootstrap-data file cannot be classified as v1 or v2; the format probe reads EOF on
+        // the first byte and must reject it with an actionable error rather than an opaque downstream failure.
+        BootstrapImporter importer = newImporter(new byte[0], "empty.bin");
+
+        BootstrapImportException ex = assertThrows(BootstrapImportException.class, importer::importData);
+        assertTrue(ex.getMessage().toLowerCase().contains("empty"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsV2WithBadMagic() throws IOException {
+        // First byte is 'R' (so the probe dispatches to the v2 path), but the remaining magic bytes are
+        // wrong. The header check must reject the mismatched magic instead of proceeding to read sections.
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        out.write('R'); // v2 first byte -> isV2() sends this down the v2 header verification
+        out.write("XXXXXXX".getBytes(StandardCharsets.US_ASCII)); // 7 bytes: 8-byte magic total, but wrong
+        out.writeByte(BootstrapV2Format.VERSION);
+        out.flush();
+
+        BootstrapImporter importer = newImporter(bos.toByteArray(), "bad-magic.bin");
+
+        BootstrapImportException ex = assertThrows(BootstrapImportException.class, importer::importData);
+        assertTrue(ex.getMessage().toLowerCase().contains("magic"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsV2WithUnsupportedVersion() throws IOException {
+        // Correct magic but a version byte the reader does not support: the header check must reject it up
+        // front so a future/corrupt version is not parsed with this reader's section assumptions.
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        out.write(BootstrapV2Format.magic());
+        out.writeByte(0x7F); // not VERSION (0x02)
+        out.flush();
+
+        BootstrapImporter importer = newImporter(bos.toByteArray(), "bad-version.bin");
+
+        BootstrapImportException ex = assertThrows(BootstrapImportException.class, importer::importData);
+        assertTrue(ex.getMessage().toLowerCase().contains("version"), ex.getMessage());
+    }
+
+    @Test
+    void rejectsTruncatedV2MissingEndMarker() throws IOException {
+        // A valid header with complete sections, but the file ends right after the last section's
+        // end-of-section sentinel with no TAG_END. Distinct from the trailing-bytes case: here the canonical
+        // terminator is absent, so the reader hits EOF where a section tag must be and reports truncation.
+        StateFixture fixture = buildState();
+        List<byte[]> blocks = syntheticBlockElements();
+        List<byte[]> values = collectValueElements(fixture.store, fixture.stateRoot);
+        List<byte[]> nodes = collectNodeElements(fixture.store, fixture.stateRoot);
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        out.write(BootstrapV2Format.magic());
+        out.writeByte(BootstrapV2Format.VERSION);
+        writeSection(out, BootstrapV2Format.TAG_BLOCKS, blocks, 1024);
+        writeSection(out, BootstrapV2Format.TAG_VALUES, values, 1024);
+        writeSection(out, BootstrapV2Format.TAG_NODES, nodes, 1024);
+        // deliberately NO out.writeByte(TAG_END): the end-of-sections marker is missing
+        out.flush();
+
+        BootstrapImporter importer = newImporter(bos.toByteArray(), "truncated-no-end.bin");
+
+        BootstrapImportException ex = assertThrows(BootstrapImportException.class, importer::importData);
+        assertTrue(ex.getMessage().toLowerCase().contains("truncated"), ex.getMessage());
+    }
+
     /** An origin store plus the hash of a saved state trie that mixes short and long values. */
     private static final class StateFixture {
         final TrieStore store;

--- a/rskj-core/src/test/java/co/rsk/db/importer/provider/BootstrapFileHandlerTest.java
+++ b/rskj-core/src/test/java/co/rsk/db/importer/provider/BootstrapFileHandlerTest.java
@@ -34,6 +34,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -156,6 +157,63 @@ class BootstrapFileHandlerTest {
         BootstrapFileHandler handler = createHandlerWithTempPath(urlProvider, unzipper, downloadDir);
 
         BootstrapDataEntry entry = new BootstrapDataEntry(1L, "2024-01-01", "path/to/db", expectedHash, null);
+        Map<String, BootstrapDataEntry> entries = new HashMap<>();
+        entries.put("pubkey1", entry);
+
+        assertThrows(BootstrapImportException.class, () -> handler.retrieveAndUnpack(entries));
+    }
+
+    @Test
+    void retrieveAndUnpack_streamsHashOverMultipleBuffersForLargeFile() throws Exception {
+        // A fixture larger than HASH_BUFFER_SIZE (64 KiB) so checkFileHash's streaming loop performs several
+        // digest.update iterations, exercising the multi-buffer path the ~14-byte fixtures never reach. The
+        // incrementally streamed digest must equal the one-shot HashUtil.sha256 over the full bytes.
+        byte[] fileContent = new byte[64 * 1024 * 3 + 123]; // > 3 buffers, with a non-buffer-aligned tail
+        new Random(42).nextBytes(fileContent);
+        Path sourceFile = tempDir.resolve("large-source.zip");
+        Files.write(sourceFile, fileContent);
+        String expectedHash = Hex.toHexString(HashUtil.sha256(fileContent));
+
+        URL fileUrl = sourceFile.toUri().toURL();
+        BootstrapURLProvider urlProvider = mock(BootstrapURLProvider.class);
+        when(urlProvider.getFullURL(any())).thenReturn(fileUrl);
+
+        Unzipper unzipper = mock(Unzipper.class);
+        Path downloadDir = tempDir.resolve("download-large");
+        Files.createDirectories(downloadDir);
+        BootstrapFileHandler handler = createHandlerWithTempPath(urlProvider, unzipper, downloadDir);
+
+        BootstrapDataEntry entry = new BootstrapDataEntry(1L, "2024-01-01", "path/to/db", expectedHash, null);
+        Map<String, BootstrapDataEntry> entries = new HashMap<>();
+        entries.put("pubkey1", entry);
+
+        assertDoesNotThrow(() -> handler.retrieveAndUnpack(entries));
+        verify(unzipper).unzip(any(InputStream.class), eq(downloadDir));
+    }
+
+    @Test
+    void retrieveAndUnpack_rejectsLargeFileWhenOneByteMutated() throws Exception {
+        // Same > 64 KiB multi-buffer fixture, but the expected hash is computed over a one-byte-mutated copy.
+        // The streamed digest of the real bytes must NOT match, so the import is rejected — proving the
+        // streaming loop actually digests every buffer (including the byte flipped in a later buffer).
+        byte[] fileContent = new byte[64 * 1024 * 2 + 7];
+        new Random(7).nextBytes(fileContent);
+        Path sourceFile = tempDir.resolve("large-source-mut.zip");
+        Files.write(sourceFile, fileContent);
+
+        byte[] mutated = fileContent.clone();
+        mutated[fileContent.length - 1] ^= 0x01; // flip one bit in the last byte (in a later buffer)
+        String mismatchedHash = Hex.toHexString(HashUtil.sha256(mutated));
+
+        URL fileUrl = sourceFile.toUri().toURL();
+        BootstrapURLProvider urlProvider = mock(BootstrapURLProvider.class);
+        when(urlProvider.getFullURL(any())).thenReturn(fileUrl);
+
+        Path downloadDir = tempDir.resolve("download-large-mut");
+        Files.createDirectories(downloadDir);
+        BootstrapFileHandler handler = createHandlerWithTempPath(urlProvider, mock(Unzipper.class), downloadDir);
+
+        BootstrapDataEntry entry = new BootstrapDataEntry(1L, "2024-01-01", "path/to/db", mismatchedHash, null);
         Map<String, BootstrapDataEntry> entries = new HashMap<>();
         entries.put("pubkey1", entry);
 

--- a/rskj-core/src/test/java/co/rsk/trie/MultiTrieStoreTest.java
+++ b/rskj-core/src/test/java/co/rsk/trie/MultiTrieStoreTest.java
@@ -18,7 +18,11 @@
 
 package co.rsk.trie;
 
+import org.ethereum.crypto.Keccak256Helper;
+import org.ethereum.datasource.HashMapDB;
 import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -63,6 +67,32 @@ class MultiTrieStoreTest {
         verify(store1, never()).save(trie);
         verify(store2, never()).save(trie);
         verify(store3).save(trie);
+    }
+
+    @Test
+    void saveValueDelegatesToCurrentStoreAndIsRetrievableByHash() {
+        // saveValue must write only to the current (newest) epoch store; the value is then retrievable by
+        // its keccak256 value-hash through the MultiTrieStore's newest-to-oldest lookup, and the older
+        // epochs are never written to.
+        TrieStore currentStore = new TrieStoreImpl(new HashMapDB());
+        TrieStore store2 = mock(TrieStore.class);
+        TrieStore store3 = mock(TrieStore.class);
+        TrieStoreFactory storeFactory = mock(TrieStoreFactory.class);
+        when(storeFactory.newInstance("48")).thenReturn(currentStore); // newest epoch -> current store
+        when(storeFactory.newInstance("47")).thenReturn(store2);
+        when(storeFactory.newInstance("46")).thenReturn(store3);
+        MultiTrieStore store = new MultiTrieStore(49, 3, storeFactory, null);
+
+        byte[] value = "a-long-bootstrap-value-well-over-32-bytes-long".getBytes(StandardCharsets.UTF_8);
+        store.saveValue(value);
+
+        // only the newest store received the write
+        verify(store2, never()).saveValue(any());
+        verify(store3, never()).saveValue(any());
+
+        // retrievable by its value-hash (keccak256 of the value), served from the current store
+        byte[] valueHash = Keccak256Helper.keccak256(value);
+        assertArrayEquals(value, store.retrieveValue(valueHash));
     }
 
     @Test


### PR DESCRIPTION
## Additional test coverage for #3589

This PR targets the `is/fix-bootstrap-exporter` branch so the tests fold directly into #3589. **Tests only — no production changes.** All new tests pass against the branch head, alongside the existing 43 tests in the affected classes.

These close coverage gaps in behaviors this PR introduces that the current tests do not exercise:

### 1. Chunk-length absolute ceiling — `BootstrapImporterV2Test`
- `rejectsChunkLengthAbovePerChunkCeilingBeforeAllocating` — a declared chunk length of `MAX_CHUNK_BYTES + 1` (512 MiB + 1) is rejected **before** `new byte[]`.
- `rejectsNegativeChunkLengthBeforeAllocating` — a negative declared length is rejected.

The existing `rejectsChunkLengthExceedingFileSizeBeforeAllocating` only hits the `len > remaining` branch. The absolute `len > MAX_CHUNK_BYTES` / `len < 0` ceiling — the guard that bounds allocation *regardless of file size*, which is the point of the bounded-memory design — was untested.

### 2. Streamed hash over multiple buffers — `BootstrapFileHandlerTest`
- `retrieveAndUnpack_streamsHashOverMultipleBuffersForLargeFile` — a fixture larger than `HASH_BUFFER_SIZE` (64 KiB) so the streamed digest loop iterates; asserts the streamed digest equals `HashUtil.sha256(full)`.
- `retrieveAndUnpack_rejectsLargeFileWhenOneByteMutated` — same multi-buffer size with a one-byte mutation, asserting rejection (proves every buffer is fed to the digest).

The existing hash tests use ~14-byte fixtures, so the multi-buffer streaming loop (the part that makes the >2 GiB archive hashing bounded-memory) never actually runs.

### 3. Header / framing negatives — `BootstrapImporterV2Test`
- `rejectsEmptyFile`, `rejectsV2WithBadMagic`, `rejectsV2WithUnsupportedVersion`, and `rejectsTruncatedV2MissingEndMarker` (distinct from the existing trailing-bytes test).

### 4. `MultiTrieStore.saveValue` — `MultiTrieStoreTest`
- `saveValueDelegatesToCurrentStoreAndIsRetrievableByHash` — the new `saveValue` writes only to the current store and the value is retrievable by its hash.

No product defects were found while writing these — every test passes against the code as written.
