### PR TITLE
test: calibrate the RPC health-probe timeout to the host machine

### DIFF
--- a/rskj-core/src/integrationTest/java/co/rsk/rpc/EthCallIntegrationTest.java
+++ b/rskj-core/src/integrationTest/java/co/rsk/rpc/EthCallIntegrationTest.java
@@ -34,6 +34,9 @@ import java.net.ServerSocket;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -61,6 +64,12 @@ class EthCallIntegrationTest {
     // Generous client-side HTTP timeout for expensive calls.
     private static final long EXPENSIVE_CALL_TIMEOUT_MS = 120_000;
     private static final long BATCH_CALL_TIMEOUT_MS = 300_000;
+
+    // Health-probe budget used by concurrentHighGasCalls_shouldTestRpcResponsiveness. It is
+    // derived at runtime from a calibration call rather than hard-coded -- see that test.
+    private static final long MIN_PROBE_TIMEOUT_MS = 2_000;
+    private static final long MAX_PROBE_TIMEOUT_MS = 15_000;
+    private static final int PROBE_TIMEOUT_FACTOR = 6;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -244,13 +253,25 @@ class EthCallIntegrationTest {
      * hold a Netty thread briefly. Brief transient probe failures under peak
      * saturation are expected — the defense against individual-call flooding
      * is network-level rate limiting, not thread availability.
+     * <p>
+     * The per-probe timeout is calibrated at runtime instead of hard-coded. eth_call is
+     * handled on the Netty event-loop thread that owns the connection (see
+     * {@code Web3HttpServer}, which adds the JSON-RPC handler with no separate executor
+     * group), so the worst case for a health probe is waiting out the call currently
+     * occupying its event loop. That wait is a multiple of how long one capped call takes
+     * on this machine, and machines vary: a CI runner with half the cores runs the same
+     * call ~1.5x slower and gives the node half the event-loop threads to absorb them.
+     * An absolute wall-clock budget therefore encodes the speed of whichever runner it was
+     * tuned on. The success-rate requirement below is unchanged (60% of probes answered);
+     * only the budget each probe is given now scales with the host.
      */
     @Test
     void concurrentHighGasCalls_shouldTestRpcResponsiveness() throws Exception {
         String cmd = String.format("%s -cp %s/%s co.rsk.Start --reset %s",
                 baseJavaCmd, buildLibsPath, jarName, strBaseArgs);
 
-        int totalProbes = 5;
+        int totalProbes = 10;
+        int minSuccessfulProbes = 6;
 
         Process proc = startNode(cmd);
         try {
@@ -260,6 +281,20 @@ class EthCallIntegrationTest {
             Response baselineResponse = sendHealthProbe(rpcPort, 5000);
             Assertions.assertEquals(200, baselineResponse.code(),
                     "Baseline health probe should succeed without heavy load");
+
+            // Calibrate the probe budget against this machine: time one capped eth_call
+            // with the node otherwise idle.
+            long calibrationStart = System.currentTimeMillis();
+            sendJsonRpcMessage(buildEthCallPayload(SHA3_LOOP_BYTECODE, GAS_10M, 0), rpcPort, EXPENSIVE_CALL_TIMEOUT_MS);
+            long singleCallMs = System.currentTimeMillis() - calibrationStart;
+
+            // A probe arriving at a saturated event loop waits for the call ahead of it, and
+            // every in-flight call is itself slower than the idle measurement because the
+            // worker threads oversubscribe the cores. PROBE_TIMEOUT_FACTOR covers both.
+            long probeTimeoutMs = Math.min(MAX_PROBE_TIMEOUT_MS,
+                    Math.max(MIN_PROBE_TIMEOUT_MS, singleCallMs * PROBE_TIMEOUT_FACTOR));
+            System.out.printf("Idle eth_call took %dms on %d cores; probe timeout set to %dms%n",
+                    singleCallMs, Runtime.getRuntime().availableProcessors(), probeTimeoutMs);
 
             // Launch concurrent high-gas calls to stress the RPC layer.
             // Each call is capped at callGasCap (10M, ~0.5s per call).
@@ -289,14 +324,17 @@ class EthCallIntegrationTest {
 
             tasksStarted.await(10, TimeUnit.SECONDS);
 
-            // Send sequential health probes with short timeout.
-            // In a normal state, eth_blockNumber responds quickly.
-            // Probes failing indicates high load saturation.
+            // Send sequential health probes. In a normal state eth_blockNumber responds
+            // quickly; probes exceeding the calibrated budget indicate load saturation.
             AtomicInteger failedProbes = new AtomicInteger(0);
+            List<Long> probeLatencies = new ArrayList<>();
             for (int i = 0; i < totalProbes; i++) {
+                long probeStart = System.currentTimeMillis();
                 try {
-                    Response probeResponse = sendHealthProbe(rpcPort, 2000);
-                    if (probeResponse.code() != 200) {
+                    Response probeResponse = sendHealthProbe(rpcPort, probeTimeoutMs);
+                    if (probeResponse.code() == 200) {
+                        probeLatencies.add(System.currentTimeMillis() - probeStart);
+                    } else {
                         failedProbes.incrementAndGet();
                     }
                 } catch (IOException e) {
@@ -307,12 +345,28 @@ class EthCallIntegrationTest {
 
             executor.shutdownNow();
 
-            Assertions.assertTrue(failedProbes.get() <= 2,
-                    String.format("Expected at most 2 out of %d health probes to timeout due to load, but %d failed",
-                            totalProbes, failedProbes.get()));
+            Collections.sort(probeLatencies);
+            String latencySummary = probeLatencies.isEmpty()
+                    ? "none answered"
+                    : String.format("median=%dms max=%dms", probeLatencies.get(probeLatencies.size() / 2),
+                            probeLatencies.get(probeLatencies.size() - 1));
 
-            System.out.printf("Load test: %d out of %d health probes failed during concurrent execution%n",
-                    failedProbes.get(), totalProbes);
+            Assertions.assertTrue(probeLatencies.size() >= minSuccessfulProbes,
+                    String.format("Expected at least %d of %d health probes to be answered within %dms "
+                                    + "(calibrated from a %dms idle eth_call), but only %d were. Answered: %s",
+                            minSuccessfulProbes, totalProbes, probeTimeoutMs, singleCallMs,
+                            probeLatencies.size(), latencySummary));
+
+            // The regression this test really guards: saturation must be transient, never a
+            // permanent wedge. Once the concurrent load drains, the RPC has to answer again.
+            await().atMost(30, TimeUnit.SECONDS)
+                    .pollInterval(1, TimeUnit.SECONDS)
+                    .ignoreExceptions()
+                    .alias("RPC did not recover after the concurrent load drained")
+                    .until(() -> sendHealthProbe(rpcPort, 5_000).code() == 200);
+
+            System.out.printf("Load test: %d of %d health probes answered within %dms (%s), %d failed%n",
+                    probeLatencies.size(), totalProbes, probeTimeoutMs, latencySummary, failedProbes.get());
         } finally {
             destroyNode(proc);
         }


### PR DESCRIPTION
## Description

This change makes one integration test stable. It touches one file. It does not change production code.

The test is `EthCallIntegrationTest.concurrentHighGasCalls_shouldTestRpcResponsiveness`.

- **The probe timeout now adapts to the machine.** Before this change, each health probe had a fixed limit of 2000 ms. Now the test measures one idle `eth_call` at 10M gas. The test then gives each probe 6 times that measurement. The limit stays between 2 s and 15 s.
- **The success rate does not change.** The test still requires 60% of the probes to answer. The count changes from 3 of 5 to 6 of 10.
- **The test now checks recovery.** After the concurrent load stops, the RPC interface must answer again. The old test does not check this.
- **The failure message now shows the measurements.** The message gives the calibration value, the calculated limit, and the median and maximum probe latency.

## Motivation and Context

The test fails at random. The cause is the time limit in the test, not the behaviour of the node.

Netty runs `eth_call` on the event-loop thread that owns the connection. `Web3HttpServer` adds `jsonRpcWeb3ServerHandler` to the pipeline without a separate executor group. A health probe must therefore wait for the call that occupies its event loop.

`new NioEventLoopGroup()` creates `availableProcessors() * 2` threads. A machine with fewer cores gives the node fewer event-loop threads. The same call is also approximately 1.5 times slower on that machine. Both effects increase the probe latency.

A fixed limit of 2000 ms therefore records the speed of one machine. On a slower machine the test fails for a reason that is not related to the code under test.

The margin is small even on fast hardware. On an 11-core development machine, the slowest probe takes 2090 ms in one run and 2167 ms in a second run. Both values are above the old limit of 2000 ms.

## How Has This Been Tested?

Command: `./gradlew integrationTest --tests "co.rsk.rpc.EthCallIntegrationTest.concurrentHighGasCalls_shouldTestRpcResponsiveness"`. Environment: JDK 17, macOS, 11 cores. Result: pass.

```
Node ready after 5190ms
Idle eth_call took 612ms on 11 cores; probe timeout set to 3672ms
Load test: 10 of 10 health probes answered within 3672ms (median=1359ms max=2167ms), 0 failed
```

The maximum of 2167 ms is above the old limit of 2000 ms. That probe fails the old test on this machine.

`./gradlew checkstyleIntegrationTest` also passes.

The test cannot pass without a working node. Three conditions must hold: the baseline probe returns 200, the calibration call completes, and the recovery check succeeds.

This branch has no full local run of the `integrationTest` suite. The pipeline on this pull request runs the full suite.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:

  The diff contains one file under `src/integrationTest`. Consensus behaviour, gas accounting, state transitions and the Bridge do not change. No activation code is necessary.

  The box "Tests for the changes have been added" stays empty. This change modifies an existing test. It does not add a new test class.

  The three new constants stay next to the other timeout constants. A reader sees the factor and the limits without a read of the test body.
