### PR TITLE
refactor: extracted markTxIdAsProcessed from markTxAsProcessed 

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -761,19 +761,19 @@ public class BridgeSupport {
 
     private void markTxAsProcessed(BtcTransaction btcTx) throws IOException {
         // Mark tx as processed on this block (and use the txid without the witness)
-        long rskHeight = rskExecutionBlock.getNumber();
-        Sha256Hash btcTxId = btcTx.getHash(false);
-        markTxIdAsProcessed(btcTxId, rskHeight);
+        Sha256Hash btcTxHash = btcTx.getHash(false);
+        markBtcTxHashAsProcessed(btcTxHash);
         logger.debug(
             "[markTxAsProcessed] Mark btc transaction {} (wtxid: {}) as processed at height {}",
-            btcTxId,
+            btcTxHash,
             btcTx.getHash(true),
-            rskHeight
+            rskExecutionBlock.getNumber()
         );
     }
 
-    private void markTxIdAsProcessed(Sha256Hash btcTxId, long rskHeight) throws IOException {
-        provider.setHeightBtcTxhashAlreadyProcessed(btcTxId, rskHeight);
+    private void markBtcTxHashAsProcessed(Sha256Hash btcTxHash) throws IOException {
+        long rskHeight = rskExecutionBlock.getNumber();
+        provider.setHeightBtcTxhashAlreadyProcessed(btcTxHash, rskHeight);
     }
 
     private boolean shouldProcessPegInVersionLegacy(

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -762,13 +762,18 @@ public class BridgeSupport {
     private void markTxAsProcessed(BtcTransaction btcTx) throws IOException {
         // Mark tx as processed on this block (and use the txid without the witness)
         long rskHeight = rskExecutionBlock.getNumber();
-        provider.setHeightBtcTxhashAlreadyProcessed(btcTx.getHash(false), rskHeight);
+        Sha256Hash btcTxId = btcTx.getHash(false);
+        markTxIdAsProcessed(btcTxId, rskHeight);
         logger.debug(
             "[markTxAsProcessed] Mark btc transaction {} (wtxid: {}) as processed at height {}",
-            btcTx.getHash(),
+            btcTxId,
             btcTx.getHash(true),
             rskHeight
         );
+    }
+
+    private void markTxIdAsProcessed(Sha256Hash btcTxId, long rskHeight) throws IOException {
+        provider.setHeightBtcTxhashAlreadyProcessed(btcTxId, rskHeight);
     }
 
     private boolean shouldProcessPegInVersionLegacy(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
markTxAsProcessed(BtcTransaction btcTx) marks a BTC transaction as processed. It only uses one thing from the full BtcTransaction it receives: btcTx.getHash(false) (the no-witness txid, the actual key persisted via provider.setHeightBtcTxhashAlreadyProcessed(...)). Then, btcTx.getHash(true)(the witness hash/wtxid) is used only in a debug log line.

However, by changing the method markTxAsProcessed to receive a txid, we are increasing the risk of misusing it. This is because, from the dev’s point of view, markTxAsProcessed can receive a txid or a wtxid. Having markTxAsProcessed as is deletes this risk because the method itself is computing the txid and not the wtxid. 

Therefore, we decided to create a method markTxIdAsProcessed that will be called from markTxAsProcessed once it computes the txid.

In the future, markTxIdAsProcessed will be called only from registerPegoutTransaction.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
