### PR TITLE
fix: enforce canonical RLP scalar encodings in authorization tuples

### DIFF
--- a/rskj-core/src/main/java/org/ethereum/core/transaction/SetCodeAuthorization.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/SetCodeAuthorization.java
@@ -20,6 +20,7 @@ package org.ethereum.core.transaction;
 import co.rsk.core.RskAddress;
 import org.bouncycastle.util.BigIntegers;
 import org.ethereum.config.Constants;
+import org.ethereum.core.transaction.parser.util.CommonParsingUtils;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.crypto.signature.ECDSASignature;
 import org.ethereum.util.RLP;
@@ -42,7 +43,7 @@ public class SetCodeAuthorization {
     public SetCodeAuthorization(BigInteger chainId, RskAddress address, byte[] nonce, ECDSASignature signature) {
         this.chainId = Objects.requireNonNull(chainId, "chainId");
         this.address = Objects.requireNonNull(address, "address");
-        this.nonce = Objects.requireNonNull(nonce, "nonce").clone();
+        this.nonce = minimalNonce(Objects.requireNonNull(nonce, "nonce"));
         this.signature = Objects.requireNonNull(signature, "signature");
     }
 
@@ -52,6 +53,17 @@ public class SetCodeAuthorization {
 
     public RskAddress getAddress() {
         return address;
+    }
+
+    /**
+     * Strips leading zero bytes so the stored nonce is the minimal big-endian encoding of its value.
+     *
+     * <p>The nonce is read by two consumers that must agree: {@link #getSigningHash()} and
+     * {@code AuthorizationListCodec.encodeTuple}. Normalizing here — rather than in either reader —
+     * keeps the bytes an authorization is signed over identical to the bytes it is encoded as.
+     */
+    private static byte[] minimalNonce(byte[] nonce) {
+        return CommonParsingUtils.unsignedBytes(BigIntegers.fromUnsignedByteArray(nonce));
     }
 
     public byte[] getNonceBytes() {

--- a/rskj-core/src/main/java/org/ethereum/core/transaction/parser/util/AuthorizationListCodec.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/parser/util/AuthorizationListCodec.java
@@ -31,6 +31,7 @@ import org.ethereum.util.RLPList;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -124,6 +125,7 @@ public final class AuthorizationListCodec {
 
         byte[] chainIdData = inner.get(0).getRLPData();
         CommonParsingUtils.requireDataWordBytes(chainIdData, "Authorization chain_id is not valid");
+        CommonParsingUtils.requireCanonicalScalar(chainIdData, "Authorization chain_id");
         BigInteger chainId = decodeChainId(chainIdData);
         RskAddress address = decodeAddress(inner.get(1).getRLPData());
         byte[] nonce = inner.get(2).getRLPData();
@@ -133,21 +135,37 @@ public final class AuthorizationListCodec {
             nonce = ByteUtil.cloneBytes(nonce);
         }
         CommonParsingUtils.requireDataWordBytes(nonce, "Authorization nonce is not valid");
+        CommonParsingUtils.requireCanonicalScalar(nonce, "Authorization nonce");
         validateNonceValue(decodeNonce(nonce));
-        byte yParity = parseYParity(inner.get(3).getRLPData());
+        byte[] yParityData = inner.get(3).getRLPData();
+        CommonParsingUtils.requireCanonicalScalar(yParityData, "Authorization y_parity");
+        byte yParity = parseYParity(yParityData);
         byte[] r = inner.get(4).getRLPData();
         byte[] s = inner.get(5).getRLPData();
         if (r == null || s == null) {
             throw new IllegalArgumentException("Authorization list tuple signature is incomplete");
         }
-        CommonParsingUtils.requireSignatureComponent(r, "Authorization signature r is not valid");
-        CommonParsingUtils.requireSignatureComponent(s, "Authorization signature s is not valid");
+        CommonParsingUtils.requireDataWordBytes(r, "Authorization signature r is not valid");
+        CommonParsingUtils.requireDataWordBytes(s, "Authorization signature s is not valid");
+        CommonParsingUtils.requireCanonicalScalar(r, "Authorization signature r");
+        CommonParsingUtils.requireCanonicalScalar(s, "Authorization signature s");
         byte v = (byte) (Transaction.LOWER_REAL_V + yParity);
         ECDSASignature signature = ECDSASignature.fromComponents(r, s, v);
 
         SetCodeAuthorization auth = new SetCodeAuthorization(chainId, address, nonce, signature);
         validateAuthorization(auth);
+        requireCanonicalTupleEncoding(tupleBytes, auth);
         return auth;
+    }
+
+    /**
+     * Rejects a tuple whose RLP framing is not minimal, by requiring that re-encoding it reproduces
+     * the bytes received.
+     */
+    private static void requireCanonicalTupleEncoding(byte[] tupleBytes, SetCodeAuthorization auth) {
+        if (!Arrays.equals(tupleBytes, encodeTuple(auth))) {
+            throw new IllegalArgumentException("Authorization list tuple is not canonically encoded");
+        }
     }
 
     private static SetCodeAuthorization parseCallArgumentsEntry(CallArguments.AuthorizationListEntry entry, int index) {

--- a/rskj-core/src/main/java/org/ethereum/core/transaction/parser/util/AuthorizationListCodec.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/parser/util/AuthorizationListCodec.java
@@ -93,6 +93,11 @@ public final class AuthorizationListCodec {
 
     public static byte[] encodeTuple(SetCodeAuthorization auth) {
         validateAuthorization(auth);
+        return encodeTupleUnchecked(auth);
+    }
+
+    /** Pure encoder. The round-trip check in decodeTuple has already validated the authorization. */
+    private static byte[] encodeTupleUnchecked(SetCodeAuthorization auth) {
         byte yParity = (byte) (auth.getSignature().getV() - Transaction.LOWER_REAL_V);
         return RLP.encodeList(
                 RLP.encodeBigInteger(auth.getChainId()),
@@ -136,10 +141,9 @@ public final class AuthorizationListCodec {
         }
         CommonParsingUtils.requireDataWordBytes(nonce, "Authorization nonce is not valid");
         CommonParsingUtils.requireCanonicalScalar(nonce, "Authorization nonce");
-        validateNonceValue(decodeNonce(nonce));
-        byte[] yParityData = inner.get(3).getRLPData();
-        CommonParsingUtils.requireCanonicalScalar(yParityData, "Authorization y_parity");
-        byte yParity = parseYParity(yParityData);
+        requireNonceInRange(decodeUnsignedBigInteger(nonce));
+        byte yParity = CommonParsingUtils.parseCanonicalYParity(
+                inner.get(3).getRLPData(), "Authorization y_parity");
         byte[] r = inner.get(4).getRLPData();
         byte[] s = inner.get(5).getRLPData();
         if (r == null || s == null) {
@@ -154,16 +158,16 @@ public final class AuthorizationListCodec {
 
         SetCodeAuthorization auth = new SetCodeAuthorization(chainId, address, nonce, signature);
         validateAuthorization(auth);
-        requireCanonicalTupleEncoding(tupleBytes, auth);
+        requireCanonicalTupleRlp(tupleBytes, auth);
         return auth;
     }
 
     /**
-     * Rejects a tuple whose RLP framing is not minimal, by requiring that re-encoding it reproduces
-     * the bytes received.
+     * Requires re-encoding to reproduce the bytes received, covering the whole RLP frame: list
+     * header, item prefixes and scalar minimality. Catches the prefixes per-field checks cannot see.
      */
-    private static void requireCanonicalTupleEncoding(byte[] tupleBytes, SetCodeAuthorization auth) {
-        if (!Arrays.equals(tupleBytes, encodeTuple(auth))) {
+    private static void requireCanonicalTupleRlp(byte[] tupleBytes, SetCodeAuthorization auth) {
+        if (!Arrays.equals(tupleBytes, encodeTupleUnchecked(auth))) {
             throw new IllegalArgumentException("Authorization list tuple is not canonically encoded");
         }
     }
@@ -203,15 +207,15 @@ public final class AuthorizationListCodec {
             nonce = new byte[0];
         }
         CommonParsingUtils.requireDataWordBytes(nonce, "Authorization nonce is not valid");
-        validateNonceValue(decodeNonce(nonce));
-        byte yParity = parseYParity(HexUtils.strHexOrStrNumberToByteArray(entry.getYParity()));
+        requireNonceInRange(decodeUnsignedBigInteger(nonce));
+        byte yParity = parseNormalizedYParity(HexUtils.strHexOrStrNumberToByteArray(entry.getYParity()));
         byte[] r = HexUtils.stringHexToByteArray(entry.getR());
         byte[] s = HexUtils.stringHexToByteArray(entry.getS());
         if (r == null || s == null) {
             throw invalidParamError("Authorization list entry signature r/s must be hex at index " + index);
         }
-        CommonParsingUtils.requireSignatureComponent(r, "Authorization signature r is not valid");
-        CommonParsingUtils.requireSignatureComponent(s, "Authorization signature s is not valid");
+        CommonParsingUtils.requireNormalizedSignatureComponent(r, "Authorization signature r is not valid");
+        CommonParsingUtils.requireNormalizedSignatureComponent(s, "Authorization signature s is not valid");
         byte v = (byte) (Transaction.LOWER_REAL_V + yParity);
         ECDSASignature signature = ECDSASignature.fromComponents(r, s, v);
 
@@ -242,20 +246,21 @@ public final class AuthorizationListCodec {
         return new RskAddress(addressData);
     }
 
-    private static BigInteger decodeNonce(byte[] nonce) {
-        if (nonce == null) {
+    private static BigInteger decodeUnsignedBigInteger(byte[] value) {
+        if (value == null) {
             return BigInteger.ZERO;
         }
-        return new BigInteger(1, nonce);
+        return new BigInteger(1, value);
     }
 
-    private static void validateNonceValue(BigInteger nonceValue) {
+    private static void requireNonceInRange(BigInteger nonceValue) {
         if (nonceValue.signum() < 0 || nonceValue.compareTo(MAX_NONCE) >= 0) {
             throw new IllegalArgumentException("Authorization nonce must be non-negative and less than 2^64 - 1");
         }
     }
 
-    private static byte parseYParity(byte[] yParityData) {
+    /** RPC path only: accepts the 0x00 that a JSON quantity of "0x0" decodes to. */
+    private static byte parseNormalizedYParity(byte[] yParityData) {
         if (yParityData == null || yParityData.length == 0) {
             return 0;
         }
@@ -273,7 +278,7 @@ public final class AuthorizationListCodec {
         if (auth.getChainId().signum() < 0 || auth.getChainId().compareTo(MAX_CHAIN_ID) >= 0) {
             throw new IllegalArgumentException("Authorization chain_id must be non-negative and less than 2^256");
         }
-        validateNonceValue(decodeNonce(auth.getNonceBytes()));
+        requireNonceInRange(decodeUnsignedBigInteger(auth.getNonceBytes()));
 
         ECDSASignature signature = auth.getSignature();
         BigInteger r = signature.getR();

--- a/rskj-core/src/main/java/org/ethereum/core/transaction/parser/util/CommonParsingUtils.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/parser/util/CommonParsingUtils.java
@@ -52,6 +52,16 @@ public final class CommonParsingUtils {
         }
     }
 
+    /**
+     * Rejects a scalar field that was received with a leading zero byte.
+     */
+    public static void requireCanonicalScalar(byte[] field, String fieldLabel) {
+        if (field != null && field.length > 0 && field[0] == 0) {
+            throw new IllegalArgumentException(
+                    fieldLabel + " must not have leading zero bytes; zero is encoded as the empty string");
+        }
+    }
+
     public static void requireSignatureComponent(byte[] component, String message) {
         if (component == null) {
             return;

--- a/rskj-core/src/main/java/org/ethereum/core/transaction/parser/util/CommonParsingUtils.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/parser/util/CommonParsingUtils.java
@@ -62,7 +62,30 @@ public final class CommonParsingUtils {
         }
     }
 
-    public static void requireSignatureComponent(byte[] component, String message) {
+    /**
+     * Canonical y_parity parse shared by the typed envelope and the authorization tuple: empty is
+     * zero, a leading zero or a payload wider than one byte is rejected, and the value must be 0 or 1.
+     */
+    public static byte parseCanonicalYParity(byte[] yParityData, String fieldLabel) {
+        if (yParityData == null || yParityData.length == 0) {
+            return 0;
+        }
+        requireCanonicalScalar(yParityData, fieldLabel);
+        if (yParityData.length > 1) {
+            throw new IllegalArgumentException(fieldLabel + " must fit in a single byte");
+        }
+        byte yParity = yParityData[0];
+        if (yParity != 0 && yParity != 1) {
+            throw new IllegalArgumentException(fieldLabel + " must be 0 or 1, got: " + (yParity & 0xFF));
+        }
+        return yParity;
+    }
+
+    /**
+     * Checks the component's numeric value, ignoring leading zeros, so it accepts non-minimal
+     * encodings. On a canonical-RLP path use requireDataWordBytes + requireCanonicalScalar instead.
+     */
+    public static void requireNormalizedSignatureComponent(byte[] component, String message) {
         if (component == null) {
             return;
         }

--- a/rskj-core/src/main/java/org/ethereum/core/transaction/parser/util/Type0SignatureUtils.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/parser/util/Type0SignatureUtils.java
@@ -49,10 +49,10 @@ public final class Type0SignatureUtils {
         byte[] r = txFields.get(rIndex).getRLPData();
         byte[] s = txFields.get(sIndex).getRLPData();
         if (r != null) {
-            CommonParsingUtils.requireSignatureComponent(r, "Signature R is not valid");
+            CommonParsingUtils.requireNormalizedSignatureComponent(r, "Signature R is not valid");
         }
         if (s != null) {
-            CommonParsingUtils.requireSignatureComponent(s, "Signature S is not valid");
+            CommonParsingUtils.requireNormalizedSignatureComponent(s, "Signature S is not valid");
         }
 
         return new SignedSignature(chainId, ECDSASignature.fromComponents(r, s, getRealV(v)));

--- a/rskj-core/src/main/java/org/ethereum/core/transaction/parser/util/TypedTransactionCodec.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/parser/util/TypedTransactionCodec.java
@@ -41,7 +41,8 @@ public final class TypedTransactionCodec {
         byte[] s = txFields.get(sIndex).getRLPData();
         // Validated before the unsigned early return so the field is checked on every path.
         // Callers run requireFieldCount first, so the index always exists.
-        byte yParity = parseTypedYParity(txFields.get(yParityIndex).getRLPData());
+        byte yParity = CommonParsingUtils.parseCanonicalYParity(
+                txFields.get(yParityIndex).getRLPData(), "Typed transaction yParity");
 
         if (r == null && s == null) {
             byte chainId = parseTypedTxChainId(txFields.get(chainIdIndex).getRLPData());
@@ -51,38 +52,11 @@ public final class TypedTransactionCodec {
         if (r == null || s == null) {
             throw new IllegalArgumentException("Typed transaction signature is incomplete");
         }
-        CommonParsingUtils.requireSignatureComponent(r, "Signature R is not valid");
-        CommonParsingUtils.requireSignatureComponent(s, "Signature S is not valid");
+        CommonParsingUtils.requireNormalizedSignatureComponent(r, "Signature R is not valid");
+        CommonParsingUtils.requireNormalizedSignatureComponent(s, "Signature S is not valid");
         byte v = (byte) (LOWER_REAL_V + yParity);
         byte chainId = parseTypedTxChainId(txFields.get(chainIdIndex).getRLPData());
         return new SignedSignature(chainId, ECDSASignature.fromComponents(r, s, v));
-    }
-
-    /**
-     * Parses the yParity field of a typed transaction envelope.
-     *
-     * <p>Rejects payloads wider than one byte and values outside {@code {0, 1}}. A multi-byte
-     * payload such as {@code 0x00 0x01} would otherwise read as yParity 0 and recover a different
-     * address than the signer.
-     *
-     * <p>Both encodings of zero are accepted: the canonical empty item that RLP produces for the
-     * integer 0, and a single {@code 0x00} byte. The latter is non-canonical per EIP-2718, but it
-     * cannot be used for malleability here — {@code Transaction.getEncoded} re-encodes the parsed
-     * fields through {@code TransactionEncoderFactory} instead of retaining the raw bytes, so both
-     * spellings yield the same transaction hash.
-     */
-    private static byte parseTypedYParity(byte[] yParityData) {
-        if (yParityData == null || yParityData.length == 0) {
-            return 0;
-        }
-        if (yParityData.length > 1) {
-            throw new IllegalArgumentException("Typed transaction yParity must fit in a single byte");
-        }
-        byte yParity = yParityData[0];
-        if (yParity != 0 && yParity != 1) {
-            throw new IllegalArgumentException("Typed transaction yParity must be 0 or 1, got: " + (yParity & 0xFF));
-        }
-        return yParity;
     }
 
     /**

--- a/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/BlockExecutorTest.java
@@ -110,6 +110,7 @@ import co.rsk.test.dsl.WorldDslProcessor;
 import co.rsk.trie.Trie;
 import co.rsk.trie.TrieStore;
 import co.rsk.trie.TrieStoreImpl;
+import org.ethereum.core.transaction.parser.util.CommonParsingUtils;
 
 /**
  * Created by ajlopez on 29/07/2016.
@@ -3570,10 +3571,11 @@ public class BlockExecutorTest {
             byte chainId,
             ECKey authorityKey
     ) {
+        byte[] nonceBytes = CommonParsingUtils.unsignedBytes(nonce);
         byte[] rlpEncoded = RLP.encodeList(
                 RLP.encodeBigInteger(BigInteger.valueOf(chainId)),
                 RLP.encodeElement(delegatedAddress.getBytes()),
-                RLP.encodeElement(nonce.toByteArray())
+                RLP.encodeElement(nonceBytes)
         );
 
         byte[] payload = new byte[1 + rlpEncoded.length];
@@ -3587,7 +3589,7 @@ public class BlockExecutorTest {
         return new SetCodeAuthorization(
                 BigInteger.valueOf(chainId),
                 delegatedAddress,
-                nonce.toByteArray(),
+                nonceBytes,
                 signature
         );
     }

--- a/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/SetCodeAuthorizationTransactionExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/SetCodeAuthorizationTransactionExecutorTest.java
@@ -52,6 +52,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import org.ethereum.core.transaction.parser.util.CommonParsingUtils;
 
 
  class SetCodeAuthorizationTransactionExecutorTest {
@@ -640,10 +641,11 @@ import static org.mockito.Mockito.when;
             ECKey authorityKey
     ) {
 
+        byte[] nonceBytes = CommonParsingUtils.unsignedBytes(new BigInteger(1, nonce));
         byte[] rlpEncoded = RLP.encodeList(
                 RLP.encodeBigInteger(chainId),
                 RLP.encodeElement(delegatedAddress.getBytes()),
-                RLP.encodeElement(nonce)
+                RLP.encodeElement(nonceBytes)
         );
 
         byte[] payload = new byte[1 + rlpEncoded.length];
@@ -656,7 +658,7 @@ import static org.mockito.Mockito.when;
         return new SetCodeAuthorization(
                         chainId,
                         delegatedAddress,
-                        nonce,
+                        nonceBytes,
                         signature
                 );
     }

--- a/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/helper/Type4TransactionExecutorHelperTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/transactionexecutor/helper/Type4TransactionExecutorHelperTest.java
@@ -49,6 +49,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import org.ethereum.core.transaction.parser.util.CommonParsingUtils;
 
 public abstract class Type4TransactionExecutorHelperTest {
 
@@ -146,10 +147,11 @@ public abstract class Type4TransactionExecutorHelperTest {
             byte chainId,
             ECKey authorityKey
     ) {
+        byte[] nonceBytes = CommonParsingUtils.unsignedBytes(nonce);
         byte[] rlpEncoded = RLP.encodeList(
                 RLP.encodeBigInteger(BigInteger.valueOf(chainId)),
                 RLP.encodeElement(delegatedAddress.getBytes()),
-                RLP.encodeElement(nonce.toByteArray())
+                RLP.encodeElement(nonceBytes)
         );
 
         byte[] payload = new byte[1 + rlpEncoded.length];
@@ -163,7 +165,7 @@ public abstract class Type4TransactionExecutorHelperTest {
         return new SetCodeAuthorization(
                 BigInteger.valueOf(chainId),
                 delegatedAddress,
-                nonce.toByteArray(),
+                nonceBytes,
                 signature
         );
     }

--- a/rskj-core/src/test/java/org/ethereum/core/Rskip545DeepDslTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/Rskip545DeepDslTest.java
@@ -249,7 +249,7 @@ class Rskip545DeepDslTest {
                 RLP.encodeList(
                         RLP.encodeBigInteger(BigInteger.valueOf(Constants.REGTEST_CHAIN_ID)),
                         RLP.encodeElement(DELEGATE_03.getBytes()),
-                        RLP.encodeElement(BigInteger.ZERO.toByteArray())
+                        RLP.encodeElement(new byte[0])
                 )
         );
         assertArrayEquals(HashUtil.keccak256(expectedPayload), auth.getSigningHash());

--- a/rskj-core/src/test/java/org/ethereum/core/Rskip545TestSupport.java
+++ b/rskj-core/src/test/java/org/ethereum/core/Rskip545TestSupport.java
@@ -23,6 +23,7 @@ import org.ethereum.config.Constants;
 import org.ethereum.core.transaction.SetCodeAuthorization;
 import org.ethereum.core.transaction.TransactionType;
 import org.ethereum.core.transaction.parser.util.AuthorizationListCodec;
+import org.ethereum.core.transaction.parser.util.CommonParsingUtils;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.crypto.signature.ECDSASignature;
@@ -62,10 +63,11 @@ public final class Rskip545TestSupport {
             BigInteger nonce,
             byte chainId
     ) {
+        byte[] nonceBytes = CommonParsingUtils.unsignedBytes(nonce);
         byte[] rlpEncoded = RLP.encodeList(
                 RLP.encodeBigInteger(BigInteger.valueOf(chainId & 0xFF)),
                 RLP.encodeElement(delegate.getBytes()),
-                RLP.encodeElement(nonce.toByteArray())
+                RLP.encodeElement(nonceBytes)
         );
         byte[] payload = new byte[1 + rlpEncoded.length];
         payload[0] = 0x05;
@@ -75,7 +77,7 @@ public final class Rskip545TestSupport {
         return new SetCodeAuthorization(
                 BigInteger.valueOf(chainId & 0xFF),
                 delegate,
-                nonce.toByteArray(),
+                nonceBytes,
                 signature
         );
     }

--- a/rskj-core/src/test/java/org/ethereum/core/Rskip545TestSupport.java
+++ b/rskj-core/src/test/java/org/ethereum/core/Rskip545TestSupport.java
@@ -264,7 +264,7 @@ public final class Rskip545TestSupport {
     ) {
         byte[][] fields = new byte[][]{
                 RLP.encodeByte(REGTEST_CHAIN_ID),
-                RLP.encodeElement(BigInteger.ZERO.toByteArray()),
+                RLP.encodeElement(new byte[0]),
                 RLP.encodeCoinNonNullZero(DEFAULT_MAX_PRIORITY),
                 RLP.encodeCoinNonNullZero(DEFAULT_MAX_FEE),
                 RLP.encodeElement(gasLimit.toByteArray()),

--- a/rskj-core/src/test/java/org/ethereum/core/transaction/parser/RawTransactionEnvelopeParserTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/transaction/parser/RawTransactionEnvelopeParserTest.java
@@ -370,6 +370,35 @@ class RawTransactionEnvelopeParserTest {
     }
 
     @Test
+    void fromRaw_type4WithOverlongTuplePrefix_throws() {
+        byte[] authList = Rskip545TestSupport.authListWithModifiedTupleField(
+                0, new byte[]{(byte) 0x81, 0x21});
+        byte[] raw = signedType4RawWithAuthList(authList);
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> Transaction.fromRaw(raw));
+
+        assertTrue(ex.getMessage().contains("canonically encoded"), ex.getMessage());
+    }
+
+    @Test
+    void fromRaw_type4WithCanonicalTuple_parses() {
+        byte[] raw = signedType4RawWithAuthList(Rskip545TestSupport.defaultAuthListBytes());
+
+        Transaction tx = Transaction.fromRaw(raw);
+
+        assertEquals(1, tx.getAuthorizationList().size());
+    }
+
+    private static byte[] signedType4RawWithAuthList(byte[] authListBytes) {
+        byte[][] fields = Rskip545TestSupport.defaultSignedType4Fields(
+                Rskip545TestSupport.DEFAULT_RECEIVER, authListBytes);
+        fields[11] = RLP.encodeElement(new byte[]{0x01});
+        fields[12] = RLP.encodeElement(new byte[]{0x01});
+        return Rskip545TestSupport.buildRawType4Bytes(fields);
+    }
+
+    @Test
     void parse_type4PlaceholderSignatureFields_parses() {
         Transaction tx = buildSignedType4Tx();
         byte[] raw = new Type4TransactionEncoder().encodeSigned(tx);

--- a/rskj-core/src/test/java/org/ethereum/core/transaction/parser/util/AuthorizationListCodecTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/transaction/parser/util/AuthorizationListCodecTest.java
@@ -552,12 +552,12 @@ class AuthorizationListCodecTest {
     }
 
     @Test
-    void privateDecodeNonce_null_returnsZero() throws Exception {
-        java.lang.reflect.Method decodeNonce = AuthorizationListCodec.class.getDeclaredMethod(
-                "decodeNonce", byte[].class);
-        decodeNonce.setAccessible(true);
+    void privateDecodeUnsignedBigInteger_null_returnsZero() throws Exception {
+        java.lang.reflect.Method decodeUnsignedBigInteger = AuthorizationListCodec.class.getDeclaredMethod(
+                "decodeUnsignedBigInteger", byte[].class);
+        decodeUnsignedBigInteger.setAccessible(true);
 
-        assertEquals(BigInteger.ZERO, decodeNonce.invoke(null, (Object) null));
+        assertEquals(BigInteger.ZERO, decodeUnsignedBigInteger.invoke(null, (Object) null));
     }
 
     @Test
@@ -748,7 +748,7 @@ class AuthorizationListCodecTest {
     void decodeTuple_oversizeSignatureRWithLeadingZero_reportsLengthError() {
         SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
         byte[] tuple = rebuildTupleField(reference, 4,
-                RLP.encodeElement(withLeadingZero(BigIntegers.asUnsignedByteArray(reference.getSignature().getR()))));
+                RLP.encodeElement(zeroPaddedBeyondDataWord(reference.getSignature().getR())));
 
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
                 () -> decodeSingleTuple(tuple));
@@ -794,6 +794,18 @@ class AuthorizationListCodecTest {
         return padded;
     }
 
+    /**
+     * Always 33 bytes with a leading zero, so the length rule fires whatever the signature draw:
+     * r is only 32 bytes while r >= 2**248, so a bare prepend gives 32 bytes about 1 draw in 256.
+     */
+    private static byte[] zeroPaddedBeyondDataWord(BigInteger value) {
+        byte[] magnitude = BigIntegers.asUnsignedByteArray(value);
+        byte[] padded = new byte[Transaction.DATAWORD_LENGTH + 1];
+        int taken = Math.min(Transaction.DATAWORD_LENGTH, magnitude.length);
+        System.arraycopy(magnitude, magnitude.length - taken, padded, padded.length - taken, taken);
+        return padded;
+    }
+
     @Test
     void decodeTuple_overlongItemPrefixOnChainId_throws() {
         SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
@@ -825,11 +837,6 @@ class AuthorizationListCodecTest {
                 ex.getMessage());
     }
 
-    private static byte[] withLeadingZero(byte[] value) {
-        byte[] padded = new byte[value.length + 1];
-        System.arraycopy(value, 0, padded, 1, value.length);
-        return padded;
-    }
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------

--- a/rskj-core/src/test/java/org/ethereum/core/transaction/parser/util/AuthorizationListCodecTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/transaction/parser/util/AuthorizationListCodecTest.java
@@ -674,6 +674,163 @@ class AuthorizationListCodecTest {
     }
 
     // -------------------------------------------------------------------------
+    // Canonical RLP scalar encodings
+    // -------------------------------------------------------------------------
+
+    @Test
+    void decodeTuple_nonMinimalChainId_throws() {
+        SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
+        byte[] tuple = rebuildTupleField(reference, 0, RLP.encodeElement(new byte[]{0x00, 0x21}));
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> decodeSingleTuple(tuple));
+        assertTrue(ex.getMessage().contains("chain_id"), ex.getMessage());
+    }
+
+    @Test
+    void decodeTuple_nonMinimalNonce_throws() {
+        SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
+        byte[] tuple = rebuildTupleField(reference, 2, RLP.encodeElement(new byte[]{0x00, 0x01}));
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> decodeSingleTuple(tuple));
+        assertTrue(ex.getMessage().contains("nonce"), ex.getMessage());
+    }
+
+    @Test
+    void decodeTuple_nonMinimalZeroNonce_throws() {
+        SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
+        byte[] tuple = rebuildTupleField(reference, 2, new byte[]{0x00});
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> decodeSingleTuple(tuple));
+        assertTrue(ex.getMessage().contains("nonce"), ex.getMessage());
+    }
+
+    @Test
+    void decodeTuple_nonCanonicalZeroYParity_throws() {
+        SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
+        byte[] tuple = rebuildTupleField(reference, 3, new byte[]{0x00});
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> decodeSingleTuple(tuple));
+        assertTrue(ex.getMessage().contains("y_parity"), ex.getMessage());
+    }
+
+    /**
+     * Padded to exactly 32 bytes, so the data-word length check passes and the minimality check is
+     * what rejects it. A 33-byte payload would be caught by the length rule instead and would not
+     * exercise this at all.
+     */
+    @Test
+    void decodeTuple_nonMinimalSignatureR_throws() {
+        SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
+        byte[] tuple = rebuildTupleField(reference, 4,
+                RLP.encodeElement(zeroPaddedToDataWord(reference.getSignature().getR())));
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> decodeSingleTuple(tuple));
+        assertTrue(ex.getMessage().contains("signature r must not have leading zero bytes"), ex.getMessage());
+    }
+
+    @Test
+    void decodeTuple_nonMinimalSignatureS_throws() {
+        SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
+        byte[] tuple = rebuildTupleField(reference, 5,
+                RLP.encodeElement(zeroPaddedToDataWord(reference.getSignature().getS())));
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> decodeSingleTuple(tuple));
+        assertTrue(ex.getMessage().contains("signature s must not have leading zero bytes"), ex.getMessage());
+    }
+
+    @Test
+    void decodeTuple_oversizeSignatureRWithLeadingZero_reportsLengthError() {
+        SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
+        byte[] tuple = rebuildTupleField(reference, 4,
+                RLP.encodeElement(withLeadingZero(BigIntegers.asUnsignedByteArray(reference.getSignature().getR()))));
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> decodeSingleTuple(tuple));
+        assertTrue(ex.getMessage().contains("Authorization signature r is not valid"), ex.getMessage());
+    }
+
+    @Test
+    void encodeTuple_zeroNonce_emitsCanonicalEmptyString() {
+        SetCodeAuthorization auth = new SetCodeAuthorization(
+                BigInteger.valueOf(33),
+                Rskip545TestSupport.minimalAuthorization((byte) 33).getAddress(),
+                new byte[]{0x00},
+                Rskip545TestSupport.minimalAuthorization((byte) 33).getSignature());
+
+        byte[] tuple = AuthorizationListCodec.encodeTuple(auth);
+
+        RLPList inner = RLP.decodeList(tuple);
+        assertEquals(0, inner.get(2).getRLPRawData().length,
+                "nonce zero must be encoded as the empty string 0x80, not as 0x00");
+    }
+
+    @Test
+    void parseFromCallArguments_zeroNonce_normalizesToCanonicalBytes() {
+        SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
+        CallArguments.AuthorizationListEntry entry = validEntry(reference, reference.getSignature());
+        entry.setNonce("0x0");
+
+        SetCodeAuthorization auth = AuthorizationListCodec.parseFromCallArguments(List.of(entry)).get(0);
+
+        assertEquals(0, auth.getNonceBytes().length,
+                "nonce zero must be held as the empty byte array so the signing hash matches the canonical form");
+    }
+
+    /**
+     * The low 31 bytes of {@code value}, left-padded with one zero byte to a full 32-byte data word.
+     * Still a valid curve scalar, so the tuple fails on encoding rather than on its signature value.
+     */
+    private static byte[] zeroPaddedToDataWord(BigInteger value) {
+        byte[] magnitude = BigIntegers.asUnsignedByteArray(value);
+        byte[] padded = new byte[32];
+        int taken = Math.min(31, magnitude.length);
+        System.arraycopy(magnitude, magnitude.length - taken, padded, 32 - taken, taken);
+        return padded;
+    }
+
+    @Test
+    void decodeTuple_overlongItemPrefixOnChainId_throws() {
+        SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
+        byte[] tuple = rebuildTupleField(reference, 0, new byte[]{(byte) 0x81, 0x21});
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> decodeSingleTuple(tuple));
+        assertTrue(ex.getMessage().contains("canonically encoded"), ex.getMessage());
+    }
+
+    @Test
+    void decodeTuple_longFormLengthOnShortNonce_throws() {
+        SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
+        byte[] tuple = rebuildTupleField(reference, 2, new byte[]{(byte) 0xb8, 0x01, 0x01});
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> decodeSingleTuple(tuple));
+        assertTrue(ex.getMessage().contains("canonically encoded"), ex.getMessage());
+    }
+
+    @Test
+    void decodeTuple_leadingZeroNonce_reportsFieldSpecificMessage() {
+        SetCodeAuthorization reference = Rskip545TestSupport.minimalAuthorization((byte) 33);
+        byte[] tuple = rebuildTupleField(reference, 2, RLP.encodeElement(new byte[]{0x00, 0x01}));
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> decodeSingleTuple(tuple));
+        assertTrue(ex.getMessage().contains("Authorization nonce must not have leading zero bytes"),
+                ex.getMessage());
+    }
+
+    private static byte[] withLeadingZero(byte[] value) {
+        byte[] padded = new byte[value.length + 1];
+        System.arraycopy(value, 0, padded, 1, value.length);
+        return padded;
+    }
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 

--- a/rskj-core/src/test/java/org/ethereum/core/transaction/parser/util/CommonParsingUtilsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/transaction/parser/util/CommonParsingUtilsTest.java
@@ -22,6 +22,8 @@ import co.rsk.core.RskAddress;
 import org.ethereum.util.RLP;
 import org.ethereum.util.RLPList;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.math.BigInteger;
 
@@ -162,20 +164,20 @@ class CommonParsingUtilsTest {
     }
 
     @Test
-    void requireSignatureComponent_signPaddedFullWord_doesNotThrow() {
+    void requireNormalizedSignatureComponent_signPaddedFullWord_doesNotThrow() {
         byte[] component = new byte[33];
         component[1] = (byte) 0x80;
 
-        assertDoesNotThrow(() -> CommonParsingUtils.requireSignatureComponent(component, "Signature R is not valid"));
+        assertDoesNotThrow(() -> CommonParsingUtils.requireNormalizedSignatureComponent(component, "Signature R is not valid"));
     }
 
     @Test
-    void requireSignatureComponent_exceedsLimit_throws() {
+    void requireNormalizedSignatureComponent_exceedsLimit_throws() {
         byte[] oversize = new byte[33];
         oversize[0] = 0x01;
 
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
-                () -> CommonParsingUtils.requireSignatureComponent(oversize, "Signature R is not valid"));
+                () -> CommonParsingUtils.requireNormalizedSignatureComponent(oversize, "Signature R is not valid"));
         assertTrue(ex.getMessage().contains("Signature R is not valid"));
     }
 
@@ -233,5 +235,40 @@ class CommonParsingUtilsTest {
                 () -> CommonParsingUtils.requireFieldCount(list, 9, "TestType"));
         assertTrue(ex.getMessage().contains("TestType"));
         assertTrue(ex.getMessage().contains("9"));
+    }
+
+    // -------------------------------------------------------------------------
+    // parseCanonicalYParity — shared by the typed envelope and the authorization tuple
+    // -------------------------------------------------------------------------
+
+    @Test
+    void parseCanonicalYParity_emptyOrNull_isZero() {
+        assertEquals(0, CommonParsingUtils.parseCanonicalYParity(null, "y"));
+        assertEquals(0, CommonParsingUtils.parseCanonicalYParity(new byte[0], "y"));
+    }
+
+    @Test
+    void parseCanonicalYParity_one_isReturned() {
+        assertEquals(1, CommonParsingUtils.parseCanonicalYParity(new byte[]{1}, "y"));
+    }
+
+    @Test
+    void parseCanonicalYParity_singleZeroByte_throws() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> CommonParsingUtils.parseCanonicalYParity(new byte[]{0}, "y"));
+        assertTrue(ex.getMessage().contains("must not have leading zero bytes"), ex.getMessage());
+    }
+
+    @Test
+    void parseCanonicalYParity_multiByte_throws() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CommonParsingUtils.parseCanonicalYParity(new byte[]{1, 0}, "y"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(bytes = {2, 5, 27, (byte) 0xFF})
+    void parseCanonicalYParity_outOfRange_throws(byte value) {
+        assertThrows(IllegalArgumentException.class,
+                () -> CommonParsingUtils.parseCanonicalYParity(new byte[]{value}, "y"));
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/core/transaction/parser/util/TypedTransactionCodecTest.java
+++ b/rskj-core/src/test/java/org/ethereum/core/transaction/parser/util/TypedTransactionCodecTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for {@link TypedTransactionCodec}.
@@ -118,7 +119,7 @@ class TypedTransactionCodecTest {
         byte[] dummyRS = new byte[32];
         byte[] encoded = RLP.encodeList(
                 RLP.encodeElement(new byte[]{33}),       // chainId = 33
-                RLP.encodeElement(new byte[]{yParity}),  // yParity
+                RLP.encodeByte(yParity),                 // yParity, as the encoder spells it
                 RLP.encodeElement(dummyRS),              // r
                 RLP.encodeElement(dummyRS)               // s
         );
@@ -160,6 +161,37 @@ class TypedTransactionCodecTest {
                 RLP.encodeElement(new byte[]{2}),   // invalid yParity
                 RLP.encodeElement(dummyRS),
                 RLP.encodeElement(dummyRS)
+        );
+        RLPList list = (RLPList) RLP.decode2(encoded).get(0);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> TypedTransactionCodec.parseTypedSignatureState(list, 0, 1, 2, 3));
+    }
+
+    /** The shared parse rejects 0x00 on the envelope, as it already did on the authorization tuple. */
+    @Test
+    void parseTypedSignatureState_yParityLeadingZero_throws() {
+        byte[] dummyRS = new byte[32];
+        byte[] encoded = RLP.encodeList(
+                RLP.encodeElement(new byte[]{33}),
+                RLP.encodeElement(new byte[]{0}),
+                RLP.encodeElement(dummyRS),
+                RLP.encodeElement(dummyRS)
+        );
+        RLPList list = (RLPList) RLP.decode2(encoded).get(0);
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> TypedTransactionCodec.parseTypedSignatureState(list, 0, 1, 2, 3));
+        assertTrue(ex.getMessage().contains("must not have leading zero bytes"), ex.getMessage());
+    }
+
+    @Test
+    void parseTypedSignatureState_unsignedYParityLeadingZero_throws() {
+        byte[] encoded = RLP.encodeList(
+                RLP.encodeElement(new byte[]{33}),
+                RLP.encodeElement(new byte[]{0}),
+                RLP.encodeElement(null),
+                RLP.encodeElement(null)
         );
         RLPList list = (RLPList) RLP.decode2(encoded).get(0);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Enforces canonical RLP scalar encodings for the six-field RSKIP545 authorization tuple on both the decode and the encode side.

## Motivation and Context
decodeTuple validated each field's length and value but never that its encoding was minimal, so five of the six fields accepted non-canonical RLP. On the encode side nothing owned the nonce's canonical form: encodeTuple byte-preserved it through RLP.encodeElement, which returns a single zero byte verbatim, and getSigningHash read the same unnormalized bytes. One root cause — the tuple's scalars had no single point that decided what their minimal form is.

## How Has This Been Tested?
New tests was added covering non-minimal chain_id, nonce, y_parity, r and s.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Requires Activation Code (Hard Fork)


* **Other information**:
