### PR TITLE
Gate delegation resolution behind RSKIP545

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/core/DelegationCodeResolver.java
+++ b/rskj-core/src/main/java/org/ethereum/core/DelegationCodeResolver.java
@@ -18,6 +18,8 @@
 package org.ethereum.core;
 
 import co.rsk.core.RskAddress;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.util.ByteUtil;
 
 import java.util.Arrays;
@@ -60,7 +62,8 @@ public class DelegationCodeResolver {
     public static byte[] getExecutionCode(
             Repository repository,
             RskAddress address,
-            Predicate<RskAddress> isPrecompile) {
+            Predicate<RskAddress> isPrecompile,
+            ActivationConfig.ForBlock activationConfig) {
 
         if (!repository.isExist(address)) {
             return ByteUtil.EMPTY_BYTE_ARRAY;
@@ -72,7 +75,7 @@ public class DelegationCodeResolver {
             return ByteUtil.EMPTY_BYTE_ARRAY;
         }
 
-        if (!isDelegatedCode(code)) {
+        if (!activationConfig.isActive(ConsensusRule.RSKIP545) || !isDelegatedCode(code)) {
             return code;
         }
 

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -422,7 +422,7 @@ public class TransactionExecutor {
             result.spendGas(gasUsed);
             profiler.stop(metric);
         } else {
-            byte[] code = DelegationCodeResolver.getExecutionCode(track, targetAddress, this::isPrecompile);
+            byte[] code = DelegationCodeResolver.getExecutionCode(track, targetAddress, this::isPrecompile, this.activations);
             // Code is never null; empty array means no executable code
             if (isEmpty(code)) {
                 gasLeftover = GasCost.subtract(GasCost.toGas(tx.getGasLimit()), basicTxCost);

--- a/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
+++ b/rskj-core/src/main/java/org/ethereum/vm/program/Program.java
@@ -857,7 +857,7 @@ public class Program {
 
         // FETCH THE CODE
         byte[] programCode = DelegationCodeResolver
-                .getExecutionCode(getStorage(), codeAddress, this::isPrecompile);
+                .getExecutionCode(getStorage(), codeAddress, this::isPrecompile, this.activations);
         // programCode is never null; empty array means no executable code
 
         // Always first remove funds from sender

--- a/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/InternalDelegationExecutionTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/InternalDelegationExecutionTest.java
@@ -1,0 +1,324 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2026 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.core.bc.transactionexecutor;
+
+import co.rsk.blockchain.utils.BlockGenerator;
+import co.rsk.config.TestSystemProperties;
+import co.rsk.core.Coin;
+import co.rsk.core.RskAddress;
+import co.rsk.core.TransactionExecutorFactory;
+import co.rsk.peg.BridgeSupportFactory;
+import co.rsk.peg.RepositoryBtcBlockStoreWithCache;
+import com.typesafe.config.ConfigValueFactory;
+import org.ethereum.config.Constants;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
+import org.ethereum.core.Account;
+import org.ethereum.core.Block;
+import org.ethereum.core.BlockFactory;
+import org.ethereum.core.BlockTxSignatureCache;
+import org.ethereum.core.DelegationCodeResolver;
+import org.ethereum.core.ReceivedTxSignatureCache;
+import org.ethereum.core.Repository;
+import org.ethereum.core.Transaction;
+import org.ethereum.db.BlockStoreDummy;
+import org.ethereum.vm.PrecompiledContracts;
+import org.ethereum.vm.program.invoke.ProgramInvokeFactoryImpl;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.Collections;
+
+import static co.rsk.RskTestUtils.createRepository;
+import static co.rsk.core.bc.BlockExecutorTest.createAccount;
+
+class InternalDelegationExecutionTest {
+
+    private static final long PRE_ACTIVATION_BLOCK = 2L;
+    private static final long POST_ACTIVATION_BLOCK = 1L;
+
+    @Test
+    void internalCall_beforeRskip545Activation_doesNotResolveDelegation() {
+        TestSystemProperties config = configWithRskip545ActivationAt(PRE_ACTIVATION_BLOCK);
+
+        Repository track = createRepository().startTracking();
+
+        Account sender = createAccount("internalCallBeforeRskip545Sender", track, Coin.valueOf(6_000_000));
+        Account caller = createAccount("internalCallBeforeRskip545Caller", track, Coin.ZERO);
+        Account target = createAccount("internalCallBeforeRskip545Target", track, Coin.ZERO);
+        Account delegated = createAccount("internalCallBeforeRskip545Delegate", track, Coin.ZERO);
+
+        /*
+         * caller.code:
+         *
+         *     CALL target
+         *     return CALL result (0/1)
+         */
+        track.setupContract(caller.getAddress());
+        track.saveCode(caller.getAddress(), buildInternalCallCode(target.getAddress()));
+
+
+        // Historical state containing: target.code = EF0100 || delegated
+        track.setupContract(target.getAddress());
+        track.saveCode(target.getAddress(), DelegationCodeResolver.createDelegatedCode(delegated.getAddress()));
+
+        track.setupContract(delegated.getAddress());
+        track.saveCode(delegated.getAddress(), new byte[] { 0x00 });
+
+        track.commit();
+
+        Block block = createBlock(config, track, createLegacyCall(config, sender, caller.getAddress(), track.getNonce(sender.getAddress())));
+
+        Assertions.assertEquals(1L, block.getNumber());
+
+        // Sanity check: RSKIP545 activates at block 2, while this block is block 1.
+        Assertions.assertFalse(config.getActivationConfig().isActive(ConsensusRule.RSKIP545, block.getNumber()));
+
+        TransactionExecutorFactory factory = getTransactionExecutorFactory(config);
+        Transaction tx = block.getTransactionsList().get(0);
+
+        var executor = factory.newInstance(tx, 0, block.getCoinbase(), track, block, 0L);
+
+        Assertions.assertTrue(executor.executeTransaction());
+
+        /*
+         * Parent execution itself succeeds.
+         *
+         * The internal CALL fails because EF is executed with legacy
+         * semantics, but CALL converts that child failure into result = 0.
+         */
+        Assertions.assertNull(executor.getResult().getException());
+        Assertions.assertFalse(executor.getResult().isRevert());
+
+        byte[] expected = new byte[32];
+
+        Assertions.assertArrayEquals(expected, executor.getResult().getHReturn());
+    }
+
+    @Test
+    void internalCall_afterRskip545Activation_resolvesDelegation() {
+        TestSystemProperties config = configWithRskip545ActivationAt(POST_ACTIVATION_BLOCK);
+
+        Repository track = createRepository().startTracking();
+
+        Account sender = createAccount("internalCallAfterRskip545Sender", track, Coin.valueOf(6_000_000));
+        Account caller = createAccount("internalCallAfterRskip545Caller", track, Coin.ZERO);
+        Account target = createAccount("internalCallAfterRskip545Target", track, Coin.ZERO);
+        Account delegated = createAccount("internalCallAfterRskip545Delegate", track, Coin.ZERO);
+
+        track.setupContract(caller.getAddress());
+        track.saveCode(caller.getAddress(), buildInternalCallCode(target.getAddress()));
+
+        track.setupContract(target.getAddress());
+        track.saveCode(target.getAddress(), DelegationCodeResolver.createDelegatedCode(delegated.getAddress()));
+
+
+        // Delegated runtime: STOP
+        track.setupContract(delegated.getAddress());
+        track.saveCode(delegated.getAddress(), new byte[] { 0x00 });
+        track.commit();
+
+        Block block = createBlock(config, track, createLegacyCall(config, sender, caller.getAddress(), track.getNonce(sender.getAddress())));
+        Assertions.assertEquals(1L, block.getNumber());
+
+        Assertions.assertTrue(config.getActivationConfig().isActive(org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP545, block.getNumber()));
+
+        TransactionExecutorFactory factory = getTransactionExecutorFactory(config);
+        Transaction tx = block.getTransactionsList().get(0);
+
+        var executor = factory.newInstance(tx, 0, block.getCoinbase(), track, block, 0L);
+
+        Assertions.assertTrue(executor.executeTransaction());
+        Assertions.assertNull(executor.getResult().getException());
+        Assertions.assertFalse(executor.getResult().isRevert());
+
+
+        // CALL success is represented by 1. MSTORE serializes that value as a 32-byte word:
+        byte[] expected = new byte[32];
+        expected[31] = 0x01;
+
+        Assertions.assertArrayEquals(expected, executor.getResult().getHReturn());
+    }
+
+    private static TestSystemProperties configWithRskip545ActivationAt(long activationBlock) {
+        return new TestSystemProperties(
+                rawConfig -> rawConfig.withValue(
+                        "blockchain.config.consensusRules.rskip545",
+                        ConfigValueFactory.fromAnyRef(activationBlock)
+                )
+        );
+    }
+
+    private static Transaction createLegacyCall(TestSystemProperties config, Account sender, RskAddress receiver, BigInteger nonce) {
+        Transaction tx = Transaction.builder()
+                .nonce(nonce)
+                .gasPrice(BigInteger.ONE)
+                .gasLimit(BigInteger.valueOf(2_000_000))
+                .receiveAddress(receiver)
+                .chainId(config.getNetworkConstants().getChainId())
+                .value(Coin.ZERO)
+                .build();
+
+        tx.sign(sender.getEcKey().getPrivKeyBytes());
+
+        return tx;
+    }
+
+    private static Block createBlock(TestSystemProperties config, Repository track, Transaction tx) {
+        BlockGenerator blockGenerator = new BlockGenerator(Constants.regtest(), config.getActivationConfig());
+
+        Block genesis = blockGenerator.getGenesisBlock();
+        genesis.setStateRoot(track.getRoot());
+
+        return blockGenerator.createChildBlock(genesis, Collections.singletonList(tx), Collections.emptyList(), 1, null);
+    }
+
+    private static TransactionExecutorFactory getTransactionExecutorFactory(TestSystemProperties config) {
+        BlockTxSignatureCache signatureCache = new BlockTxSignatureCache(new ReceivedTxSignatureCache());
+
+        var btcBlockStoreFactory = new RepositoryBtcBlockStoreWithCache.Factory(config.getNetworkConstants().getBridgeConstants().getBtcParams());
+
+        var bridgeSupportFactory = new BridgeSupportFactory(btcBlockStoreFactory, config.getNetworkConstants().getBridgeConstants(), config.getActivationConfig(), signatureCache);
+
+        return new TransactionExecutorFactory(
+                config,
+                new BlockStoreDummy(),
+                null,
+                new BlockFactory(config.getActivationConfig()),
+                new ProgramInvokeFactoryImpl(),
+                new PrecompiledContracts(
+                        config,
+                        bridgeSupportFactory,
+                        signatureCache
+                ),
+                signatureCache
+        );
+    }
+
+    /**
+     * Builds runtime code equivalent to:
+     *
+     *     bool success = target.call("");
+     *     return success ? 1 : 0;
+     *
+     * EVM:
+     *
+     *     PUSH1  00       // outSize
+     *     PUSH1  00       // outOffset
+     *     PUSH1  00       // inSize
+     *     PUSH1  00       // inOffset
+     *     PUSH1  00       // value
+     *     PUSH20 target
+     *     PUSH3  0fffff   // gas
+     *     CALL
+     *
+     *     PUSH1  00
+     *     MSTORE
+     *
+     *     PUSH1  20       // size
+     *     PUSH1  00       // offset
+     *     RETURN
+     */
+    private static byte[] buildInternalCallCode(RskAddress target) {
+        byte[] address = target.getBytes();
+
+        byte[] code = new byte[
+                2 +     // PUSH1 outSize
+                        2 +     // PUSH1 outOffset
+                        2 +     // PUSH1 inSize
+                        2 +     // PUSH1 inOffset
+                        2 +     // PUSH1 value
+                        21 +    // PUSH20 target
+                        4 +     // PUSH3 gas
+                        1 +     // CALL
+                        2 +     // PUSH1 0
+                        1 +     // MSTORE
+                        2 +     // PUSH1 32
+                        2 +     // PUSH1 0
+                        1       // RETURN
+                ];
+
+        int i = 0;
+
+        // outSize = 0
+        code[i++] = 0x60; // PUSH1
+        code[i++] = 0x00;
+
+        // outOffset = 0
+        code[i++] = 0x60;
+        code[i++] = 0x00;
+
+        // inSize = 0
+        code[i++] = 0x60;
+        code[i++] = 0x00;
+
+        // inOffset = 0
+        code[i++] = 0x60;
+        code[i++] = 0x00;
+
+        // value = 0
+        code[i++] = 0x60;
+        code[i++] = 0x00;
+
+        // target
+        code[i++] = 0x73; // PUSH20
+
+        System.arraycopy(
+                address,
+                0,
+                code,
+                i,
+                address.length
+        );
+
+        i += address.length;
+
+        /*
+         * gas = 0x0fffff
+         */
+        code[i++] = 0x62; // PUSH3
+        code[i++] = 0x0f;
+        code[i++] = (byte) 0xff;
+        code[i++] = (byte) 0xff;
+
+        code[i++] = (byte) 0xf1; // CALL
+
+        /*
+         * Stack now contains CALL result:
+         *
+         * 0 = child execution failed
+         * 1 = child execution succeeded
+         */
+
+        // MSTORE(0, callResult)
+        code[i++] = 0x60; // PUSH1
+        code[i++] = 0x00;
+        code[i++] = 0x52; // MSTORE
+
+        // RETURN(0, 32)
+        code[i++] = 0x60; // PUSH1
+        code[i++] = 0x20;
+
+        code[i++] = 0x60; // PUSH1
+        code[i++] = 0x00;
+
+        code[i] = (byte) 0xf3; // RETURN
+
+        return code;
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/InternalDelegationExecutionTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/InternalDelegationExecutionTest.java
@@ -136,7 +136,7 @@ class InternalDelegationExecutionTest {
         Block block = createBlock(config, track, createLegacyCall(config, sender, caller.getAddress(), track.getNonce(sender.getAddress())));
         Assertions.assertEquals(1L, block.getNumber());
 
-        Assertions.assertTrue(config.getActivationConfig().isActive(org.ethereum.config.blockchain.upgrades.ConsensusRule.RSKIP545, block.getNumber()));
+        Assertions.assertTrue(config.getActivationConfig().isActive(ConsensusRule.RSKIP545, block.getNumber()));
 
         TransactionExecutorFactory factory = getTransactionExecutorFactory(config);
         Transaction tx = block.getTransactionsList().get(0);

--- a/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/TransactionExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/TransactionExecutorTest.java
@@ -37,6 +37,7 @@ import org.ethereum.db.ReceiptStore;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.PrecompiledContractArgs;
 import org.ethereum.vm.PrecompiledContracts;
+import org.ethereum.vm.program.invoke.ProgramInvoke;
 import org.ethereum.vm.program.invoke.ProgramInvokeFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -383,6 +384,62 @@ class TransactionExecutorTest {
                 transaction, txIndex, executionBlock.getCoinbase(), repository, executionBlock, 0L);
 
         assertFalse(txExecutor.executeTransaction());
+    }
+
+    @Test
+    void topLevelLegacyCall_beforeRskip545Activation_doesNotResolveDelegation() {
+        activationConfig = ActivationConfigsForTest.allBut(ConsensusRule.RSKIP545);
+        when(config.getActivationConfig()).thenReturn(activationConfig);
+
+        MutableRepository cacheTrack = mock(MutableRepository.class);
+        when(repository.startTracking()).thenReturn(cacheTrack);
+
+        RskAddress delegated = new RskAddress("0000000000000000000000000000000000000003");
+        byte[] historicalDelegationCode = DelegationCodeResolver.createDelegatedCode(delegated);
+        byte[] delegatedRuntimeCode = new byte[] { 0x00 }; // STOP
+
+        // Sender
+        when(repository.getNonce(sender)).thenReturn(BigInteger.ONE);
+        when(repository.getBalance(sender)).thenReturn(Coin.valueOf(1_000_000));
+        // Historical account containing EF0100 || delegated.
+        when(repository.isExist(receiver)).thenReturn(true);
+        when(repository.getCode(receiver)).thenReturn(historicalDelegationCode);
+
+        when(repository.isExist(delegated)).thenReturn(true);
+        when(repository.getCode(delegated)).thenReturn(delegatedRuntimeCode);
+
+        when(executionBlock.getGasLimit()).thenReturn(BigInteger.valueOf(6_800_000).toByteArray());
+
+        Transaction tx = getTransaction(sender, receiver, BigInteger.valueOf(600_000).toByteArray(), BigInteger.ONE.toByteArray(), Coin.valueOf(1), Coin.ZERO);
+        when(tx.getHash()).thenReturn(new Keccak256(HashUtil.keccak256(BigInteger.valueOf(1).toByteArray())));
+        ProgramInvoke programInvoke = mock(ProgramInvoke.class);
+
+        when(programInvokeFactory.createProgramInvoke(eq(tx), eq(txIndex), eq(executionBlock), eq(cacheTrack), eq(blockStore), any(SignatureCache.class))).thenReturn(programInvoke);
+
+        when(programInvoke.getRepository()).thenReturn(cacheTrack);
+        when(programInvoke.getOwnerAddress()).thenReturn(DataWord.valueOf(receiver.getBytes()));
+        when(programInvoke.getCallerAddress()).thenReturn(DataWord.valueOf(sender.getBytes()));
+        when(programInvoke.getBalance()).thenReturn(DataWord.ZERO);
+        when(programInvoke.getCallValue()).thenReturn(DataWord.ZERO);
+        when(programInvoke.getDataSize()).thenReturn(DataWord.ZERO);
+        when(programInvoke.getGas()).thenReturn(600_000L);
+
+        TransactionExecutorFactory factory = new TransactionExecutorFactory(config, blockStore, receiptStore, blockFactory, programInvokeFactory, precompiledContracts, new BlockTxSignatureCache(new ReceivedTxSignatureCache()));
+        TransactionExecutor executor = factory.newInstance(tx, txIndex, executionBlock.getCoinbase(), repository, executionBlock, 0L);
+
+        assertTrue(executor.executeTransaction());
+        verify(repository).getCode(receiver);
+
+        verify(repository, never()).isExist(delegated);
+        verify(repository, never()).getCode(delegated);
+
+        verify(programInvokeFactory).createProgramInvoke(eq(tx), eq(txIndex), eq(executionBlock), eq(cacheTrack), eq(blockStore), any(SignatureCache.class));
+        assertNotNull(executor.getResult().getException());
+
+        String message = executor.getResult().getException().getMessage();
+
+        assertTrue(message.contains("Invalid operation code"));
+        assertTrue(message.contains("opcode[ef]"));
     }
 
     private void mockRepositoryForAnAccountWithBalance(RskAddress sender, long val) {

--- a/rskj-core/src/test/java/org/ethereum/core/DelegationCodeResolverTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/DelegationCodeResolverTest.java
@@ -18,7 +18,11 @@
 package org.ethereum.core;
 
 import co.rsk.core.RskAddress;
+import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
+import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.util.ByteUtil;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.ethereum.core.DelegationCodeResolver.createDelegatedCode;
@@ -27,9 +31,20 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class DelegationCodeResolverTest {
+
+    ActivationConfig.ForBlock activationConfig;
+    Repository repository;
+
+    @BeforeEach
+    void setUp() {
+        activationConfig = mock(ActivationConfig.ForBlock.class);
+        repository = mock(Repository.class);
+    }
 
     @Test
     void createDelegatedCode_nullAddress_throws() {
@@ -63,15 +78,16 @@ class DelegationCodeResolverTest {
 
     @Test
     void getExecutionCode_returnsEmptyWhenTargetAccountDoesNotExist() {
-        Repository repository = mock(Repository.class);
         RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
 
+        when(activationConfig.isActive(ConsensusRule.RSKIP545)).thenReturn(true);
         when(repository.isExist(target)).thenReturn(false);
 
         byte[] code = DelegationCodeResolver.getExecutionCode(
                 repository,
                 target,
-                address -> false
+                address -> false,
+                activationConfig
         );
 
         assertArrayEquals(ByteUtil.EMPTY_BYTE_ARRAY, code);
@@ -79,16 +95,17 @@ class DelegationCodeResolverTest {
 
     @Test
     void getExecutionCode_returnsEmptyWhenTargetHasNoCode() {
-        Repository repository = mock(Repository.class);
         RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
 
         when(repository.isExist(target)).thenReturn(true);
         when(repository.getCode(target)).thenReturn(ByteUtil.EMPTY_BYTE_ARRAY);
+        when(activationConfig.isActive(ConsensusRule.RSKIP545)).thenReturn(true);
 
         byte[] code = DelegationCodeResolver.getExecutionCode(
                 repository,
                 target,
-                address -> false
+                address -> false,
+                activationConfig
         );
 
         assertArrayEquals(ByteUtil.EMPTY_BYTE_ARRAY, code);
@@ -96,18 +113,18 @@ class DelegationCodeResolverTest {
 
     @Test
     void getExecutionCode_returnsEmptyWhenDelegatedAddressIsPrecompile() {
-        Repository repository = mock(Repository.class);
-
         RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
         RskAddress delegated = new RskAddress("0000000000000000000000000000000000000002");
 
         when(repository.isExist(target)).thenReturn(true);
         when(repository.getCode(target)).thenReturn(createDelegatedCode(delegated));
+        when(activationConfig.isActive(ConsensusRule.RSKIP545)).thenReturn(true);
 
         byte[] code = DelegationCodeResolver.getExecutionCode(
                 repository,
                 target,
-                delegated::equals
+                delegated::equals,
+                activationConfig
         );
 
         assertArrayEquals(ByteUtil.EMPTY_BYTE_ARRAY, code);
@@ -115,8 +132,6 @@ class DelegationCodeResolverTest {
 
     @Test
     void getExecutionCode_returnsDelegatedCodeWhenDelegatedAccountExists() {
-        Repository repository = mock(Repository.class);
-
         RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
         RskAddress delegated = new RskAddress("0000000000000000000000000000000000000002");
 
@@ -127,11 +142,13 @@ class DelegationCodeResolverTest {
 
         when(repository.isExist(delegated)).thenReturn(true);
         when(repository.getCode(delegated)).thenReturn(delegatedRuntimeCode);
+        when(activationConfig.isActive(ConsensusRule.RSKIP545)).thenReturn(true);
 
         byte[] code = DelegationCodeResolver.getExecutionCode(
                 repository,
                 target,
-                address -> false
+                address -> false,
+                activationConfig
         );
 
         assertArrayEquals(delegatedRuntimeCode, code);
@@ -139,8 +156,6 @@ class DelegationCodeResolverTest {
 
     @Test
     void getExecutionCode_returnsDelegatedCodeWithoutResolvingDelegationChain() {
-        Repository repository = mock(Repository.class);
-
         RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
         RskAddress delegated = new  RskAddress("0000000000000000000000000000000000000002");
         RskAddress secondDelegation = new RskAddress("0000000000000000000000000000000000000003");
@@ -153,10 +168,13 @@ class DelegationCodeResolverTest {
         when(repository.isExist(delegated)).thenReturn(true);
         when(repository.getCode(delegated)).thenReturn(delegatedCode);
 
+        when(activationConfig.isActive(ConsensusRule.RSKIP545)).thenReturn(true);
+
         byte[] code = DelegationCodeResolver.getExecutionCode(
                 repository,
                 target,
-                address -> false
+                address -> false,
+                activationConfig
         );
 
         assertArrayEquals(delegatedCode, code);
@@ -164,17 +182,16 @@ class DelegationCodeResolverTest {
 
     @Test
     void getExecutionCode_returnsEmptyWhenTargetCodeIsNull() {
-        Repository repository = mock(Repository.class);
-
         RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
         when(repository.isExist(target)).thenReturn(true);
         when(repository.getCode(target)).thenReturn(null);
-
+        when(activationConfig.isActive(ConsensusRule.RSKIP545)).thenReturn(true);
 
         byte[] code = DelegationCodeResolver.getExecutionCode(
                 repository,
                 target,
-                address -> false
+                address -> false,
+                activationConfig
         );
 
         assertArrayEquals(ByteUtil.EMPTY_BYTE_ARRAY, code);
@@ -182,17 +199,16 @@ class DelegationCodeResolverTest {
 
     @Test
     void getExecutionCode_returnsEmptyWhenDelegatedAccountCodeIsLength0() {
-        Repository repository = mock(Repository.class);
-
         RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
         when(repository.isExist(target)).thenReturn(true);
         when(repository.getCode(target)).thenReturn(new byte[0]);
-
+        when(activationConfig.isActive(ConsensusRule.RSKIP545)).thenReturn(true);
 
         byte[] code = DelegationCodeResolver.getExecutionCode(
                 repository,
                 target,
-                address -> false
+                address -> false,
+                activationConfig
         );
 
         assertArrayEquals(ByteUtil.EMPTY_BYTE_ARRAY, code);
@@ -200,8 +216,6 @@ class DelegationCodeResolverTest {
 
     @Test
     void getExecutionCode_returnsDelegatedCodeWhenDelegatedAddressIsNotPrecompileAndExists() {
-        Repository repository = mock(Repository.class);
-
         RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
         RskAddress delegated = new RskAddress("0000000000000000000000000000000000000002");
 
@@ -213,11 +227,13 @@ class DelegationCodeResolverTest {
 
         when(repository.isExist(delegated)).thenReturn(true);
         when(repository.getCode(delegated)).thenReturn(delegatedRuntimeCode);
+        when(activationConfig.isActive(ConsensusRule.RSKIP545)).thenReturn(true);
 
         byte[] code = DelegationCodeResolver.getExecutionCode(
                 repository,
                 target,
-                address -> false
+                address -> false,
+                activationConfig
         );
 
         assertArrayEquals(delegatedRuntimeCode, code);
@@ -225,8 +241,6 @@ class DelegationCodeResolverTest {
 
     @Test
     void getExecutionCode_returnsEmptyWhenDelegatedAddressIsNotPrecompileAndDoesNotExist() {
-        Repository repository = mock(Repository.class);
-
         RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
         RskAddress delegated = new RskAddress("0000000000000000000000000000000000000002");
 
@@ -239,10 +253,13 @@ class DelegationCodeResolverTest {
         when(repository.isExist(delegated)).thenReturn(false);
         when(repository.getCode(delegated)).thenReturn(delegatedRuntimeCode);
 
+        when(activationConfig.isActive(ConsensusRule.RSKIP545)).thenReturn(true);
+
         byte[] code = DelegationCodeResolver.getExecutionCode(
                 repository,
                 target,
-                address -> false
+                address -> false,
+                activationConfig
         );
 
         assertArrayEquals(ByteUtil.EMPTY_BYTE_ARRAY, code);
@@ -250,20 +267,97 @@ class DelegationCodeResolverTest {
 
     @Test
     void getExecutionCode_returnsTargetCodeWhenCodeIsNotDelegated() {
-        Repository repository = mock(Repository.class);
-
         RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
         byte[] runtimeCode = new byte[] { 0x01, 0x02, 0x03 };
 
         when(repository.isExist(target)).thenReturn(true);
         when(repository.getCode(target)).thenReturn(runtimeCode);
+        when(activationConfig.isActive(ConsensusRule.RSKIP545)).thenReturn(true);
 
         byte[] code = DelegationCodeResolver.getExecutionCode(
                 repository,
                 target,
-                address -> false
+                address -> false,
+                activationConfig
         );
 
         assertArrayEquals(runtimeCode, code);
     }
+
+    @Test
+    void getExecutionCode_beforeRskip545Activation_returnsLiteralDelegationCode() {
+        RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
+        RskAddress delegated = new RskAddress("0000000000000000000000000000000000000002");
+
+        byte[] delegationCode = createDelegatedCode(delegated);
+        byte[] delegatedRuntimeCode = new byte[] { 0x01, 0x02, 0x03 };
+
+        when(repository.isExist(target)).thenReturn(true);
+        when(repository.getCode(target)).thenReturn(delegationCode);
+        when(repository.isExist(delegated)).thenReturn(true);
+        when(repository.getCode(delegated)).thenReturn(delegatedRuntimeCode);
+
+        when(activationConfig.isActive(ConsensusRule.RSKIP545)).thenReturn(false);
+
+        byte[] code = DelegationCodeResolver.getExecutionCode(
+                repository,
+                target,
+                address -> false,
+                activationConfig
+        );
+
+        assertArrayEquals(delegationCode, code);
+    }
+
+    @Test
+    void getExecutionCode_atRskip545Activation_resolvesDelegatedCode() {
+        RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
+        RskAddress delegated = new RskAddress("0000000000000000000000000000000000000002");
+
+        byte[] delegationCode = createDelegatedCode(delegated);
+        byte[] delegatedRuntimeCode = new byte[] { 0x01, 0x02, 0x03 };
+
+        when(repository.isExist(target)).thenReturn(true);
+        when(repository.getCode(target)).thenReturn(delegationCode);
+
+        when(repository.isExist(delegated)).thenReturn(true);
+        when(repository.getCode(delegated)).thenReturn(delegatedRuntimeCode);
+
+        when(activationConfig.isActive(ConsensusRule.RSKIP545)).thenReturn(true);
+
+        byte[] code = DelegationCodeResolver.getExecutionCode(repository,
+                target,
+                address -> false,
+                activationConfig
+        );
+
+        assertArrayEquals(delegatedRuntimeCode, code);
+    }
+
+    @Test
+    void getExecutionCode_beforeRskip545Activation_doesNotResolveDelegatedAddress() {
+        ActivationConfig.ForBlock activationConfig = mock(ActivationConfig.ForBlock.class);
+
+        RskAddress target = new RskAddress("0000000000000000000000000000000000000001");
+        RskAddress delegated = new RskAddress("0000000000000000000000000000000000000002");
+
+        byte[] delegationCode = createDelegatedCode(delegated);
+
+        when(repository.isExist(target)).thenReturn(true);
+        when(repository.getCode(target)).thenReturn(delegationCode);
+        when(activationConfig.isActive(ConsensusRule.RSKIP545)).thenReturn(false);
+
+        byte[] code = DelegationCodeResolver.getExecutionCode(
+                repository,
+                target,
+                address -> false,
+                activationConfig
+        );
+
+        assertArrayEquals(delegationCode, code);
+
+        verify(repository, never()).isExist(delegated);
+        verify(repository, never()).getCode(delegated);
+    }
+
 }

--- a/rskj-core/src/test/java/org/ethereum/core/DelegationCodeResolverTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/DelegationCodeResolverTest.java
@@ -19,7 +19,6 @@ package org.ethereum.core;
 
 import co.rsk.core.RskAddress;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
-import org.ethereum.config.blockchain.upgrades.ActivationConfigsForTest;
 import org.ethereum.config.blockchain.upgrades.ConsensusRule;
 import org.ethereum.util.ByteUtil;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
## Description
Gate delegation resolution behind RSKIP545 activation.
Preserve legacy execution semantics before the activation block.
Resolve `EF0100 || address` delegation code only after activation.

## Motivation and Context
Delegation resolution must not affect execution before RSKIP545 activation.
Pre-activation historical state may already contain delegation-shaped code.
The gate ensures block execution follows the consensus rules active at that height.

## How Has This Been Tested?
Added coverage for internal calls before RSKIP545 activation.
Added coverage verifying delegation resolution after RSKIP545 activation.
Pre-activation tests use historical state since RSKIP544 prevents new `0xEF` deployments.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x ] Requires Activation Code (Hard Fork)


* **Other information**:
RSKIP544 prevents deploying new runtime code starting with `0xEF`.
The pre-activation scenario therefore targets delegation code already present in historical state.
RSKIP545 controls when that existing code starts being interpreted as delegation.