### PR TITLE
Fix Type-4 authorization chain ID validation to accept 0 or the outer transaction chain ID.

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/core/SetCodeAuthorizationTransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/SetCodeAuthorizationTransactionExecutor.java
@@ -18,7 +18,6 @@
 package org.ethereum.core;
 
 import co.rsk.core.RskAddress;
-import org.ethereum.config.Constants;
 import org.ethereum.core.transaction.SetCodeAuthorization;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.signature.Secp256k1;
@@ -31,6 +30,7 @@ import java.security.SignatureException;
 public class SetCodeAuthorizationTransactionExecutor {
 
     public static final byte[] CODE_FOR_CLEANING_DELEGATED_ADDRESS = new byte[0];
+    final BigInteger UNIVERSAL_CHAIN_ID = BigInteger.ZERO;
 
     public long processAuthorizationTuple(Repository repository, BigInteger outerTransactionChainId, SetCodeAuthorization authorization) {
         verifyChainId(authorization.getChainId(), outerTransactionChainId);
@@ -54,12 +54,6 @@ public class SetCodeAuthorizationTransactionExecutor {
     }
 
     private void verifyChainId(BigInteger chainId, BigInteger outerTransactionChainId) {
-        final BigInteger UNIVERSAL_CHAIN_ID = BigInteger.ZERO;
-        boolean valid = chainId.equals(UNIVERSAL_CHAIN_ID) || chainId.equals(BigInteger.valueOf(Constants.MAINNET_CHAIN_ID)) || chainId.equals(BigInteger.valueOf(Constants.TESTNET_CHAIN_ID)) || chainId.equals(BigInteger.valueOf(Constants.REGTEST_CHAIN_ID));
-        if (!valid) {
-            throw new IllegalStateException("Invalid chain ID");
-        }
-
         if (!chainId.equals(UNIVERSAL_CHAIN_ID) && !chainId.equals(outerTransactionChainId)) {
             throw new IllegalStateException("Chain ID mismatch");
         }

--- a/rskj-core/src/main/java/org/ethereum/core/SetCodeAuthorizationTransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/SetCodeAuthorizationTransactionExecutor.java
@@ -30,7 +30,7 @@ import java.security.SignatureException;
 public class SetCodeAuthorizationTransactionExecutor {
 
     public static final byte[] CODE_FOR_CLEANING_DELEGATED_ADDRESS = new byte[0];
-    final BigInteger UNIVERSAL_CHAIN_ID = BigInteger.ZERO;
+    private static final BigInteger UNIVERSAL_CHAIN_ID = BigInteger.ZERO;
 
     public long processAuthorizationTuple(Repository repository, BigInteger outerTransactionChainId, SetCodeAuthorization authorization) {
         verifyChainId(authorization.getChainId(), outerTransactionChainId);

--- a/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/TransactionExecutor.java
@@ -333,7 +333,7 @@ public class TransactionExecutor {
 
     private long processAuthorizationList(List<SetCodeAuthorization> authorizationList, Repository repository, Transaction tx) {
         SetCodeAuthorizationTransactionExecutor authorizationTransactionExecutor = new SetCodeAuthorizationTransactionExecutor();
-        BigInteger outerTransactionChainId = BigInteger.valueOf(tx.getChainId());
+        BigInteger outerTransactionChainId = BigInteger.valueOf(Byte.toUnsignedInt(tx.getChainId()));
         long totalRefund = 0;
 
         for (SetCodeAuthorization authorization : authorizationList) {

--- a/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/SetCodeAuthorizationTransactionExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/SetCodeAuthorizationTransactionExecutorTest.java
@@ -22,8 +22,8 @@ import org.bouncycastle.util.BigIntegers;
 import org.ethereum.config.Constants;
 import org.ethereum.core.DelegationCodeResolver;
 import org.ethereum.core.Repository;
-import org.ethereum.core.Transaction;
 import org.ethereum.core.SetCodeAuthorizationTransactionExecutor;
+import org.ethereum.core.Transaction;
 import org.ethereum.core.transaction.SetCodeAuthorization;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.math.BigInteger;
@@ -43,6 +44,7 @@ import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.ZERO;
 import static org.ethereum.config.Constants.MAINNET_CHAIN_ID;
 import static org.ethereum.config.Constants.REGTEST_CHAIN_ID;
+import static org.ethereum.config.Constants.TESTNET2_CHAIN_ID;
 import static org.ethereum.config.Constants.TESTNET_CHAIN_ID;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -62,8 +64,6 @@ import org.ethereum.core.transaction.parser.util.CommonParsingUtils;
  class SetCodeAuthorizationTransactionExecutorTest {
 
     private static final BigInteger ZERO_CHAIN_ID = ZERO;
-    private static final BigInteger ONE_CHAIN_ID = ONE;
-
     private static final BigInteger NONCE_ONE_VALUE = ONE;
     private static final byte[] NONCE_ONE = NONCE_ONE_VALUE.toByteArray();
     private static final byte[] EMPTY_CODE =  new byte[0];
@@ -127,63 +127,6 @@ import org.ethereum.core.transaction.parser.util.CommonParsingUtils;
         );
 
         assertEquals("Nonce must be < 2^64 - 1", ex.getMessage());
-    }
-
-    @Test
-    void processAuthorizationTuple_shouldThrow_whenChainIdIsInvalid() {
-        var tuple =
-                new SetCodeAuthorization(
-                        BigInteger.valueOf(9999),
-                        randomAddress(),
-                        new byte[]{0x01},
-                        mock(ECDSASignature.class)
-                );
-
-        IllegalStateException ex = assertThrows(
-                IllegalStateException.class,
-                () -> executor.processAuthorizationTuple(repository, ONE_CHAIN_ID, tuple)
-        );
-
-        assertEquals("Invalid chain ID", ex.getMessage());
-    }
-
-    @Test
-    void processAuthorizationTuple_shouldThrow_whenChainIdDoesNotMatchOuterTransaction() {
-       var tuple =
-                new SetCodeAuthorization(
-                        BigInteger.valueOf(MAINNET_CHAIN_ID),
-                        randomAddress(),
-                        new byte[]{0x01},
-                        mock(ECDSASignature.class)
-                );
-
-        IllegalStateException ex = assertThrows(
-                IllegalStateException.class,
-                () -> executor.processAuthorizationTuple(
-                        repository,
-                        BigInteger.valueOf(TESTNET_CHAIN_ID),
-                        tuple
-                )
-        );
-
-        assertEquals("Chain ID mismatch", ex.getMessage());
-    }
-
-    @Test
-    void processAuthorizationTuple_shouldAllowUniversalChainIdWithAnyOuterChainId() {
-        ECKey authorityKey = new ECKey();
-        RskAddress authority = new RskAddress(authorityKey.getAddress());
-
-        var tuple = createValidAuthorizationTuple(RskAddress.ZERO_ADDRESS,
-                NONCE_ONE, ZERO_CHAIN_ID, authorityKey);
-
-        when(repository.getCode(authority)).thenReturn(null);
-        when(repository.getNonce(authority)).thenReturn(NONCE_ONE_VALUE);
-
-        long refund = executor.processAuthorizationTuple(repository, BigInteger.valueOf(33), tuple);
-        verify(repository).saveCode(eq(authority), aryEq(EMPTY_CODE));
-        verify(repository).increaseNonce(authority);
-        assertEquals(0L, refund);
     }
 
     @Test
@@ -288,29 +231,77 @@ import org.ethereum.core.transaction.parser.util.CommonParsingUtils;
         verify(repository, never()).increaseNonce(any());
     }
 
-    @ParameterizedTest
-    @ValueSource(longs = {MAINNET_CHAIN_ID, TESTNET_CHAIN_ID, REGTEST_CHAIN_ID})
-    void processAuthorizationTuple_shouldAllowChainId_whenOuterChainIdMatches(long chainIdValue) {
-        ECKey authorityKey = new ECKey();
-        RskAddress authority = new RskAddress(authorityKey.getAddress());
+     @ParameterizedTest
+     @CsvSource({
+             "30, 31",
+             "31, 30",
+             "32, 34",
+             "34, 32",
+             "127, 128",
+             "128, 127",
+             "128, 255",
+             "255, 128",
+             "254, 255",
+             "255, 254"
+     })
+     void processAuthorizationTuple_shouldRejectNonZeroChainId_whenOuterChainIdDoesNotMatch(long authorizationChainIdValue, long outerChainIdValue) {
+         BigInteger authorizationChainId = BigInteger.valueOf(authorizationChainIdValue);
+         BigInteger outerChainId = BigInteger.valueOf(outerChainIdValue);
 
-        BigInteger chainId = BigInteger.valueOf(chainIdValue);
+         var tuple = new SetCodeAuthorization(authorizationChainId, randomAddress(), NONCE_ONE, mock(ECDSASignature.class));
 
-        var tuple = createValidAuthorizationTuple(
-                RskAddress.ZERO_ADDRESS,
-                NONCE_ONE,
-                chainId,
-                authorityKey
-        );
+         IllegalStateException ex = assertThrows(
+                 IllegalStateException.class,
+                 () -> executor.processAuthorizationTuple(
+                         repository,
+                         outerChainId,
+                         tuple
+                 )
+         );
 
-        when(repository.getCode(authority)).thenReturn(null);
-        when(repository.getNonce(authority)).thenReturn(ONE);
+         assertEquals("Chain ID mismatch", ex.getMessage());
 
-        executor.processAuthorizationTuple(repository, chainId, tuple);
+         verify(repository, never()).getCode(any());
+         verify(repository, never()).getNonce(any());
+         verify(repository, never()).saveCode(any(), any());
+         verify(repository, never()).increaseNonce(any());
+     }
 
-        verify(repository).saveCode(eq(authority), aryEq(EMPTY_CODE));
-        verify(repository).increaseNonce(authority);
-    }
+     @ParameterizedTest
+     @ValueSource(longs = {
+             MAINNET_CHAIN_ID,
+             TESTNET_CHAIN_ID,
+             32,
+             REGTEST_CHAIN_ID,
+             TESTNET2_CHAIN_ID,
+             50,
+             127,
+             128,
+             255
+     })
+     void processAuthorizationTuple_shouldAllowNonZeroChainId_whenOuterChainIdMatches(long chainIdValue) {
+         ECKey authorityKey = new ECKey();
+         RskAddress authority = new RskAddress(authorityKey.getAddress());
+
+         BigInteger chainId = BigInteger.valueOf(chainIdValue);
+
+         var tuple = createValidAuthorizationTuple(
+                 RskAddress.ZERO_ADDRESS,
+                 NONCE_ONE,
+                 chainId,
+                 authorityKey
+         );
+
+         when(repository.getCode(authority)).thenReturn(null);
+         when(repository.getNonce(authority)).thenReturn(NONCE_ONE_VALUE);
+
+         assertDoesNotThrow(() ->
+                 executor.processAuthorizationTuple(repository, chainId, tuple)
+         );
+
+         verify(repository).saveCode(eq(authority), aryEq(EMPTY_CODE));
+         verify(repository).increaseNonce(authority);
+     }
 
     @Test
     void processAuthorizationTuple_shouldSaveExactDelegatedAddressInCode() {
@@ -657,70 +648,123 @@ import org.ethereum.core.transaction.parser.util.CommonParsingUtils;
         verify(repository).increaseNonce(authority);
      }
 
-    @ParameterizedTest
-    @ValueSource(ints = {2, 3, 4, 7, 255})
-    void processAuthorizationTuple_shouldThrow_whenYParityIsOutsideParityRange(int yParity) {
-        var tuple = authorizationWithYParity(yParity);
+     @ParameterizedTest
+     @ValueSource(ints = {2, 3, 4, 7, 255})
+     void processAuthorizationTuple_shouldThrow_whenYParityIsOutsideParityRange(int yParity) {
+         var tuple = authorizationWithYParity(yParity);
 
-        IllegalStateException ex = assertThrows(
-                IllegalStateException.class,
-                () -> executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple)
-        );
+         IllegalStateException ex = assertThrows(
+                 IllegalStateException.class,
+                 () -> executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple)
+         );
 
-        assertEquals("Signature y_parity must be 0 or 1", ex.getMessage());
-        verify(repository, never()).saveCode(any(), any());
-        verify(repository, never()).increaseNonce(any());
-    }
+         assertEquals("Signature y_parity must be 0 or 1", ex.getMessage());
+         verify(repository, never()).saveCode(any(), any());
+         verify(repository, never()).increaseNonce(any());
+     }
 
-    @ParameterizedTest
-    @MethodSource("signatureComponentsOutsideCurveRange")
-    void processAuthorizationTuple_shouldThrow_whenSignatureComponentsAreOutsideCurveRange(
-            BigInteger r, BigInteger s) {
-        var tuple = authorizationWithSignatureComponents(r, s);
+     @ParameterizedTest
+     @MethodSource("signatureComponentsOutsideCurveRange")
+     void processAuthorizationTuple_shouldThrow_whenSignatureComponentsAreOutsideCurveRange(
+             BigInteger r, BigInteger s) {
+         var tuple = authorizationWithSignatureComponents(r, s);
 
-        IllegalStateException ex = assertThrows(
-                IllegalStateException.class,
-                () -> executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple)
-        );
+         IllegalStateException ex = assertThrows(
+                 IllegalStateException.class,
+                 () -> executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple)
+         );
 
-        assertEquals("Signature r and s must be in [1, secp256k1n)", ex.getMessage());
-        verify(repository, never()).saveCode(any(), any());
-        verify(repository, never()).increaseNonce(any());
-    }
+         assertEquals("Signature r and s must be in [1, secp256k1n)", ex.getMessage());
+         verify(repository, never()).saveCode(any(), any());
+         verify(repository, never()).increaseNonce(any());
+     }
 
-    private static Stream<Arguments> signatureComponentsOutsideCurveRange() {
-        BigInteger curveOrder = Constants.getSECP256K1N();
-        return Stream.of(
-                Arguments.of(ZERO, ONE),
-                Arguments.of(curveOrder, ONE),
-                Arguments.of(ONE, ZERO),
-                Arguments.of(ONE, curveOrder)
-        );
-    }
+     private static Stream<Arguments> signatureComponentsOutsideCurveRange() {
+         BigInteger curveOrder = Constants.getSECP256K1N();
+         return Stream.of(
+                 Arguments.of(ZERO, ONE),
+                 Arguments.of(curveOrder, ONE),
+                 Arguments.of(ONE, ZERO),
+                 Arguments.of(ONE, curveOrder)
+         );
+     }
 
-    private SetCodeAuthorization authorizationWithSignatureComponents(BigInteger r, BigInteger s) {
-        SetCodeAuthorization signed = createValidAuthorizationTuple(
-                RskAddress.ZERO_ADDRESS, NONCE_ONE, ZERO_CHAIN_ID, new ECKey());
-        ECDSASignature signature = ECDSASignature.fromComponents(
-                BigIntegers.asUnsignedByteArray(r),
-                BigIntegers.asUnsignedByteArray(s),
-                signed.getSignature().getV()
-        );
+     private SetCodeAuthorization authorizationWithSignatureComponents(BigInteger r, BigInteger s) {
+         SetCodeAuthorization signed = createValidAuthorizationTuple(
+                 RskAddress.ZERO_ADDRESS, NONCE_ONE, ZERO_CHAIN_ID, new ECKey());
+         ECDSASignature signature = ECDSASignature.fromComponents(
+                 BigIntegers.asUnsignedByteArray(r),
+                 BigIntegers.asUnsignedByteArray(s),
+                 signed.getSignature().getV()
+         );
 
-        return new SetCodeAuthorization(ZERO_CHAIN_ID, RskAddress.ZERO_ADDRESS, NONCE_ONE, signature);
-    }
+         return new SetCodeAuthorization(ZERO_CHAIN_ID, RskAddress.ZERO_ADDRESS, NONCE_ONE, signature);
+     }
 
-    private SetCodeAuthorization authorizationWithYParity(int yParity) {
-        SetCodeAuthorization signed = createValidAuthorizationTuple(
-                RskAddress.ZERO_ADDRESS, NONCE_ONE, ZERO_CHAIN_ID, new ECKey());
-        ECDSASignature signature = ECDSASignature.fromComponents(
-                BigIntegers.asUnsignedByteArray(signed.getSignature().getR()),
-                BigIntegers.asUnsignedByteArray(signed.getSignature().getS()),
-                (byte) (Transaction.LOWER_REAL_V + yParity)
-        );
+     private SetCodeAuthorization authorizationWithYParity(int yParity) {
+         SetCodeAuthorization signed = createValidAuthorizationTuple(
+                 RskAddress.ZERO_ADDRESS, NONCE_ONE, ZERO_CHAIN_ID, new ECKey());
+         ECDSASignature signature = ECDSASignature.fromComponents(
+                 BigIntegers.asUnsignedByteArray(signed.getSignature().getR()),
+                 BigIntegers.asUnsignedByteArray(signed.getSignature().getS()),
+                 (byte) (Transaction.LOWER_REAL_V + yParity)
+         );
 
-        return new SetCodeAuthorization(ZERO_CHAIN_ID, RskAddress.ZERO_ADDRESS, NONCE_ONE, signature);
-    }
+         return new SetCodeAuthorization(ZERO_CHAIN_ID, RskAddress.ZERO_ADDRESS, NONCE_ONE, signature);
+     }
+
+     @ParameterizedTest
+     @ValueSource(longs = {
+             MAINNET_CHAIN_ID,
+             TESTNET_CHAIN_ID,
+             32,
+             REGTEST_CHAIN_ID,
+             TESTNET2_CHAIN_ID,
+             127,
+             128,
+             255
+     })
+     void processAuthorizationTuple_shouldAllowUniversalChainId_withAnyOuterChainId(long outerChainIdValue) {
+         ECKey authorityKey = new ECKey();
+         RskAddress authority = new RskAddress(authorityKey.getAddress());
+
+         var tuple = createValidAuthorizationTuple(RskAddress.ZERO_ADDRESS, NONCE_ONE, ZERO_CHAIN_ID, authorityKey);
+
+         when(repository.getCode(authority)).thenReturn(null);
+         when(repository.getNonce(authority)).thenReturn(NONCE_ONE_VALUE);
+
+         assertDoesNotThrow(() ->
+                 executor.processAuthorizationTuple(
+                         repository,
+                         BigInteger.valueOf(outerChainIdValue),
+                         tuple
+                 )
+         );
+
+         verify(repository).saveCode(eq(authority), aryEq(EMPTY_CODE));
+         verify(repository).increaseNonce(authority);
+     }
+
+     @Test
+     void processAuthorizationTuple_shouldNotRequireChainIdToBelongToKnownNetworkList() {
+         ECKey authorityKey = new ECKey();
+         RskAddress authority = new RskAddress(authorityKey.getAddress());
+
+         BigInteger chainId = BigInteger.valueOf(50);
+
+         var tuple = createValidAuthorizationTuple(RskAddress.ZERO_ADDRESS, NONCE_ONE, chainId, authorityKey);
+
+         when(repository.getCode(authority)).thenReturn(null);
+         when(repository.getNonce(authority)).thenReturn(NONCE_ONE_VALUE);
+
+         assertDoesNotThrow(() ->
+                 executor.processAuthorizationTuple(repository, chainId, tuple)
+         );
+
+         verify(repository).saveCode(eq(authority), aryEq(EMPTY_CODE));
+         verify(repository).increaseNonce(authority);
+     }
+
 
     private SetCodeAuthorization createValidAuthorizationTuple(
             RskAddress delegatedAddress,

--- a/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/Type4TransactionExecutorTests.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/Type4TransactionExecutorTests.java
@@ -1747,8 +1747,7 @@ class Type4TransactionExecutorTests extends Type4TransactionExecutorHelperTest {
         when(constants.getChainId()).thenReturn(chainId);
         mockAccountWithBalanceAndNonce(tracker, sender, 1_000_000, ONE_NONCE);
         mockReceiver(receiver, EMPTY_CODE);
-        mockAuthorizationAccount(authorizationTracker, authority, ZERO_NONCE, EMPTY_CODE
-        );
+        mockAuthorizationAccount(authorizationTracker, authority, ZERO_NONCE, EMPTY_CODE);
 
         var authorization = createValidAuthorizationTuple(delegatedAddress, ZERO_NONCE, BigInteger.valueOf(chainIdValue), authorityKey);
 

--- a/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/Type4TransactionExecutorTests.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/Type4TransactionExecutorTests.java
@@ -37,6 +37,8 @@ import org.ethereum.vm.GasCost;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.exception.VMException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InOrder;
 
 import java.math.BigInteger;
@@ -1729,6 +1731,85 @@ class Type4TransactionExecutorTests extends Type4TransactionExecutorHelperTest {
         assertTrue(combinedRefund > maxRefund, "The authorization refund must push the combined refund above the cap");
 
         assertEquals(maxRefund, deductedRefund);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {127, 128, 255})
+    void type4TransactionProcessesAuthorizationWithUnsignedChainId(int chainIdValue) {
+        var authorityKey = new ECKey();
+        var authority = new RskAddress(authorityKey.getAddress());
+
+        var cacheTracker = mock(MutableRepository.class);
+        var authorizationTracker = mock(MutableRepository.class);
+
+        when(tracker.startTracking()).thenReturn(cacheTracker, authorizationTracker);
+        byte chainId = (byte) chainIdValue;
+        when(constants.getChainId()).thenReturn(chainId);
+        mockAccountWithBalanceAndNonce(tracker, sender, 1_000_000, ONE_NONCE);
+        mockReceiver(receiver, EMPTY_CODE);
+        mockAuthorizationAccount(authorizationTracker, authority, ZERO_NONCE, EMPTY_CODE
+        );
+
+        var authorization = createValidAuthorizationTuple(delegatedAddress, ZERO_NONCE, BigInteger.valueOf(chainIdValue), authorityKey);
+
+        var tx = createSignedType4Transaction(
+                senderKey,
+                (byte) chainIdValue,
+                ONE_NONCE,
+                600_000,
+                1,
+                1,
+                receiver,
+                2,
+                EMPTY_DATA,
+                authorization
+        );
+
+        var txExecutor = newExecutor(tx);
+
+        assertTrue(txExecutor.executeTransaction());
+
+        verifyValidAuthorityChanges(authorizationTracker, authority, delegatedAddress);
+    }
+
+    @Test
+    void type4TransactionSkipsAuthorizationWhenUnsignedOuterChainIdDoesNotMatch() {
+        var authorityKey = new ECKey();
+        var authority = new RskAddress(authorityKey.getAddress());
+
+        var cacheTracker = mock(MutableRepository.class);
+        var authorizationTracker = mock(MutableRepository.class);
+
+        when(tracker.startTracking()).thenReturn(cacheTracker, authorizationTracker);
+        byte outerChainId = (byte) 128;
+        when(constants.getChainId()).thenReturn(outerChainId);
+        mockAccountWithBalanceAndNonce(tracker, sender, 1_000_000, ONE_NONCE);
+        mockReceiver(receiver, EMPTY_CODE);
+
+        var authorization = createValidAuthorizationTuple(delegatedAddress, ZERO_NONCE, BigInteger.valueOf(127), authorityKey);
+
+        var tx = createSignedType4Transaction(
+                senderKey,
+                outerChainId,
+                ONE_NONCE,
+                600_000,
+                1,
+                1,
+                receiver,
+                2,
+                EMPTY_DATA,
+                authorization
+        );
+
+        var txExecutor = newExecutor(tx);
+
+        assertTrue(txExecutor.executeTransaction());
+
+        verifyInvalidAuthorityChanges(
+                authorizationTracker,
+                authority,
+                delegatedAddress
+        );
     }
 
     private static byte[] clearStorageSlotsAndBurnGas(int numberOfSlots, int gasBurningOperations) {

--- a/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/helper/Type4TransactionExecutorHelperTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/helper/Type4TransactionExecutorHelperTest.java
@@ -147,9 +147,23 @@ public abstract class Type4TransactionExecutorHelperTest {
             byte chainId,
             ECKey authorityKey
     ) {
+        return createValidAuthorizationTuple(
+                delegatedAddress,
+                nonce,
+                BigInteger.valueOf(Byte.toUnsignedInt(chainId)),
+                authorityKey
+        );
+    }
+
+    protected SetCodeAuthorization createValidAuthorizationTuple(
+            RskAddress delegatedAddress,
+            BigInteger nonce,
+            BigInteger chainId,
+            ECKey authorityKey
+    ) {
         byte[] nonceBytes = CommonParsingUtils.unsignedBytes(nonce);
         byte[] rlpEncoded = RLP.encodeList(
-                RLP.encodeBigInteger(BigInteger.valueOf(chainId)),
+                RLP.encodeBigInteger(chainId),
                 RLP.encodeElement(delegatedAddress.getBytes()),
                 RLP.encodeElement(nonceBytes)
         );
@@ -163,7 +177,7 @@ public abstract class Type4TransactionExecutorHelperTest {
                 ECDSASignature.fromSignature(authorityKey.sign(HashUtil.keccak256(payload)));
 
         return new SetCodeAuthorization(
-                BigInteger.valueOf(chainId),
+                chainId,
                 delegatedAddress,
                 nonceBytes,
                 signature


### PR DESCRIPTION
## Description
Fix Type-4 authorization chain ID validation to accept 0 or the outer transaction chain ID. Also handle the outer chain ID as an unsigned byte.

## Motivation and Context
The previous implementation only accepted chain IDs 0, 30, 31, and 33, incorrectly rejecting devnet (32) and testnet2 (34).
Additionally, chain IDs above 127 were interpreted as negative Java byte values, causing valid authorization tuples to be rejected

## How Has This Been Tested?
Added tests covering supported chain IDs, universal 0, mismatched IDs, and unsigned boundaries (127, 128, 255).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)

* **Other information**: -
