### PR TITLE
feat: refactored validationsForRegisterBtcTransaction

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -3514,7 +3514,7 @@ public class BridgeSupport {
                 return false;
             }
         } catch (Exception e) {
-            String panicMessage = String.format("[validationsForRegisterBtcTransaction] Btc Tx %s Supplied Height is %d but should be greater than 0", btcTxHash, height);
+            String panicMessage = String.format("[areHeightAndConfirmationsValid] Btc Tx %s with supplied Height %d could not be validated", btcTxHash, height);
             logger.warn(panicMessage);
             return false;
         }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -3515,7 +3515,7 @@ public class BridgeSupport {
             }
         } catch (Exception e) {
             String panicMessage = String.format("[areHeightAndConfirmationsValid] Btc Tx %s with supplied Height %d could not be validated", btcTxHash, height);
-            logger.warn(panicMessage);
+            logger.warn(panicMessage, e);
             return false;
         }
         return true;

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -3523,7 +3523,7 @@ public class BridgeSupport {
 
     private static void validatePMTSize(byte[] pmtSerialized) throws BridgeIllegalArgumentException {
         if (!PartialMerkleTreeFormatUtils.hasExpectedSize(pmtSerialized)) {
-            String message = "PartialMerkleTree doesn't have expected size";
+            String message = "[validatePMTSize] PartialMerkleTree doesn't have expected size";
             logger.warn(message);
             throw new BridgeIllegalArgumentException(message);
         }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java
@@ -3476,6 +3476,34 @@ public class BridgeSupport {
             throws BlockStoreException, VerificationException.EmptyInputsOrOutputs, BridgeIllegalArgumentException {
 
         // Validates height and confirmations for tx
+        if (!areHeightAndConfirmationsValid(btcTxHash, height)) {
+            return false;
+        }
+
+        // Validates pmt size
+        validatePMTSize(pmtSerialized);
+
+        // Calculates merkleRoot
+        Optional<Sha256Hash> merkleRoot = getMerkleRoot(btcTxHash, pmtSerialized);
+        if (merkleRoot.isEmpty()) {
+            return false;
+        }
+
+        // Validates inputs count
+        logger.info("[validationsForRegisterBtcTransaction] Going to validate inputs for btc tx {}", btcTxHash);
+        BridgeUtils.validateInputsCount(btcTxSerialized, activations.isActive(ConsensusRule.RSKIP143));
+
+        // Check the merkle root equals merkle root of btc block at specified height in the btc best chain
+        // BTC blockstore is available since we've already queried the best chain height
+        if (!isMerkleRootWithBlockHeaderValid(btcTxHash, height, merkleRoot.get())) {
+            return false;
+        }
+
+        logger.trace("[validationsForRegisterBtcTransaction] Btc tx: {} successfully validated", btcTxHash);
+        return true;
+    }
+
+    private boolean areHeightAndConfirmationsValid(Sha256Hash btcTxHash, int height) {
         try {
             int acceptableConfirmationsAmount = bridgeConstants.getBtc2RskMinimumAcceptableConfirmations();
             if (!BridgeUtils.validateHeightAndConfirmations(
@@ -3490,37 +3518,33 @@ public class BridgeSupport {
             logger.warn(panicMessage);
             return false;
         }
+        return true;
+    }
 
-        // Validates pmt size
+    private static void validatePMTSize(byte[] pmtSerialized) throws BridgeIllegalArgumentException {
         if (!PartialMerkleTreeFormatUtils.hasExpectedSize(pmtSerialized)) {
             String message = "PartialMerkleTree doesn't have expected size";
             logger.warn(message);
             throw new BridgeIllegalArgumentException(message);
         }
+    }
 
-        // Calculates merkleRoot
-        Sha256Hash merkleRoot;
+    private Optional<Sha256Hash> getMerkleRoot(Sha256Hash btcTxHash, byte[] pmtSerialized) throws BridgeIllegalArgumentException {
         try {
-            merkleRoot = BridgeUtils.calculateMerkleRoot(networkParameters, pmtSerialized, btcTxHash);
-            if (merkleRoot == null) {
-                return false;
-            }
+            return Optional.ofNullable(BridgeUtils.calculateMerkleRoot(networkParameters, pmtSerialized, btcTxHash));
         } catch (VerificationException e) {
             throw new BridgeIllegalArgumentException(e.getMessage(), e);
         }
+    }
 
-        // Validates inputs count
-        logger.info("[validationsForRegisterBtcTransaction] Going to validate inputs for btc tx {}", btcTxHash);
-        BridgeUtils.validateInputsCount(btcTxSerialized, activations.isActive(ConsensusRule.RSKIP143));
-
-        // Check the merkle root equals merkle root of btc block at specified height in the btc best chain
-        // BTC blockstore is available since we've already queried the best chain height
-        logger.trace("[validationsForRegisterBtcTransaction] Getting btc block at height: {}", height);
+    private boolean isMerkleRootWithBlockHeaderValid(Sha256Hash btcTxHash, int height, Sha256Hash merkleRoot) throws BlockStoreException {
+        logger.trace("[isMerkleRootWithBlockHeaderValid] Getting btc block at height: {}", height);
         BtcBlock blockHeader = btcBlockStore.getStoredBlockAtMainChainHeight(height).getHeader();
-        logger.trace("[validationsForRegisterBtcTransaction] Validating block merkle root at height: {}", height);
+
+        logger.trace("[isMerkleRootWithBlockHeaderValid] Validating block merkle root at height: {}", height);
         if (!isBlockMerkleRootValid(merkleRoot, blockHeader)){
             String panicMessage = String.format(
-                "[validationsForRegisterBtcTransaction] Btc Tx %s Supplied merkle root %s does not match block's merkle root %s",
+                "[isMerkleRootWithBlockHeaderValid] Btc Tx %s Supplied merkle root %s does not match block's merkle root %s",
                 btcTxHash.toString(),
                 merkleRoot,
                 blockHeader.getMerkleRoot()
@@ -3528,8 +3552,6 @@ public class BridgeSupport {
             logger.warn(panicMessage);
             return false;
         }
-
-        logger.trace("[validationsForRegisterBtcTransaction] Btc tx: {} successfully validated", btcTxHash);
         return true;
     }
 

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -544,15 +544,15 @@ public final class BridgeUtils {
         return authorizer.isAuthorized(rskTx, signatureCache);
     }
 
-    public static boolean validateHeightAndConfirmations(int height, int btcBestChainHeight, int acceptableConfirmationsAmount, Sha256Hash btcTxHash) throws Exception {
+    public static boolean validateHeightAndConfirmations(int height, int btcBestChainHeight, int acceptableConfirmationsAmount, Sha256Hash btcTxHash) {
         // Check there are at least N blocks on top of the supplied height
         if (height < 0) {
-            throw new Exception("Height can't be lower than 0");
+             logger.warn("[validateHeightAndConfirmations] Btc Tx {} Supplied Height is {} but should be greater than 0", btcTxHash, height);            return false;
         }
         int confirmations = btcBestChainHeight - height + 1;
         if (confirmations < acceptableConfirmationsAmount) {
             logger.warn(
-                    "Btc Tx {} at least {} confirmations are required, but there are only {} confirmations",
+                    "[validateHeightAndConfirmations] Btc Tx {} at least {} confirmations are required, but there are only {} confirmations",
                     btcTxHash,
                     acceptableConfirmationsAmount,
                     confirmations
@@ -562,12 +562,12 @@ public final class BridgeUtils {
         return true;
     }
 
-    public static Sha256Hash calculateMerkleRoot(NetworkParameters networkParameters, byte[] pmtSerialized, Sha256Hash btcTxHash) throws VerificationException{
+    public static Sha256Hash calculateMerkleRoot(NetworkParameters networkParameters, byte[] pmtSerialized, Sha256Hash btcTxHash) throws VerificationException {
         PartialMerkleTree pmt = new PartialMerkleTree(networkParameters, pmtSerialized, 0);
         List<Sha256Hash> hashesInPmt = new ArrayList<>();
         Sha256Hash merkleRoot = pmt.getTxnHashAndMerkleRoot(hashesInPmt);
         if (!hashesInPmt.contains(btcTxHash)) {
-            logger.warn("Supplied Btc Tx {} is not in the supplied partial merkle tree", btcTxHash);
+            logger.warn("[calculateMerkleRoot] Supplied Btc Tx {} is not in the supplied partial merkle tree", btcTxHash);
             return null;
         }
         return merkleRoot;
@@ -577,12 +577,12 @@ public final class BridgeUtils {
         if (BtcTransactionFormatUtils.getInputsCount(btcTxSerialized) == 0) {
             if (isActiveRskip) {
                 if (BtcTransactionFormatUtils.getInputsCountForSegwit(btcTxSerialized) == 0) {
-                    logger.warn("Provided btc segwit tx has no inputs");
+                    logger.warn("[validateInputsCount] Provided btc segwit tx has no inputs");
                     // this is the exception thrown by co.rsk.bitcoinj.core.BtcTransaction#verify when there are no inputs.
                     throw new VerificationException.EmptyInputsOrOutputs();
                 }
             } else {
-                logger.warn("Provided btc tx has no inputs ");
+                logger.warn("[validateInputsCount] Provided btc tx has no inputs ");
                 // this is the exception thrown by co.rsk.bitcoinj.core.BtcTransaction#verify when there are no inputs.
                 throw new VerificationException.EmptyInputsOrOutputs();
             }

--- a/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
+++ b/rskj-core/src/main/java/co/rsk/peg/BridgeUtils.java
@@ -547,7 +547,8 @@ public final class BridgeUtils {
     public static boolean validateHeightAndConfirmations(int height, int btcBestChainHeight, int acceptableConfirmationsAmount, Sha256Hash btcTxHash) {
         // Check there are at least N blocks on top of the supplied height
         if (height < 0) {
-             logger.warn("[validateHeightAndConfirmations] Btc Tx {} Supplied Height is {} but should be greater than 0", btcTxHash, height);            return false;
+             logger.warn("[validateHeightAndConfirmations] Btc Tx {} Supplied Height is {} but should be greater than or equal to 0", btcTxHash, height);
+             return false;
         }
         int confirmations = btcBestChainHeight - height + 1;
         if (confirmations < acceptableConfirmationsAmount) {

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeTest.java
@@ -1,6 +1,9 @@
 package co.rsk.peg;
 
+import static co.rsk.RskTestUtils.createRepository;
+import static co.rsk.RskTestUtils.createRskBlock;
 import static co.rsk.core.RskAddress.ZERO_ADDRESS;
+import static co.rsk.peg.BridgeSupportTestUtil.buildPMTAndRecreateChainForTransactionRegistration;
 import static co.rsk.peg.PegTestUtils.createHash3;
 import static org.ethereum.vm.PrecompiledContracts.BRIDGE_ADDR;
 import static org.junit.jupiter.api.Assertions.*;
@@ -13,6 +16,7 @@ import co.rsk.bitcoinj.script.Script;
 import co.rsk.bitcoinj.store.BlockStoreException;
 import co.rsk.core.types.bytes.Bytes;
 import co.rsk.peg.BridgeMethods.AuthorizerProvider;
+import co.rsk.peg.btcLockSender.BtcLockSenderProvider;
 import co.rsk.peg.constants.BridgeConstants;
 import co.rsk.peg.constants.BridgeMainNetConstants;
 import co.rsk.peg.constants.BridgeTestNetConstants;
@@ -21,14 +25,21 @@ import co.rsk.crypto.Keccak256;
 import co.rsk.peg.bitcoin.BitcoinTestUtils;
 import co.rsk.peg.federation.*;
 import co.rsk.peg.federation.FederationMember.KeyType;
+import co.rsk.peg.feeperkb.FeePerKbSupport;
+import co.rsk.peg.feeperkb.FeePerKbSupportImpl;
+import co.rsk.peg.feeperkb.FeePerKbStorageProviderImpl;
 import co.rsk.peg.flyover.FlyoverTxResponseCodes;
+import co.rsk.peg.pegininstructions.PeginInstructionsProvider;
+import co.rsk.peg.storage.InMemoryStorage;
 import co.rsk.peg.union.UnionBridgeSupport;
 import co.rsk.peg.union.UnionResponseCode;
 import co.rsk.peg.union.constants.UnionBridgeConstants;
 import co.rsk.peg.utils.BridgeEventLogger;
+import co.rsk.peg.utils.BridgeEventLoggerImpl;
 import co.rsk.peg.vote.AddressBasedAuthorizer;
 import co.rsk.test.builders.BridgeBuilder;
 import co.rsk.test.builders.BridgeSupportBuilder;
+import co.rsk.test.builders.FederationSupportBuilder;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.time.Instant;
@@ -44,6 +55,7 @@ import org.ethereum.core.*;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.vm.DataWord;
+import org.ethereum.vm.LogInfo;
 import org.ethereum.vm.MessageCall;
 import org.ethereum.vm.exception.VMException;
 import org.junit.jupiter.api.*;
@@ -424,6 +436,79 @@ class BridgeTest {
             anyInt(),
             any(byte[].class)
         );
+    }
+
+    @Test
+    void registerBtcTransaction_withNoInputs_shouldThrowEmptyInputsOrOutputs() throws BlockStoreException {
+        // Arrange
+        ActivationConfig.ForBlock activations = ActivationConfigsForTest.all().forBlock(0);
+
+        Repository repository = createRepository();
+        BridgeStorageProvider bridgeStorageProvider = new BridgeStorageProvider(repository, networkParameters, activations);
+
+        FederationStorageProvider federationStorageProvider = new FederationStorageProviderImpl(new InMemoryStorage());
+        Block executionBlock = createRskBlock(1);
+        FederationSupport federationSupport = FederationSupportBuilder.builder()
+            .withFederationConstants(bridgeMainNetConstants.getFederationConstants())
+            .withFederationStorageProvider(federationStorageProvider)
+            .withRskExecutionBlock(executionBlock)
+            .withActivations(activations)
+            .build();
+
+        BtcBlockStoreWithCache.Factory btcBlockStoreFactory = new RepositoryBtcBlockStoreWithCache.Factory(networkParameters, 100, 100);
+        BtcBlockStoreWithCache btcBlockStore = btcBlockStoreFactory.newInstance(repository, bridgeMainNetConstants, bridgeStorageProvider, activations);
+
+        List<LogInfo> logs = new ArrayList<>();
+        BridgeEventLogger bridgeEventLogger = new BridgeEventLoggerImpl(bridgeMainNetConstants, activations, logs);
+
+        FeePerKbSupport feePerKbSupport = new FeePerKbSupportImpl(
+            bridgeMainNetConstants.getFeePerKbConstants(),
+            new FeePerKbStorageProviderImpl(new InMemoryStorage())
+        );
+
+        BridgeSupport bridgeSupport = BridgeSupportBuilder.builder()
+            .withActivations(activations)
+            .withExecutionBlock(executionBlock)
+            .withBridgeConstants(bridgeMainNetConstants)
+            .withProvider(bridgeStorageProvider)
+            .withRepository(repository)
+            .withEventLogger(bridgeEventLogger)
+            .withBtcBlockStoreFactory(btcBlockStoreFactory)
+            .withBtcLockSenderProvider(new BtcLockSenderProvider())
+            .withPeginInstructionsProvider(new PeginInstructionsProvider())
+            .withFederationSupport(federationSupport)
+            .withFeePerKbSupport(feePerKbSupport)
+            .build();
+
+        BtcTransaction btcTransactionWithNoInputs = new BtcTransaction(networkParameters);
+        Address userAddress = BitcoinTestUtils.createP2PKHAddress(networkParameters, "userAddress");
+        btcTransactionWithNoInputs.addOutput(Coin.COIN, userAddress);
+        assertEquals(1, btcTransactionWithNoInputs.getOutputs().size());
+        assertEquals(0, btcTransactionWithNoInputs.getInputs().size());
+
+        int height = 5;
+        PartialMerkleTree pmt = buildPMTAndRecreateChainForTransactionRegistration(
+            bridgeStorageProvider,
+            bridgeMainNetConstants,
+            height,
+            btcTransactionWithNoInputs,
+            btcBlockStore
+        );
+
+        Bridge bridge = bridgeBuilder
+            .activationConfig(ActivationConfigsForTest.all())
+            .bridgeSupport(bridgeSupport)
+            .build();
+
+        byte[] data = Bridge.REGISTER_BTC_TRANSACTION.encode(
+            btcTransactionWithNoInputs.bitcoinSerialize(),
+            height,
+            pmt.bitcoinSerialize()
+        );
+
+        // Act & Assert
+        VMException exception = assertThrows(VMException.class, () -> bridge.execute(data));
+        assertInstanceOf(VerificationException.EmptyInputsOrOutputs.class, exception.getCause());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeUtilsTest.java
@@ -414,16 +414,16 @@ class BridgeUtilsTest {
 
     @Test
     void validateHeightAndConfirmations_invalid_height() {
-        Assertions.assertThrows(Exception.class, () -> Assertions.assertFalse(BridgeUtils.validateHeightAndConfirmations(-1, 0, 0, null)));
+        Assertions.assertFalse(BridgeUtils.validateHeightAndConfirmations(-1, 0, 0, null));
     }
 
     @Test
-    void validateHeightAndConfirmation_insufficient_confirmations() throws Exception {
+    void validateHeightAndConfirmations_insufficient_confirmations() {
         Assertions.assertFalse(BridgeUtils.validateHeightAndConfirmations(2, 5, 10, Sha256Hash.of(Hex.decode("ab"))));
     }
 
     @Test
-    void validateHeightAndConfirmation_enough_confirmations() throws Exception {
+    void validateHeightAndConfirmations_enough_confirmations() {
         Assertions.assertTrue(BridgeUtils.validateHeightAndConfirmations(
             2,
             5,


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->

## Description
`validationsForRegisterBtcTransaction` mixed several independent validations (height/confirmations, PMT size, merkle root calculation, merkle root vs. block header) in one method, with a nullable Sha256Hash return from BridgeUtils.calculateMerkleRoot and an Exception thrown by BridgeUtils.validateHeightAndConfirmations used purely to signal an invalid height back up to a catch block. 

This PR splits the method into named helpers (areHeightAndConfirmationsValid, validatePMTSize, getMerkleRoot, isMerkleRootWithBlockHeaderValid) and cleans up the two smells:

- `BridgeUtils.validateHeightAndConfirmations` **no longer throws Exception when height < 0**. It now logs a warning (with the btcTxHash and height) and returns false directly. Behavior is unchanged from the caller's perspective — a negative height still results in validationsForRegisterBtcTransaction returning false but the control flow is now explicit and doesn't rely on catching an exception whose only purpose was to encode "invalid input" as a signal. This makes the method more predictable to read and call: the return value alone tells you the outcome, rather than requiring the caller to also handle a thrown exception for one specific input case.
- `BridgeUtils.calculateMerkleRoot's` nullable return is now wrapped in Optional<Sha256Hash> at the call site (getMerkleRoot), replacing a null check with Optional.isEmpty().
- Log lines across the touched methods are tagged with their own method name ([areHeightAndConfirmationsValid], [calculateMerkleRoot], [validateInputsCount], [isMerkleRootWithBlockHeaderValid], [getMerkleRoot]) for traceability, consistent with the rest of the file.

No consensus-relevant behavior change: all validation outcomes (true/false/thrown exceptions for the cases that still throw) are identical to before.

Tests:
- In `BridgeUtilsTest`, the "invalid height" case no longer needs assertThrows since the method now returns false.
- Added BridgeTest#registerBtcTransaction_withNoInputs_shouldThrowEmptyInputsOrOutputs, exercising Bridge.execute end-to-end with a BTC tx that has no inputs, asserting it throws VerificationException.EmptyInputsOrOutputs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**:
