### PR TITLE
Improvements, refactors and fixes for VETIVER-9.0.4

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Java & Gradle
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 #v5.2.0
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: 'gradle'
 

--- a/docs/03-node-operators/04-setup/03-configuration/02-cli.md
+++ b/docs/03-node-operators/04-setup/03-configuration/02-cli.md
@@ -276,6 +276,50 @@ The `ShowStateInfo` command is a tool for displaying state information of a spec
     INFO [clitool] [main]  ShowStateInfo finished
 ```
 
+#### ValidateState
+
+The `ValidateState` command walks the state trie of a block and reports every node and long value the trie references that is not present in the state database. It is meant for a state database that was populated out of band — restored from a snapshot, imported from bootstrap data, or copied between nodes — where an incomplete state would otherwise only show up later, at first state access.
+
+It checks **presence**, not integrity: it verifies that everything the trie references can be retrieved, not that the stored bytes hash to the key they are filed under. A report of "complete" therefore means nothing is missing, not that the state root is correct.
+
+The command exits `0` when the state is complete and non-zero when it is not, so it can gate a script.
+
+**Usage:**
+
+- `java -cp rsk.jar co.rsk.cli.tools.ValidateState [-b <block_number>] --<network_flag>`
+
+**Options:**
+
+- `-b, --block`: The block number, or "best", whose state should be validated. Defaults to `best`.
+
+**Example:**
+
+- `java -cp rsk.jar co.rsk.cli.tools.ValidateState -b best --testnet`
+
+**Output:**
+
+```shell
+    INFO [clitool] [main]  ValidateState started
+    INFO [clitool] [main]  Block number: 7654321
+    INFO [clitool] [main]  Block hash: 53fe6e9269d26a38d15f368a3b8b647ae6b66e4fe27bd6bd6ee5f4b675129753
+    INFO [clitool] [main]  State root: 587e0645e09d60af77ee04591ac843af14c99f6c498713aeb565f25f2d419cd0
+    INFO [clitool] [main]  Trie nodes visited: 16834271
+    INFO [clitool] [main]  Embedded nodes visited: 7415223
+    INFO [clitool] [main]  Long values visited: 183472
+    INFO [clitool] [main]  Gaps found: 0
+    INFO [clitool] [main]  State is complete
+    INFO [clitool] [main]  ValidateState finished
+```
+
+When something is missing, each gap is named (up to a capped sample) and the command reports the state as incomplete:
+
+```shell
+    INFO [clitool] [main]  Gaps found: 2
+    INFO [clitool] [main]  missing node: 4ce5c4861124fac10fdda43f62df4cf8137136e4c654305a8e9e3572f76b46c9
+    INFO [clitool] [main]  missing long value: 5c0700caa04b0e28aa38d3d4a74a560332c38111cb1ac2292a89512d009658d2
+    INFO [clitool] [main]  State is INCOMPLETE
+```
+
 #### IndexBlooms
 
 The `IndexBlooms` is a tool for indexing block blooms for a specific block range.

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1194,8 +1194,9 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         if (blockParentDependantValidationRule == null) {
             Constants commonConstants = getRskSystemProperties().getNetworkConstants();
+            byte chainId = commonConstants.getChainId();
             blockParentDependantValidationRule = new BlockParentCompositeRule(
-                    new BlockTxsFieldsValidationRule(getBlockTxSignatureCache()),
+                    new BlockTxsFieldsValidationRule(getBlockTxSignatureCache(), chainId),
                     new BlockTxsValidationRule(getRepositoryLocator(), getBlockTxSignatureCache()),
                     new PrevMinGasPriceRule(),
                     new BlockParentNumberRule(),
@@ -1212,8 +1213,9 @@ public class RskContext implements NodeContext, NodeBootstrapper {
 
         if (snapBlockParentDependantValidationRule == null) {
             Constants commonConstants = getRskSystemProperties().getNetworkConstants();
+            byte chainId = commonConstants.getChainId();
             snapBlockParentDependantValidationRule = new BlockParentCompositeRule(
-                    new BlockTxsFieldsValidationRule(getBlockTxSignatureCache()),
+                    new BlockTxsFieldsValidationRule(getBlockTxSignatureCache(), chainId),
                     new PrevMinGasPriceRule(),
                     new BlockParentNumberRule(),
                     new BlockDifficultyRule(getDifficultyCalculator()),

--- a/rskj-core/src/main/java/co/rsk/RskContext.java
+++ b/rskj-core/src/main/java/co/rsk/RskContext.java
@@ -1196,12 +1196,12 @@ public class RskContext implements NodeContext, NodeBootstrapper {
             Constants commonConstants = getRskSystemProperties().getNetworkConstants();
             byte chainId = commonConstants.getChainId();
             blockParentDependantValidationRule = new BlockParentCompositeRule(
-                    new BlockTxsFieldsValidationRule(getBlockTxSignatureCache(), chainId),
-                    new BlockTxsValidationRule(getRepositoryLocator(), getBlockTxSignatureCache()),
-                    new PrevMinGasPriceRule(),
                     new BlockParentNumberRule(),
                     new BlockDifficultyRule(getDifficultyCalculator()),
-                    new BlockParentGasLimitRule(commonConstants.getGasLimitBoundDivisor())
+                    new BlockParentGasLimitRule(commonConstants.getGasLimitBoundDivisor()),
+                    new PrevMinGasPriceRule(),
+                    new BlockTxsFieldsValidationRule(getBlockTxSignatureCache(), chainId),
+                    new BlockTxsValidationRule(getRepositoryLocator(), getBlockTxSignatureCache())
             );
         }
 
@@ -1215,11 +1215,11 @@ public class RskContext implements NodeContext, NodeBootstrapper {
             Constants commonConstants = getRskSystemProperties().getNetworkConstants();
             byte chainId = commonConstants.getChainId();
             snapBlockParentDependantValidationRule = new BlockParentCompositeRule(
-                    new BlockTxsFieldsValidationRule(getBlockTxSignatureCache(), chainId),
-                    new PrevMinGasPriceRule(),
                     new BlockParentNumberRule(),
                     new BlockDifficultyRule(getDifficultyCalculator()),
-                    new BlockParentGasLimitRule(commonConstants.getGasLimitBoundDivisor())
+                    new BlockParentGasLimitRule(commonConstants.getGasLimitBoundDivisor()),
+                    new PrevMinGasPriceRule(),
+                    new BlockTxsFieldsValidationRule(getBlockTxSignatureCache(), chainId)
             );
         }
 

--- a/rskj-core/src/main/java/co/rsk/cli/tools/ValidateState.java
+++ b/rskj-core/src/main/java/co/rsk/cli/tools/ValidateState.java
@@ -1,0 +1,240 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2026 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.cli.tools;
+
+import co.rsk.cli.PicoCliToolRskContextAware;
+import co.rsk.crypto.Keccak256;
+import co.rsk.trie.NodeReference;
+import co.rsk.trie.Trie;
+import co.rsk.trie.TrieStore;
+import com.google.common.annotations.VisibleForTesting;
+import org.ethereum.core.Block;
+import org.ethereum.db.BlockStore;
+import org.ethereum.util.ByteUtil;
+import picocli.CommandLine;
+
+import javax.annotation.Nonnull;
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * The entry point for the validate state CLI util.
+ * <p>
+ * Walks the state trie of a block and reports every referenced node or long value that is not present in
+ * the state database, so an incomplete state can be detected up front rather than at first state access.
+ * A state database populated out of band — restored from a snapshot, imported from bootstrap data, or
+ * copied between nodes — can be missing pieces the block headers give no hint about.
+ * <p>
+ * What this checks and what it does not: the walk asserts <b>presence</b>. Every node and long value the
+ * trie references must be retrievable from the store. It does <b>not</b> re-hash stored bytes to check they
+ * match the key they are filed under, so a report of "complete" means nothing is missing, not that the
+ * state root is correct.
+ * <p>
+ * The walk drives itself off {@link TrieStore#retrieve(byte[])} rather than {@link NodeReference#getNode()},
+ * because a reference deserialized from the store stops the JVM when its node cannot be retrieved — which
+ * is the very condition this tool has to survive and report. Nodes are not memoized as they are visited, so
+ * peak retention stays proportional to the trie depth rather than to the size of the state.
+ * <p>
+ * This is an experimental/unsupported tool.
+ * <p>
+ * Required cli args:
+ * - args[0] - block number or "best" (defaults to "best")
+ */
+@CommandLine.Command(name = "validate-state", mixinStandardHelpOptions = true, version = "validate-state 1.0",
+        description = "Validates that every node and long value the state trie of a block references is present in the state database")
+public class ValidateState extends PicoCliToolRskContextAware {
+
+    /** How many individual gaps are listed in the report; the total count is always reported in full. */
+    private static final int MAX_REPORTED_GAPS = 20;
+
+    @CommandLine.Option(names = {"-b", "--block"}, description = "block number or \"best\" (default: ${DEFAULT-VALUE})",
+            defaultValue = "best")
+    private String blockNum;
+
+    private final Printer printer;
+
+    public static void main(String[] args) {
+        create(MethodHandles.lookup().lookupClass()).execute(args);
+    }
+
+    @SuppressWarnings("unused")
+    public ValidateState() { // used via reflection
+        this(ValidateState::printInfo);
+    }
+
+    @VisibleForTesting
+    ValidateState(@Nonnull Printer printer) {
+        this.printer = Objects.requireNonNull(printer);
+    }
+
+    @Override
+    public Integer call() {
+        BlockStore blockStore = ctx.getBlockStore();
+        TrieStore trieStore = ctx.getTrieStore();
+
+        Block block;
+        try {
+            block = resolveBlock(blockStore);
+        } catch (NumberFormatException e) {
+            // An unparseable --block is a usage error, not a missing block; keep the two distinct so the
+            // message tells the operator which one they hit.
+            printer.println("Invalid block: " + blockNum + " (expected a block number or \"best\")");
+            return 1;
+        }
+
+        if (block == null) {
+            printer.println("Block not found: " + blockNum);
+            return 1;
+        }
+
+        // RSKIP126 remapped the header's state root, so the root to look up in the store is the translated
+        // one, not the raw header field.
+        Keccak256 stateRoot = ctx.getStateRootHandler().translate(block.getHeader());
+
+        printer.println("Block number: " + block.getNumber());
+        printer.println("Block hash: " + ByteUtil.toHexString(block.getHash().getBytes()));
+        printer.println("State root: " + stateRoot.toHexString());
+
+        Optional<Trie> root = retrieveNode(trieStore, stateRoot);
+        if (!root.isPresent()) {
+            printer.println("State root does not resolve to a node in the state database");
+            printer.println("State is INCOMPLETE");
+            return 1;
+        }
+
+        Report report = new Report();
+        walk(trieStore, root.get(), report);
+
+        printer.println("Trie nodes visited: " + report.nodes);
+        printer.println("Embedded nodes visited: " + report.embeddedNodes);
+        printer.println("Long values visited: " + report.longValues);
+        printer.println("Gaps found: " + report.gaps);
+
+        report.reported.forEach(printer::println);
+        if (report.gaps > report.reported.size()) {
+            printer.println("... and " + (report.gaps - report.reported.size()) + " more");
+        }
+
+        if (report.gaps > 0) {
+            printer.println("State is INCOMPLETE");
+            return 1;
+        }
+
+        printer.println("State is complete");
+        return 0;
+    }
+
+    private Block resolveBlock(BlockStore blockStore) {
+        if ("best".equals(blockNum)) {
+            return blockStore.getBestBlock();
+        }
+
+        return blockStore.getChainBlockByNumber(Long.parseLong(blockNum));
+    }
+
+    /**
+     * Visits {@code trie}, probes its long value if it has one, and recurses into both children. A gap ends
+     * that subtree only — the walk carries on with the siblings so one report names every gap it can reach,
+     * instead of stopping at the first.
+     */
+    private void walk(TrieStore trieStore, Trie trie, Report report) {
+        report.nodes++;
+
+        if (trie.hasLongValue()) {
+            // A long value is referenced by hash and read lazily: deserializing the node that references it
+            // does not touch it, so it has to be probed explicitly or a missing one goes unnoticed.
+            Keccak256 valueHash = trie.getValueHash();
+            if (retrieveValue(trieStore, valueHash) == null) {
+                report.recordGap("missing long value: " + valueHash.toHexString());
+            } else {
+                report.longValues++;
+            }
+        }
+
+        walkChild(trieStore, trie.getLeft(), report);
+        walkChild(trieStore, trie.getRight(), report);
+    }
+
+    private void walkChild(TrieStore trieStore, NodeReference reference, Report report) {
+        if (reference.isEmpty()) {
+            return;
+        }
+
+        if (reference.wasLoaded()) {
+            // An embedded child is serialized inline in its parent's message and rehydrated in memory, and
+            // is deliberately not stored under its own hash. Looking it up in the store would report a gap
+            // for every one of them, so it is traversed in memory instead. Reading the node back off an
+            // already-loaded reference touches no store and cannot stop the JVM.
+            report.embeddedNodes++;
+            reference.getNode().ifPresent(child -> walk(trieStore, child, report));
+            return;
+        }
+
+        Optional<Keccak256> hash = reference.getHash();
+        if (!hash.isPresent()) {
+            return;
+        }
+
+        Optional<Trie> child = retrieveNode(trieStore, hash.get());
+        if (!child.isPresent()) {
+            report.recordGap("missing node: " + hash.get().toHexString());
+            return;
+        }
+
+        walk(trieStore, child.get(), report);
+    }
+
+    /**
+     * Retrieves a node, mapping a failure to retrieve it onto an empty result. Legacy (Orchid) node messages
+     * resolve their long value while being deserialized, so a node whose value is missing can fail by
+     * throwing here rather than by returning empty.
+     */
+    private static Optional<Trie> retrieveNode(TrieStore trieStore, Keccak256 hash) {
+        try {
+            return trieStore.retrieve(hash.getBytes());
+        } catch (RuntimeException e) {
+            return Optional.empty();
+        }
+    }
+
+    private static byte[] retrieveValue(TrieStore trieStore, Keccak256 hash) {
+        try {
+            return trieStore.retrieveValue(hash.getBytes());
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    private static class Report {
+        private long nodes;
+        private long embeddedNodes;
+        private long longValues;
+        private long gaps;
+        private final List<String> reported = new ArrayList<>();
+
+        private void recordGap(String description) {
+            gaps++;
+            if (reported.size() < MAX_REPORTED_GAPS) {
+                reported.add(description);
+            }
+        }
+    }
+}

--- a/rskj-core/src/main/java/co/rsk/db/importer/BootstrapImporter.java
+++ b/rskj-core/src/main/java/co/rsk/db/importer/BootstrapImporter.java
@@ -239,13 +239,24 @@ public class BootstrapImporter {
     /**
      * Applies {@code action} to every element of a section chunk (after rejecting empty elements) and
      * returns how many were processed. The decode/count/empty-check invariant lives here for all sections;
-     * only the per-element action differs (save a block, a long value, or a state node).
+     * only the per-element action differs (save a block, a long value, or a state node). Any raw failure while
+     * decoding the chunk ({@link RLP#decode2}) or applying an element (e.g. {@code Trie.fromMessage} on an
+     * undecodable node message) is translated into an actionable {@link BootstrapImportException} rather than
+     * escaping as an opaque {@code RLPException} / {@code IllegalArgumentException} / {@code NullPointerException}.
      */
     private long importElements(byte[] chunk, String section, Consumer<byte[]> action) {
         long imported = 0;
-        for (RLPElement element : RLP.decode2(chunk)) {
-            action.accept(requireNonEmptyElement(element, section));
-            imported++;
+        try {
+            for (RLPElement element : RLP.decode2(chunk)) {
+                action.accept(requireNonEmptyElement(element, section));
+                imported++;
+            }
+        } catch (BootstrapImportException e) {
+            // already actionable (an empty element, or a node's missing long value) — keep its specific message
+            throw e;
+        } catch (RuntimeException e) {
+            throw new BootstrapImportException("Bootstrap-data v2 " + section
+                    + " section is malformed or corrupt (a chunk element could not be decoded or applied)", e);
         }
         return imported;
     }

--- a/rskj-core/src/main/java/co/rsk/db/importer/BootstrapImporter.java
+++ b/rskj-core/src/main/java/co/rsk/db/importer/BootstrapImporter.java
@@ -61,13 +61,12 @@ public class BootstrapImporter {
     private static final Logger logger = LoggerFactory.getLogger(BootstrapImporter.class);
 
     private static final int READ_BUFFER_SIZE = 64 * 1024;
-    // A chunk is read into a single byte[], so per-chunk memory must stay bounded. The exporter flushes
-    // once its buffer crosses CHUNK_MAX on an element boundary, so a well-formed chunk is at most
-    // CHUNK_MAX plus one element; 2x CHUNK_MAX gives ample headroom while rejecting a corrupt length that
-    // would otherwise allocate up to a ~2 GiB byte[]. Held as an int (via toIntExact) so a validated length
-    // always fits the new byte[(int) len] allocation by construction; CHUNK_MAX is a documented tuning
-    // knob, and raising it past ~1 GiB fails fast at class-load here rather than overflowing the cast.
-    private static final int MAX_CHUNK_BYTES = Math.toIntExact(2 * BootstrapV2Format.CHUNK_MAX);
+    // A chunk is read into a single byte[], so per-chunk memory must stay bounded. The reader rejects any
+    // chunk whose declared length exceeds MAX_CHUNK_LEN — the format-contract ceiling, defined independently
+    // of the exporter's CHUNK_MAX flush threshold so that changing that tuning knob can never silently make a
+    // deployed reader reject an otherwise-valid snapshot. Held as an int (via toIntExact) so a validated
+    // length always fits the new byte[(int) len] allocation by construction.
+    private static final int MAX_CHUNK_BYTES = Math.toIntExact(BootstrapV2Format.MAX_CHUNK_LEN);
 
     // The sections the v2 import consumes. Any other tag (e.g. a future manifest a newer exporter adds) is
     // skipped without being read into memory, so an older reader tolerates optional sections.

--- a/rskj-core/src/main/java/co/rsk/db/importer/BootstrapV2Format.java
+++ b/rskj-core/src/main/java/co/rsk/db/importer/BootstrapV2Format.java
@@ -38,7 +38,7 @@ import java.nio.charset.StandardCharsets;
  * SECTION =
  *   [1 byte  section tag]
  *   zero or more chunks:
- *       [8-byte big-endian chunk length L]   (0 &lt; L &le; CHUNK_MAX, plus the rare single oversized element)
+ *       [8-byte big-endian chunk length L]   (0 &lt; L &le; MAX_CHUNK_LEN; a reader rejects any larger chunk)
  *       [L bytes: a concatenation of whole canonical RLP elements]
  *   [8-byte big-endian 0]                    &lt;- end-of-section sentinel
  * </pre>
@@ -82,10 +82,22 @@ public final class BootstrapV2Format {
 
     /**
      * Soft cap on a chunk's payload. The exporter flushes a chunk once its buffer crosses this on an
-     * element boundary; a single element larger than this still becomes its own (oversized) chunk. Kept
-     * well under {@code Integer.MAX_VALUE} so a chunk always fits a bounded {@code byte[]}.
+     * element boundary; a single element larger than this still becomes its own (oversized) chunk. This is
+     * an exporter-side <b>tuning knob</b>, not part of the on-disk contract — a different exporter may pick a
+     * different value. Kept well under {@code Integer.MAX_VALUE} so a chunk always fits a bounded {@code byte[]}.
      */
     public static final long CHUNK_MAX = 256L * 1024 * 1024;
+
+    /**
+     * Format-contract ceiling on a single chunk's declared on-disk length: a reader MUST reject any chunk
+     * whose length exceeds this. Unlike {@link #CHUNK_MAX} (an exporter tuning knob), this is a fixed part
+     * of the contract, so every reader accepts exactly the same chunk sizes regardless of the exporter's
+     * flush threshold — changing {@code CHUNK_MAX} can never silently make deployed readers reject otherwise
+     * valid snapshots. An exporter must keep every emitted chunk within this bound (its {@code CHUNK_MAX}
+     * plus the largest single element it may emit must not exceed it). Kept well under {@code Integer.MAX_VALUE}
+     * so a validated length always fits a bounded {@code byte[]}.
+     */
+    public static final long MAX_CHUNK_LEN = 512L * 1024 * 1024;
 
     private BootstrapV2Format() {
     }

--- a/rskj-core/src/main/java/co/rsk/db/importer/bootstrap-data-format.md
+++ b/rskj-core/src/main/java/co/rsk/db/importer/bootstrap-data-format.md
@@ -54,7 +54,7 @@ SECTION end      (tag 0x00)   <- terminator (a bare tag byte, no chunks)
 SECTION =
   [1 byte  section tag]
   zero or more chunks:
-      [8-byte big-endian chunk length L]   (0 < L; normally L <= CHUNK_MAX)
+      [8-byte big-endian chunk length L]   (0 < L <= MAX_CHUNK_LEN; a reader rejects any larger chunk)
       [L bytes: a concatenation of whole canonical RLP elements]
   [8-byte big-endian 0]                    <- end-of-section sentinel
 ```
@@ -115,11 +115,10 @@ for pre-import validation) — but is not written or read today.
 ### Robustness
 
 Chunk length fields are validated before any allocation: a length must be positive, must not exceed
-`2 * CHUNK_MAX` (headroom over the "CHUNK_MAX plus one oversized element" worst case while rejecting a
-corrupt length), and must not exceed the bytes actually remaining in the file (catches truncation and
-corrupt lengths). A missing end-of-sections marker (EOF before `TAG_END`) is rejected as truncated. The
-import also fails fast if the blocks or the nodes section is absent or empty, rather than "succeeding"
-with no state and only crashing later at first state access.
+`MAX_CHUNK_LEN` (the format-contract ceiling — see below), and must not exceed the bytes actually remaining
+in the file (catches truncation and corrupt lengths). A missing end-of-sections marker (EOF before
+`TAG_END`) is rejected as truncated. The import also fails fast if the blocks or the nodes section is absent
+or empty, rather than "succeeding" with no state and only crashing later at first state access.
 
 ## Constants
 
@@ -134,10 +133,15 @@ Defined in [`BootstrapV2Format.java`](./BootstrapV2Format.java):
 | `TAG_NODES`    | `0x02`           | state trie nodes section                            |
 | `TAG_VALUES`   | `0x03`           | long trie values section                            |
 | `TAG_MANIFEST` | `0x04`           | reserved (unused)                                   |
-| `CHUNK_MAX`    | `256 MiB`        | soft chunk-flush threshold (tuning only)            |
+| `CHUNK_MAX`     | `256 MiB`        | soft chunk-flush threshold (exporter tuning only)   |
+| `MAX_CHUNK_LEN` | `512 MiB`        | hard per-chunk length ceiling a reader enforces     |
 
-`CHUNK_MAX` is a tuning knob (peak memory vs. chunk count), not a hard limit — changing it does not break
-compatibility, since chunk lengths are self-describing.
+`CHUNK_MAX` is an exporter tuning knob (peak memory vs. chunk count), not part of the contract — a different
+exporter may pick a different value. `MAX_CHUNK_LEN` is the contract: readers reject any chunk longer than
+it, so it must stay fixed across versions, and every exporter must keep its chunks within it (`CHUNK_MAX`
+plus the largest single element it can emit must not exceed `MAX_CHUNK_LEN`). Deriving the reader's ceiling
+from `MAX_CHUNK_LEN` rather than from `CHUNK_MAX` is what keeps changing the tuning knob from silently making
+deployed readers reject otherwise-valid snapshots.
 
 ## v1 (legacy) format
 

--- a/rskj-core/src/main/java/co/rsk/db/importer/bootstrap-data-format.md
+++ b/rskj-core/src/main/java/co/rsk/db/importer/bootstrap-data-format.md
@@ -117,8 +117,11 @@ for pre-import validation) — but is not written or read today.
 Chunk length fields are validated before any allocation: a length must be positive, must not exceed
 `MAX_CHUNK_LEN` (the format-contract ceiling — see below), and must not exceed the bytes actually remaining
 in the file (catches truncation and corrupt lengths). A missing end-of-sections marker (EOF before
-`TAG_END`) is rejected as truncated. The import also fails fast if the blocks or the nodes section is absent
-or empty, rather than "succeeding" with no state and only crashing later at first state access.
+`TAG_END`) is rejected as truncated. Reading a chunk's bytes and decoding/applying its elements is wrapped
+so that corrupt data (undecodable RLP, a malformed node message, a referenced value missing) surfaces as an
+actionable `BootstrapImportException` rather than an opaque `RLPException` / `IllegalArgumentException` /
+`NullPointerException`. The import also fails fast if the blocks or the nodes section is absent or empty,
+rather than "succeeding" with no state and only crashing later at first state access.
 
 ## Constants
 

--- a/rskj-core/src/main/java/co/rsk/validators/BlockTxsFieldsValidationRule.java
+++ b/rskj-core/src/main/java/co/rsk/validators/BlockTxsFieldsValidationRule.java
@@ -33,9 +33,11 @@ public class BlockTxsFieldsValidationRule implements BlockParentDependantValidat
     private static final Logger logger = LoggerFactory.getLogger("blockvalidator");
 
     private final SignatureCache signatureCache;
-    
-    public BlockTxsFieldsValidationRule(SignatureCache signatureCache) {
+    private final byte chainId;
+
+    public BlockTxsFieldsValidationRule(SignatureCache signatureCache, byte chainId) {
         this.signatureCache = signatureCache;
+        this.chainId = chainId;
     }
 
     @Override
@@ -47,6 +49,11 @@ public class BlockTxsFieldsValidationRule implements BlockParentDependantValidat
 
         List<Transaction> txs = block.getTransactionsList();
         for (Transaction tx : txs) {
+            if (!tx.acceptTransactionSignature(chainId)) {
+                logger.warn("Transaction signature not accepted for chain id {}", chainId);
+                return false;
+            }
+
             try {
                 tx.verify(signatureCache);
             } catch (RuntimeException e) {

--- a/rskj-core/src/test/java/co/rsk/cli/tools/ValidateStateTest.java
+++ b/rskj-core/src/test/java/co/rsk/cli/tools/ValidateStateTest.java
@@ -1,0 +1,257 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2026 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.cli.tools;
+
+import co.rsk.RskContext;
+import co.rsk.config.RskSystemProperties;
+import co.rsk.config.TestSystemProperties;
+import co.rsk.crypto.Keccak256;
+import co.rsk.db.StateRootHandler;
+import co.rsk.db.StateRootsStoreImpl;
+import co.rsk.trie.Trie;
+import co.rsk.trie.TrieStore;
+import co.rsk.trie.TrieStoreImpl;
+import co.rsk.util.NodeStopper;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockHeader;
+import org.ethereum.crypto.Keccak256Helper;
+import org.ethereum.datasource.DbKind;
+import org.ethereum.datasource.HashMapDB;
+import org.ethereum.db.BlockStore;
+import org.ethereum.db.ByteArrayWrapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers {@link ValidateState} against a state trie held in a real {@link TrieStoreImpl} over an in-memory
+ * key-value store, so a gap can be created by deleting an individual key.
+ * <p>
+ * Every expectation is the hash the test itself removed (or, for the long value, the keccak of the value
+ * bytes the test itself wrote), never a hash re-derived by running the walk under test.
+ * <p>
+ * The fixture is asserted to actually contain what each case needs — a stored non-root node, a long value,
+ * and at least one embedded child — because a trie that happened to contain none of a given shape would let
+ * an implementation that mishandles that shape pass unnoticed.
+ */
+class ValidateStateTest {
+
+    /** Longer than 32 bytes, so the trie stores it out of line, keyed by its hash. */
+    private static final byte[] LONG_VALUE = "a state value long enough to be stored out of line".getBytes(StandardCharsets.UTF_8);
+    private static final Keccak256 LONG_VALUE_HASH = new Keccak256(Keccak256Helper.keccak256(LONG_VALUE));
+
+    @TempDir
+    private Path tempDir;
+
+    private HashMapDB db;
+    private TrieStore trieStore;
+    private Keccak256 stateRoot;
+
+    @BeforeEach
+    void buildState() {
+        db = new HashMapDB().setClearOnClose(false);
+        trieStore = new TrieStoreImpl(db);
+
+        // enough short-valued keys to push the trie past a single level, so it holds both stored internal
+        // nodes and small terminal nodes the store embeds into their parent
+        Trie trie = new Trie(trieStore);
+        for (int i = 0; i < 24; i++) {
+            trie = trie.put("account-" + i, new byte[]{(byte) i, 0x0a, 0x0b, 0x0c});
+        }
+        trie = trie.put("account-with-a-long-value", LONG_VALUE);
+
+        trieStore.save(trie);
+        trieStore.flush();
+
+        stateRoot = trie.getHash();
+    }
+
+    @Test
+    void reportsCompleteStateAndExitsZeroWhenNothingIsMissing() {
+        Result result = validate(stateRoot);
+
+        assertTrue(result.output.contains("State is complete"), result.output);
+        assertTrue(counter(result.output, "Trie nodes visited:") > 0, result.output);
+        assertEquals(1, counter(result.output, "Long values visited:"), result.output);
+        assertEquals(0, counter(result.output, "Gaps found:"), result.output);
+        verify(result.stopper).stop(0);
+    }
+
+    @Test
+    void reportsCompleteStateWhenTheTrieHoldsEmbeddedChildren() {
+        // an embedded child is inlined in its parent and is deliberately not stored under its own hash, so
+        // looking one up in the store reports a gap that is not there. This case only discriminates while
+        // the fixture actually contains embedded children, which is asserted rather than assumed.
+        Result result = validate(stateRoot);
+
+        assertTrue(counter(result.output, "Embedded nodes visited:") > 0,
+                "the fixture must contain embedded children for this case to mean anything:\n" + result.output);
+        assertEquals(0, counter(result.output, "Gaps found:"), result.output);
+        assertTrue(result.output.contains("State is complete"), result.output);
+        verify(result.stopper).stop(0);
+    }
+
+    @Test
+    void reportsTheMissingNodeAndExitsNonZeroWhenAStoredNodeIsAbsent() {
+        List<Keccak256> storedNodes = storedNonRootNodeHashes();
+        assertFalse(storedNodes.isEmpty(), "the fixture must contain a stored non-root node to remove");
+
+        Keccak256 removed = storedNodes.get(0);
+        db.delete(removed.getBytes());
+
+        Result result = validate(stateRoot);
+
+        assertTrue(result.output.contains("missing node: " + removed.toHexString()), result.output);
+        assertTrue(counter(result.output, "Gaps found:") >= 1, result.output);
+        assertTrue(result.output.contains("State is INCOMPLETE"), result.output);
+        verify(result.stopper).stop(1);
+    }
+
+    @Test
+    void reportsTheMissingLongValueAndExitsNonZeroWhenTheValueIsAbsent() {
+        assertNotNull(db.get(LONG_VALUE_HASH.getBytes()), "the fixture must hold the long value to remove");
+        db.delete(LONG_VALUE_HASH.getBytes());
+
+        Result result = validate(stateRoot);
+
+        assertTrue(result.output.contains("missing long value: " + LONG_VALUE_HASH.toHexString()), result.output);
+        assertEquals(0, counter(result.output, "Long values visited:"), result.output);
+        assertTrue(result.output.contains("State is INCOMPLETE"), result.output);
+        verify(result.stopper).stop(1);
+    }
+
+    @Test
+    void reportsAnUnresolvedRootWithoutWalkingWhenTheStateRootIsAbsent() {
+        Keccak256 absentRoot = new Keccak256(Keccak256Helper.keccak256("a root that was never stored".getBytes(StandardCharsets.UTF_8)));
+
+        Result result = validate(absentRoot);
+
+        assertTrue(result.output.contains("State root does not resolve"), result.output);
+        assertFalse(result.output.contains("Trie nodes visited:"),
+                "an unresolved root must be reported without walking:\n" + result.output);
+        assertTrue(result.output.contains("State is INCOMPLETE"), result.output);
+        verify(result.stopper).stop(1);
+    }
+
+    @Test
+    void reportsAnUnparseableBlockArgumentAsUsageRatherThanAMissingBlock() {
+        Result result = validate(stateRoot, "not-a-number");
+
+        assertTrue(result.output.contains("Invalid block: not-a-number"), result.output);
+        assertFalse(result.output.contains("Block not found"),
+                "an unparseable --block is a usage error, not a missing block:\n" + result.output);
+        assertFalse(result.output.contains("Trie nodes visited:"),
+                "a rejected argument must be reported without walking:\n" + result.output);
+        verify(result.stopper).stop(1);
+    }
+
+    private Result validate(Keccak256 root) {
+        return validate(root, "best");
+    }
+
+    private Result validate(Keccak256 root, String blockArg) {
+        Block bestBlock = blockWithStateRoot(root);
+
+        BlockStore blockStore = mock(BlockStore.class);
+        when(blockStore.getBestBlock()).thenReturn(bestBlock);
+
+        RskSystemProperties rskSystemProperties = mock(RskSystemProperties.class);
+        doReturn(tempDir.toString()).when(rskSystemProperties).databaseDir();
+        doReturn(DbKind.LEVEL_DB).when(rskSystemProperties).databaseKind();
+
+        RskContext rskContext = mock(RskContext.class);
+        doReturn(blockStore).when(rskContext).getBlockStore();
+        doReturn(trieStore).when(rskContext).getTrieStore();
+        doReturn(stateRootHandler()).when(rskContext).getStateRootHandler();
+        doReturn(rskSystemProperties).when(rskContext).getRskSystemProperties();
+
+        NodeStopper stopper = mock(NodeStopper.class);
+        StringBuilder output = new StringBuilder();
+
+        ValidateState tool = new ValidateState(line -> output.append(line).append('\n'));
+        tool.execute(new String[]{"--block", blockArg}, () -> rskContext, stopper);
+
+        return new Result(output.toString(), stopper);
+    }
+
+    private static StateRootHandler stateRootHandler() {
+        return new StateRootHandler(new TestSystemProperties().getActivationConfig(), new StateRootsStoreImpl(new HashMapDB()));
+    }
+
+    private static Block blockWithStateRoot(Keccak256 root) {
+        BlockHeader header = mock(BlockHeader.class);
+        when(header.getNumber()).thenReturn(1L);
+        when(header.getStateRoot()).thenReturn(root.getBytes());
+
+        Block block = mock(Block.class);
+        when(block.getNumber()).thenReturn(1L);
+        when(block.getHash()).thenReturn(new Keccak256(Keccak256Helper.keccak256("a block".getBytes(StandardCharsets.UTF_8))));
+        when(block.getHeader()).thenReturn(header);
+
+        return block;
+    }
+
+    /**
+     * Every key the store holds is a 32-byte hash of either a node message or a long value, so removing the
+     * root and the one known long value leaves exactly the stored non-root nodes. Sorted so the case removes
+     * the same node on every run.
+     */
+    private List<Keccak256> storedNonRootNodeHashes() {
+        return db.keys().stream()
+                .map(ByteArrayWrapper::getData)
+                .map(Keccak256::new)
+                .filter(hash -> !hash.equals(stateRoot))
+                .filter(hash -> !hash.equals(LONG_VALUE_HASH))
+                .sorted(Comparator.comparing(Keccak256::toHexString))
+                .collect(Collectors.toList());
+    }
+
+    private static long counter(String output, String label) {
+        Matcher matcher = Pattern.compile("^" + Pattern.quote(label) + " (\\d+)$", Pattern.MULTILINE).matcher(output);
+        assertTrue(matcher.find(), "no '" + label + "' line in:\n" + output);
+
+        return Long.parseLong(matcher.group(1));
+    }
+
+    private static final class Result {
+        private final String output;
+        private final NodeStopper stopper;
+
+        private Result(String output, NodeStopper stopper) {
+            this.output = output;
+            this.stopper = stopper;
+        }
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorBuilder.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockValidatorBuilder.java
@@ -75,7 +75,8 @@ public class BlockValidatorBuilder {
 
     public BlockValidatorBuilder addBlockTxsFieldsValidationRule() {
         this.blockTxsFieldsValidationRule = new BlockTxsFieldsValidationRule(
-                new BlockTxSignatureCache(new ReceivedTxSignatureCache()));
+                new BlockTxSignatureCache(new ReceivedTxSignatureCache()),
+                config.getNetworkConstants().getChainId());
         return this;
     }
 

--- a/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterV2Test.java
+++ b/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterV2Test.java
@@ -222,6 +222,32 @@ class BootstrapImporterV2Test {
     }
 
     @Test
+    void rejectsChunkLengthExceedingTheFormatContractCeiling() throws IOException {
+        // a declared chunk length just past MAX_CHUNK_LEN (the format-contract ceiling, independent of the
+        // exporter's CHUNK_MAX tuning knob) must be rejected up front, before any allocation.
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        out.write(BootstrapV2Format.magic());
+        out.writeByte(BootstrapV2Format.VERSION);
+        out.writeByte(BootstrapV2Format.TAG_BLOCKS);
+        out.writeLong(BootstrapV2Format.MAX_CHUNK_LEN + 1); // over the contract ceiling; no payload follows
+        out.flush();
+
+        BootstrapImporter importer = newImporter(bos.toByteArray(), "over-ceiling.bin");
+
+        BootstrapImportException ex = assertThrows(BootstrapImportException.class, importer::importData);
+        assertTrue(ex.getMessage().toLowerCase().contains("out of range"), ex.getMessage());
+    }
+
+    @Test
+    void formatContractChunkCeilingCoversAFullFlushChunk() {
+        // the reader's contract ceiling must admit at least one full exporter flush chunk, otherwise a
+        // legitimately-produced snapshot could be rejected.
+        assertTrue(BootstrapV2Format.MAX_CHUNK_LEN >= BootstrapV2Format.CHUNK_MAX,
+                "MAX_CHUNK_LEN must be >= CHUNK_MAX");
+    }
+
+    @Test
     void failsWithActionableErrorWhenNodeReferencesMissingLongValue() throws IOException {
         StateFixture fixture = buildState();
         assertFalse(collectValueElements(fixture.store, fixture.stateRoot).isEmpty(),

--- a/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterV2Test.java
+++ b/rskj-core/src/test/java/co/rsk/db/importer/BootstrapImporterV2Test.java
@@ -344,6 +344,50 @@ class BootstrapImporterV2Test {
     }
 
     @Test
+    void failsWithActionableErrorWhenNodeElementIsNotAValidNodeMessage() throws IOException {
+        // a nodes element that is well-formed RLP and non-empty, but not a decodable trie-node message: its
+        // flags byte declares a (non-embedded) left child, yet the buffer is truncated before the 32-byte
+        // child hash, so Trie.fromMessage reads past the end. That decode failure runs outside saveNode's
+        // translation and would otherwise escape raw; it must surface as an actionable BootstrapImportException.
+        StateFixture fixture = buildState();
+        List<byte[]> nodes = new ArrayList<>();
+        nodes.add(RLP.encodeElement(new byte[]{0x08})); // flags: leftNodePresent, non-embedded; no hash follows
+        byte[] v2 = assembleV2(1024,
+                syntheticBlockElements(), nodes, collectValueElements(fixture.store, fixture.stateRoot));
+
+        BootstrapImporter importer = newImporter(v2, "malformed-node.bin");
+
+        assertThrows(BootstrapImportException.class, importer::importData);
+    }
+
+    @Test
+    void failsWithActionableErrorWhenChunkIsNotDecodableRlp() throws IOException {
+        // a nodes section carrying a single chunk whose bytes are not decodable as RLP elements: RLP.decode2
+        // would otherwise throw a raw RLPException. It must surface as an actionable BootstrapImportException.
+        StateFixture fixture = buildState();
+        byte[] malformedChunk = new byte[]{(byte) 0x83, 0x01, 0x02}; // RLP header says 3-byte string, only 2 follow
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(bos);
+        out.write(BootstrapV2Format.magic());
+        out.writeByte(BootstrapV2Format.VERSION);
+        writeSection(out, BootstrapV2Format.TAG_BLOCKS, syntheticBlockElements(), 1024);
+        writeSection(out, BootstrapV2Format.TAG_VALUES,
+                collectValueElements(fixture.store, fixture.stateRoot), 1024);
+        // a hand-written nodes section with one malformed chunk (bypasses writeSection's whole-element framing)
+        out.writeByte(BootstrapV2Format.TAG_NODES);
+        out.writeLong(malformedChunk.length);
+        out.write(malformedChunk);
+        out.writeLong(0L); // end-of-section sentinel
+        out.writeByte(BootstrapV2Format.TAG_END);
+        out.flush();
+
+        BootstrapImporter importer = newImporter(bos.toByteArray(), "malformed-chunk.bin");
+
+        assertThrows(BootstrapImportException.class, importer::importData);
+    }
+
+    @Test
     void rejectsUnrecognizedFirstByteAsNeitherV1NorV2() throws IOException {
         // First byte is neither the v2 magic ('R') nor a v1 RLP list prefix (0xc0+): a corrupt or wrong file
         // must be rejected up front with a clear error, not sent down the v1 path to fail with an opaque


### PR DESCRIPTION
## Description
  Five self-contained changes across block parent-validation, the bootstrap-data v2 importer, and CLI tooling. None of them change consensus behaviour.

**Block parent-validation**

- **Chain-id check**. `BlockTxsFieldsValidationRule` now takes the network chain id and rejects a transaction whose signature is not acceptable for it, before `tx.verify()` recovers the sender. 

- **Rule ordering**. The parent-validator composites now run the cheap header/parent rules (parent number, difficulty, parent gas limit, previous min gas price) before the per-transaction rules. 

**Bootstrap-data v2 import**

- **Chunk-length ceiling.** The reader validated declared chunk lengths against 2 * CHUNK_MAX, an exporter tuning knob the format doc allows to change, so retuning it could make already-deployed readers reject valid snapshots. Adds MAX_CHUNK_LEN (512 MiB) to `BootstrapV2Format` as the format-contract ceiling and validates against that instead. 

- **Error reporting**. RLP.decode2 on chunk bytes and the per-element `Trie.fromMessage `ran outside the import's error translation, so corrupt or truncated data escaped as a raw `RLPException`, `IllegalArgumentException` or `NullPointerException` without naming the failing section. importElements now wraps the decode-and-apply loop so those surface as `BootstrapImportException`; already-actionable exceptions (empty element, missing long value) keep their specific messages.

**New CLI tool**

- **co.rsk.cli.tools.ValidateState** resolves a block (default best), translates the state root, walks the trie, and reports every referenced node and long value that is not retrievable, exiting non-zero on any gap. It checks presence, not integrity — stored bytes are not re-hashed against the key they are filed under — stated in both the javadoc and the docs entry.

- **Three trie properties shape the walk**: it drives off TrieStore.retrieve rather than getNode(), since an unresolvable store-backed reference halts the JVM; long values are referenced by hash and read lazily, so each is probed explicitly; and embedded nodes are never stored under their own hash, so they are traversed in memory instead of looked up. Nodes are not memoized, keeping retention proportional to trie depth rather than state size.

## Motivation and Context

- **Validation path**. Do the cheapest sufficient work first, and keep block validation consistent with what execution already enforces. Neither change alters which blocks the node accepts, so no activation gating is involved.

- **Bootstrap v2**. An exporter tuning constant had leaked into the reader's accept/reject boundary, so a future retune could invalidate snapshots for readers already in the field; pinning the ceiling to a documented format constant makes accepted chunk sizes a property of the format, not of whichever exporter wrote the file. Separately, a truncated or corrupt snapshot gave operators a stack trace with no indication of which section was at fault.

- **ValidateState**. A state database populated out of band — snapshot restore, bootstrap import, copied between nodes — can be missing trie nodes or long values that nothing detects until the node first reads that state. An explicit offline check is a better place to find out than a consensus-critical read path.

## How Has This Been Tested?

- **BootstrapImporterV2Test** — over-ceiling chunk rejected; MAX_CHUNK_LEN >= CHUNK_MAX invariant asserted so a future retune cannot silently invert the two; a nodes element that is valid RLP but not a decodable node message, and a chunk that is not decodable RLP at all, both surface as BootstrapImportException naming the section.
- **ValidateStateTest** — five cases over a real trie store: complete state, removed non-root node, removed long value, unresolvable root, embedded children. Each expects the hash the test itself removed, and asserts the fixture holds the shape it probes, so no case passes vacuously.
- **BlockValidatorBuilder** updated for the new BlockTxsFieldsValidationRule constructor, so the existing block-validation suites exercise the chain-id check.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)