### PR TITLE
Revert "fix: improve yParity validation in TypedTransactionCodec"

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Java & Gradle
         uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e #v5.1.0
         with:
-          java-version: '21'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
 

--- a/rskj-core/src/main/java/org/ethereum/core/transaction/parser/util/TypedTransactionCodec.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/parser/util/TypedTransactionCodec.java
@@ -42,9 +42,6 @@ public final class TypedTransactionCodec {
                                                       int sIndex) {
         byte[] r = txFields.get(rIndex).getRLPData();
         byte[] s = txFields.get(sIndex).getRLPData();
-        // Validated before the unsigned early return so the field is checked on every path.
-        // Callers run requireFieldCount first, so the index always exists.
-        byte yParity = parseTypedYParity(txFields.get(yParityIndex).getRLPData());
 
         if (r == null && s == null) {
             byte chainId = parseTypedTxChainId(txFields.get(chainIdIndex).getRLPData());
@@ -56,6 +53,7 @@ public final class TypedTransactionCodec {
         }
         CommonParsingUtils.requireSignatureComponent(r, "Signature R is not valid");
         CommonParsingUtils.requireSignatureComponent(s, "Signature S is not valid");
+        byte yParity = parseTypedYParity(txFields.get(yParityIndex).getRLPData());
         byte v = (byte) (LOWER_REAL_V + yParity);
         byte chainId = parseTypedTxChainId(txFields.get(chainIdIndex).getRLPData());
         return new SignedSignature(chainId, ECDSASignature.fromComponents(r, s, v));
@@ -69,27 +67,8 @@ public final class TypedTransactionCodec {
         return parseTypedTxChainId(HexUtils.strHexOrStrNumberToByteArray(chainIdHex));
     }
 
-    /**
-     * Parses the yParity field of a typed transaction envelope.
-     *
-     * <p>Rejects payloads wider than one byte and values outside {@code {0, 1}}. A multi-byte
-     * payload such as {@code 0x00 0x01} would otherwise read as yParity 0 and recover a different
-     * address than the signer.
-     *
-     * <p>Both encodings of zero are accepted: the canonical empty item that RLP produces for the
-     * integer 0, and a single {@code 0x00} byte. The latter is non-canonical per EIP-2718, but it
-     * cannot be used for malleability here — {@code Transaction.getEncoded} re-encodes the parsed
-     * fields through {@code TransactionEncoderFactory} instead of retaining the raw bytes, so both
-     * spellings yield the same transaction hash.
-     */
     private static byte parseTypedYParity(byte[] yParityData) {
-        if (yParityData == null || yParityData.length == 0) {
-            return 0;
-        }
-        if (yParityData.length > 1) {
-            throw new IllegalArgumentException("Typed transaction yParity must fit in a single byte");
-        }
-        byte yParity = yParityData[0];
+        byte yParity = (yParityData != null && yParityData.length > 0) ? yParityData[0] : 0;
         if (yParity != 0 && yParity != 1) {
             throw new IllegalArgumentException("Typed transaction yParity must be 0 or 1, got: " + (yParity & 0xFF));
         }

--- a/rskj-core/src/test/java/org/ethereum/core/transaction/parser/util/TypedTransactionCodecTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/transaction/parser/util/TypedTransactionCodecTest.java
@@ -31,7 +31,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -101,35 +100,6 @@ class TypedTransactionCodecTest {
         assertEquals(33, ((UnsignedSignature) state).chainId() & 0xFF);
     }
 
-    /** yParity is validated on the unsigned path too, not only when r and s are present. */
-    @Test
-    void parseTypedSignatureState_unsignedWithMultiByteYParity_throws() {
-        byte[] encoded = RLP.encodeList(
-                RLP.encodeElement(new byte[]{33}),      // chainId = 33
-                RLP.encodeElement(new byte[]{0, 1}),    // yParity spans two bytes
-                RLP.encodeElement(null),                // r absent
-                RLP.encodeElement(null)                 // s absent
-        );
-        RLPList list = (RLPList) RLP.decode2(encoded).get(0);
-
-        assertThrows(IllegalArgumentException.class,
-                () -> TypedTransactionCodec.parseTypedSignatureState(list, 0, 1, 2, 3));
-    }
-
-    @Test
-    void parseTypedSignatureState_unsignedWithYParityOutOfRange_throws() {
-        byte[] encoded = RLP.encodeList(
-                RLP.encodeElement(new byte[]{33}),
-                RLP.encodeElement(new byte[]{2}),   // invalid yParity
-                RLP.encodeElement(null),
-                RLP.encodeElement(null)
-        );
-        RLPList list = (RLPList) RLP.decode2(encoded).get(0);
-
-        assertThrows(IllegalArgumentException.class,
-                () -> TypedTransactionCodec.parseTypedSignatureState(list, 0, 1, 2, 3));
-    }
-
     // -------------------------------------------------------------------------
     // parseTypedSignatureState — incomplete signature (only one of r, s)
     // -------------------------------------------------------------------------
@@ -185,49 +155,12 @@ class TypedTransactionCodecTest {
         assertEquals(33, ((SignedSignature) state).chainId() & 0xFF);
     }
 
-    /**
-     * RLP encodes the integer 0 as an empty item, so an absent yParity field is the canonical
-     * encoding of yParity 0 — not a missing field. It must decode to {@code v = 27}.
-     */
-    @Test
-    void parseTypedSignatureState_emptyYParity_decodesAsZero() {
-        byte[] dummyRS = new byte[32];
-        byte[] encoded = RLP.encodeList(
-                RLP.encodeElement(new byte[]{33}),  // chainId = 33
-                RLP.encodeByte((byte) 0),           // yParity = 0, canonically encoded as empty
-                RLP.encodeElement(dummyRS),         // r
-                RLP.encodeElement(dummyRS)          // s
-        );
-        RLPList list = (RLPList) RLP.decode2(encoded).get(0);
-        assertNull(list.get(1).getRLPData(), "yParity 0 must be encoded as an empty RLP item");
-
-        SignatureState state = TypedTransactionCodec.parseTypedSignatureState(list, 0, 1, 2, 3);
-
-        assertInstanceOf(SignedSignature.class, state);
-        assertEquals((byte) 27, ((SignedSignature) state).signature().getV());
-    }
-
     @Test
     void parseTypedSignatureState_yParityOutOfRange_throws() {
         byte[] dummyRS = new byte[32];
         byte[] encoded = RLP.encodeList(
                 RLP.encodeElement(new byte[]{33}),
                 RLP.encodeElement(new byte[]{2}),   // invalid yParity
-                RLP.encodeElement(dummyRS),
-                RLP.encodeElement(dummyRS)
-        );
-        RLPList list = (RLPList) RLP.decode2(encoded).get(0);
-
-        assertThrows(IllegalArgumentException.class,
-                () -> TypedTransactionCodec.parseTypedSignatureState(list, 0, 1, 2, 3));
-    }
-
-    @Test
-    void parseTypedSignatureState_yParityMultiByte_throws() {
-        byte[] dummyRS = new byte[32];
-        byte[] encoded = RLP.encodeList(
-                RLP.encodeElement(new byte[]{33}),
-                RLP.encodeElement(new byte[]{0, 1}),
                 RLP.encodeElement(dummyRS),
                 RLP.encodeElement(dummyRS)
         );


### PR DESCRIPTION
Reverts rsksmart/rskj#3651