### PR TITLE
Publish the integrationTest HTML report when the job fails

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -358,3 +358,12 @@ jobs:
       - name: Run tests
         run: |
           ./gradlew --no-daemon --stacktrace integrationTest
+
+      - name: Upload HTML Test Report
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
+        with:
+          retention-days: 7
+          name: integration-tests-html-test-report
+          path: |
+            rskj-core/build/reports/tests/integrationTest/


### PR DESCRIPTION
## Description

The `integration-tests` job uploads no artifacts, so when a test fails the only surviving record is the console log. That log carries just the assertion's file and line:

```
SnapshotSyncIntegrationTest > whenStartTheServerAndClientNodes_thenTheClientWillSynchWithServer() FAILED
    org.opentest4j.AssertionFailedError at SnapshotSyncIntegrationTest.java:166
24 tests completed, 1 failed
```

The failure message, the stack trace and the per-class captured stdout all live in `rskj-core/build/reports/tests/integrationTest/`, which dies with the runner.

This adds an `Upload HTML Test Report` step to that job, mirroring the one `unit-tests-java17` already has (same pinned action SHA, same `if: failure()`, same 7-day retention).

The `path` is scoped to `rskj-core/build/reports/tests/integrationTest/` rather than all of `rskj-core/build/reports/`. On a fresh runner running only `integrationTest` the two are equivalent, but the narrow path makes that a guarantee instead of a coincidence, so the artifact cannot pick up unrelated report output.

## Motivation and Context

Diagnosing an integration-test failure currently means re-running the suite locally and hoping it reproduces — the suite takes ~26 minutes in CI, and the tests that fail most often are the ones that spawn real nodes and are timing-sensitive.

The report closes that gap because it captures the per-class **Standard output** tab, which never reaches the console log. For `SnapshotSyncIntegrationTest` that tab carries lines like:

```
Snapshot sync status after 3.67 minutes -> synced: true, snapStarted: true,
  snapFinished: true, serverTip: 0x2718, clientTip: 0x2718
```

On a failing run those fields say *which* condition broke — whether snap sync never started, or started and stalled, and where the two tips diverged. That is the difference between "it didn't sync" and a diagnosis.

The artifact is small. Measured from a real local run of the full suite:

| | On disk | Files | Zipped |
|---|---|---|---|
| `reports/tests/integrationTest/` | 125 KB | 13 | **~23 KB** |

For comparison, the existing `test-reports` artifact is 37 MB and `build-files` is 293 MB. It also only uploads on failure, so green runs are unaffected.

## How Has This Been Tested?

The workflow YAML parses and the job's step list resolves as expected (`Run tests` followed by `Upload HTML Test Report`).

To confirm the report is actually produced on failure and contains what this PR claims, I deliberately broke one assertion in `EthCallIntegrationTest.callGasCap_limitsExecutionTime` and ran the full suite locally with the same command CI uses:

```
./gradlew --no-daemon --stacktrace integrationTest
  -> 23 tests completed, 1 failed
  -> BUILD FAILED in 23m 14s
```

Gradle wrote the 13-file report, and the failing class page contained the full message, the stack trace and the captured stdout:

```
org.opentest4j.AssertionFailedError: 50M gas call (357ms) should take at most
  1.5x the time of the 10M gas call (479ms). ==> expected: <true> but was: <false>
  at co.rsk.rpc.EthCallIntegrationTest.callGasCap_limitsExecutionTime(EthCallIntegrationTest.java:178)
```

The deliberate break was reverted; this PR contains only the workflow change. Note that the upload step itself cannot execute until the workflow is on a branch CI runs, so the step is verified end-to-end by this PR's own CI only if a job fails — the local run verifies the input it consumes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)


* **Other information**: CI-only change — one step added to `.github/workflows/build_and_test.yml`. No production or test code is touched, which is why none of the "Types of changes" boxes apply and no tests are added.
