### PR TITLE
Reject contract-originated calls on federation-only Bridge methods

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/Bridge.java
+++ b/rskj-core/src/main/java/co/rsk/peg/Bridge.java
@@ -1572,8 +1572,35 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
         };
     }
 
+    /**
+     * Rejects calls to federation-only functions that originate from a contract.
+     *
+     * <p>
+     * Functions guarded by {@link #activeAndRetiringFederationOnly} and
+     * {@link #activeRetiringAndProposedFederationOnly} are meant to be invoked only by
+     * federation members through externally signed transactions (i.e. signed by the HSM).
+     * A contract could otherwise reach these functions through an internal transaction
+     * (e.g. a delegate call), potentially bypassing the requirement of having the HSM
+     * sign the transaction. Since a federation member always interacts with the Bridge
+     * through an externally originated transaction, contract-originated calls are never
+     * legitimate for these functions and are therefore rejected.
+     * </p>
+     */
+    private static void rejectIfCalledFromContract(org.ethereum.core.Transaction rskTx, String funcName) throws VMException {
+        if (BridgeUtils.isContractTx(rskTx)) {
+            String errorMessage = String.format(
+                "The function '%s' can only be called by federation members through an externally signed transaction, not from a contract",
+                funcName
+            );
+            logger.warn(errorMessage);
+            throw new VMException(errorMessage);
+        }
+    }
+
     public static BridgeMethods.BridgeMethodExecutor activeAndRetiringFederationOnly(BridgeMethods.BridgeMethodExecutor decoratee, String funcName) {
         return (self, args) -> {
+            rejectIfCalledFromContract(self.rskTx, funcName);
+
             boolean isFromActiveFed = BridgeUtils.isFromFederateMember(self.rskTx, self.bridgeSupport.getActiveFederation(), self.signatureCache);
 
             Optional<Federation> retiringFederation = self.bridgeSupport.getRetiringFederation();
@@ -1594,6 +1621,8 @@ public class Bridge extends PrecompiledContracts.PrecompiledContract {
 
     public static BridgeMethods.BridgeMethodExecutor activeRetiringAndProposedFederationOnly(BridgeMethods.BridgeMethodExecutor decoratee, String funcName) {
         return (self, args) -> {
+            rejectIfCalledFromContract(self.rskTx, funcName);
+
             boolean isFromActiveFed = BridgeUtils.isFromFederateMember(self.rskTx, self.bridgeSupport.getActiveFederation(), self.signatureCache);
 
             Optional<Federation> retiringFederation = self.bridgeSupport.getRetiringFederation();

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -46,6 +46,7 @@ import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.MessageCall;
 import org.ethereum.vm.exception.VMException;
+import org.ethereum.vm.program.InternalTransaction;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.*;
@@ -1011,6 +1012,125 @@ class BridgeTest {
         // Then
         verify(bridgeSupportMock, times(1)).getActiveFederation();
         verify(bridgeSupportMock, times(1)).getRetiringFederation();
+        verify(decorate, times(1)).execute(any(), any());
+    }
+
+    @Test
+    void activeAndRetiringFederationOnly_calledFromContract_evenWhenSenderIsFederationMember_throwsVMException() throws Exception {
+        // Given
+        BridgeMethods.BridgeMethodExecutor decorate = mock(
+            BridgeMethods.BridgeMethodExecutor.class
+        );
+        BridgeMethods.BridgeMethodExecutor executor = Bridge.activeAndRetiringFederationOnly(
+            decorate,
+            "updateCollections"
+        );
+
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+
+        // The internal (contract) transaction is crafted so its sender is a legitimate
+        // active federation member (member with PK 100 has RSK key derived from PK 101).
+        // Even so, it must be rejected because it originates from a contract (e.g. through
+        // a delegate call) rather than an externally signed transaction.
+        byte[] federationMemberRskAddress = ECKey.fromPrivate(BigInteger.valueOf(101)).getAddress();
+        Transaction contractTx = new InternalTransaction(
+            Keccak256.ZERO_HASH.getBytes(), 0, 0, null, null, null,
+            federationMemberRskAddress, null, null, null, null, null
+        );
+
+        ActivationConfig activationConfig = ActivationConfigsForTest.papyrus200();
+
+        Bridge bridge = bridgeBuilder
+            .transaction(contractTx)
+            .activationConfig(activationConfig)
+            .bridgeSupport(bridgeSupportMock)
+            .build();
+
+        // When / Then
+        assertThrows(VMException.class, () -> executor.execute(bridge, null));
+
+        // The contract check short-circuits before the federation membership check runs
+        // and the decorated method is never executed.
+        verify(bridgeSupportMock, never()).getActiveFederation();
+        verify(bridgeSupportMock, never()).getRetiringFederation();
+        verify(decorate, never()).execute(any(), any());
+    }
+
+    @Test
+    void activeRetiringAndProposedFederationOnly_calledFromContract_evenWhenSenderIsFederationMember_throwsVMException() throws Exception {
+        // Given
+        BridgeMethods.BridgeMethodExecutor decorate = mock(
+            BridgeMethods.BridgeMethodExecutor.class
+        );
+        BridgeMethods.BridgeMethodExecutor executor = Bridge.activeRetiringAndProposedFederationOnly(
+            decorate,
+            "addSignature"
+        );
+
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+
+        // Sender is a legitimate active federation member, but the call originates from a
+        // contract (internal transaction), so it must be rejected all the same.
+        byte[] federationMemberRskAddress = ECKey.fromPrivate(BigInteger.valueOf(101)).getAddress();
+        Transaction contractTx = new InternalTransaction(
+            Keccak256.ZERO_HASH.getBytes(), 0, 0, null, null, null,
+            federationMemberRskAddress, null, null, null, null, null
+        );
+
+        ActivationConfig activationConfig = ActivationConfigsForTest.papyrus200();
+
+        Bridge bridge = bridgeBuilder
+            .transaction(contractTx)
+            .activationConfig(activationConfig)
+            .bridgeSupport(bridgeSupportMock)
+            .build();
+
+        // When / Then
+        assertThrows(VMException.class, () -> executor.execute(bridge, null));
+
+        verify(bridgeSupportMock, never()).getActiveFederation();
+        verify(bridgeSupportMock, never()).getRetiringFederation();
+        verify(bridgeSupportMock, never()).getProposedFederation();
+        verify(decorate, never()).execute(any(), any());
+    }
+
+    @Test
+    void activeRetiringAndProposedFederationOnly_calledFromExternalTxByFederationMember_OK() throws Exception {
+        // Given
+        BridgeMethods.BridgeMethodExecutor decorate = mock(
+            BridgeMethods.BridgeMethodExecutor.class
+        );
+        BridgeMethods.BridgeMethodExecutor executor = Bridge.activeRetiringAndProposedFederationOnly(
+            decorate,
+            "addSignature"
+        );
+
+        int senderPK = 101; // Sender PK belongs to active federation member PKs
+        Integer[] memberPKs = new Integer[]{ 100, 200, 300, 400, 500, 600 };
+        Federation activeFederation = FederationTestUtils.getFederation(memberPKs);
+
+        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
+        doReturn(activeFederation).when(bridgeSupportMock).getActiveFederation();
+        doReturn(Optional.empty()).when(bridgeSupportMock).getRetiringFederation();
+        doReturn(Optional.empty()).when(bridgeSupportMock).getProposedFederation();
+
+        ECKey key = ECKey.fromPrivate(BigInteger.valueOf(senderPK));
+        RskAddress txSender = new RskAddress(key.getAddress());
+        Transaction rskTxMock = mock(Transaction.class);
+        doReturn(txSender).when(rskTxMock).getSender(any(SignatureCache.class));
+
+        ActivationConfig activationConfig = ActivationConfigsForTest.papyrus200();
+
+        Bridge bridge = bridgeBuilder
+            .transaction(rskTxMock)
+            .activationConfig(activationConfig)
+            .bridgeSupport(bridgeSupportMock)
+            .build();
+
+        // When
+        executor.execute(bridge, null);
+
+        // Then
         verify(decorate, times(1)).execute(any(), any());
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.*;
+import java.util.function.BiFunction;
 import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.TestUtils;
@@ -1015,16 +1016,34 @@ class BridgeTest {
         verify(decorate, times(1)).execute(any(), any());
     }
 
-    @Test
-    void activeAndRetiringFederationOnly_calledFromContract_evenWhenSenderIsFederationMember_throwsVMException() throws Exception {
+    /**
+     * The Bridge functions that are only callable by federation members, each paired with the
+     * decorator that enforces the restriction. Used to validate the contract-call rejection and
+     * the federation-member happy path across every federation-only method.
+     */
+    private static Stream<Arguments> federationOnlyMethods() {
+        BiFunction<BridgeMethods.BridgeMethodExecutor, String, BridgeMethods.BridgeMethodExecutor> activeAndRetiring =
+            Bridge::activeAndRetiringFederationOnly;
+        BiFunction<BridgeMethods.BridgeMethodExecutor, String, BridgeMethods.BridgeMethodExecutor> activeRetiringAndProposed =
+            Bridge::activeRetiringAndProposedFederationOnly;
+
+        return Stream.of(
+            Arguments.of("updateCollections", activeAndRetiring),
+            Arguments.of("receiveHeaders", activeAndRetiring),
+            Arguments.of("registerBtcTransaction", activeAndRetiring),
+            Arguments.of("addSignature", activeRetiringAndProposed)
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("federationOnlyMethods")
+    void federationOnlyMethod_calledFromContract_evenWhenSenderIsFederationMember_throwsVMException(
+        String funcName,
+        BiFunction<BridgeMethods.BridgeMethodExecutor, String, BridgeMethods.BridgeMethodExecutor> decoratorFactory
+    ) throws Exception {
         // Given
-        BridgeMethods.BridgeMethodExecutor decorate = mock(
-            BridgeMethods.BridgeMethodExecutor.class
-        );
-        BridgeMethods.BridgeMethodExecutor executor = Bridge.activeAndRetiringFederationOnly(
-            decorate,
-            "updateCollections"
-        );
+        BridgeMethods.BridgeMethodExecutor decorate = mock(BridgeMethods.BridgeMethodExecutor.class);
+        BridgeMethods.BridgeMethodExecutor executor = decoratorFactory.apply(decorate, funcName);
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
 
@@ -1033,70 +1052,33 @@ class BridgeTest {
         // rather than an externally signed transaction.
         Transaction contractTx = createContractTxFromFederationMember();
 
-        ActivationConfig activationConfig = ActivationConfigsForTest.papyrus200();
-
         Bridge bridge = bridgeBuilder
             .transaction(contractTx)
-            .activationConfig(activationConfig)
+            .activationConfig(ActivationConfigsForTest.all())
             .bridgeSupport(bridgeSupportMock)
             .build();
 
         // When / Then
         assertThrows(VMException.class, () -> executor.execute(bridge, null));
 
-        // The contract check short-circuits before the federation membership check runs
+        // The contract check short-circuits before any federation membership check runs
         // and the decorated method is never executed.
-        verify(bridgeSupportMock, never()).getActiveFederation();
-        verify(bridgeSupportMock, never()).getRetiringFederation();
-        verify(decorate, never()).execute(any(), any());
-    }
-
-    @Test
-    void activeRetiringAndProposedFederationOnly_calledFromContract_evenWhenSenderIsFederationMember_throwsVMException() throws Exception {
-        // Given
-        BridgeMethods.BridgeMethodExecutor decorate = mock(
-            BridgeMethods.BridgeMethodExecutor.class
-        );
-        BridgeMethods.BridgeMethodExecutor executor = Bridge.activeRetiringAndProposedFederationOnly(
-            decorate,
-            "addSignature"
-        );
-
-        BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
-
-        // Sender is a legitimate active federation member, but the call originates from a
-        // contract (internal transaction), so it must be rejected all the same.
-        Transaction contractTx = createContractTxFromFederationMember();
-
-        ActivationConfig activationConfig = ActivationConfigsForTest.papyrus200();
-
-        Bridge bridge = bridgeBuilder
-            .transaction(contractTx)
-            .activationConfig(activationConfig)
-            .bridgeSupport(bridgeSupportMock)
-            .build();
-
-        // When / Then
-        assertThrows(VMException.class, () -> executor.execute(bridge, null));
-
         verify(bridgeSupportMock, never()).getActiveFederation();
         verify(bridgeSupportMock, never()).getRetiringFederation();
         verify(bridgeSupportMock, never()).getProposedFederation();
         verify(decorate, never()).execute(any(), any());
     }
 
-    @Test
-    void activeRetiringAndProposedFederationOnly_calledFromExternalTxByFederationMember_OK() throws Exception {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("federationOnlyMethods")
+    void federationOnlyMethod_calledFromExternalTxByFederationMember_OK(
+        String funcName,
+        BiFunction<BridgeMethods.BridgeMethodExecutor, String, BridgeMethods.BridgeMethodExecutor> decoratorFactory
+    ) throws Exception {
         // Given
-        BridgeMethods.BridgeMethodExecutor decorate = mock(
-            BridgeMethods.BridgeMethodExecutor.class
-        );
-        BridgeMethods.BridgeMethodExecutor executor = Bridge.activeRetiringAndProposedFederationOnly(
-            decorate,
-            "addSignature"
-        );
+        BridgeMethods.BridgeMethodExecutor decorate = mock(BridgeMethods.BridgeMethodExecutor.class);
+        BridgeMethods.BridgeMethodExecutor executor = decoratorFactory.apply(decorate, funcName);
 
-        int senderPK = 101; // Sender PK belongs to active federation member PKs
         Integer[] memberPKs = new Integer[]{ 100, 200, 300, 400, 500, 600 };
         Federation activeFederation = FederationTestUtils.getFederation(memberPKs);
 
@@ -1105,16 +1087,15 @@ class BridgeTest {
         doReturn(Optional.empty()).when(bridgeSupportMock).getRetiringFederation();
         doReturn(Optional.empty()).when(bridgeSupportMock).getProposedFederation();
 
-        ECKey key = ECKey.fromPrivate(BigInteger.valueOf(senderPK));
-        RskAddress txSender = new RskAddress(key.getAddress());
+        // Sender is the RSK address of active federation member with BTC PK 100 (RSK key
+        // derived from PK 101), sending an externally signed (non-contract) transaction.
+        RskAddress txSender = new RskAddress(ECKey.fromPrivate(BigInteger.valueOf(101)).getAddress());
         Transaction rskTxMock = mock(Transaction.class);
         doReturn(txSender).when(rskTxMock).getSender(any(SignatureCache.class));
 
-        ActivationConfig activationConfig = ActivationConfigsForTest.papyrus200();
-
         Bridge bridge = bridgeBuilder
             .transaction(rskTxMock)
-            .activationConfig(activationConfig)
+            .activationConfig(ActivationConfigsForTest.all())
             .bridgeSupport(bridgeSupportMock)
             .build();
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -1028,15 +1028,10 @@ class BridgeTest {
 
         BridgeSupport bridgeSupportMock = mock(BridgeSupport.class);
 
-        // The internal (contract) transaction is crafted so its sender is a legitimate
-        // active federation member (member with PK 100 has RSK key derived from PK 101).
-        // Even so, it must be rejected because it originates from a contract (e.g. through
-        // a delegate call) rather than an externally signed transaction.
-        byte[] federationMemberRskAddress = ECKey.fromPrivate(BigInteger.valueOf(101)).getAddress();
-        Transaction contractTx = new InternalTransaction(
-            Keccak256.ZERO_HASH.getBytes(), 0, 0, null, null, null,
-            federationMemberRskAddress, null, null, null, null, null
-        );
+        // Even though the sender is a legitimate active federation member, the call must be
+        // rejected because it originates from a contract (e.g. through a delegate call)
+        // rather than an externally signed transaction.
+        Transaction contractTx = createContractTxFromFederationMember();
 
         ActivationConfig activationConfig = ActivationConfigsForTest.papyrus200();
 
@@ -1071,11 +1066,7 @@ class BridgeTest {
 
         // Sender is a legitimate active federation member, but the call originates from a
         // contract (internal transaction), so it must be rejected all the same.
-        byte[] federationMemberRskAddress = ECKey.fromPrivate(BigInteger.valueOf(101)).getAddress();
-        Transaction contractTx = new InternalTransaction(
-            Keccak256.ZERO_HASH.getBytes(), 0, 0, null, null, null,
-            federationMemberRskAddress, null, null, null, null, null
-        );
+        Transaction contractTx = createContractTxFromFederationMember();
 
         ActivationConfig activationConfig = ActivationConfigsForTest.papyrus200();
 
@@ -1132,6 +1123,20 @@ class BridgeTest {
 
         // Then
         verify(decorate, times(1)).execute(any(), any());
+    }
+
+    /**
+     * Builds an internal (contract-originated) transaction whose sender is a legitimate
+     * active federation member. The member with BTC PK 100 has its RSK key derived from
+     * PK 101 (see {@link FederationTestUtils#getFederationMembersFromPks}), so this
+     * address belongs to the federation built from PKs {100, 200, 300, 400, 500, 600}.
+     */
+    private static Transaction createContractTxFromFederationMember() {
+        byte[] federationMemberRskAddress = ECKey.fromPrivate(BigInteger.valueOf(101)).getAddress();
+        return new InternalTransaction(
+            Keccak256.ZERO_HASH.getBytes(), 0, 0, null, null, null,
+            federationMemberRskAddress, null, null, null, null, null
+        );
     }
 
     @Test


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The Bridge exposes a set of methods that are restricted to federation members through two decorators: `Bridge::activeAndRetiringFederationOnly` and `Bridge::activeRetiringAndProposedFederationOnly`. These guard the following methods:

- `updateCollections` — always federation-only
- `addSignature` — always federation-only
- `receiveHeaders` — federation-only branch (when not public)
- `registerBtcTransaction` — federation-only branch (when not public)

This change adds a `BridgeUtils.isContractTx(rskTx)` check inside both decorators. When the call originates from a contract (i.e. the transaction is an `InternalTransaction`), it is rejected with a `VMException` before the federation-membership check runs. Since a federation member always interacts with the Bridge through a top-level, externally signed transaction, a contract-originated call to these methods is never legitimate.

The check is added inside the decorators (not on the `BridgeMethods` enum entries), so the *public* branches of `receiveHeaders` / `registerBtcTransaction` are intentionally left unaffected.

Implemented **without** an RSKIP activation gate, as an initial version pending security-team validation (see *Other information*).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As part of the preparatory work for Account Abstraction (AA) on rskj, we are hardening the Bridge against a potential bypass: a pegnatory could craft a delegated/internal call to the Bridge to reach federation-only methods, potentially bypassing the requirement of having the HSM sign the transaction. Rejecting contract-originated calls on these methods closes that vector as defense-in-depth.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Added unit tests in `BridgeTest` (using a real `InternalTransaction`, since `isContractTx` compares the concrete class):

- `activeAndRetiringFederationOnly_calledFromContract_evenWhenSenderIsFederationMember_throwsVMException` — an internal tx whose sender is a **legitimate active federation member** is still rejected; the decorated method is never executed.
- `activeRetiringAndProposedFederationOnly_calledFromContract_evenWhenSenderIsFederationMember_throwsVMException` — same guarantee for the proposed-federation decorator.
- `activeRetiringAndProposedFederationOnly_calledFromExternalTxByFederationMember_OK` — happy path: an externally signed tx from a federation member still passes.

All existing `activeAndRetiringFederationOnly*`, `updateCollections*`, `addSignature*`, `receiveHeaders*`, and `registerBtcTransaction*` tests continue to pass (0 failures). Verified that no existing integration/performance test invokes these four methods through the Bridge via an internal transaction.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:

This is a consensus-relevant area (the Bridge runs on all nodes), so the "Requires Activation Code" box is left unchecked pending security-team review. Analysis:
- A plain `CALL` from a contract already fails today — the internal tx sender is the calling contract's address, never a federation member, so `isFromFederateMember` already rejects it. `isContractTx` rejects nothing new on this path.
- `DELEGATECALL` / `CALLCODE` are already blocked for these methods post-**RSKIP417** by the call-type restriction (all four are `RESTRICTED_TO_CALL`).

On current mainnet the change is therefore most likely a behavioral no-op, which is the argument for shipping ungated. However, any newly-added rejection that could — via an unproven path — reject a previously-accepted transaction would fork upgraded vs. non-upgraded nodes. **Recommendation:** confirm with the security team that no historical/edge path lets a contract-originated tx currently pass the federation check; if there is any doubt, gate this behind an RSKIP activation. The `rejectIfCalledFromContract` helper is trivially wrappable in an `activations.isActive(...)` check if gating is decided.