### PR TITLE
refactor: remove redundant typed transaction activation check from TxPendingValidator

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Java & Gradle
         uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e #v5.1.0
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'gradle'
 

--- a/rskj-core/src/main/java/co/rsk/net/handler/TxPendingValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/TxPendingValidator.java
@@ -73,14 +73,12 @@ public class TxPendingValidator {
     public TransactionValidationResult isValid(Transaction tx, Block executionBlock, @Nullable AccountState state) {
         long executionBlockNumber = executionBlock.getNumber();
         ActivationConfig.ForBlock activations = activationConfig.forBlock(executionBlockNumber);
-        BigInteger gasLimit = activationConfig.areActive(executionBlockNumber, ConsensusRule.RSKIP351, ConsensusRule.RSKIP144)
-                ? BigInteger.valueOf(Math.max(BlockUtils.getSublistGasLimit(executionBlock, true, constants.getMinSequentialSetGasLimit()), BlockUtils.getSublistGasLimit(executionBlock, false, constants.getMinSequentialSetGasLimit())))
-                : BigIntegers.fromUnsignedByteArray(executionBlock.getGasLimit());
-        Coin minimumGasPrice = executionBlock.getMinimumGasPrice();
-        long bestBlockNumber = executionBlock.getNumber();
         if (tx.isTypedTransactionNotAllowed(activations)) {
             return TransactionValidationResult.withError("transaction type " + tx.getTypePrefix() + " is not supported before its activation");
         }
+
+        BigInteger gasLimit = resolveGasLimit(executionBlock, executionBlockNumber);
+        Coin minimumGasPrice = executionBlock.getMinimumGasPrice();
 
         long basicTxCost = tx.transactionCost(constants, activations, signatureCache);
 
@@ -91,7 +89,7 @@ public class TxPendingValidator {
             return TransactionValidationResult.withError("the sender account doesn't exist");
         }
 
-        if (tx.isInitCodeSizeInvalidForTx(activationConfig.forBlock(bestBlockNumber))) {
+        if (tx.isInitCodeSizeInvalidForTx(activations)) {
             return TransactionValidationResult.withError("transaction's init code size is invalid");
         }
 
@@ -108,5 +106,15 @@ public class TxPendingValidator {
         }
 
         return TransactionValidationResult.ok();
+    }
+
+    private BigInteger resolveGasLimit(Block executionBlock, long executionBlockNumber) {
+        if (activationConfig.areActive(executionBlockNumber, ConsensusRule.RSKIP351, ConsensusRule.RSKIP144)) {
+            long minSequentialSetGasLimit = constants.getMinSequentialSetGasLimit();
+            long sequentialGasLimit = BlockUtils.getSublistGasLimit(executionBlock, true, minSequentialSetGasLimit);
+            long parallelGasLimit = BlockUtils.getSublistGasLimit(executionBlock, false, minSequentialSetGasLimit);
+            return BigInteger.valueOf(Math.max(sequentialGasLimit, parallelGasLimit));
+        }
+        return BigIntegers.fromUnsignedByteArray(executionBlock.getGasLimit());
     }
 }

--- a/rskj-core/src/main/java/co/rsk/net/handler/TxPendingValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/TxPendingValidator.java
@@ -91,10 +91,6 @@ public class TxPendingValidator {
             return TransactionValidationResult.withError("the sender account doesn't exist");
         }
 
-        if (tx.getTypePrefix().isTyped() && !activations.isActive(ConsensusRule.RSKIP543)) {
-            return TransactionValidationResult.withError("typed transactions are not supported before RSKIP543 activation");
-        }
-
         if (tx.isInitCodeSizeInvalidForTx(activationConfig.forBlock(bestBlockNumber))) {
             return TransactionValidationResult.withError("transaction's init code size is invalid");
         }

--- a/rskj-core/src/main/java/co/rsk/net/handler/TxPendingValidator.java
+++ b/rskj-core/src/main/java/co/rsk/net/handler/TxPendingValidator.java
@@ -77,11 +77,7 @@ public class TxPendingValidator {
             return TransactionValidationResult.withError("transaction type " + tx.getTypePrefix() + " is not supported before its activation");
         }
 
-        BigInteger gasLimit = resolveGasLimit(executionBlock, executionBlockNumber);
-        Coin minimumGasPrice = executionBlock.getMinimumGasPrice();
-
         long basicTxCost = tx.transactionCost(constants, activations, signatureCache);
-
         if (state == null && basicTxCost != 0) {
             if (logger.isTraceEnabled()) {
                 logger.trace("[tx={}, sender={}] account doesn't exist", tx.getHash(), tx.getSender(signatureCache));
@@ -97,6 +93,8 @@ public class TxPendingValidator {
             return TransactionValidationResult.withError(String.format("transaction's size is higher than defined maximum: %s > %s", tx.getSize(), TX_MAX_SIZE));
         }
 
+        BigInteger gasLimit = resolveGasLimit(executionBlock, executionBlockNumber);
+        Coin minimumGasPrice = executionBlock.getMinimumGasPrice();
         for (TxValidatorStep step : validatorSteps) {
             TransactionValidationResult validationResult = step.validate(tx, state, gasLimit, minimumGasPrice, executionBlockNumber, basicTxCost == 0);
             if (!validationResult.transactionIsValid()) {

--- a/rskj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/rskj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -328,7 +328,7 @@ public class Transaction {
         }
 
         long authorizationListGas = 0;
-        if (isType4()) {
+        if (isType4() && authorizationList != null) {
             authorizationListGas = Math.multiplyExact(GasCost.PER_EMPTY_ACCOUNT_COST, authorizationList.size());
         }
 
@@ -343,7 +343,9 @@ public class Transaction {
             return true;
         }
         TransactionType type = typePrefix.type();
-        if ((type == TransactionType.TYPE_1 || type == TransactionType.TYPE_2)
+        // Type 1 / 2 / 4 all depend on RSKIP-546 fields (access_list, and for type 2/4 fee caps).
+        // Type 4 additionally requires RSKIP-545 (set-code / authorization_list).
+        if ((type == TransactionType.TYPE_1 || type == TransactionType.TYPE_2 || type == TransactionType.TYPE_4)
                 && !activations.isActive(ConsensusRule.RSKIP546)) {
             return true;
         }

--- a/rskj-core/src/test/java/co/rsk/net/handler/TxPendingValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/TxPendingValidatorTest.java
@@ -30,8 +30,13 @@ import org.ethereum.core.*;
 import org.ethereum.core.transaction.TransactionType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.math.BigInteger;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -189,8 +194,6 @@ class TxPendingValidatorTest {
     void isValid_ShouldBeInvalid_WhenTypedTransactionAndRSKIP543IsNotActivated() {
         Block executionBlock = mock(Block.class);
         when(executionBlock.getNumber()).thenReturn(10L);
-        when(executionBlock.getGasLimit()).thenReturn(BigInteger.valueOf(10L).toByteArray());
-        when(executionBlock.getMinimumGasPrice()).thenReturn(Coin.valueOf(1L));
 
         Transaction tx = mock(Transaction.class);
         when(tx.getTypePrefix()).thenReturn(TransactionTypePrefix.typed(TransactionType.TYPE_1));
@@ -213,13 +216,17 @@ class TxPendingValidatorTest {
         assertFalse(result.transactionIsValid());
         assertTrue(result.getErrorMessage().contains("is not supported before its activation"));
         verify(tx).isTypedTransactionNotAllowed(forBlock);
+        verify(executionBlock, never()).getGasLimit();
+        verify(executionBlock, never()).getMinimumGasPrice();
         verify(tx, never()).transactionCost(any(), any(), any());
         verify(tx, never()).isInitCodeSizeInvalidForTx(any());
         verify(tx, never()).getSize();
     }
 
-    @Test
-    void isValid_ShouldRejectRealTypedTransactionBeforeFurtherValidation_WhenRSKIP543IsNotActivated() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("realTypedTransactionsBlockedBeforeRskip543")
+    void isValid_ShouldRejectRealTypedTransaction_WhenRSKIP543IsNotActivated(
+            String typeLabel, Supplier<Transaction> txSupplier) {
         long executionBlockNumber = 10L;
         TestSystemProperties config = new TestSystemProperties(baseConfig -> baseConfig.withValue(
                 "blockchain.config.hardforkActivationHeights.vetiver900",
@@ -227,10 +234,11 @@ class TxPendingValidatorTest {
         ));
         ActivationConfig activationConfig = config.getActivationConfig();
         ActivationConfig.ForBlock activations = activationConfig.forBlock(executionBlockNumber);
-        Transaction tx = Rskip546TestSupport.unsignedType1();
+        Transaction tx = txSupplier.get();
 
         assertFalse(activations.isActive(ConsensusRule.RSKIP543));
-        assertTrue(tx.isTypedTransactionNotAllowed(activations));
+        assertTrue(tx.isTypedTransactionNotAllowed(activations),
+                typeLabel + " must be blocked by isTypedTransactionNotAllowed before RSKIP543");
 
         Block executionBlock = mock(Block.class);
         when(executionBlock.getNumber()).thenReturn(executionBlockNumber);
@@ -244,7 +252,16 @@ class TxPendingValidatorTest {
         TransactionValidationResult result = validator.isValid(tx, executionBlock, mock(AccountState.class));
 
         assertFalse(result.transactionIsValid());
-        assertTrue(result.getErrorMessage().contains("is not supported before its activation"));
+        assertTrue(result.getErrorMessage().contains("is not supported before its activation"),
+                typeLabel + " rejection message should indicate the activation requirement, got: "
+                        + result.getErrorMessage());
+    }
+
+    private static Stream<Arguments> realTypedTransactionsBlockedBeforeRskip543() {
+        return Stream.of(
+                Arguments.of("type1", (Supplier<Transaction>) Rskip546TestSupport::unsignedType1),
+                Arguments.of("type4", (Supplier<Transaction>) Rskip545TestSupport::unsignedType4)
+        );
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/net/handler/TxPendingValidatorTest.java
+++ b/rskj-core/src/test/java/co/rsk/net/handler/TxPendingValidatorTest.java
@@ -22,6 +22,7 @@ import co.rsk.config.TestSystemProperties;
 import co.rsk.core.Coin;
 import co.rsk.core.bc.BlockUtils;
 import co.rsk.net.TransactionValidationResult;
+import com.typesafe.config.ConfigValueFactory;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
@@ -208,6 +209,39 @@ class TxPendingValidatorTest {
                 config.getNetworkConstants(), activationConfig, config.getNumOfAccountSlots(), signatureCache);
 
         TransactionValidationResult result = validator.isValid(tx, executionBlock, null);
+
+        assertFalse(result.transactionIsValid());
+        assertTrue(result.getErrorMessage().contains("is not supported before its activation"));
+        verify(tx).isTypedTransactionNotAllowed(forBlock);
+        verify(tx, never()).transactionCost(any(), any(), any());
+        verify(tx, never()).isInitCodeSizeInvalidForTx(any());
+        verify(tx, never()).getSize();
+    }
+
+    @Test
+    void isValid_ShouldRejectRealTypedTransactionBeforeFurtherValidation_WhenRSKIP543IsNotActivated() {
+        long executionBlockNumber = 10L;
+        TestSystemProperties config = new TestSystemProperties(baseConfig -> baseConfig.withValue(
+                "blockchain.config.hardforkActivationHeights.vetiver900",
+                ConfigValueFactory.fromAnyRef(executionBlockNumber + 1)
+        ));
+        ActivationConfig activationConfig = config.getActivationConfig();
+        ActivationConfig.ForBlock activations = activationConfig.forBlock(executionBlockNumber);
+        Transaction tx = Rskip546TestSupport.unsignedType1();
+
+        assertFalse(activations.isActive(ConsensusRule.RSKIP543));
+        assertTrue(tx.isTypedTransactionNotAllowed(activations));
+
+        Block executionBlock = mock(Block.class);
+        when(executionBlock.getNumber()).thenReturn(executionBlockNumber);
+        when(executionBlock.getGasLimit()).thenReturn(BigInteger.valueOf(100_000L).toByteArray());
+        when(executionBlock.getMinimumGasPrice()).thenReturn(Coin.valueOf(1L));
+
+        SignatureCache signatureCache = new BlockTxSignatureCache(new ReceivedTxSignatureCache());
+        TxPendingValidator validator = new TxPendingValidator(
+                config.getNetworkConstants(), activationConfig, config.getNumOfAccountSlots(), signatureCache);
+
+        TransactionValidationResult result = validator.isValid(tx, executionBlock, mock(AccountState.class));
 
         assertFalse(result.transactionIsValid());
         assertTrue(result.getErrorMessage().contains("is not supported before its activation"));

--- a/rskj-core/src/test/java/org/ethereum/core/Rskip545DeepDslTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/Rskip545DeepDslTest.java
@@ -460,12 +460,21 @@ class Rskip545DeepDslTest {
         org.mockito.Mockito.when(allInactive.isActive(ConsensusRule.RSKIP543)).thenReturn(false);
         assertTrue(tx.isTypedTransactionNotAllowed(allInactive));
 
-        var only545 = org.mockito.Mockito.mock(
+        var without546 = org.mockito.Mockito.mock(
                 org.ethereum.config.blockchain.upgrades.ActivationConfig.ForBlock.class);
-        org.mockito.Mockito.when(only545.isActive(ConsensusRule.RSKIP543)).thenReturn(true);
-        org.mockito.Mockito.when(only545.isActive(ConsensusRule.RSKIP546)).thenReturn(true);
-        org.mockito.Mockito.when(only545.isActive(ConsensusRule.RSKIP545)).thenReturn(false);
-        assertTrue(tx.isTypedTransactionNotAllowed(only545));
+        org.mockito.Mockito.when(without546.isActive(ConsensusRule.RSKIP543)).thenReturn(true);
+        org.mockito.Mockito.when(without546.isActive(ConsensusRule.RSKIP546)).thenReturn(false);
+        org.mockito.Mockito.when(without546.isActive(ConsensusRule.RSKIP545)).thenReturn(true);
+        assertTrue(tx.isTypedTransactionNotAllowed(without546),
+                "Type 4 must be rejected when RSKIP-546 is inactive");
+
+        var without545 = org.mockito.Mockito.mock(
+                org.ethereum.config.blockchain.upgrades.ActivationConfig.ForBlock.class);
+        org.mockito.Mockito.when(without545.isActive(ConsensusRule.RSKIP543)).thenReturn(true);
+        org.mockito.Mockito.when(without545.isActive(ConsensusRule.RSKIP546)).thenReturn(true);
+        org.mockito.Mockito.when(without545.isActive(ConsensusRule.RSKIP545)).thenReturn(false);
+        assertTrue(tx.isTypedTransactionNotAllowed(without545),
+                "Type 4 must be rejected when RSKIP-545 is inactive");
     }
 
     // =========================================================================

--- a/rskj-core/src/test/java/org/ethereum/core/Rskip545DeepDslTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/Rskip545DeepDslTest.java
@@ -53,6 +53,8 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Deep RSKIP-545 DSL integration tests mapped to the specification sections in
@@ -455,24 +457,24 @@ class Rskip545DeepDslTest {
     @Test
     void activation_requiresRskip543And546And545() {
         Transaction tx = world.getTransactionByName("txMultiAuthLastWins");
-        var allInactive = org.mockito.Mockito.mock(
+        var allInactive = mock(
                 org.ethereum.config.blockchain.upgrades.ActivationConfig.ForBlock.class);
-        org.mockito.Mockito.when(allInactive.isActive(ConsensusRule.RSKIP543)).thenReturn(false);
+        when(allInactive.isActive(ConsensusRule.RSKIP543)).thenReturn(false);
         assertTrue(tx.isTypedTransactionNotAllowed(allInactive));
 
-        var without546 = org.mockito.Mockito.mock(
+        var without546 = mock(
                 org.ethereum.config.blockchain.upgrades.ActivationConfig.ForBlock.class);
-        org.mockito.Mockito.when(without546.isActive(ConsensusRule.RSKIP543)).thenReturn(true);
-        org.mockito.Mockito.when(without546.isActive(ConsensusRule.RSKIP546)).thenReturn(false);
-        org.mockito.Mockito.when(without546.isActive(ConsensusRule.RSKIP545)).thenReturn(true);
+        when(without546.isActive(ConsensusRule.RSKIP543)).thenReturn(true);
+        when(without546.isActive(ConsensusRule.RSKIP546)).thenReturn(false);
+        when(without546.isActive(ConsensusRule.RSKIP545)).thenReturn(true);
         assertTrue(tx.isTypedTransactionNotAllowed(without546),
                 "Type 4 must be rejected when RSKIP-546 is inactive");
 
-        var without545 = org.mockito.Mockito.mock(
+        var without545 = mock(
                 org.ethereum.config.blockchain.upgrades.ActivationConfig.ForBlock.class);
-        org.mockito.Mockito.when(without545.isActive(ConsensusRule.RSKIP543)).thenReturn(true);
-        org.mockito.Mockito.when(without545.isActive(ConsensusRule.RSKIP546)).thenReturn(true);
-        org.mockito.Mockito.when(without545.isActive(ConsensusRule.RSKIP545)).thenReturn(false);
+        when(without545.isActive(ConsensusRule.RSKIP543)).thenReturn(true);
+        when(without545.isActive(ConsensusRule.RSKIP546)).thenReturn(true);
+        when(without545.isActive(ConsensusRule.RSKIP545)).thenReturn(false);
         assertTrue(tx.isTypedTransactionNotAllowed(without545),
                 "Type 4 must be rejected when RSKIP-545 is inactive");
     }

--- a/rskj-core/src/test/java/org/ethereum/core/Rskip545DslTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/Rskip545DslTest.java
@@ -494,6 +494,19 @@ class Rskip545DslTest {
                 "Type 4 must be allowed when RSKIP-545 is active in this world");
     }
 
+    @Test
+    void type4_blockedWhenRskip546Inactive() {
+        Transaction tx = world.getTransactionByName("txType4SelfAuth");
+        var without546 = org.mockito.Mockito.mock(
+                org.ethereum.config.blockchain.upgrades.ActivationConfig.ForBlock.class);
+        org.mockito.Mockito.when(without546.isActive(ConsensusRule.RSKIP543)).thenReturn(true);
+        org.mockito.Mockito.when(without546.isActive(ConsensusRule.RSKIP546)).thenReturn(false);
+        org.mockito.Mockito.when(without546.isActive(ConsensusRule.RSKIP545)).thenReturn(true);
+
+        assertTrue(tx.isTypedTransactionNotAllowed(without546),
+                "Type 4 must be rejected when RSKIP-546 is inactive");
+    }
+
     // =========================================================================
     // Chain height sanity
     // =========================================================================

--- a/rskj-core/src/test/java/org/ethereum/core/Rskip545DslTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/Rskip545DslTest.java
@@ -499,11 +499,11 @@ class Rskip545DslTest {
     @Test
     void type4_blockedWhenRskip546Inactive() {
         Transaction tx = world.getTransactionByName("txType4SelfAuth");
-        var without546 = org.mockito.Mockito.mock(
+        var without546 = mock(
                 org.ethereum.config.blockchain.upgrades.ActivationConfig.ForBlock.class);
-        org.mockito.Mockito.when(without546.isActive(ConsensusRule.RSKIP543)).thenReturn(true);
-        org.mockito.Mockito.when(without546.isActive(ConsensusRule.RSKIP546)).thenReturn(false);
-        org.mockito.Mockito.when(without546.isActive(ConsensusRule.RSKIP545)).thenReturn(true);
+        when(without546.isActive(ConsensusRule.RSKIP543)).thenReturn(true);
+        when(without546.isActive(ConsensusRule.RSKIP546)).thenReturn(false);
+        when(without546.isActive(ConsensusRule.RSKIP545)).thenReturn(true);
 
         assertTrue(tx.isTypedTransactionNotAllowed(without546),
                 "Type 4 must be rejected when RSKIP-546 is inactive");

--- a/rskj-core/src/test/java/org/ethereum/core/Rskip545DslTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/Rskip545DslTest.java
@@ -50,6 +50,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * DSL integration tests for RSKIP-545: Type 4 (EIP-7702 set-code) transactions.
@@ -482,11 +484,11 @@ class Rskip545DslTest {
     void type4_blockedWhenRskip545Inactive() {
         Transaction tx = world.getTransactionByName("txType4SelfAuth");
         var activations = world.getConfig().getActivationConfig().forBlock(1);
-        var without545 = org.mockito.Mockito.mock(
+        var without545 = mock(
                 org.ethereum.config.blockchain.upgrades.ActivationConfig.ForBlock.class);
-        org.mockito.Mockito.when(without545.isActive(ConsensusRule.RSKIP543)).thenReturn(true);
-        org.mockito.Mockito.when(without545.isActive(ConsensusRule.RSKIP546)).thenReturn(true);
-        org.mockito.Mockito.when(without545.isActive(ConsensusRule.RSKIP545)).thenReturn(false);
+        when(without545.isActive(ConsensusRule.RSKIP543)).thenReturn(true);
+        when(without545.isActive(ConsensusRule.RSKIP546)).thenReturn(true);
+        when(without545.isActive(ConsensusRule.RSKIP545)).thenReturn(false);
 
         assertTrue(tx.isTypedTransactionNotAllowed(without545),
                 "Type 4 must be rejected when RSKIP-545 is inactive");

--- a/rskj-core/src/test/java/org/ethereum/core/Rskip545HardforkTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/Rskip545HardforkTest.java
@@ -109,6 +109,18 @@ class Rskip545HardforkTest {
     }
 
     @Test
+    void poolRejection_type4_blockedWhenOnlyRskip546Inactive() {
+        Transaction tx = world.getTransactionByName("txTransitionType4");
+        var activations = org.mockito.Mockito.mock(
+                org.ethereum.config.blockchain.upgrades.ActivationConfig.ForBlock.class);
+        org.mockito.Mockito.when(activations.isActive(ConsensusRule.RSKIP543)).thenReturn(true);
+        org.mockito.Mockito.when(activations.isActive(ConsensusRule.RSKIP546)).thenReturn(false);
+        org.mockito.Mockito.when(activations.isActive(ConsensusRule.RSKIP545)).thenReturn(true);
+        assertTrue(tx.isTypedTransactionNotAllowed(activations),
+                "Type 4 must be rejected when RSKIP-546 is inactive (matches Type4RawTransactionParser)");
+    }
+
+    @Test
     void poolRejection_type4_blockedWhenOnlyRskip545Inactive() {
         Transaction tx = world.getTransactionByName("txTransitionType4");
         var activations = org.mockito.Mockito.mock(

--- a/rskj-core/src/test/java/org/ethereum/core/Rskip545HardforkTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/Rskip545HardforkTest.java
@@ -42,6 +42,8 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Hardfork safety tests for RSKIP-545 (requires RSKIP-543 and RSKIP-546).
@@ -111,11 +113,11 @@ class Rskip545HardforkTest {
     @Test
     void poolRejection_type4_blockedWhenOnlyRskip546Inactive() {
         Transaction tx = world.getTransactionByName("txTransitionType4");
-        var activations = org.mockito.Mockito.mock(
+        var activations = mock(
                 org.ethereum.config.blockchain.upgrades.ActivationConfig.ForBlock.class);
-        org.mockito.Mockito.when(activations.isActive(ConsensusRule.RSKIP543)).thenReturn(true);
-        org.mockito.Mockito.when(activations.isActive(ConsensusRule.RSKIP546)).thenReturn(false);
-        org.mockito.Mockito.when(activations.isActive(ConsensusRule.RSKIP545)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP543)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP546)).thenReturn(false);
+        when(activations.isActive(ConsensusRule.RSKIP545)).thenReturn(true);
         assertTrue(tx.isTypedTransactionNotAllowed(activations),
                 "Type 4 must be rejected when RSKIP-546 is inactive (matches Type4RawTransactionParser)");
     }
@@ -123,11 +125,11 @@ class Rskip545HardforkTest {
     @Test
     void poolRejection_type4_blockedWhenOnlyRskip545Inactive() {
         Transaction tx = world.getTransactionByName("txTransitionType4");
-        var activations = org.mockito.Mockito.mock(
+        var activations = mock(
                 org.ethereum.config.blockchain.upgrades.ActivationConfig.ForBlock.class);
-        org.mockito.Mockito.when(activations.isActive(ConsensusRule.RSKIP543)).thenReturn(true);
-        org.mockito.Mockito.when(activations.isActive(ConsensusRule.RSKIP546)).thenReturn(true);
-        org.mockito.Mockito.when(activations.isActive(ConsensusRule.RSKIP545)).thenReturn(false);
+        when(activations.isActive(ConsensusRule.RSKIP543)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP546)).thenReturn(true);
+        when(activations.isActive(ConsensusRule.RSKIP545)).thenReturn(false);
         assertTrue(tx.isTypedTransactionNotAllowed(activations));
     }
 

--- a/rskj-core/src/test/java/org/ethereum/core/Rskip545TypedTransactionTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/Rskip545TypedTransactionTest.java
@@ -296,7 +296,7 @@ class Rskip545TypedTransactionTest {
 
     @ParameterizedTest(name = "rskip543={0}, rskip546={1}, rskip545={2} -> blocked={3}")
     @MethodSource("type4ActivationMatrix")
-    void isTypedTransactionNotAllowed_respectsRskip545Gate(
+    void isTypedTransactionNotAllowed_respectsType4ActivationGates(
             boolean rskip543, boolean rskip546, boolean rskip545, boolean expectBlocked) {
         Transaction tx = createType4(EMPTY_DATA);
         ActivationConfig.ForBlock activations = mockActivations(rskip543, rskip546, rskip545);
@@ -305,10 +305,13 @@ class Rskip545TypedTransactionTest {
     }
 
     private static Stream<Arguments> type4ActivationMatrix() {
+        // Mirrors Type4RawTransactionParser.validate: RSKIP-543, RSKIP-546, then RSKIP-545.
         return Stream.of(
                 Arguments.of(false, false, false, true),
                 Arguments.of(true, false, false, true),
+                Arguments.of(true, false, true, true),
                 Arguments.of(true, true, false, true),
+                Arguments.of(false, true, true, true),
                 Arguments.of(true, true, true, false)
         );
     }

--- a/rskj-core/src/test/java/org/ethereum/core/TransactionRskip545InvariantTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/TransactionRskip545InvariantTest.java
@@ -20,6 +20,7 @@ package org.ethereum.core;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.peg.constants.BridgeMainNetConstants;
+import org.apache.commons.lang3.ArrayUtils;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.exception.TransactionException;
@@ -31,7 +32,6 @@ import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.vm.GasCost;
-import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -46,6 +46,8 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 /**
  * Covers RSKIP-545 / Type 4 invariants on {@link Transaction#verify} and four-field typed
@@ -330,9 +332,9 @@ class TransactionRskip545InvariantTest {
         dataField.setAccessible(true);
         dataField.set(tx, null);
 
-        Constants constants = Mockito.mock(Constants.class);
-        Mockito.doReturn(BridgeMainNetConstants.getInstance()).when(constants).getBridgeConstants();
-        ActivationConfig.ForBlock activations = Mockito.mock(ActivationConfig.ForBlock.class);
+        Constants constants = mock(Constants.class);
+        doReturn(BridgeMainNetConstants.getInstance()).when(constants).getBridgeConstants();
+        ActivationConfig.ForBlock activations = mock(ActivationConfig.ForBlock.class);
 
         assertTrue(tx.transactionCost(constants, activations, new ReceivedTxSignatureCache()) > 0);
     }

--- a/rskj-core/src/test/java/org/ethereum/core/TransactionRskip545InvariantTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/TransactionRskip545InvariantTest.java
@@ -30,6 +30,7 @@ import org.ethereum.crypto.signature.ECDSASignature;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
+import org.ethereum.vm.GasCost;
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -334,6 +335,26 @@ class TransactionRskip545InvariantTest {
         ActivationConfig.ForBlock activations = Mockito.mock(ActivationConfig.ForBlock.class);
 
         assertTrue(tx.transactionCost(constants, activations, new ReceivedTxSignatureCache()) > 0);
+    }
+
+    @Test
+    void transactionCost_type4WithNullAuthorizationList_doesNotThrow() throws Exception {
+        Transaction tx = signedType4();
+        // Warm encode/hash while authorization_list is still present (encoder rejects null).
+        tx.getHash();
+
+        java.lang.reflect.Field authorizationListField = Transaction.class.getDeclaredField("authorizationList");
+        authorizationListField.setAccessible(true);
+        authorizationListField.set(tx, null);
+
+        Constants constants = Mockito.mock(Constants.class);
+        Mockito.doReturn(BridgeMainNetConstants.getInstance()).when(constants).getBridgeConstants();
+        ActivationConfig.ForBlock activations = Mockito.mock(ActivationConfig.ForBlock.class);
+
+        assertEquals(
+                GasCost.TRANSACTION,
+                tx.transactionCost(constants, activations, new ReceivedTxSignatureCache()),
+                "Null authorization_list must not NPE; charge no PER_EMPTY_ACCOUNT_COST");
     }
 
     @Test


### PR DESCRIPTION

## Description
Removed a redundant RSKIP543 activation check from TxPendingValidator. Typed-transaction activation validation remains centralized in Transaction.isTypedTransactionNotAllowed.

## Motivation and Context
The removed condition was unreachable because isTypedTransactionNotAllowed already rejects typed transactions when RSKIP543 is inactive using the same activation state.

Removing this duplicate check has no runtime behavior impact and avoids future divergence between two activation-validation paths.

## How Has This Been Tested?
Added tests ensuring that typed transactions are rejected before activation and that validation returns before transaction cost, init-code size, and transaction size checks are performed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)
