### PR TITLE
Rename tbd1000 network upgrade to cardamom1000

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtilsLegacy.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtilsLegacy.java
@@ -40,7 +40,7 @@ public class BridgeUtilsLegacy {
             return simulatePegoutTxSizePreHOP(federation, inputsCount, outputsCount);
         }
 
-        return simulatePegoutTxSizePreTBD1000(federation, inputsCount, outputsCount);
+        return simulatePegoutTxSizePreCardamom1000(federation, inputsCount, outputsCount);
     }
 
     private static int simulatePegoutTxSizePreHOP(Federation federation, int inputsCount, int outputsCount) {
@@ -60,15 +60,15 @@ public class BridgeUtilsLegacy {
             (OUTPUT_SIZE + 1 + OUTPUT_ADDITIONAL_DATA_SIZE) * outputsCount;
     }
 
-    private static int simulatePegoutTxSizePreTBD1000(Federation federation, int inputsCount, int outputsCount) {
+    private static int simulatePegoutTxSizePreCardamom1000(Federation federation, int inputsCount, int outputsCount) {
         boolean isLegacyFed = federation.getFormatVersion() != FederationFormatVersion.P2SH_P2WSH_ERP_FEDERATION.getFormatVersion();
 
         return isLegacyFed
-            ? simulateLegacyTxSizePreTBD1000(federation, inputsCount, outputsCount)
-            : simulateSegwitTxSizePreTBD1000(federation, inputsCount, outputsCount);
+            ? simulateLegacyTxSizePreCardamom1000(federation, inputsCount, outputsCount)
+            : simulateSegwitTxSizePreCardamom1000(federation, inputsCount, outputsCount);
     }
 
-    private static int simulateLegacyTxSizePreTBD1000(Federation federation, int inputsCount, int outputsCount) {
+    private static int simulateLegacyTxSizePreCardamom1000(Federation federation, int inputsCount, int outputsCount) {
         BtcTransaction tx = new BtcTransaction(federation.getBtcParams());
 
         for (int i = 0; i < inputsCount; i++) {
@@ -86,7 +86,7 @@ public class BridgeUtilsLegacy {
 
     // this old calculation had a bug: it wasn't adding inputs to simulate the size,
     // and in calculateTxBaseSize we were just adding the bytes from the script sig
-    private static int simulateSegwitTxSizePreTBD1000(Federation federation, int inputsCount, int outputsCount) {
+    private static int simulateSegwitTxSizePreCardamom1000(Federation federation, int inputsCount, int outputsCount) {
         BtcTransaction tx = new BtcTransaction(federation.getBtcParams());
 
         for (int i = 0; i < outputsCount; i++) {

--- a/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/NetworkUpgrade.java
+++ b/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/NetworkUpgrade.java
@@ -37,7 +37,7 @@ public enum NetworkUpgrade {
     REED800("reed800"),
     REED810("reed810"),
     VETIVER900("vetiver900"),
-    TBD1000("tbd1000");
+    CARDAMOM1000("cardamom1000");
 
     private final String name;
 

--- a/rskj-core/src/main/resources/config/main.conf
+++ b/rskj-core/src/main/resources/config/main.conf
@@ -18,7 +18,7 @@ blockchain.config {
         reed800 = 8052200,
         reed810 = -1,
         vetiver900 = 8804200,
-        tbd1000 = -1
+        cardamom1000 = -1
     },
     consensusRules = {
         rskip536 = 8804200 # Already in testnet as part of Reed 8.1.0, configuring same height as Vetiver activation

--- a/rskj-core/src/main/resources/config/regtest.conf
+++ b/rskj-core/src/main/resources/config/regtest.conf
@@ -18,7 +18,7 @@ blockchain.config {
         reed800 = 0,
         reed810 = 0,
         vetiver900 = 0,
-        tbd1000 = 0
+        cardamom1000 = 0
     },
     consensusRules = {
         rskip97 = -1 # disable orchid difficulty drop

--- a/rskj-core/src/main/resources/config/testnet.conf
+++ b/rskj-core/src/main/resources/config/testnet.conf
@@ -18,7 +18,7 @@ blockchain.config {
         reed800 = 6835700,
         reed810 = 7139600,
         vetiver900 = 7604200,
-        tbd1000 = -1
+        cardamom1000 = -1
     },
     consensusRules = {
         rskip97 = -1, # disable orchid difficulty drop

--- a/rskj-core/src/main/resources/config/testnet2.conf
+++ b/rskj-core/src/main/resources/config/testnet2.conf
@@ -18,7 +18,7 @@ blockchain.config {
         reed800 = -1,
         reed810 = -1,
         vetiver900 = -1,
-        tbd1000 = -1
+        cardamom1000 = -1
     },
     consensusRules = {
         rskip97 = -1, # disable orchid difficulty drop

--- a/rskj-core/src/main/resources/expected.conf
+++ b/rskj-core/src/main/resources/expected.conf
@@ -21,7 +21,7 @@ blockchain = {
             reed800 = <height>
             reed810 = <height>
             vetiver900 = <height>
-            tbd1000 = <height>
+            cardamom1000 = <height>
         }
         consensusRules = {
             areBridgeTxsPaid = <hardforkName>

--- a/rskj-core/src/main/resources/reference.conf
+++ b/rskj-core/src/main/resources/reference.conf
@@ -75,7 +75,7 @@ blockchain = {
             rskip375 = fingerroot500
             rskip376 = arrowhead600
             rskip377 = fingerroot500
-            rskip378 = tbd1000
+            rskip378 = cardamom1000
             rskip379 = arrowhead600
             rskip383 = fingerroot500
             rskip385 = fingerroot500
@@ -104,7 +104,7 @@ blockchain = {
             rskip544 = vetiver900
             rskip551 = vetiver900
             rskip552 = vetiver900
-            rskip559 = tbd1000
+            rskip559 = cardamom1000
         }
     }
     gc = {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSupportGetEstimatedFeesTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSupportGetEstimatedFeesTest.java
@@ -430,7 +430,7 @@ class BridgeSupportGetEstimatedFeesTest {
     }
 
     @Nested
-    class PostVetiverPreTBD1000Activations {
+    class PostVetiverPreCardamom1000Activations {
 
         @BeforeEach
         void setUp() {
@@ -474,7 +474,7 @@ class BridgeSupportGetEstimatedFeesTest {
     }
 
     @Nested
-    class PostTBD1000Activations {
+    class PostCardamom1000Activations {
         @BeforeEach
         void setUp() {
             setUpBridgeAndFederationSupport(ALL_ACTIVATIONS, FEE_PER_KB);

--- a/rskj-core/src/test/java/co/rsk/peg/PegUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/PegUtilsTest.java
@@ -165,7 +165,7 @@ class PegUtilsTest {
     }
 
     @Test
-    void test_getTransactionType_before_tbd_600() {
+    void test_getTransactionType_before_rskip379() {
         // Arrange
         ActivationConfig.ForBlock fingerrootActivations = ActivationConfigsForTest.fingerroot500().forBlock(0);
         Wallet liveFederationWallet = mock(Wallet.class);

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigTest.java
@@ -57,7 +57,7 @@ class ActivationConfigTest {
         "    reed800: 0",
         "    reed810: 0",
         "    vetiver900: 0",
-        "    tbd1000: 0",
+        "    cardamom1000: 0",
         "},",
         "consensusRules: {",
         "    areBridgeTxsPaid: afterBridgeSync,",
@@ -129,7 +129,7 @@ class ActivationConfigTest {
         "    rskip375: fingerroot500",
         "    rskip376: arrowhead600",
         "    rskip377: fingerroot500",
-        "    rskip378: tbd1000",
+        "    rskip378: cardamom1000",
         "    rskip379: arrowhead600",
         "    rskip383: fingerroot500",
         "    rskip385: fingerroot500",
@@ -158,7 +158,7 @@ class ActivationConfigTest {
         "    rskip544: vetiver900",
         "    rskip551: vetiver900",
         "    rskip552: vetiver900",
-        "    rskip559: tbd1000",
+        "    rskip559: cardamom1000",
         "}"
     ));
 

--- a/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
+++ b/rskj-core/src/test/java/org/ethereum/config/blockchain/upgrades/ActivationConfigsForTest.java
@@ -216,7 +216,7 @@ public class ActivationConfigsForTest {
         ));
     }
 
-    private static List<ConsensusRule> getTbd1000Rskips() {
+    private static List<ConsensusRule> getCardamom1000Rskips() {
         return new ArrayList<>(List.of(
             ConsensusRule.RSKIP378,
             ConsensusRule.RSKIP559
@@ -493,18 +493,18 @@ public class ActivationConfigsForTest {
         return rskips;
     }
 
-    public static List<ConsensusRule> tbd1000AllRskips() {
+    public static List<ConsensusRule> cardamom1000AllRskips() {
         var rskips = vetiver900AllRskips();
-        rskips.addAll(getTbd1000Rskips());
+        rskips.addAll(getCardamom1000Rskips());
         return rskips;
     }
 
-    public static ActivationConfig tbd1000() {
-        return tbd1000(Collections.emptyList());
+    public static ActivationConfig cardamom1000() {
+        return cardamom1000(Collections.emptyList());
     }
 
-    public static ActivationConfig tbd1000(List<ConsensusRule> except) {
-        return enableTheseDisableThose(tbd1000AllRskips(), except);
+    public static ActivationConfig cardamom1000(List<ConsensusRule> except) {
+        return enableTheseDisableThose(cardamom1000AllRskips(), except);
     }
 
     public static ActivationConfig regtest() {


### PR DESCRIPTION
This pull request renames the upcoming network upgrade and related code references from "TBD1000" to "Cardamom1000" throughout the codebase. This change ensures consistency in naming for the new network upgrade across configuration files, enums, method names, test classes, and documentation.

The most important changes are:

**Network Upgrade Renaming:**

* The enum value `TBD1000` in `NetworkUpgrade` is renamed to `CARDAMOM1000`, and all references to `tbd1000` in configuration files (`main.conf`, `testnet.conf`, `testnet2.conf`, `regtest.conf`, `expected.conf`, `reference.conf`) are updated to `cardamom1000`. [[1]](diffhunk://#diff-4c7001ff5a60f29fb3d12823e5d2222f752aabd0da5cc9b4384f92185e554c8dL40-R40) [[2]](diffhunk://#diff-8bf15243506cb7b8fa608c181426bfb92cdb3e3913273f0557c50d7145d439ceL21-R21) [[3]](diffhunk://#diff-417cf8805d1d2f915396931196185be2befe73345ad856af5bc638aa2abe8d87L21-R21) [[4]](diffhunk://#diff-e509d16a0b0cde289d6ecca8a9c5e26a3fd092a5ee1d023c7c526ad1d5882b26L21-R21) [[5]](diffhunk://#diff-1dd4b3838c62daa47bbfc9598269f7ae09ac0d1a56eda1255719a3751cb88424L21-R21) [[6]](diffhunk://#diff-2572da6381e2d05659399cd69cc76545b8c2da4b5399d8226fa08000d8972175L24-R24) [[7]](diffhunk://#diff-242a8c6b5d9003504710db696af1f94412a52cdbd3369df55cff4be2ea8697eaL78-R78) [[8]](diffhunk://#diff-242a8c6b5d9003504710db696af1f94412a52cdbd3369df55cff4be2ea8697eaL107-R107)

**Code Refactoring:**

* All method and class names previously referencing `TBD1000` are updated to use `Cardamom1000`, including method names in `BridgeUtilsLegacy.java` and test classes. [[1]](diffhunk://#diff-9e4828bcb7d416d9fc5d4063b43eb141008639c84bab962562260e585e49282bL43-R43) [[2]](diffhunk://#diff-9e4828bcb7d416d9fc5d4063b43eb141008639c84bab962562260e585e49282bL63-R71) [[3]](diffhunk://#diff-9e4828bcb7d416d9fc5d4063b43eb141008639c84bab962562260e585e49282bL89-R89) [[4]](diffhunk://#diff-68f3b014896c925ecedf4dd9fb8ad4803688b2153e7fb31e0c9b8f037b4392b0L433-R433) [[5]](diffhunk://#diff-68f3b014896c925ecedf4dd9fb8ad4803688b2153e7fb31e0c9b8f037b4392b0L477-R477) [[6]](diffhunk://#diff-50c85824820bb55cf1abea194e7caf5e6dedec1cfbe589efc094f1af5f9aa32dL219-R219) [[7]](diffhunk://#diff-50c85824820bb55cf1abea194e7caf5e6dedec1cfbe589efc094f1af5f9aa32dL496-R507)

**Test Updates:**

* Test cases, test configuration, and expected outputs are updated to reflect the new upgrade name, ensuring that all assertions and test data use `cardamom1000` instead of `tbd1000`. [[1]](diffhunk://#diff-38c5f765460ba8c01658ec41319f665f06a9c4a40fc4b49872c1a3967dc5f9bdL60-R60) [[2]](diffhunk://#diff-38c5f765460ba8c01658ec41319f665f06a9c4a40fc4b49872c1a3967dc5f9bdL132-R132) [[3]](diffhunk://#diff-38c5f765460ba8c01658ec41319f665f06a9c4a40fc4b49872c1a3967dc5f9bdL161-R161) [[4]](diffhunk://#diff-e280a4e357dd32414a28045063e66fd1a5350cc87f21250f665778adb8edafd1L168-R168)

These updates ensure that the codebase is ready for the Cardamom1000 upgrade and avoids confusion or inconsistencies related to the upgrade's naming.

`rit:tbd1000-rename`