### PR TITLE
Remove Java 17 HashSet iteration-order emulation

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSerializationUtils.java
@@ -26,7 +26,6 @@ import co.rsk.bitcoinj.core.*;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
-import co.rsk.peg.PegoutsWaitingForConfirmations.EntriesStore;
 import co.rsk.peg.bitcoin.UtxoUtils;
 import co.rsk.peg.federation.constants.FederationConstants;
 import co.rsk.peg.vote.ABICallElection;
@@ -820,7 +819,7 @@ public class BridgeSerializationUtils {
 
     // For the serialization format, see BridgeSerializationUtils::serializePegoutsWaitingForConfirmations
     private static PegoutsWaitingForConfirmations deserializePegoutsWaitingForConfirmationsWithoutTxHash(RLPList rlpList, NetworkParameters networkParameters) {
-        var entries = EntriesStore.setOfEntries();
+        var entries = new HashSet<PegoutsWaitingForConfirmations.Entry>();
 
         int n = rlpList.size() / 2;
         for (int k = 0; k < n; k++) {
@@ -836,7 +835,7 @@ public class BridgeSerializationUtils {
     }
 
     private static PegoutsWaitingForConfirmations deserializePegoutWaitingForConfirmationsWithTxHash(RLPList rlpList, NetworkParameters networkParameters) {
-        var entries = EntriesStore.setOfEntries();
+        var entries = new HashSet<PegoutsWaitingForConfirmations.Entry>();
 
         int n = rlpList.size() / 3;
         for (int k = 0; k < n; k++) {

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeStorageProvider.java
@@ -25,7 +25,6 @@ import static org.ethereum.config.blockchain.upgrades.ConsensusRule.*;
 import co.rsk.bitcoinj.core.*;
 import co.rsk.core.RskAddress;
 import co.rsk.crypto.Keccak256;
-import co.rsk.peg.PegoutsWaitingForConfirmations.EntriesStore;
 import co.rsk.peg.bitcoin.CoinbaseInformation;
 import co.rsk.peg.flyover.FlyoverFederationInformation;
 import java.io.IOException;
@@ -213,7 +212,7 @@ public class BridgeStorageProvider {
 
         var entriesDeser = getFromRepository(PEGOUTS_WAITING_FOR_CONFIRMATIONS,
                 data -> BridgeSerializationUtils.deserializePegoutsWaitingForConfirmations(data, networkParameters).getEntries(activations));
-        var entries = EntriesStore.setOfEntries(entriesDeser);
+        var entries = new HashSet<>(entriesDeser);
 
         if (!activations.isActive(RSKIP146)) {
             pegoutsWaitingForConfirmations = new PegoutsWaitingForConfirmations(entries);

--- a/rskj-core/src/main/java/co/rsk/peg/PegoutsWaitingForConfirmations.java
+++ b/rskj-core/src/main/java/co/rsk/peg/PegoutsWaitingForConfirmations.java
@@ -104,33 +104,10 @@ public class PegoutsWaitingForConfirmations {
      */
     public static class EntriesStore {
 
-        // From java SDK
-        private static final float DEFAULT_LOAD_FACTOR = 0.75f;
-
         private final HashSet<Entry> entriesSet;
 
-        /**
-         * Must be equal to new HashSet() call in Java 17.
-         * Uset it to preserve old behaviour in Java21+.
-         */
-        public static HashSet<Entry> setOfEntries() {
-            return new HashSet<>(16, DEFAULT_LOAD_FACTOR);
-        }
-
-        /**
-         * This is a standard code for `new HashSet<>(entries);` in Java 17.
-         * Coefficients were changed in Java 21.
-         * Use it to prserve old behaviour in Java21+. 
-         */
-        public static HashSet<Entry> setOfEntries(Collection<Entry> entries) {
-            // Need to hardcode Java 17 init params here to preserve old behaviour in Java 21+
-            var ehs = new HashSet<Entry>(Math.max((int) (entries.size()/DEFAULT_LOAD_FACTOR) + 1, 16));
-            ehs.addAll(entries);
-            return ehs;
-        }
-
         private EntriesStore(Collection<Entry> entries) {
-            this.entriesSet = EntriesStore.setOfEntries(entries);
+            this.entriesSet = new HashSet<>(entries);
         }
 
         private boolean hasEnoughConfirmations(Entry entry, Long currentBlockNumber, Integer minimumConfirmations) {


### PR DESCRIPTION
EntriesStore.setOfEntries(...) hardcoded Java 17's HashSet initial capacity so Java 21+ would reproduce the old iteration order that getNextPegoutWithEnoughConfirmations' findFirst() depends on. Revert those construction sites (PegoutsWaitingForConfirmations, BridgeStorageProvider, BridgeSerializationUtils) to the JVM-native new HashSet<>(...), and drop the now-unused EntriesStore imports.

Part of the Java 21 pegout-selection work: forward determinism is provided by the RSKIP559 BTC_TX_COMPARATOR sort, and historic re-execution by the hardcoded selection dataset (separate changes on the integration branch).
