### PR TITLE
fix: apply authorization tuple checks per tuple instead of at parse time

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/core/SetCodeAuthorizationTransactionExecutor.java
+++ b/rskj-core/src/main/java/org/ethereum/core/SetCodeAuthorizationTransactionExecutor.java
@@ -66,6 +66,8 @@ public class SetCodeAuthorizationTransactionExecutor {
     }
 
     private RskAddress checkRecoveredAuthority(SetCodeAuthorization setCodeAuthorization) {
+        setCodeAuthorization.verifyYParity();
+        setCodeAuthorization.verifySignatureComponents();
         setCodeAuthorization.verifyLowS();
 
         byte[] messageHash =  setCodeAuthorization.getSigningHash();
@@ -74,7 +76,8 @@ public class SetCodeAuthorizationTransactionExecutor {
         try {
             key = Secp256k1.getInstance().signatureToKey(messageHash, setCodeAuthorization.getSignature());
 
-        } catch (SignatureException e) {
+        } catch (SignatureException | IllegalArgumentException e) {
+            // Bouncy Castle reports an r that is not a curve x coordinate as IllegalArgumentException.
             throw new IllegalStateException("Signature recovery failed", e);
         }
 

--- a/rskj-core/src/main/java/org/ethereum/core/transaction/SetCodeAuthorization.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/SetCodeAuthorization.java
@@ -20,6 +20,7 @@ package org.ethereum.core.transaction;
 import co.rsk.core.RskAddress;
 import org.bouncycastle.util.BigIntegers;
 import org.ethereum.config.Constants;
+import org.ethereum.core.Transaction;
 import org.ethereum.core.transaction.parser.util.CommonParsingUtils;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.crypto.signature.ECDSASignature;
@@ -96,6 +97,29 @@ public class SetCodeAuthorization {
 
     public BigInteger getNonceAsInteger() {
         return BigIntegers.fromUnsignedByteArray(nonce);
+    }
+
+    /**
+     * Rejects a y_parity outside {@code {0, 1}}, per tuple, since the decoder admits any single byte.
+     * Recovery cannot do it: headers 31/32 make y_parity 4 and 5 recover the same authority as 0
+     * and 1, so the tuple would be applied rather than skipped.
+     */
+    public void verifyYParity() {
+        byte v = signature.getV();
+        if (v != Transaction.LOWER_REAL_V && v != Transaction.LOWER_REAL_V + 1) {
+            throw new IllegalStateException("Signature y_parity must be 0 or 1");
+        }
+    }
+
+    /**
+     * Rejects signature components outside {@code [1, secp256k1n)}, per tuple, since the decoder
+     * admits any value below {@code 2^256}. The Bouncy Castle backend only sign-checks r and s, so
+     * key recovery cannot do this either.
+     */
+    public void verifySignatureComponents() {
+        if (!signature.validateComponentsWithoutV()) {
+            throw new IllegalStateException("Signature r and s must be in [1, secp256k1n)");
+        }
     }
 
     /**

--- a/rskj-core/src/main/java/org/ethereum/core/transaction/parser/util/AuthorizationListCodec.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/parser/util/AuthorizationListCodec.java
@@ -45,7 +45,7 @@ public final class AuthorizationListCodec {
 
     private static final int TUPLE_FIELD_COUNT = 6;
     private static final BigInteger MAX_CHAIN_ID = BigInteger.ONE.shiftLeft(256);
-    private static final BigInteger MAX_NONCE = BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE);
+    private static final BigInteger MAX_NONCE = BigInteger.ONE.shiftLeft(64);
     private static final BigInteger MAX_SIGNATURE_COMPONENT = BigInteger.ONE.shiftLeft(256);
 
     private AuthorizationListCodec() {}
@@ -142,13 +142,9 @@ public final class AuthorizationListCodec {
         CommonParsingUtils.requireDataWordBytes(nonce, "Authorization nonce is not valid");
         CommonParsingUtils.requireCanonicalScalar(nonce, "Authorization nonce");
         requireNonceInRange(decodeUnsignedBigInteger(nonce));
-        byte yParity = CommonParsingUtils.parseCanonicalYParity(
-                inner.get(3).getRLPData(), "Authorization y_parity");
-        byte[] r = inner.get(4).getRLPData();
-        byte[] s = inner.get(5).getRLPData();
-        if (r == null || s == null) {
-            throw new IllegalArgumentException("Authorization list tuple signature is incomplete");
-        }
+        byte yParity = parseTupleYParity(inner.get(3).getRLPData());
+        byte[] r = CommonParsingUtils.nullToEmpty(inner.get(4).getRLPData());
+        byte[] s = CommonParsingUtils.nullToEmpty(inner.get(5).getRLPData());
         CommonParsingUtils.requireDataWordBytes(r, "Authorization signature r is not valid");
         CommonParsingUtils.requireDataWordBytes(s, "Authorization signature s is not valid");
         CommonParsingUtils.requireCanonicalScalar(r, "Authorization signature r");
@@ -226,7 +222,23 @@ public final class AuthorizationListCodec {
                 signature
         );
         validateAuthorization(auth);
+        requireProcessableAuthorization(auth, index);
         return auth;
+    }
+
+    /**
+     * The raw decoding path deliberately admits tuples that processing will skip, so that one bad
+     * tuple cannot invalidate a whole signed transaction.
+     */
+    private static void requireProcessableAuthorization(SetCodeAuthorization auth, int index) {
+        try {
+            auth.verifyNonceRange();
+            auth.verifyYParity();
+            auth.verifySignatureComponents();
+        } catch (IllegalStateException e) {
+            throw invalidParamError(
+                    "Authorization list entry at index " + index + " is not processable: " + e.getMessage());
+        }
     }
 
     private static BigInteger decodeChainId(byte[] chainIdData) {
@@ -253,10 +265,26 @@ public final class AuthorizationListCodec {
         return new BigInteger(1, value);
     }
 
+    /** Decode bound {@code nonce < 2^64}; the tighter {@code < 2^64 - 1} is a processing step. */
     private static void requireNonceInRange(BigInteger nonceValue) {
         if (nonceValue.signum() < 0 || nonceValue.compareTo(MAX_NONCE) >= 0) {
-            throw new IllegalArgumentException("Authorization nonce must be non-negative and less than 2^64 - 1");
+            throw new IllegalArgumentException("Authorization nonce must be non-negative and less than 2^64");
         }
+    }
+
+    /**
+     * Wire path: canonical and single-byte, but any value. Restricting it to {@code {0, 1}} is a
+     * processing step, so it cannot use the shared {@code parseCanonicalYParity}.
+     */
+    private static byte parseTupleYParity(byte[] yParityData) {
+        if (yParityData == null || yParityData.length == 0) {
+            return 0;
+        }
+        CommonParsingUtils.requireCanonicalScalar(yParityData, "Authorization y_parity");
+        if (yParityData.length > 1) {
+            throw new IllegalArgumentException("Authorization y_parity must fit in a single byte");
+        }
+        return yParityData[0];
     }
 
     /** RPC path only: accepts the 0x00 that a JSON quantity of "0x0" decodes to. */
@@ -267,11 +295,7 @@ public final class AuthorizationListCodec {
         if (yParityData.length > 1) {
             throw new IllegalArgumentException("Authorization y_parity must fit in a single byte");
         }
-        byte yParity = yParityData[0];
-        if (yParity != 0 && yParity != 1) {
-            throw new IllegalArgumentException("Authorization y_parity must be 0 or 1, got: " + (yParity & 0xFF));
-        }
-        return yParity;
+        return yParityData[0];
     }
 
     private static void validateAuthorization(SetCodeAuthorization auth) {
@@ -281,12 +305,13 @@ public final class AuthorizationListCodec {
         requireNonceInRange(decodeUnsignedBigInteger(auth.getNonceBytes()));
 
         ECDSASignature signature = auth.getSignature();
-        BigInteger r = signature.getR();
-        BigInteger s = signature.getS();
-        if (!signature.validateComponentsWithoutV()) {
-            throw new IllegalArgumentException("Authorization signature components are invalid");
+        // The curve range moved to processing, so this is the only remaining lower bound;
+        // asUnsignedByteArray drops the sign instead of failing, so -1 would encode as 0xff.
+        if (signature.getR().signum() < 0 || signature.getS().signum() < 0) {
+            throw new IllegalArgumentException("Authorization signature r and s must be non-negative");
         }
-        if (r.compareTo(MAX_SIGNATURE_COMPONENT) >= 0 || s.compareTo(MAX_SIGNATURE_COMPONENT) >= 0) {
+        if (signature.getR().compareTo(MAX_SIGNATURE_COMPONENT) >= 0
+                || signature.getS().compareTo(MAX_SIGNATURE_COMPONENT) >= 0) {
             throw new IllegalArgumentException("Authorization signature r and s must be less than 2^256");
         }
     }

--- a/rskj-core/src/main/java/org/ethereum/core/transaction/parser/util/AuthorizationListCodec.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/parser/util/AuthorizationListCodec.java
@@ -133,22 +133,10 @@ public final class AuthorizationListCodec {
         CommonParsingUtils.requireCanonicalScalar(chainIdData, "Authorization chain_id");
         BigInteger chainId = decodeChainId(chainIdData);
         RskAddress address = decodeAddress(inner.get(1).getRLPData());
-        byte[] nonce = inner.get(2).getRLPData();
-        if (nonce == null) {
-            nonce = new byte[0];
-        } else {
-            nonce = ByteUtil.cloneBytes(nonce);
-        }
-        CommonParsingUtils.requireDataWordBytes(nonce, "Authorization nonce is not valid");
-        CommonParsingUtils.requireCanonicalScalar(nonce, "Authorization nonce");
-        requireNonceInRange(decodeUnsignedBigInteger(nonce));
-        byte yParity = parseTupleYParity(inner.get(3).getRLPData());
-        byte[] r = CommonParsingUtils.nullToEmpty(inner.get(4).getRLPData());
-        byte[] s = CommonParsingUtils.nullToEmpty(inner.get(5).getRLPData());
-        CommonParsingUtils.requireDataWordBytes(r, "Authorization signature r is not valid");
-        CommonParsingUtils.requireDataWordBytes(s, "Authorization signature s is not valid");
-        CommonParsingUtils.requireCanonicalScalar(r, "Authorization signature r");
-        CommonParsingUtils.requireCanonicalScalar(s, "Authorization signature s");
+        byte[] nonce = decodeAndValidateNonce(inner.get(2));
+        byte yParity = decodeAndValidateYParity(inner.get(3).getRLPData());
+        byte[] r = decodeAndValidateSignatureComponent(inner.get(4), "r");
+        byte[] s = decodeAndValidateSignatureComponent(inner.get(5), "s");
         byte v = (byte) (Transaction.LOWER_REAL_V + yParity);
         ECDSASignature signature = ECDSASignature.fromComponents(r, s, v);
 
@@ -272,11 +260,30 @@ public final class AuthorizationListCodec {
         }
     }
 
+    /** Decode bounds for the nonce, measured as received. */
+    private static byte[] decodeAndValidateNonce(RLPElement field) {
+        byte[] rawNonce = field.getRLPData();
+        byte[] nonce = rawNonce == null ? new byte[0] : ByteUtil.cloneBytes(rawNonce);
+        CommonParsingUtils.requireDataWordBytes(nonce, "Authorization nonce is not valid");
+        CommonParsingUtils.requireCanonicalScalar(nonce, "Authorization nonce");
+        requireNonceInRange(decodeUnsignedBigInteger(nonce));
+        return nonce;
+    }
+
+    /** Decode bounds for r/s; the curve range {@code [1, secp256k1n)} is a processing step. */
+    private static byte[] decodeAndValidateSignatureComponent(RLPElement field, String fieldName) {
+        byte[] component = CommonParsingUtils.nullToEmpty(field.getRLPData());
+        CommonParsingUtils.requireDataWordBytes(
+                component, "Authorization signature " + fieldName + " is not valid");
+        CommonParsingUtils.requireCanonicalScalar(component, "Authorization signature " + fieldName);
+        return component;
+    }
+
     /**
-     * Wire path: canonical and single-byte, but any value. Restricting it to {@code {0, 1}} is a
-     * processing step, so it cannot use the shared {@code parseCanonicalYParity}.
+     * Wire path: canonical and single-byte, but any value, since restricting it to {@code {0, 1}}
+     * is a processing step. That is why it cannot use the shared {@code parseCanonicalYParity}.
      */
-    private static byte parseTupleYParity(byte[] yParityData) {
+    private static byte decodeAndValidateYParity(byte[] yParityData) {
         if (yParityData == null || yParityData.length == 0) {
             return 0;
         }

--- a/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/dto/TransactionResultDTO.java
@@ -169,7 +169,7 @@ public class TransactionResultDTO {
                     HexUtils.toQuantityJsonHex(auth.getChainId()),
                     auth.getAddress().toJsonString(),
                     HexUtils.toQuantityJsonHex(auth.getNonceBytes()),
-                    HexUtils.toQuantityJsonHex((long) signature.getV() - Transaction.LOWER_REAL_V),
+                    HexUtils.toQuantityJsonHex((signature.getV() - Transaction.LOWER_REAL_V) & 0xFF),
                     HexUtils.toQuantityJsonHex(signature.getR()),
                     HexUtils.toQuantityJsonHex(signature.getS())
             ));

--- a/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/SetCodeAuthorizationTransactionExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/SetCodeAuthorizationTransactionExecutorTest.java
@@ -22,6 +22,7 @@ import org.bouncycastle.util.BigIntegers;
 import org.ethereum.config.Constants;
 import org.ethereum.core.DelegationCodeResolver;
 import org.ethereum.core.Repository;
+import org.ethereum.core.Transaction;
 import org.ethereum.core.SetCodeAuthorizationTransactionExecutor;
 import org.ethereum.core.transaction.SetCodeAuthorization;
 import org.ethereum.crypto.ECKey;
@@ -31,9 +32,12 @@ import org.ethereum.util.RLP;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.math.BigInteger;
+import java.util.stream.Stream;
 
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.ZERO;
@@ -64,6 +68,7 @@ import org.ethereum.core.transaction.parser.util.CommonParsingUtils;
     private static final byte[] NONCE_ONE = NONCE_ONE_VALUE.toByteArray();
     private static final byte[] EMPTY_CODE =  new byte[0];
     private static final BigInteger SECP256K1N_HALF = Constants.getSECP256K1N().divide(BigInteger.valueOf(2));
+    private static final BigInteger R_WITHOUT_CURVE_POINT = BigInteger.valueOf(5);
 
     private Repository repository;
     private SetCodeAuthorizationTransactionExecutor executor;
@@ -185,7 +190,10 @@ import org.ethereum.core.transaction.parser.util.CommonParsingUtils;
     void processAuthorizationTuple_shouldThrow_whenSignatureRecoveryFails() {
         ECDSASignature signature = mock(ECDSASignature.class);
 
+        when(signature.getV()).thenReturn(Transaction.LOWER_REAL_V);
+        when(signature.getR()).thenReturn(R_WITHOUT_CURVE_POINT);
         when(signature.getS()).thenReturn(ONE);
+        when(signature.validateComponentsWithoutV()).thenReturn(true);
 
         var tuple = new SetCodeAuthorization(
                         ZERO_CHAIN_ID,
@@ -633,6 +641,71 @@ import org.ethereum.core.transaction.parser.util.CommonParsingUtils;
         verify(repository).saveCode(eq(authority), aryEq(createDelegatedCode(delegated)));
         verify(repository).increaseNonce(authority);
      }
+
+    @ParameterizedTest
+    @ValueSource(ints = {2, 3, 4, 7, 255})
+    void processAuthorizationTuple_shouldThrow_whenYParityIsOutsideParityRange(int yParity) {
+        var tuple = authorizationWithYParity(yParity);
+
+        IllegalStateException ex = assertThrows(
+                IllegalStateException.class,
+                () -> executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple)
+        );
+
+        assertEquals("Signature y_parity must be 0 or 1", ex.getMessage());
+        verify(repository, never()).saveCode(any(), any());
+        verify(repository, never()).increaseNonce(any());
+    }
+
+    @ParameterizedTest
+    @MethodSource("signatureComponentsOutsideCurveRange")
+    void processAuthorizationTuple_shouldThrow_whenSignatureComponentsAreOutsideCurveRange(
+            BigInteger r, BigInteger s) {
+        var tuple = authorizationWithSignatureComponents(r, s);
+
+        IllegalStateException ex = assertThrows(
+                IllegalStateException.class,
+                () -> executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple)
+        );
+
+        assertEquals("Signature r and s must be in [1, secp256k1n)", ex.getMessage());
+        verify(repository, never()).saveCode(any(), any());
+        verify(repository, never()).increaseNonce(any());
+    }
+
+    private static Stream<Arguments> signatureComponentsOutsideCurveRange() {
+        BigInteger curveOrder = Constants.getSECP256K1N();
+        return Stream.of(
+                Arguments.of(ZERO, ONE),
+                Arguments.of(curveOrder, ONE),
+                Arguments.of(ONE, ZERO),
+                Arguments.of(ONE, curveOrder)
+        );
+    }
+
+    private SetCodeAuthorization authorizationWithSignatureComponents(BigInteger r, BigInteger s) {
+        SetCodeAuthorization signed = createValidAuthorizationTuple(
+                RskAddress.ZERO_ADDRESS, NONCE_ONE, ZERO_CHAIN_ID, new ECKey());
+        ECDSASignature signature = ECDSASignature.fromComponents(
+                BigIntegers.asUnsignedByteArray(r),
+                BigIntegers.asUnsignedByteArray(s),
+                signed.getSignature().getV()
+        );
+
+        return new SetCodeAuthorization(ZERO_CHAIN_ID, RskAddress.ZERO_ADDRESS, NONCE_ONE, signature);
+    }
+
+    private SetCodeAuthorization authorizationWithYParity(int yParity) {
+        SetCodeAuthorization signed = createValidAuthorizationTuple(
+                RskAddress.ZERO_ADDRESS, NONCE_ONE, ZERO_CHAIN_ID, new ECKey());
+        ECDSASignature signature = ECDSASignature.fromComponents(
+                BigIntegers.asUnsignedByteArray(signed.getSignature().getR()),
+                BigIntegers.asUnsignedByteArray(signed.getSignature().getS()),
+                (byte) (Transaction.LOWER_REAL_V + yParity)
+        );
+
+        return new SetCodeAuthorization(ZERO_CHAIN_ID, RskAddress.ZERO_ADDRESS, NONCE_ONE, signature);
+    }
 
     private SetCodeAuthorization createValidAuthorizationTuple(
             RskAddress delegatedAddress,

--- a/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/SetCodeAuthorizationTransactionExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/SetCodeAuthorizationTransactionExecutorTest.java
@@ -422,6 +422,21 @@ import org.ethereum.core.transaction.parser.util.CommonParsingUtils;
     }
 
     @Test
+    void processAuthorizationTuple_highS_throws() {
+        var tuple = authorizationWithRecoverableSignatureAndS(
+                BigInteger.ONE.shiftLeft(256).subtract(ONE));
+
+        IllegalStateException ex = assertThrows(
+                IllegalStateException.class,
+                () -> executor.processAuthorizationTuple(repository, ZERO_CHAIN_ID, tuple)
+        );
+
+        assertEquals("Signature r and s must be in [1, secp256k1n)", ex.getMessage());
+        verify(repository, never()).saveCode(any(), any());
+        verify(repository, never()).increaseNonce(any());
+    }
+
+    @Test
     void processAuthorizationTuple_shouldAcceptSignatureSJustBelowHalfCurveOrder() {
         var tuple = authorizationWithRecoverableSignatureAndS(SECP256K1N_HALF.subtract(ONE));
 

--- a/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/Type4TransactionExecutorWithRealRepositoryTests.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/Type4TransactionExecutorWithRealRepositoryTests.java
@@ -40,10 +40,15 @@ import org.ethereum.core.Rskip545TestSupport;
 import org.ethereum.core.SignatureCache;
 import org.ethereum.core.Transaction;
 import org.ethereum.core.TransactionExecutor;
+import org.bouncycastle.util.BigIntegers;
 import org.ethereum.core.transaction.SetCodeAuthorization;
 import org.ethereum.crypto.HashUtil;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.crypto.signature.Secp256k1;
+import org.ethereum.crypto.signature.Secp256k1Service;
 import org.ethereum.crypto.signature.ECDSASignature;
 import org.ethereum.datasource.HashMapDB;
+import org.mockito.MockedStatic;
 import org.ethereum.db.MutableRepository;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.GasCost;
@@ -54,6 +59,7 @@ import org.ethereum.vm.program.invoke.ProgramInvokeFactoryImpl;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
+import java.security.SignatureException;
 import java.util.List;
 
 import static org.ethereum.util.ByteUtil.EMPTY_BYTE_ARRAY;
@@ -63,10 +69,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.AdditionalMatchers.aryEq;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -79,6 +89,8 @@ import static org.mockito.Mockito.when;
 class Type4TransactionExecutorWithRealRepositoryTests extends Type4TransactionExecutorHelperTest {
 
     private static final byte[] ARBITRARY_CONTRACT_CODE = Hex.decode("60006000f3");
+    /** Maps onto compressed-key header 31, which recovers successfully to the wrong authority. */
+    private static final int COMPRESSED_KEY_Y_PARITY = 4;
     private static final byte[] DELEGATED_PREFIX_ONLY = new byte[] {(byte) 0xef, 0x01, 0x00};
     private static final byte[] DELEGATED_WRONG_LENGTH = new byte[] {(byte) 0xef, 0x01, 0x00, 0x01};
     /** Stores 0x42 at slot 0, then stores ADDRESS at slot 1. */
@@ -89,6 +101,127 @@ class Type4TransactionExecutorWithRealRepositoryTests extends Type4TransactionEx
     // -------------------------------------------------------------------------
     // Invalid authorization handling
     // -------------------------------------------------------------------------
+
+    @Test
+    void tupleWithNonceAtMaxUint64MinusOne_isSkippedWhileSiblingTupleApplies() {
+        BigInteger maxUint64MinusOne = BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE);
+
+        assertOnlyOffendingTupleIsSkipped(
+                createValidAuthorizationTuple(
+                        delegatedAddress, maxUint64MinusOne, constants.getChainId(), authorityKey));
+    }
+
+    @Test
+    void tupleWithOutOfRangeYParity_isSkippedWhileSiblingTupleApplies() {
+        SetCodeAuthorization signed = createValidAuthorizationTuple(
+                delegatedAddress, ZERO_NONCE, constants.getChainId(), authorityKey);
+
+        assertOnlyOffendingTupleIsSkipped(withSignature(signed, ECDSASignature.fromComponents(
+                BigIntegers.asUnsignedByteArray(signed.getSignature().getR()),
+                BigIntegers.asUnsignedByteArray(signed.getSignature().getS()),
+                (byte) (Transaction.LOWER_REAL_V + COMPRESSED_KEY_Y_PARITY))));
+    }
+
+    @Test
+    void tupleWithZeroSignatureR_isSkippedWhileSiblingTupleApplies() {
+        SetCodeAuthorization signed = createValidAuthorizationTuple(
+                delegatedAddress, ZERO_NONCE, constants.getChainId(), authorityKey);
+
+        assertOnlyOffendingTupleIsSkipped(withSignature(signed, ECDSASignature.fromComponents(
+                BigIntegers.asUnsignedByteArray(BigInteger.ZERO),
+                BigIntegers.asUnsignedByteArray(signed.getSignature().getS()),
+                signed.getSignature().getV())));
+    }
+
+    @Test
+    void tupleRecoveringZeroAuthority_isSkippedWhileSiblingTupleApplies() throws SignatureException {
+        SetCodeAuthorization offendingTuple = createValidAuthorizationTuple(
+                createRandomAddress(), ZERO_NONCE, constants.getChainId(), authorityKey);
+        SkippedTupleScenario scenario = prepareSkippedTupleScenario(offendingTuple);
+
+        ECKey zeroAddressKey = mock(ECKey.class);
+        when(zeroAddressKey.getAddress()).thenReturn(new byte[RskAddress.LENGTH_IN_BYTES]);
+
+        Secp256k1Service realService = Secp256k1.getInstance();
+        Secp256k1Service stubbedService = mock(Secp256k1Service.class, delegatesTo(realService));
+        doReturn(zeroAddressKey).when(stubbedService)
+                .signatureToKey(aryEq(offendingTuple.getSigningHash()), any());
+
+        try (MockedStatic<Secp256k1> secp256k1 = mockStatic(Secp256k1.class)) {
+            secp256k1.when(Secp256k1::getInstance).thenReturn(stubbedService);
+
+            assertTrue(newExecutorWithRealSignatureCache(scenario.tx(), scenario.repository())
+                    .executeTransaction());
+        }
+
+        assertSiblingTupleApplied(scenario);
+        assertAuthorityStateUnchanged(
+                scenario.repository(), RskAddress.ZERO_ADDRESS, EMPTY_CODE, ZERO_NONCE);
+    }
+
+    private void assertOnlyOffendingTupleIsSkipped(SetCodeAuthorization offendingTuple) {
+        SkippedTupleScenario scenario = prepareSkippedTupleScenario(offendingTuple);
+
+        assertTrue(newExecutorWithRealSignatureCache(scenario.tx(), scenario.repository())
+                .executeTransaction());
+
+        assertSiblingTupleApplied(scenario);
+    }
+
+    private SkippedTupleScenario prepareSkippedTupleScenario(SetCodeAuthorization offendingTuple) {
+        MutableRepository repository = createRepository();
+        ECKey siblingAuthorityKey = new ECKey();
+        RskAddress siblingAuthority = new RskAddress(siblingAuthorityKey.getAddress());
+
+        prepareAuthority(repository, authorityAddress, ZERO_NONCE, EMPTY_CODE);
+        prepareAuthority(repository, siblingAuthority, ZERO_NONCE, EMPTY_CODE);
+        fundSender(repository, ZERO_NONCE, 1_000_000);
+        prepareReceiver(repository);
+
+        SetCodeAuthorization siblingTuple = createValidAuthorizationTuple(
+                delegatedAddress, ZERO_NONCE, constants.getChainId(), siblingAuthorityKey);
+
+        Transaction built = createSignedType4Transaction(
+                senderKey,
+                constants.getChainId(),
+                ZERO_NONCE,
+                600_000,
+                1,
+                1,
+                receiver,
+                2,
+                EMPTY_DATA,
+                offendingTuple,
+                siblingTuple
+        );
+        Transaction tx = Transaction.fromRaw(built.getEncoded());
+        assertArrayEquals(built.getEncoded(), tx.getEncoded(),
+                "Offending tuple must survive a raw encoding round trip unchanged");
+        assertEquals(built.getHash(), tx.getHash());
+        mockSuccessfulProgramInvokeForAnyRepository(tx);
+
+        return new SkippedTupleScenario(repository, tx, siblingAuthority);
+    }
+
+    private void assertSiblingTupleApplied(SkippedTupleScenario scenario) {
+        MutableRepository repository = scenario.repository();
+
+        assertAuthorityStateUnchanged(repository, authorityAddress, EMPTY_CODE, ZERO_NONCE);
+        assertAuthorityDelegatedTo(repository, scenario.siblingAuthority(), delegatedAddress);
+        assertEquals(ONE_NONCE, repository.getNonce(scenario.siblingAuthority()));
+        assertValueTransferredToReceiver(repository, receiver, 2);
+    }
+
+    private record SkippedTupleScenario(
+            MutableRepository repository,
+            Transaction tx,
+            RskAddress siblingAuthority
+    ) {}
+
+    private SetCodeAuthorization withSignature(SetCodeAuthorization base, ECDSASignature signature) {
+        return new SetCodeAuthorization(
+                base.getChainId(), base.getAddress(), base.getNonceBytes(), signature);
+    }
 
     @Test
     void wrongSignature_doesNotMutateAuthorityCodeOrNonce() {

--- a/rskj-core/src/test/java/org/ethereum/core/transaction/parser/Type4RawTransactionParserTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/transaction/parser/Type4RawTransactionParserTest.java
@@ -393,15 +393,39 @@ class Type4RawTransactionParserTest {
                 () -> parser.parse(TransactionTypePrefix.typed(TransactionType.TYPE_4), fields));
     }
 
-    @ParameterizedTest(name = "parse_rlp rejects auth yParity={0}")
-    @ValueSource(ints = {2, 5})
-    void parse_rlp_authYParityInvalid_throws(int yParityValue) {
+    @ParameterizedTest(name = "parse_rlp accepts auth yParity={0}")
+    @ValueSource(ints = {2, 5, 255})
+    void parse_rlp_authYParityOutsideParityRange_succeeds(int yParityValue) {
         byte[] authList = Rskip545TestSupport.authListWithModifiedTupleField(
                 3, RLP.encodeByte((byte) yParityValue));
-        RLPList fields = Rskip545TestSupport.buildType4RlpList(RECEIVER, authList);
 
-        assertThrows(IllegalArgumentException.class,
-                () -> parser.parse(TransactionTypePrefix.typed(TransactionType.TYPE_4), fields));
+        assertDoesNotThrow(() -> parseSignedType4WithAuthList(authList));
+    }
+
+    @Test
+    void parse_rlp_authNonceAtMaxUint64MinusOne_succeeds() {
+        byte[] authList = Rskip545TestSupport.authListWithModifiedTupleField(
+                2, RLP.encodeBigInteger(BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE)));
+
+        assertDoesNotThrow(() -> parseSignedType4WithAuthList(authList));
+    }
+
+    @ParameterizedTest(name = "parse_rlp accepts auth signature field {0} = 0")
+    @ValueSource(ints = {4, 5})
+    void parse_rlp_authZeroSignatureComponent_succeeds(int fieldIndex) {
+        byte[] authList = Rskip545TestSupport.authListWithModifiedTupleField(
+                fieldIndex, RLP.encodeElement(new byte[0]));
+
+        assertDoesNotThrow(() -> parseSignedType4WithAuthList(authList));
+    }
+
+    private ParsedType4Transaction parseSignedType4WithAuthList(byte[] authList) {
+        byte[][] encodedFields = Rskip545TestSupport.defaultSignedType4Fields(RECEIVER, authList);
+        encodedFields[11] = RLP.encodeElement(BigIntegers.asUnsignedByteArray(BigInteger.ONE));
+        encodedFields[12] = RLP.encodeElement(BigIntegers.asUnsignedByteArray(BigInteger.ONE));
+        RLPList fields = RLP.decodeList(RLP.encodeList(encodedFields));
+
+        return parser.parse(TransactionTypePrefix.typed(TransactionType.TYPE_4), fields);
     }
 
     /**

--- a/rskj-core/src/test/java/org/ethereum/core/transaction/parser/util/AuthorizationListCodecTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/transaction/parser/util/AuthorizationListCodecTest.java
@@ -40,6 +40,7 @@ import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -52,6 +53,8 @@ class AuthorizationListCodecTest {
 
     private static final BigInteger SECP256K1N_HALF =
             Constants.getSECP256K1N().divide(BigInteger.valueOf(2));
+    private static final int R_FIELD_INDEX = 4;
+    private static final int S_FIELD_INDEX = 5;
 
     // -------------------------------------------------------------------------
     // encodeList / decodeListUnchecked
@@ -152,6 +155,42 @@ class AuthorizationListCodecTest {
         assertEquals(BigInteger.valueOf(33), auth.getChainId());
         assertEquals(reference.getAddress(), auth.getAddress());
         assertEquals(BigInteger.ONE, new BigInteger(1, auth.getNonceBytes()));
+    }
+
+    @Test
+    void parseFromCallArguments_nonceAtMaxUint64MinusOne_throws() {
+        SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
+        CallArguments.AuthorizationListEntry entry = validEntry(reference, reference.getSignature());
+        entry.setNonce("0xffffffffffffffff");
+
+        RskJsonRpcRequestException ex = assertThrows(RskJsonRpcRequestException.class,
+                () -> AuthorizationListCodec.parseFromCallArguments(List.of(entry)));
+
+        assertTrue(ex.getMessage().contains("2^64 - 1"), ex.getMessage());
+    }
+
+    @Test
+    void parseFromCallArguments_yParityOutsideParityRange_throws() {
+        SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
+        CallArguments.AuthorizationListEntry entry = validEntry(reference, reference.getSignature());
+        entry.setYParity("0x4");
+
+        RskJsonRpcRequestException ex = assertThrows(RskJsonRpcRequestException.class,
+                () -> AuthorizationListCodec.parseFromCallArguments(List.of(entry)));
+
+        assertTrue(ex.getMessage().contains("y_parity"), ex.getMessage());
+    }
+
+    @Test
+    void parseFromCallArguments_zeroSignatureR_throws() {
+        SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
+        CallArguments.AuthorizationListEntry entry = validEntry(reference, reference.getSignature());
+        entry.setR("0x0");
+
+        RskJsonRpcRequestException ex = assertThrows(RskJsonRpcRequestException.class,
+                () -> AuthorizationListCodec.parseFromCallArguments(List.of(entry)));
+
+        assertTrue(ex.getMessage().contains("secp256k1n"), ex.getMessage());
     }
 
     @Test
@@ -306,15 +345,14 @@ class AuthorizationListCodecTest {
     }
 
     @Test
-    void decodeTuple_nonceAtMaxUint64MinusOne_throws() {
+    void decodeTuple_nonceAtMaxUint64MinusOne_decodes() {
         SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
-        byte[] tuple = rebuildTupleField(reference, 2,
-                RLP.encodeBigInteger(BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE)));
+        BigInteger maxUint64MinusOne = BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE);
+        byte[] tuple = rebuildTupleField(reference, 2, RLP.encodeBigInteger(maxUint64MinusOne));
 
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> decodeSingleTuple(tuple));
-        assertTrue(ex.getMessage().contains("2^64"),
-                "Expected nonce range error, got: " + ex.getMessage());
+        SetCodeAuthorization decoded = decodeSingleTuple(tuple);
+
+        assertEquals(maxUint64MinusOne, new BigInteger(1, decoded.getNonceBytes()));
     }
 
     @Test
@@ -327,16 +365,35 @@ class AuthorizationListCodecTest {
         assertEquals(maxAllowed, new BigInteger(1, decoded.getNonceBytes()));
     }
 
-    @Test
-    void decodeTuple_missingSignatureComponents_throws() {
+    @ParameterizedTest
+    @ValueSource(ints = {R_FIELD_INDEX, S_FIELD_INDEX})
+    void decodeTuple_zeroSignatureComponent_decodes(int fieldIndex) {
         SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
-        byte[] tuple = rebuildTupleField(reference, 4, RLP.encodeElement(null));
+        byte[] tuple = rebuildTupleField(reference, fieldIndex, RLP.encodeElement(new byte[0]));
 
-        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> AuthorizationListCodec.decodeTuple(RLP.decode2(tuple).get(0)));
+        SetCodeAuthorization decoded = decodeSingleTuple(tuple);
 
-        assertTrue(ex.getMessage().contains("incomplete"),
-                "Expected incomplete signature error, got: " + ex.getMessage());
+        assertEquals(BigInteger.ZERO, signatureComponent(decoded, fieldIndex));
+        assertArrayEquals(tuple, AuthorizationListCodec.encodeTuple(decoded));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {R_FIELD_INDEX, S_FIELD_INDEX})
+    void decodeTuple_signatureComponentAtCurveOrder_decodes(int fieldIndex) {
+        SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
+        BigInteger curveOrder = Constants.getSECP256K1N();
+        byte[] tuple = rebuildTupleField(reference, fieldIndex, RLP.encodeBigInteger(curveOrder));
+
+        SetCodeAuthorization decoded = decodeSingleTuple(tuple);
+
+        assertEquals(curveOrder, signatureComponent(decoded, fieldIndex));
+        assertArrayEquals(tuple, AuthorizationListCodec.encodeTuple(decoded));
+    }
+
+    private static BigInteger signatureComponent(SetCodeAuthorization authorization, int fieldIndex) {
+        return fieldIndex == R_FIELD_INDEX
+                ? authorization.getSignature().getR()
+                : authorization.getSignature().getS();
     }
 
     @Test
@@ -348,12 +405,28 @@ class AuthorizationListCodecTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {2, 5})
-    void decodeTuple_invalidYParityValue_throws(int yParityValue) {
+    @ValueSource(ints = {2, 5, 255})
+    void decodeTuple_yParityOutsideParityRange_decodes(int yParityValue) {
         SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
         byte[] tuple = rebuildTupleField(reference, 3, RLP.encodeByte((byte) yParityValue));
 
-        assertThrows(IllegalArgumentException.class, () -> decodeSingleTuple(tuple));
+        SetCodeAuthorization decoded = decodeSingleTuple(tuple);
+
+        assertEquals(yParityValue, (decoded.getSignature().getV() - Transaction.LOWER_REAL_V) & 0xFF);
+    }
+
+    /**
+     * A tuple carrying an out-of-range y_parity must re-encode to the exact bytes it was decoded
+     * from, otherwise admitting it at decode time would shift the enclosing transaction hash.
+     */
+    @Test
+    void encodeTuple_yParityOutsideParityRange_roundTrips() {
+        SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
+        byte[] tuple = rebuildTupleField(reference, 3, RLP.encodeByte((byte) 255));
+
+        byte[] reencoded = AuthorizationListCodec.encodeTuple(decodeSingleTuple(tuple));
+
+        assertArrayEquals(tuple, reencoded);
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/core/transaction/parser/util/AuthorizationListCodecTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/transaction/parser/util/AuthorizationListCodecTest.java
@@ -582,6 +582,20 @@ class AuthorizationListCodecTest {
     }
 
     @Test
+    void decodeTuple_highS_decodes() {
+        SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
+        BigInteger maxDecodableS = BigInteger.ONE.shiftLeft(256).subtract(BigInteger.ONE);
+        byte[] tuple = rebuildTupleField(
+                reference,
+                5,
+                RLP.encodeElement(BigIntegers.asUnsignedByteArray(maxDecodableS)));
+
+        SetCodeAuthorization decoded = decodeSingleTuple(tuple);
+
+        assertEquals(maxDecodableS, decoded.getSignature().getS());
+    }
+
+    @Test
     void decodeTuple_nullNonceField_defaultsToEmpty() {
         SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
         byte[] tuple = rebuildTupleField(reference, 2, RLP.encodeElement(null));
@@ -744,6 +758,26 @@ class AuthorizationListCodecTest {
 
         assertThrows(IllegalArgumentException.class,
                 () -> AuthorizationListCodec.encodeTuple(bad));
+    }
+
+    /** {@code asUnsignedByteArray} drops the sign rather than failing, so -1 would encode as 0xff. */
+    @ParameterizedTest
+    @ValueSource(ints = {R_FIELD_INDEX, S_FIELD_INDEX})
+    void encodeTuple_negativeSignatureComponent_throws(int fieldIndex) {
+        SetCodeAuthorization auth = Rskip545TestSupport.minimalAuthorization((byte) 33);
+        BigInteger negative = BigInteger.valueOf(-1);
+        SetCodeAuthorization bad = new SetCodeAuthorization(
+                auth.getChainId(),
+                auth.getAddress(),
+                auth.getNonceBytes(),
+                new ECDSASignature(
+                        fieldIndex == R_FIELD_INDEX ? negative : auth.getSignature().getR(),
+                        fieldIndex == S_FIELD_INDEX ? negative : auth.getSignature().getS(),
+                        auth.getSignature().getV()));
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> AuthorizationListCodec.encodeTuple(bad));
+        assertEquals("Authorization signature r and s must be non-negative", ex.getMessage());
     }
 
     // -------------------------------------------------------------------------

--- a/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionResultDTOTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/dto/TransactionResultDTOTest.java
@@ -18,6 +18,7 @@
 package org.ethereum.rpc.dto;
 
 import co.rsk.config.TestSystemProperties;
+import org.bouncycastle.util.BigIntegers;
 import co.rsk.core.Coin;
 import co.rsk.core.RskAddress;
 import co.rsk.remasc.RemascTransaction;
@@ -38,6 +39,8 @@ import org.ethereum.crypto.signature.ECDSASignature;
 import org.ethereum.util.RLP;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
 import java.lang.reflect.Method;
@@ -399,6 +402,31 @@ class TransactionResultDTOTest {
         Assertions.assertEquals("0x0", entry.getYParity());
         Assertions.assertEquals("0x1", entry.getR());
         Assertions.assertEquals("0x2", entry.getS());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {2, 100, 101, 255})
+    void encodeAuthorizationList_rendersYParityOutsideParityRange(int yParity) throws Exception {
+        SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
+        ECDSASignature signature = ECDSASignature.fromComponents(
+                BigIntegers.asUnsignedByteArray(reference.getSignature().getR()),
+                BigIntegers.asUnsignedByteArray(reference.getSignature().getS()),
+                (byte) (Transaction.LOWER_REAL_V + yParity)
+        );
+        SetCodeAuthorization authorization = new SetCodeAuthorization(
+                reference.getChainId(), reference.getAddress(), reference.getNonceBytes(), signature);
+
+        Method encode = TransactionResultDTO.class.getDeclaredMethod(
+                "encodeAuthorizationList", List.class);
+        encode.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        List<TransactionResultDTO.AuthorizationListEntryDTO> entries =
+                (List<TransactionResultDTO.AuthorizationListEntryDTO>)
+                        encode.invoke(null, List.of(authorization));
+
+        Assertions.assertEquals(
+                "0x" + Integer.toHexString(yParity), entries.get(0).getYParity());
     }
 
     @Test


### PR DESCRIPTION
Fixes validations to ensure not invalidate whole transaction for tuples processing failures.

## Description
RSKIP-545 has two validation tiers: decode bounds (`nonce < 2**64`, `y_parity < 2**8`, `r`/`s < 2**256`, ...) invalidate the whole transaction, while processing-step failures skip just that tuple. Four checks were enforced in the wrong tier.

`AuthorizationListCodec` now decodes to the actual bounds (nonce `< 2^64`, any single-byte `y_parity`, `r`/`s < 2^256` without the curve-range check). `SetCodeAuthorization` gains `verifyYParity()` and `verifySignatureComponents()`, run during processing in `checkRecoveredAuthority` where the executor already rolls back and continues per tuple.

Also catches `IllegalArgumentException` during recovery (Bouncy Castle's error for a non-curve `r`), and masks the authorization-list `y_parity` in `TransactionResultDTO` so values above 127 aren't sign-extended.

## Motivation and Context
Malformated tuple discarded the whole transaction along with valid siblings. The changes fix it.

## How Has This Been Tested?
Updated unit tests assert the previously-rejected values now decode, that processing still rejects and skip them, and that two-tuple transaction with a bad tuple first still executes and applies the good tuple.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
