### PR TITLE
Set default to read-all, remove other read at job level

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,13 +1,13 @@
 name: 'Dependency Review'
 on: [pull_request]
 
+# Declare default permissions as read only.
 permissions: read-all
 
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       pull-requests: write
     steps:
       - name: 'Checkout Repository'

--- a/.github/workflows/devportal-update.yml
+++ b/.github/workflows/devportal-update.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
 
+# Declare default permissions as read only.
 permissions: read-all
 
 jobs:

--- a/.github/workflows/docker-verification.yml
+++ b/.github/workflows/docker-verification.yml
@@ -8,9 +8,7 @@ on:
     types: [opened, synchronize, reopened]
 
 # Declare default permissions as read only.
-permissions:
-  contents: read
-  actions: read
+permissions: read-all
 
 jobs:
   docker:

--- a/.github/workflows/fuzz-test.yml
+++ b/.github/workflows/fuzz-test.yml
@@ -12,6 +12,9 @@ on:
         required: false
         default: 'master'
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   fuzz-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/reproducible-build-pr.yml
+++ b/.github/workflows/reproducible-build-pr.yml
@@ -25,8 +25,8 @@ on:
 
 # Only read permission is needed. The cross-repo PR is opened with the
 # scoped App token, NOT GITHUB_TOKEN.
-permissions:
-  contents: read
+# Declare default permissions as read only.
+permissions: read-all
 
 concurrency:
   group: reproducible-build-pr-${{ github.ref }}

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -53,8 +53,8 @@ on:
         description: 'modifier resolved from version.properties at the ref'
         value: ${{ jobs.reproducible-build.outputs.modifier }}
 
-permissions:
-  contents: read
+# Declare default permissions as read only.
+permissions: read-all
 
 concurrency:
   # Key by the ref actually being built (inputs.ref for dispatch/call, the commit

--- a/.github/workflows/rskj-core-automated-tests.yml
+++ b/.github/workflows/rskj-core-automated-tests.yml
@@ -48,8 +48,8 @@ on:
 
 # Least privilege at the top level; the only job that needs a write scope
 # (pull-requests: write, for the sticky PR comment) declares it itself.
-permissions:
-  contents: read
+# Declare default permissions as read only.
+permissions: read-all
 
 concurrency:
   group: rskj-core-automated-tests-${{ github.ref }}


### PR DESCRIPTION

## Description
- Set workflows default permissions as `read-all`.
- Remove read permissions at job level.
- Fix workflow without top level permissions defined.
- This change improves the scorecard ranking of the repository.

## Motivation and Context
- Unify configuration criteria across workflows.

## How Has This Been Tested?
All workflows has read or read-all permissions configured.

## Types of changes
- [x] Configuration
