### PR TITLE
Structured rpc transactions emit non canonical nonce encodings

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/core/transaction/parser/TransactionInput.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/parser/TransactionInput.java
@@ -283,11 +283,10 @@ public final class TransactionInput {
         return new BigInteger(1, gasLimitBytes);
     }
 
-    static byte[] resolveNonceBytes(@Nullable byte[] nonceBytes, boolean defaultToZero) {
-        if (nonceBytes != null) {
-            CommonParsingUtils.requireDataWordBytes(nonceBytes, "Nonce is not valid");
-            return nonceBytes;
-        }
-        return defaultToZero ? BigInteger.ZERO.toByteArray() : null;
+    // nonceBytes is always TransactionInput.nonce(), which never surfaces a true null
+    // (ByteUtil.cloneBytes(null) -> empty array), so no null-defaulting is needed here.
+    static byte[] resolveNonceBytes(byte[] nonceBytes) {
+        CommonParsingUtils.requireDataWordBytes(nonceBytes, "Nonce is not valid");
+        return nonceBytes;
     }
 }

--- a/rskj-core/src/main/java/org/ethereum/core/transaction/parser/TransactionInput.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/parser/TransactionInput.java
@@ -132,11 +132,11 @@ public final class TransactionInput {
 
         return new TransactionInput(
                 typePrefix,
-                nonce == null ? null : nonce.toByteArray(),
+                nonce == null ? null : CommonParsingUtils.unsignedBytes(nonce),
                 gasPrice,
                 maxPriorityFeePerGas,
                 maxFeePerGas,
-                gasLimit.toByteArray(),
+                CommonParsingUtils.unsignedBytes(gasLimit),
                 receiveAddress,
                 value,
                 data,

--- a/rskj-core/src/main/java/org/ethereum/core/transaction/parser/Type0RawTransactionParser.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/parser/Type0RawTransactionParser.java
@@ -68,7 +68,7 @@ public class Type0RawTransactionParser implements RawTransactionTypeParser<Parse
 
     @Override
     public ParsedType0Transaction parse(TransactionTypePrefix typePrefix, TransactionInput input, byte defaultChainId) {
-        byte[] nonce = TransactionInput.resolveNonceBytes(input.nonce(), false);
+        byte[] nonce = TransactionInput.resolveNonceBytes(input.nonce());
         BigInteger gasLimit = TransactionInput.resolveGasLimit(input.gasLimit());
         Coin gasPrice = CommonParsingUtils.defaultValue(input.gasPrice());
         Coin value = CommonParsingUtils.defaultValue(input.value());

--- a/rskj-core/src/main/java/org/ethereum/core/transaction/parser/Type1RawTransactionParser.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/parser/Type1RawTransactionParser.java
@@ -74,7 +74,7 @@ public class Type1RawTransactionParser implements RawTransactionTypeParser<Parse
 
     @Override
     public ParsedType1Transaction parse(TransactionTypePrefix typePrefix, TransactionInput input, byte defaultChainId) {
-        byte[] nonce = TransactionInput.resolveNonceBytes(input.nonce(), true);
+        byte[] nonce = TransactionInput.resolveNonceBytes(input.nonce());
         Coin gasPrice = CommonParsingUtils.defaultValue(input.gasPrice());
         BigInteger gasLimit = TransactionInput.resolveGasLimit(input.gasLimit());
         RskAddress receiveAddress = CommonParsingUtils.defaultAddress(input.receiveAddress());

--- a/rskj-core/src/main/java/org/ethereum/core/transaction/parser/Type2RawTransactionParser.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/parser/Type2RawTransactionParser.java
@@ -81,7 +81,7 @@ public class Type2RawTransactionParser implements RawTransactionTypeParser<Parse
 
     @Override
     public ParsedType2Transaction parse(TransactionTypePrefix typePrefix, TransactionInput input, byte defaultChainId) {
-        byte[] nonce = TransactionInput.resolveNonceBytes(input.nonce(), true);
+        byte[] nonce = TransactionInput.resolveNonceBytes(input.nonce());
         BigInteger gasLimit = TransactionInput.resolveGasLimit(input.gasLimit());
         Coin value = CommonParsingUtils.defaultValue(input.value());
         RskAddress receiveAddress = CommonParsingUtils.defaultAddress(input.receiveAddress());

--- a/rskj-core/src/main/java/org/ethereum/core/transaction/parser/Type4RawTransactionParser.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/parser/Type4RawTransactionParser.java
@@ -98,7 +98,7 @@ public class Type4RawTransactionParser implements RawTransactionTypeParser<Parse
 
     @Override
     public ParsedType4Transaction parse(TransactionTypePrefix typePrefix, TransactionInput input, byte defaultChainId) {
-        byte[] nonce = TransactionInput.resolveNonceBytes(input.nonce(), true);
+        byte[] nonce = TransactionInput.resolveNonceBytes(input.nonce());
         BigInteger gasLimit = TransactionInput.resolveGasLimit(input.gasLimit());
         Coin value = CommonParsingUtils.defaultValue(input.value());
         RskAddress receiveAddress = CommonParsingUtils.defaultAddress(input.receiveAddress());

--- a/rskj-core/src/test/java/org/ethereum/core/transaction/parser/NonceGasLimitCanonicalEncodingTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/transaction/parser/NonceGasLimitCanonicalEncodingTest.java
@@ -24,10 +24,12 @@ import org.ethereum.core.transaction.TransactionType;
 import org.ethereum.core.transaction.parser.util.AuthorizationListCodec;
 import org.ethereum.core.transaction.parser.util.CommonParsingUtils;
 import org.ethereum.rpc.CallArguments;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import javax.annotation.Nullable;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.stream.Stream;
@@ -70,6 +72,33 @@ class NonceGasLimitCanonicalEncodingTest {
     @MethodSource("typesAndBoundaries")
     void gasLimitIsCanonical(TransactionType type, BigInteger gasLimit) {
         assertCanonical(type, DEFAULT_NONCE, gasLimit);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("defaultNonceTypes")
+    void nonceOmittedDefaultsToCanonicalZero(TransactionType type) {
+        Transaction builderTx = build(type, BigInteger.ZERO, DEFAULT_GAS_LIMIT);
+        Transaction rpcTx = Transaction.fromCallArguments(callArguments(type, null, DEFAULT_GAS_LIMIT), null, REGTEST_CHAIN_ID);
+
+        byte[] expectedNonce = CommonParsingUtils.unsignedBytes(BigInteger.ZERO);
+        assertArrayEquals(expectedNonce, rpcTx.getNonce());
+        assertArrayEquals(builderTx.getNonce(), rpcTx.getNonce());
+        assertArrayEquals(builderTx.getEncodedRaw(), rpcTx.getEncodedRaw());
+
+        builderTx.sign(PRIVATE_KEY);
+        rpcTx.sign(PRIVATE_KEY);
+
+        assertArrayEquals(builderTx.getEncoded(), rpcTx.getEncoded());
+        assertEquals(builderTx.getRawHash(), rpcTx.getRawHash());
+        assertEquals(builderTx.getHash(), rpcTx.getHash());
+    }
+
+    // TransactionInput.nonce() never surfaces a true null (ByteUtil.cloneBytes(null) -> empty
+    // array), so an omitted nonce resolves to canonical empty bytes for LEGACY too, same as TYPE_1/2/4.
+    @Test
+    void legacyNonceOmittedAlsoResolvesToCanonicalZero() {
+        Transaction rpcTx = Transaction.fromCallArguments(callArguments(TransactionType.LEGACY, null, DEFAULT_GAS_LIMIT), null, REGTEST_CHAIN_ID);
+        assertArrayEquals(CommonParsingUtils.unsignedBytes(BigInteger.ZERO), rpcTx.getNonce());
     }
 
     private static void assertCanonical(TransactionType type, BigInteger nonce, BigInteger gasLimit) {
@@ -136,11 +165,13 @@ class NonceGasLimitCanonicalEncodingTest {
         };
     }
 
-    private static CallArguments callArguments(TransactionType type, BigInteger nonce, BigInteger gasLimit) {
+    private static CallArguments callArguments(TransactionType type, @Nullable BigInteger nonce, BigInteger gasLimit) {
         CallArguments args = new CallArguments();
         args.setFrom("0x0000000000000000000000000000000000000001");
         args.setTo(DEFAULT_RECEIVER.toHexString());
-        args.setNonce(hex(nonce));
+        if (nonce != null) {
+            args.setNonce(hex(nonce));
+        }
         args.setGas(hex(gasLimit));
         args.setValue("0x0");
 
@@ -177,6 +208,11 @@ class NonceGasLimitCanonicalEncodingTest {
     private static Stream<Arguments> typesAndBoundaries() {
         return SUPPORTED_TYPES.stream()
                 .flatMap(type -> BOUNDARIES.stream().map(value -> Arguments.of(type, value)));
+    }
+
+    private static Stream<Arguments> defaultNonceTypes() {
+        return Stream.of(TransactionType.TYPE_1, TransactionType.TYPE_2, TransactionType.TYPE_4)
+                .map(Arguments::of);
     }
 
     private static String hex(BigInteger value) {

--- a/rskj-core/src/test/java/org/ethereum/core/transaction/parser/NonceGasLimitCanonicalEncodingTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/transaction/parser/NonceGasLimitCanonicalEncodingTest.java
@@ -1,0 +1,189 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2026 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.ethereum.core.transaction.parser;
+
+import org.ethereum.core.Rskip545TestSupport;
+import org.ethereum.core.Transaction;
+import org.ethereum.core.transaction.SetCodeAuthorization;
+import org.ethereum.core.transaction.TransactionType;
+import org.ethereum.core.transaction.parser.util.AuthorizationListCodec;
+import org.ethereum.core.transaction.parser.util.CommonParsingUtils;
+import org.ethereum.rpc.CallArguments;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.ethereum.core.Rskip546TestSupport.DEFAULT_GAS_PRICE;
+import static org.ethereum.core.Rskip546TestSupport.DEFAULT_MAX_FEE;
+import static org.ethereum.core.Rskip546TestSupport.DEFAULT_MAX_PRIORITY;
+import static org.ethereum.core.Rskip546TestSupport.DEFAULT_RECEIVER;
+import static org.ethereum.core.Rskip546TestSupport.EMPTY_ACCESS_LIST;
+import static org.ethereum.core.Rskip546TestSupport.REGTEST_CHAIN_ID;
+import static org.ethereum.core.transaction.encoder.EncoderTestSupport.PRIVATE_KEY;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class NonceGasLimitCanonicalEncodingTest {
+
+    private static final BigInteger DEFAULT_NONCE = BigInteger.ONE;
+    private static final BigInteger DEFAULT_GAS_LIMIT = BigInteger.valueOf(21_000);
+
+    private static final List<BigInteger> BOUNDARIES = List.of(
+            BigInteger.ZERO,
+            BigInteger.valueOf(127),
+            BigInteger.valueOf(128),
+            BigInteger.valueOf(255),
+            BigInteger.valueOf(256),
+            BigInteger.valueOf(32767),
+            BigInteger.valueOf(32768)
+    );
+
+
+    private static final List<TransactionType> SUPPORTED_TYPES = List.of(TransactionType.LEGACY, TransactionType.TYPE_1, TransactionType.TYPE_2, TransactionType.TYPE_4);
+
+    @ParameterizedTest(name = "{0} nonce={1}")
+    @MethodSource("typesAndBoundaries")
+    void nonceIsCanonical(TransactionType type, BigInteger nonce) {
+        assertCanonical(type, nonce, DEFAULT_GAS_LIMIT);
+    }
+
+    @ParameterizedTest(name = "{0} gasLimit={1}")
+    @MethodSource("typesAndBoundaries")
+    void gasLimitIsCanonical(TransactionType type, BigInteger gasLimit) {
+        assertCanonical(type, DEFAULT_NONCE, gasLimit);
+    }
+
+    private static void assertCanonical(TransactionType type, BigInteger nonce, BigInteger gasLimit) {
+        Transaction builderTx = build(type, nonce, gasLimit);
+        Transaction rpcTx = Transaction.fromCallArguments(callArguments(type, nonce, gasLimit), null, REGTEST_CHAIN_ID);
+
+        byte[] expectedNonce = CommonParsingUtils.unsignedBytes(nonce);
+        byte[] expectedGasLimit = CommonParsingUtils.unsignedBytes(gasLimit);
+
+        assertArrayEquals(expectedNonce, builderTx.getNonce());
+        assertArrayEquals(expectedNonce, rpcTx.getNonce());
+        assertArrayEquals(expectedGasLimit, builderTx.getGasLimit());
+        assertArrayEquals(expectedGasLimit, rpcTx.getGasLimit());
+        assertArrayEquals(builderTx.getEncodedRaw(), rpcTx.getEncodedRaw());
+
+        builderTx.sign(PRIVATE_KEY);
+        rpcTx.sign(PRIVATE_KEY);
+
+        Transaction rawTx = Transaction.fromRaw(builderTx.getEncoded());
+
+        assertArrayEquals(builderTx.getEncoded(), rpcTx.getEncoded());
+        assertArrayEquals(builderTx.getEncoded(), rawTx.getEncoded());
+        assertEquals(builderTx.getRawHash(), rpcTx.getRawHash());
+        assertEquals(builderTx.getRawHash(), rawTx.getRawHash());
+        assertEquals(builderTx.getHash(), rpcTx.getHash());
+        assertEquals(builderTx.getHash(), rawTx.getHash());
+    }
+
+    private static Transaction build(TransactionType type, BigInteger nonce, BigInteger gasLimit) {
+        var builder = Transaction.builder()
+                .nonce(nonce)
+                .gasLimit(gasLimit)
+                .receiveAddress(DEFAULT_RECEIVER.getBytes())
+                .value(BigInteger.ZERO)
+                .chainId(REGTEST_CHAIN_ID);
+
+        return switch (type) {
+            case LEGACY -> builder
+                    .gasPrice(DEFAULT_GAS_PRICE)
+                    .build();
+
+            case TYPE_1 -> builder
+                    .type(TransactionType.TYPE_1)
+                    .gasPrice(DEFAULT_GAS_PRICE)
+                    .accessList(EMPTY_ACCESS_LIST)
+                    .build();
+
+            case TYPE_2 -> builder
+                    .type(TransactionType.TYPE_2)
+                    .maxPriorityFeePerGas(DEFAULT_MAX_PRIORITY)
+                    .maxFeePerGas(DEFAULT_MAX_FEE)
+                    .accessList(EMPTY_ACCESS_LIST)
+                    .build();
+
+            case TYPE_4 -> builder
+                    .type(TransactionType.TYPE_4)
+                    .maxPriorityFeePerGas(DEFAULT_MAX_PRIORITY)
+                    .maxFeePerGas(DEFAULT_MAX_FEE)
+                    .accessList(EMPTY_ACCESS_LIST)
+                    .authorizationList(fixedAuthorizationList())
+                    .build();
+
+            case TYPE_3 -> throw new IllegalArgumentException("Unsupported transaction type: " + type);
+        };
+    }
+
+    private static CallArguments callArguments(TransactionType type, BigInteger nonce, BigInteger gasLimit) {
+        CallArguments args = new CallArguments();
+        args.setFrom("0x0000000000000000000000000000000000000001");
+        args.setTo(DEFAULT_RECEIVER.toHexString());
+        args.setNonce(hex(nonce));
+        args.setGas(hex(gasLimit));
+        args.setValue("0x0");
+
+        switch (type) {
+            case LEGACY -> args.setGasPrice(hex(DEFAULT_GAS_PRICE.asBigInteger()));
+            case TYPE_1 -> {
+                setTypedFields(args, "0x1");
+                args.setGasPrice(hex(DEFAULT_GAS_PRICE.asBigInteger()));
+            }
+            case TYPE_2 -> {
+                setTypedFields(args, "0x2");
+                setDynamicFeeFields(args);
+            }
+            case TYPE_4 -> {
+                setTypedFields(args, "0x4");
+                setDynamicFeeFields(args);
+                args.setAuthorizationList(List.of(Rskip545TestSupport.defaultType4AuthorizationEntry()));
+            }
+            case TYPE_3 -> throw new IllegalArgumentException("Unsupported transaction type: " + type);
+        }
+        return args;
+    }
+
+    private static void setTypedFields(CallArguments args, String type) {
+        args.setType(type);
+        args.setChainId(hex(BigInteger.valueOf(REGTEST_CHAIN_ID)));
+    }
+
+    private static void setDynamicFeeFields(CallArguments args) {
+        args.setMaxPriorityFeePerGas(hex(DEFAULT_MAX_PRIORITY.asBigInteger()));
+        args.setMaxFeePerGas(hex(DEFAULT_MAX_FEE.asBigInteger()));
+    }
+
+    private static Stream<Arguments> typesAndBoundaries() {
+        return SUPPORTED_TYPES.stream()
+                .flatMap(type -> BOUNDARIES.stream().map(value -> Arguments.of(type, value)));
+    }
+
+    private static String hex(BigInteger value) {
+        return "0x" + value.toString(16);
+    }
+
+    private static List<SetCodeAuthorization> fixedAuthorizationList() {
+        return AuthorizationListCodec.parseFromCallArguments(List.of(Rskip545TestSupport.defaultType4AuthorizationEntry()));
+    }
+}

--- a/rskj-core/src/test/java/org/ethereum/core/transaction/parser/NonceGasLimitCanonicalEncodingTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/transaction/parser/NonceGasLimitCanonicalEncodingTest.java
@@ -22,7 +22,6 @@ import org.ethereum.core.Transaction;
 import org.ethereum.core.transaction.SetCodeAuthorization;
 import org.ethereum.core.transaction.TransactionType;
 import org.ethereum.core.transaction.parser.util.AuthorizationListCodec;
-import org.ethereum.core.transaction.parser.util.CommonParsingUtils;
 import org.ethereum.rpc.CallArguments;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -32,6 +31,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import javax.annotation.Nullable;
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.ethereum.core.Rskip546TestSupport.DEFAULT_GAS_PRICE;
@@ -60,6 +60,18 @@ class NonceGasLimitCanonicalEncodingTest {
     );
 
 
+    private static final Map<BigInteger, byte[]> PINNED_MINIMAL_BYTES = Map.of(
+            BigInteger.ZERO, new byte[]{},
+            BigInteger.ONE, new byte[]{0x01},
+            BigInteger.valueOf(127), new byte[]{0x7f},
+            BigInteger.valueOf(128), new byte[]{(byte) 0x80},
+            BigInteger.valueOf(255), new byte[]{(byte) 0xff},
+            BigInteger.valueOf(256), new byte[]{0x01, 0x00},
+            BigInteger.valueOf(21_000), new byte[]{0x52, 0x08},
+            BigInteger.valueOf(32767), new byte[]{0x7f, (byte) 0xff},
+            BigInteger.valueOf(32768), new byte[]{(byte) 0x80, 0x00}
+    );
+
     private static final List<TransactionType> SUPPORTED_TYPES = List.of(TransactionType.LEGACY, TransactionType.TYPE_1, TransactionType.TYPE_2, TransactionType.TYPE_4);
 
     @ParameterizedTest(name = "{0} nonce={1}")
@@ -80,7 +92,7 @@ class NonceGasLimitCanonicalEncodingTest {
         Transaction builderTx = build(type, BigInteger.ZERO, DEFAULT_GAS_LIMIT);
         Transaction rpcTx = Transaction.fromCallArguments(callArguments(type, null, DEFAULT_GAS_LIMIT), null, REGTEST_CHAIN_ID);
 
-        byte[] expectedNonce = CommonParsingUtils.unsignedBytes(BigInteger.ZERO);
+        byte[] expectedNonce = pinnedMinimalBytes(BigInteger.ZERO);
         assertArrayEquals(expectedNonce, rpcTx.getNonce());
         assertArrayEquals(builderTx.getNonce(), rpcTx.getNonce());
         assertArrayEquals(builderTx.getEncodedRaw(), rpcTx.getEncodedRaw());
@@ -98,15 +110,15 @@ class NonceGasLimitCanonicalEncodingTest {
     @Test
     void legacyNonceOmittedAlsoResolvesToCanonicalZero() {
         Transaction rpcTx = Transaction.fromCallArguments(callArguments(TransactionType.LEGACY, null, DEFAULT_GAS_LIMIT), null, REGTEST_CHAIN_ID);
-        assertArrayEquals(CommonParsingUtils.unsignedBytes(BigInteger.ZERO), rpcTx.getNonce());
+        assertArrayEquals(pinnedMinimalBytes(BigInteger.ZERO), rpcTx.getNonce());
     }
 
     private static void assertCanonical(TransactionType type, BigInteger nonce, BigInteger gasLimit) {
         Transaction builderTx = build(type, nonce, gasLimit);
         Transaction rpcTx = Transaction.fromCallArguments(callArguments(type, nonce, gasLimit), null, REGTEST_CHAIN_ID);
 
-        byte[] expectedNonce = CommonParsingUtils.unsignedBytes(nonce);
-        byte[] expectedGasLimit = CommonParsingUtils.unsignedBytes(gasLimit);
+        byte[] expectedNonce = pinnedMinimalBytes(nonce);
+        byte[] expectedGasLimit = pinnedMinimalBytes(gasLimit);
 
         assertArrayEquals(expectedNonce, builderTx.getNonce());
         assertArrayEquals(expectedNonce, rpcTx.getNonce());
@@ -125,6 +137,14 @@ class NonceGasLimitCanonicalEncodingTest {
         assertEquals(builderTx.getRawHash(), rawTx.getRawHash());
         assertEquals(builderTx.getHash(), rpcTx.getHash());
         assertEquals(builderTx.getHash(), rawTx.getHash());
+    }
+
+    private static byte[] pinnedMinimalBytes(BigInteger value) {
+        byte[] pinned = PINNED_MINIMAL_BYTES.get(value);
+        if (pinned == null) {
+            throw new IllegalArgumentException("no pinned minimal-bytes literal for " + value);
+        }
+        return pinned;
     }
 
     private static Transaction build(TransactionType type, BigInteger nonce, BigInteger gasLimit) {


### PR DESCRIPTION
## Description
Ensures nonce and gas limit values use canonical unsigned byte encoding when transactions are constructed from structured RPC inputs.

## Motivation and Context
BigInteger.toByteArray() may add a leading sign byte for values such as 128, producing non-canonical RLP.
This change ensures structured RPC transactions match canonical builder and raw transaction encodings.

## How Has This Been Tested?
Added boundary tests for nonce and gas limit across Legacy and transaction Types 1, 2, and 4.
Tests verify canonical bytes, signing preimages, signed encodings, and transaction hashes.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)