### PR TITLE
Refactor delegated code resolution into shared helper and add unit tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Java & Gradle
         uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e #v5.1.0
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'gradle'
 

--- a/rskj-core/src/main/java/org/ethereum/core/DelegationCodeResolver.java
+++ b/rskj-core/src/main/java/org/ethereum/core/DelegationCodeResolver.java
@@ -18,8 +18,10 @@
 package org.ethereum.core;
 
 import co.rsk.core.RskAddress;
+import org.ethereum.util.ByteUtil;
 
 import java.util.Arrays;
+import java.util.function.Predicate;
 
 public class DelegationCodeResolver {
 
@@ -53,5 +55,34 @@ public class DelegationCodeResolver {
     public static RskAddress extractDelegatedAddress(byte[] code) {
         byte[] addressBytes = Arrays.copyOfRange(code, PREFIX_SIZE, DELEGATION_CODE_SIZE);
         return new RskAddress(addressBytes);
+    }
+
+    public static byte[] getExecutionCode(
+            Repository repository,
+            RskAddress address,
+            Predicate<RskAddress> isPrecompile) {
+
+        if (!repository.isExist(address)) {
+            return ByteUtil.EMPTY_BYTE_ARRAY;
+        }
+
+        byte[] code = repository.getCode(address);
+
+        if (code == null || code.length == 0) {
+            return ByteUtil.EMPTY_BYTE_ARRAY;
+        }
+
+        if (!isDelegatedCode(code)) {
+            return code;
+        }
+
+        RskAddress delegatedAddress = extractDelegatedAddress(code);
+
+        if (isPrecompile.test(delegatedAddress) || !repository.isExist(delegatedAddress)) {
+            return ByteUtil.EMPTY_BYTE_ARRAY;
+        }
+
+        byte[] delegatedCode = repository.getCode(delegatedAddress);
+        return delegatedCode == null ? ByteUtil.EMPTY_BYTE_ARRAY : delegatedCode;
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -422,7 +422,7 @@ public class TransactionExecutor {
             result.spendGas(gasUsed);
             profiler.stop(metric);
         } else {
-            byte[] code = getExecutionCode(track, targetAddress);
+            byte[] code = DelegationCodeResolver.getExecutionCode(track, targetAddress, this::isPrecompile);
             // Code can be null
             if (isEmpty(code)) {
                 gasLeftover = GasCost.subtract(GasCost.toGas(tx.getGasLimit()), basicTxCost);
@@ -797,23 +797,6 @@ public class TransactionExecutor {
     @Nonnull
     public Set<RskAddress> precompiledContractsCalled() {
         return this.precompiledContractsCalled.isEmpty() ? Collections.emptySet() : new HashSet<>(this.precompiledContractsCalled);
-    }
-
-    private byte[] getExecutionCode(Repository track, RskAddress targetAddress) {
-        byte[] code = track.getCode(targetAddress);
-
-        if (!isDelegatedCode(code)) {
-            return code;
-        }
-
-        RskAddress delegatedAddress = DelegationCodeResolver
-                .extractDelegatedAddress(code);
-
-        if (isPrecompile(delegatedAddress)) {
-            return ByteUtil.EMPTY_BYTE_ARRAY;
-        }
-
-        return track.getCode(delegatedAddress);
     }
 
     private boolean isPrecompile(RskAddress address) {

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -423,7 +423,7 @@ public class TransactionExecutor {
             profiler.stop(metric);
         } else {
             byte[] code = DelegationCodeResolver.getExecutionCode(track, targetAddress, this::isPrecompile);
-            // Code can be null
+            // Code is never null; empty array means no executable code
             if (isEmpty(code)) {
                 gasLeftover = GasCost.subtract(GasCost.toGas(tx.getGasLimit()), basicTxCost);
                 result.spendGas(basicTxCost);

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -83,6 +83,7 @@ import static co.rsk.util.ListArrayUtil.getLength;
 import static co.rsk.util.ListArrayUtil.isEmpty;
 import static co.rsk.util.ListArrayUtil.nullToEmpty;
 import static java.lang.String.format;
+import static org.ethereum.core.DelegationCodeResolver.getExecutionCode;
 import static org.ethereum.util.BIUtil.isNotCovers;
 import static org.ethereum.util.BIUtil.isPositive;
 import static org.ethereum.util.BIUtil.toBI;
@@ -856,7 +857,8 @@ public class Program {
         }
 
         // FETCH THE CODE
-        byte[] programCode = getExecutionCode(codeAddress);
+        byte[] programCode = DelegationCodeResolver
+                .getExecutionCode(getStorage(), codeAddress, this::isPrecompile);
         // programCode can be null
 
         // Always first remove funds from sender
@@ -910,33 +912,6 @@ public class Program {
         } else {
             stackPushZero();
         }
-    }
-
-    private byte[] getExecutionCode(RskAddress codeAddress) {
-        if (!getStorage().isExist(codeAddress)) {
-            return EMPTY_BYTE_ARRAY;
-        }
-        byte[] code = getStorage().getCode(codeAddress);
-
-        if (code == null || code.length == 0) {
-            return EMPTY_BYTE_ARRAY;
-        }
-
-        if (!DelegationCodeResolver.isDelegatedCode(code)) {
-            return code;
-        }
-
-        RskAddress delegatedAddress = DelegationCodeResolver.extractDelegatedAddress(code);
-
-        if (isPrecompile(delegatedAddress)) {
-            return EMPTY_BYTE_ARRAY;
-        }
-
-        byte[] delegatedCode = getStorage().isExist(delegatedAddress)
-                ? getStorage().getCode(delegatedAddress)
-                : EMPTY_BYTE_ARRAY;
-
-        return delegatedCode == null ? EMPTY_BYTE_ARRAY : delegatedCode;
     }
 
     private boolean isPrecompile(RskAddress address) {

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -858,7 +858,7 @@ public class Program {
         // FETCH THE CODE
         byte[] programCode = DelegationCodeResolver
                 .getExecutionCode(getStorage(), codeAddress, this::isPrecompile);
-        // programCode can be null
+        // programCode is never null; empty array means no executable code
 
         // Always first remove funds from sender
         track.addBalance(senderAddress, endowment.negate());

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -83,7 +83,6 @@ import static co.rsk.util.ListArrayUtil.getLength;
 import static co.rsk.util.ListArrayUtil.isEmpty;
 import static co.rsk.util.ListArrayUtil.nullToEmpty;
 import static java.lang.String.format;
-import static org.ethereum.core.DelegationCodeResolver.getExecutionCode;
 import static org.ethereum.util.BIUtil.isNotCovers;
 import static org.ethereum.util.BIUtil.isPositive;
 import static org.ethereum.util.BIUtil.toBI;

--- a/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/helper/Type4TransactionExecutorHelperTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/helper/Type4TransactionExecutorHelperTest.java
@@ -248,6 +248,7 @@ public abstract class Type4TransactionExecutorHelperTest {
 
     protected void mockAccountWithCode(Repository repository, RskAddress address, byte[] code)  {
         when(repository.getCode(address)).thenReturn(code);
+        when(repository.isExist(address)).thenReturn(true);
     }
 
     protected void verifyTransactionCostBiggerOrEqualThan(Transaction tx, long expectedAuthorizationCost) {

--- a/rskj-core/src/test/java/org/ethereum/core/DelegationCodeResolverTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/DelegationCodeResolverTest.java
@@ -163,7 +163,7 @@ class DelegationCodeResolverTest {
     }
 
     @Test
-    void getExecutionCode_returnsEmptyWhenDelegatedAccountCodeIsNull() {
+    void getExecutionCode_returnsEmptyWhenTargetCodeIsNull() {
         Repository repository = mock(Repository.class);
 
         RskAddress target = new RskAddress("0000000000000000000000000000000000000001");

--- a/rskj-core/src/test/java/org/ethereum/core/DelegationCodeResolverTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/DelegationCodeResolverTest.java
@@ -18,31 +18,35 @@
 package org.ethereum.core;
 
 import co.rsk.core.RskAddress;
+import org.ethereum.util.ByteUtil;
 import org.junit.jupiter.api.Test;
 
+import static org.ethereum.core.DelegationCodeResolver.createDelegatedCode;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class DelegationCodeResolverTest {
 
     @Test
     void createDelegatedCode_nullAddress_throws() {
         assertThrows(IllegalStateException.class,
-                () -> DelegationCodeResolver.createDelegatedCode(RskAddress.nullAddress()));
+                () -> createDelegatedCode(RskAddress.nullAddress()));
     }
 
     @Test
     void createDelegatedCode_zeroAddress_throws() {
         assertThrows(IllegalStateException.class,
-                () -> DelegationCodeResolver.createDelegatedCode(RskAddress.ZERO_ADDRESS));
+                () -> createDelegatedCode(RskAddress.ZERO_ADDRESS));
     }
 
     @Test
     void createDelegatedCode_roundTripsThroughExtract() {
         RskAddress delegate = new RskAddress("0x00000000000000000000000000000000000000ab");
-        byte[] code = DelegationCodeResolver.createDelegatedCode(delegate);
+        byte[] code = createDelegatedCode(delegate);
 
         assertTrue(DelegationCodeResolver.isDelegatedCode(code));
         assertArrayEquals(delegate.getBytes(), DelegationCodeResolver.extractDelegatedAddress(code).getBytes());
@@ -50,10 +54,216 @@ class DelegationCodeResolverTest {
 
     @Test
     void isDelegatedCode_wrongPrefix_returnsFalse() {
-        byte[] code = DelegationCodeResolver.createDelegatedCode(
+        byte[] code = createDelegatedCode(
                 new RskAddress("0x0000000000000000000000000000000000000001"));
         code[0] = 0x00;
 
         assertFalse(DelegationCodeResolver.isDelegatedCode(code));
+    }
+
+    @Test
+    void getExecutionCode_returnsEmptyWhenTargetAccountDoesNotExist() {
+        Repository repository = mock(Repository.class);
+        RskAddress target =  new RskAddress("0000000000000000000000000000000000000001");
+
+        when(repository.isExist(target)).thenReturn(false);
+
+        byte[] code = DelegationCodeResolver.getExecutionCode(
+                repository,
+                target,
+                address -> false
+        );
+
+        assertArrayEquals(ByteUtil.EMPTY_BYTE_ARRAY, code);
+    }
+
+    @Test
+    void getExecutionCode_returnsEmptyWhenTargetHasNoCode() {
+        Repository repository = mock(Repository.class);
+        RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
+
+        when(repository.isExist(target)).thenReturn(true);
+        when(repository.getCode(target)).thenReturn(ByteUtil.EMPTY_BYTE_ARRAY);
+
+        byte[] code = DelegationCodeResolver.getExecutionCode(
+                repository,
+                target,
+                address -> false
+        );
+
+        assertArrayEquals(ByteUtil.EMPTY_BYTE_ARRAY, code);
+    }
+
+    @Test
+    void getExecutionCode_returnsEmptyWhenDelegatedAddressIsPrecompile() {
+        Repository repository = mock(Repository.class);
+
+        RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
+        RskAddress delegated  =new RskAddress("0000000000000000000000000000000000000002");
+
+        when(repository.isExist(target)).thenReturn(true);
+        when(repository.getCode(target)).thenReturn(createDelegatedCode(delegated));
+
+        byte[] code = DelegationCodeResolver.getExecutionCode(
+                repository,
+                target,
+                delegated::equals
+        );
+
+        assertArrayEquals(ByteUtil.EMPTY_BYTE_ARRAY, code);
+    }
+
+    @Test
+    void getExecutionCode_returnsDelegatedCodeWhenDelegatedAccountExists() {
+        Repository repository = mock(Repository.class);
+
+        RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
+        RskAddress delegated = new RskAddress("0000000000000000000000000000000000000002");
+
+        byte[] delegatedRuntimeCode = new byte[] { 0x01, 0x02, 0x03 };
+
+        when(repository.isExist(target)).thenReturn(true);
+        when(repository.getCode(target)).thenReturn(createDelegatedCode(delegated));
+
+        when(repository.isExist(delegated)).thenReturn(true);
+        when(repository.getCode(delegated)).thenReturn(delegatedRuntimeCode);
+
+        byte[] code = DelegationCodeResolver.getExecutionCode(
+                repository,
+                target,
+                address -> false
+        );
+
+        assertArrayEquals(delegatedRuntimeCode, code);
+    }
+
+    @Test
+    void getExecutionCode_returnsDelegatedCodeWithoutResolvingDelegationChain() {
+        Repository repository = mock(Repository.class);
+
+        RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
+        RskAddress delegated = new  RskAddress("0000000000000000000000000000000000000002");
+        RskAddress secondDelegation = new RskAddress("0000000000000000000000000000000000000003");
+
+        byte[] delegatedCode = createDelegatedCode(secondDelegation);
+
+        when(repository.isExist(target)).thenReturn(true);
+        when(repository.getCode(target)).thenReturn(createDelegatedCode(delegated));
+
+        when(repository.isExist(delegated)).thenReturn(true);
+        when(repository.getCode(delegated)).thenReturn(delegatedCode);
+
+        byte[] code = DelegationCodeResolver.getExecutionCode(
+                repository,
+                target,
+                address -> false
+        );
+
+        assertArrayEquals(delegatedCode, code);
+    }
+
+    @Test
+    void getExecutionCode_returnsEmptyWhenDelegatedAccountCodeIsNull() {
+        Repository repository = mock(Repository.class);
+
+        RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
+        when(repository.isExist(target)).thenReturn(true);
+        when(repository.getCode(target)).thenReturn(null);
+
+
+        byte[] code = DelegationCodeResolver.getExecutionCode(
+                repository,
+                target,
+                address -> false
+        );
+
+        assertArrayEquals(ByteUtil.EMPTY_BYTE_ARRAY, code);
+    }
+
+    @Test
+    void getExecutionCode_returnsEmptyWhenDelegatedAccountCodeIsLength0() {
+        Repository repository = mock(Repository.class);
+
+        RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
+        when(repository.isExist(target)).thenReturn(true);
+        when(repository.getCode(target)).thenReturn(new byte[0]);
+
+
+        byte[] code = DelegationCodeResolver.getExecutionCode(
+                repository,
+                target,
+                address -> false
+        );
+
+        assertArrayEquals(ByteUtil.EMPTY_BYTE_ARRAY, code);
+    }
+
+    @Test
+    void getExecutionCode_returnsDelegatedCodeWhenDelegatedAddressIsNotPrecompileAndExists() {
+        Repository repository = mock(Repository.class);
+
+        RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
+        RskAddress delegated = new RskAddress("0000000000000000000000000000000000000002");
+
+        byte[] targetDelegatedCode = createDelegatedCode(delegated);
+        byte[] delegatedRuntimeCode = new byte[] { 0x01, 0x02, 0x03 };
+
+        when(repository.isExist(target)).thenReturn(true);
+        when(repository.getCode(target)).thenReturn(targetDelegatedCode);
+
+        when(repository.isExist(delegated)).thenReturn(true);
+        when(repository.getCode(delegated)).thenReturn(delegatedRuntimeCode);
+
+        byte[] code = DelegationCodeResolver.getExecutionCode(
+                repository,
+                target,
+                address -> false
+        );
+
+        assertArrayEquals(delegatedRuntimeCode, code);
+    }
+
+    @Test
+    void getExecutionCode_returnsEmptyWhenDelegatedAddressIsNotPrecompileAndDoesNotExist() {
+        Repository repository = mock(Repository.class);
+
+        RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
+        RskAddress delegated = new RskAddress("0000000000000000000000000000000000000002");
+
+        byte[] targetDelegatedCode = createDelegatedCode(delegated);
+        byte[] delegatedRuntimeCode = new byte[] { 0x01, 0x02, 0x03 };
+
+        when(repository.isExist(target)).thenReturn(true);
+        when(repository.getCode(target)).thenReturn(targetDelegatedCode);
+
+        when(repository.isExist(delegated)).thenReturn(false);
+        when(repository.getCode(delegated)).thenReturn(delegatedRuntimeCode);
+
+        byte[] code = DelegationCodeResolver.getExecutionCode(
+                repository,
+                target,
+                address -> false
+        );
+
+        assertArrayEquals(ByteUtil.EMPTY_BYTE_ARRAY, code);
+    }
+
+    @Test
+    void getExecutionCode_returnsTargetCodeWhenCodeIsNotDelegated() {
+        Repository repository = mock(Repository.class);
+
+        RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
+        byte[] runtimeCode = new byte[] { 0x01, 0x02, 0x03 };
+
+        when(repository.isExist(target)).thenReturn(true);
+        when(repository.getCode(target)).thenReturn(runtimeCode);
+
+        byte[] code = DelegationCodeResolver.getExecutionCode(
+                repository,
+                target,
+                address -> false
+        );
+
+        assertArrayEquals(runtimeCode, code);
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/core/DelegationCodeResolverTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/DelegationCodeResolverTest.java
@@ -99,7 +99,7 @@ class DelegationCodeResolverTest {
         Repository repository = mock(Repository.class);
 
         RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
-        RskAddress delegated  =new RskAddress("0000000000000000000000000000000000000002");
+        RskAddress delegated = new RskAddress("0000000000000000000000000000000000000002");
 
         when(repository.isExist(target)).thenReturn(true);
         when(repository.getCode(target)).thenReturn(createDelegatedCode(delegated));

--- a/rskj-core/src/test/java/org/ethereum/core/DelegationCodeResolverTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/DelegationCodeResolverTest.java
@@ -64,7 +64,7 @@ class DelegationCodeResolverTest {
     @Test
     void getExecutionCode_returnsEmptyWhenTargetAccountDoesNotExist() {
         Repository repository = mock(Repository.class);
-        RskAddress target =  new RskAddress("0000000000000000000000000000000000000001");
+        RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
 
         when(repository.isExist(target)).thenReturn(false);
 


### PR DESCRIPTION
## Description
This PR extracts delegated code resolution into a shared helper in `DelegationCodeResolver` and updates both `Program` and `TransactionExecutor` to use the common implementation.

The change removes duplicated logic while preserving the existing behavior. It also adds unit tests covering the different delegated code resolution scenarios.

## Motivation and Context

Both `Program` and `TransactionExecutor` contained nearly identical logic for resolving delegated code (EIP-7702). Centralizing this logic reduces duplication, improves maintainability, and ensures both execution paths remain behaviorally consistent.

## How Has This Been Tested?
- Non-existent target account.
- Target account with null or empty code.
- Non-delegated code.
- Delegated address pointing to a precompile.
- Delegated address that does not exist.
- Delegated address with null runtime code.
- Delegated address with runtime code.
- Delegation chain resolution (single-level resolution only).
- Delegated code round-trip and delegated code validation helpers.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
