### PR TITLE
Adding typed transaction to eth_call and eth_estimateGas with tests

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
@@ -27,6 +27,7 @@ import org.ethereum.core.TransactionBuilder;
 import org.ethereum.core.TransactionExecutor;
 import org.ethereum.core.transaction.SetCodeAuthorization;
 import org.ethereum.core.transaction.TransactionType;
+import org.ethereum.core.transaction.parser.util.CommonParsingUtils;
 import org.ethereum.util.ByteUtil;
 import org.ethereum.util.RLP;
 import org.ethereum.vm.PrecompiledContracts;
@@ -97,7 +98,7 @@ public class ReversibleTransactionExecutor {
                                                     ReversibleTransactionParams params) {
         Repository track = snapshot.startTracking();
 
-        ReversibleTransaction tx = new ReversibleTransaction(track.getNonce(params.fromAddress()).toByteArray(), params);
+        ReversibleTransaction tx = new ReversibleTransaction(CommonParsingUtils.unsignedBytes(track.getNonce(params.fromAddress())), params);
 
         TransactionExecutor executor = transactionExecutorFactory
                 .newInstance(tx, 0, coinbase, track, executionBlock, 0, precompiledContracts)
@@ -168,12 +169,12 @@ public class ReversibleTransactionExecutor {
         }
 
         /**
-         * Type 2/4 transactions need both maxPriorityFeePerGas and maxFeePerGas set. If the caller
-         * gave us one or both we use those; if not, the default is to reuse gasPrice for the
-         * missing one.
+         * Type 2/4 transactions need both maxPriorityFeePerGas and maxFeePerGas set. CallArgumentsToByteArray
+         * rejects gasPrice mixed with either fee-cap field and a single fee-cap field given alone, so by the
+         * time we get here it's always both caps present, or neither — never just one. When neither was given
+         * (Type 4 via authorizationList with no fee info at all), both default to gasPrice.
          */
-        private static void applyFees(TransactionBuilder builder, TransactionType type, Coin gasPriceCoin,
-                                       byte[] maxPriorityFeePerGas, byte[] maxFeePerGas) {
+        private static void applyFees(TransactionBuilder builder, TransactionType type, Coin gasPriceCoin, byte[] maxPriorityFeePerGas, byte[] maxFeePerGas) {
             if (type == TransactionType.TYPE_2 || type == TransactionType.TYPE_4) {
                 Coin priority = maxPriorityFeePerGas != null ? RLP.parseCoinNonNullZero(ByteUtil.cloneBytes(maxPriorityFeePerGas)) : gasPriceCoin;
                 Coin maxFee = maxFeePerGas != null ? RLP.parseCoinNonNullZero(ByteUtil.cloneBytes(maxFeePerGas)) : gasPriceCoin;

--- a/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
@@ -23,118 +23,80 @@ import co.rsk.db.RepositorySnapshot;
 import org.ethereum.core.Block;
 import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionBuilder;
 import org.ethereum.core.TransactionExecutor;
+import org.ethereum.core.transaction.SetCodeAuthorization;
+import org.ethereum.core.transaction.TransactionType;
+import org.ethereum.util.ByteUtil;
+import org.ethereum.util.RLP;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.ProgramResult;
+
+import java.util.List;
 
 /**
  * Encapsulates the logic to execute a transaction in an
  * isolated environment (e.g. no persistent state changes).
  */
 public class ReversibleTransactionExecutor {
+
     private final RepositoryLocator repositoryLocator;
     private final TransactionExecutorFactory transactionExecutorFactory;
     private final PrecompiledContracts precompiledContracts;
 
-    public ReversibleTransactionExecutor(
-            RepositoryLocator repositoryLocator,
-            TransactionExecutorFactory transactionExecutorFactory,
-            PrecompiledContracts precompiledContracts) {
+    public ReversibleTransactionExecutor(RepositoryLocator repositoryLocator, TransactionExecutorFactory transactionExecutorFactory, PrecompiledContracts precompiledContracts) {
         this.repositoryLocator = repositoryLocator;
         this.transactionExecutorFactory = transactionExecutorFactory;
         this.precompiledContracts = precompiledContracts;
     }
 
-    public ReversibleTransactionExecutor(
-            RepositoryLocator repositoryLocator,
-            TransactionExecutorFactory transactionExecutorFactory) {
-        this.repositoryLocator = repositoryLocator;
-        this.transactionExecutorFactory = transactionExecutorFactory;
-        this.precompiledContracts = null;
+    /**
+     * Estimates gas against the provided snapshot using the executor's
+     * configured precompiled contracts.
+     */
+    public TransactionExecutor estimateGas(Block executionBlock, RskAddress coinbase, RepositorySnapshot snapshot,
+                                           ReversibleTransactionParams params) {
+        return reversibleExecution(snapshot, executionBlock, coinbase, precompiledContracts, params);
     }
 
-    public TransactionExecutor estimateGas(Block executionBlock, RskAddress coinbase, byte[] gasPrice, byte[] gasLimit,
-                                           byte[] toAddress, byte[] value, byte[] data, RskAddress fromAddress,
-                                           RepositorySnapshot snapshot) {
-        return reversibleExecution(
-                snapshot,
-                executionBlock,
-                coinbase,
-                gasPrice,
-                gasLimit,
-                toAddress,
-                value,
-                data,
-                fromAddress,
-                precompiledContracts
-        );
-    }
-
-    public ProgramResult executeTransaction(
+    public ProgramResult executeTransactionAtBlock(
             Block executionBlock,
             RskAddress coinbase,
-            byte[] gasPrice,
-            byte[] gasLimit,
-            byte[] toAddress,
-            byte[] value,
-            byte[] data,
-            RskAddress fromAddress) {
-        return executeTransaction(
-                repositoryLocator.snapshotAt(executionBlock.getHeader()),
-                executionBlock,
-                coinbase,
-                gasPrice,
-                gasLimit,
-                toAddress,
-                value,
-                data,
-                fromAddress,
-                precompiledContracts
-        );
+            ReversibleTransactionParams params) {
+        RepositorySnapshot snapshot = repositoryLocator.snapshotAt(executionBlock.getHeader());
+        return executeTransactionOnSnapshot(snapshot, executionBlock, coinbase, precompiledContracts, params);
     }
 
-    public ProgramResult executeTransaction(
+    public ProgramResult executeTransactionOnSnapshot(
             RepositorySnapshot snapshot,
             Block executionBlock,
             RskAddress coinbase,
-            byte[] gasPrice,
-            byte[] gasLimit,
-            byte[] toAddress,
-            byte[] value,
-            byte[] data,
-            RskAddress fromAddress) {
-        return reversibleExecution(snapshot, executionBlock, coinbase, gasPrice, gasLimit, toAddress, value, data, fromAddress, precompiledContracts).getResult();
+            PrecompiledContracts precompiledContracts,
+            ReversibleTransactionParams params) {
+        return reversibleExecution(snapshot, executionBlock, coinbase, precompiledContracts, params).getResult();
     }
 
-    public ProgramResult executeTransaction(
-            RepositorySnapshot snapshot,
-            Block executionBlock,
-            RskAddress coinbase,
+    public record ReversibleTransactionParams(
             byte[] gasPrice,
             byte[] gasLimit,
             byte[] toAddress,
             byte[] value,
             byte[] data,
             RskAddress fromAddress,
-            PrecompiledContracts precompiledContracts) {
-        return reversibleExecution(snapshot, executionBlock, coinbase, gasPrice, gasLimit, toAddress, value, data, fromAddress, precompiledContracts).getResult();
-    }
+            List<SetCodeAuthorization> authorizationList,
+            byte chainId,
+            TransactionType type,
+            byte[] accessListBytes,
+            byte[] maxPriorityFeePerGas,
+            byte[] maxFeePerGas
+    ) {}
 
     private TransactionExecutor reversibleExecution(RepositorySnapshot snapshot, Block executionBlock, RskAddress coinbase,
-                                                    byte[] gasPrice, byte[] gasLimit, byte[] toAddress, byte[] value,
-                                                    byte[] data, RskAddress fromAddress, PrecompiledContracts precompiledContracts) {
+                                                    PrecompiledContracts precompiledContracts,
+                                                    ReversibleTransactionParams params) {
         Repository track = snapshot.startTracking();
 
-        byte[] nonce = track.getNonce(fromAddress).toByteArray();
-        UnsignedTransaction tx = new UnsignedTransaction(
-                nonce,
-                gasPrice,
-                gasLimit,
-                toAddress,
-                value,
-                data,
-                fromAddress
-        );
+        ReversibleTransaction tx = new ReversibleTransaction(track.getNonce(params.fromAddress()).toByteArray(), params);
 
         TransactionExecutor executor = transactionExecutorFactory
                 .newInstance(tx, 0, coinbase, track, executionBlock, 0, precompiledContracts)
@@ -145,17 +107,85 @@ public class ReversibleTransactionExecutor {
         return executor;
     }
 
-    private static class UnsignedTransaction extends Transaction {
+    private static class ReversibleTransaction extends Transaction {
 
-        private UnsignedTransaction(
-                byte[] nonce,
-                byte[] gasPrice,
-                byte[] gasLimit,
-                byte[] receiveAddress,
-                byte[] value,
-                byte[] data,
-                RskAddress fromAddress) {
-            super(nonce, gasPrice, gasLimit, receiveAddress, value, data);
+        private ReversibleTransaction(byte[] nonce, ReversibleTransactionParams params) {
+            this(buildReversibleTransaction(nonce, params), params.fromAddress());
+        }
+
+        /**
+         * We don't call Transaction.fromCallArguments(...) directly because it would
+         * reject a Type 2/4 call that omits the fee-cap fields, and it picks the transaction type
+         * from the RPC call's type field, which callers often leave out or set wrong. So we
+         * resolve the type ourselves and fill in the missing fee-cap defaults (see #applyFees)
+         * before building.
+         */
+        private static Transaction buildReversibleTransaction(byte[] nonce, ReversibleTransactionParams params) {
+            TransactionType type = params.type();
+            Coin gasPriceCoin = RLP.parseCoinNonNullZero(ByteUtil.cloneBytes(params.gasPrice()));
+
+            TransactionBuilder builder = Transaction.builder()
+                    .type(type)
+                    .isLocalCall(true)
+                    .nonce(nonce)
+                    .gasLimit(params.gasLimit())
+                    .receiveAddress(params.toAddress())
+                    .value(RLP.parseCoinNullZero(ByteUtil.cloneBytes(params.value())))
+                    .data(params.data())
+                    .chainId(params.chainId());
+
+            applyAccessList(builder, type, params.accessListBytes());
+            applyFees(builder, type, gasPriceCoin, params.maxPriorityFeePerGas(), params.maxFeePerGas());
+            applyAuthorizationList(builder, type, params.authorizationList());
+
+            return builder.build();
+        }
+
+        private static void applyAccessList(TransactionBuilder builder, TransactionType type, byte[] accessListBytes) {
+            if (accessListBytes != null && (type == TransactionType.TYPE_1 || type == TransactionType.TYPE_2)) {
+                builder.accessList(accessListBytes);
+            }
+        }
+
+        /**
+         * Type 2/4 transactions need both maxPriorityFeePerGas and maxFeePerGas set. If the caller
+         * gave us one or both we use those; if not, the default is to reuse gasPrice for the
+         * missing one.
+         */
+        private static void applyFees(TransactionBuilder builder, TransactionType type, Coin gasPriceCoin,
+                                       byte[] maxPriorityFeePerGas, byte[] maxFeePerGas) {
+            if (type == TransactionType.TYPE_2 || type == TransactionType.TYPE_4) {
+                Coin priority = maxPriorityFeePerGas != null ? RLP.parseCoinNonNullZero(ByteUtil.cloneBytes(maxPriorityFeePerGas)) : gasPriceCoin;
+                Coin maxFee = maxFeePerGas != null ? RLP.parseCoinNonNullZero(ByteUtil.cloneBytes(maxFeePerGas)) : gasPriceCoin;
+                builder.maxPriorityFeePerGas(priority).maxFeePerGas(maxFee);
+            } else {
+                builder.gasPrice(gasPriceCoin);
+            }
+        }
+
+        private static void applyAuthorizationList(TransactionBuilder builder, TransactionType type,
+                                                     List<SetCodeAuthorization> authorizationList) {
+            if (type == TransactionType.TYPE_4) {
+                builder.authorizationList(authorizationList);
+            }
+        }
+
+        private ReversibleTransaction(Transaction transaction, RskAddress fromAddress) {
+            super(
+                    transaction.getNonce(),
+                    transaction.getGasPrice(),
+                    transaction.getGasLimit(),
+                    transaction.getReceiveAddress(),
+                    transaction.getValue(),
+                    transaction.getData(),
+                    transaction.getChainId(),
+                    transaction.isLocalCallTransaction(),
+                    transaction.getTypePrefix(),
+                    transaction.getAccessListBytes(),
+                    transaction.getMaxPriorityFeePerGas(),
+                    transaction.getMaxFeePerGas(),
+                    transaction.getAuthorizationList()
+            );
             this.sender = fromAddress;
         }
 

--- a/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
@@ -76,6 +76,7 @@ public class ReversibleTransactionExecutor {
         return reversibleExecution(snapshot, executionBlock, coinbase, precompiledContracts, params).getResult();
     }
 
+    @SuppressWarnings("java:S6218")
     public record ReversibleTransactionParams(
             byte[] gasPrice,
             byte[] gasLimit,

--- a/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
@@ -142,7 +142,7 @@ public class ReversibleTransactionExecutor {
         }
 
         private static void applyAccessList(TransactionBuilder builder, TransactionType type, byte[] accessListBytes) {
-            if (accessListBytes != null && (type == TransactionType.TYPE_1 || type == TransactionType.TYPE_2)) {
+            if (accessListBytes != null && (type == TransactionType.TYPE_1 || type == TransactionType.TYPE_2 || type == TransactionType.TYPE_4)) {
                 builder.accessList(accessListBytes);
             }
         }

--- a/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
+++ b/rskj-core/src/main/java/co/rsk/core/ReversibleTransactionExecutor.java
@@ -113,6 +113,25 @@ public class ReversibleTransactionExecutor {
             this(buildReversibleTransaction(nonce, params), params.fromAddress());
         }
 
+        private ReversibleTransaction(Transaction transaction, RskAddress fromAddress) {
+            super(
+                    transaction.getNonce(),
+                    transaction.getGasPrice(),
+                    transaction.getGasLimit(),
+                    transaction.getReceiveAddress(),
+                    transaction.getValue(),
+                    transaction.getData(),
+                    transaction.getChainId(),
+                    transaction.isLocalCallTransaction(),
+                    transaction.getTypePrefix(),
+                    transaction.getAccessListBytes(),
+                    transaction.getMaxPriorityFeePerGas(),
+                    transaction.getMaxFeePerGas(),
+                    transaction.getAuthorizationList()
+            );
+            this.sender = fromAddress;
+        }
+
         /**
          * We don't call Transaction.fromCallArguments(...) directly because it would
          * reject a Type 2/4 call that omits the fee-cap fields, and it picks the transaction type
@@ -168,25 +187,6 @@ public class ReversibleTransactionExecutor {
             if (type == TransactionType.TYPE_4) {
                 builder.authorizationList(authorizationList);
             }
-        }
-
-        private ReversibleTransaction(Transaction transaction, RskAddress fromAddress) {
-            super(
-                    transaction.getNonce(),
-                    transaction.getGasPrice(),
-                    transaction.getGasLimit(),
-                    transaction.getReceiveAddress(),
-                    transaction.getValue(),
-                    transaction.getData(),
-                    transaction.getChainId(),
-                    transaction.isLocalCallTransaction(),
-                    transaction.getTypePrefix(),
-                    transaction.getAccessListBytes(),
-                    transaction.getMaxPriorityFeePerGas(),
-                    transaction.getMaxFeePerGas(),
-                    transaction.getAuthorizationList()
-            );
-            this.sender = fromAddress;
         }
 
         @Override

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
@@ -40,6 +40,7 @@ import org.ethereum.core.Repository;
 import org.ethereum.core.Transaction;
 import org.ethereum.core.TransactionExecutor;
 import org.ethereum.core.TransactionPool;
+import org.ethereum.core.transaction.TransactionType;
 import org.ethereum.datasource.HashMapDB;
 import org.ethereum.db.MutableRepository;
 import org.ethereum.rpc.CallArguments;
@@ -355,6 +356,7 @@ public class EthModule
     }
 
     public static ReversibleTransactionExecutor.ReversibleTransactionParams buildParams(CallArgumentsToByteArray hexArgs, byte[] gasLimit, byte defaultChainId) {
+        TransactionType type = hexArgs.resolveType();
         return new ReversibleTransactionExecutor.ReversibleTransactionParams(
                 hexArgs.getGasPrice(),
                 gasLimit,
@@ -363,8 +365,8 @@ public class EthModule
                 hexArgs.getData(),
                 hexArgs.getFromAddress(),
                 hexArgs.getAuthorizationList(),
-                hexArgs.getChainId(defaultChainId),
-                hexArgs.resolveType(),
+                hexArgs.getChainId(type, defaultChainId),
+                type,
                 hexArgs.getAccessListBytes(),
                 hexArgs.getMaxPriorityFeePerGasBytes(),
                 hexArgs.getMaxFeePerGasBytes()

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/eth/EthModule.java
@@ -31,7 +31,6 @@ import co.rsk.rpc.ExecutionBlockRetriever;
 import co.rsk.trie.Trie;
 import co.rsk.trie.TrieStoreImpl;
 import co.rsk.util.HexUtils;
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.tuple.Pair;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.Block;
@@ -169,10 +168,14 @@ public class EthModule
 
         String hReturn = null;
         try {
-            ProgramResult programResult = mutableRepository != null ?
-                    callConstant(callArgs, block, mutableRepository, overrideablePrecompiledContracts) :
-                    callConstant(callArgs, block);
-
+            ProgramResult programResult;
+            CallArgumentsToByteArray hexArgs = new CallArgumentsToByteArray(callArgs);
+            ReversibleTransactionExecutor.ReversibleTransactionParams params = buildParams(hexArgs, hexArgs.gasLimitForCall(this.gasCallCap), this.chainId);
+            if (mutableRepository != null) {
+                programResult = reversibleTransactionExecutor.executeTransactionOnSnapshot(mutableRepository, block, block.getCoinbase(), overrideablePrecompiledContracts, params);
+            } else {
+                programResult = reversibleTransactionExecutor.executeTransactionAtBlock(block, block.getCoinbase(), params);
+            }
             handleTransactionRevertIfHappens(programResult);
             hReturn = HexUtils.toUnformattedJsonHex(programResult.getHReturn());
             return hReturn;
@@ -238,17 +241,13 @@ public class EthModule
         String estimation = null;
         try {
             CallArgumentsToByteArray hexArgs = new CallArgumentsToByteArray(args.toCallArguments());
+            ReversibleTransactionExecutor.ReversibleTransactionParams params = buildParams(hexArgs, ByteUtil.longToBytes(gasEstimationCap), this.chainId);
 
             TransactionExecutor executor = reversibleTransactionExecutor.estimateGas(
                     block,
                     block.getCoinbase(),
-                    hexArgs.getGasPrice(),
-                    ByteUtil.longToBytes(gasEstimationCap),
-                    hexArgs.getToAddress(),
-                    hexArgs.getValue(),
-                    hexArgs.getData(),
-                    hexArgs.getFromAddress(),
-                    snapshot
+                    snapshot,
+                    params
             );
 
             ProgramResult res = executor.getResult();
@@ -355,34 +354,20 @@ public class EthModule
         }
     }
 
-    @VisibleForTesting
-    public ProgramResult callConstant(CallArguments args, Block executionBlock) {
-        CallArgumentsToByteArray hexArgs = new CallArgumentsToByteArray(args);
-        return reversibleTransactionExecutor.executeTransaction(
-                executionBlock,
-                executionBlock.getCoinbase(),
+    public static ReversibleTransactionExecutor.ReversibleTransactionParams buildParams(CallArgumentsToByteArray hexArgs, byte[] gasLimit, byte defaultChainId) {
+        return new ReversibleTransactionExecutor.ReversibleTransactionParams(
                 hexArgs.getGasPrice(),
-                hexArgs.gasLimitForCall(this.gasCallCap),
-                hexArgs.getToAddress(),
-                hexArgs.getValue(),
-                hexArgs.getData(),
-                hexArgs.getFromAddress()
-        );
-    }
-
-    public ProgramResult callConstant(CallArguments args, Block executionBlock, RepositorySnapshot snapshot, PrecompiledContracts precompiledContracts) {
-        CallArgumentsToByteArray hexArgs = new CallArgumentsToByteArray(args);
-        return reversibleTransactionExecutor.executeTransaction(
-                snapshot,
-                executionBlock,
-                executionBlock.getCoinbase(),
-                hexArgs.getGasPrice(),
-                hexArgs.gasLimitForCall(this.gasCallCap),
+                gasLimit,
                 hexArgs.getToAddress(),
                 hexArgs.getValue(),
                 hexArgs.getData(),
                 hexArgs.getFromAddress(),
-                precompiledContracts
+                hexArgs.getAuthorizationList(),
+                hexArgs.getChainId(defaultChainId),
+                hexArgs.resolveType(),
+                hexArgs.getAccessListBytes(),
+                hexArgs.getMaxPriorityFeePerGasBytes(),
+                hexArgs.getMaxFeePerGasBytes()
         );
     }
 

--- a/rskj-core/src/main/java/org/ethereum/core/transaction/parser/util/Rskip546FeeValidation.java
+++ b/rskj-core/src/main/java/org/ethereum/core/transaction/parser/util/Rskip546FeeValidation.java
@@ -30,6 +30,7 @@ public final class Rskip546FeeValidation {
 
     public static final String ERR_PRIORITY_REQUIRES_MAX_FEE = "maxPriorityFeePerGas requires maxFeePerGas";
     public static final String ERR_MAX_FEE_REQUIRES_PRIORITY = "maxFeePerGas requires maxPriorityFeePerGas";
+    public static final String ERR_GAS_PRICE_WITH_FEE_CAPS = "both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified";
 
     private Rskip546FeeValidation() {}
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/converters/CallArgumentsToByteArray.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/converters/CallArgumentsToByteArray.java
@@ -31,7 +31,6 @@ import org.ethereum.util.ByteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import java.math.BigInteger;
 import java.util.List;
 

--- a/rskj-core/src/main/java/org/ethereum/rpc/converters/CallArgumentsToByteArray.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/converters/CallArgumentsToByteArray.java
@@ -134,10 +134,7 @@ public class CallArgumentsToByteArray {
 
     public List<SetCodeAuthorization> getAuthorizationList() {
         List<CallArguments.AuthorizationListEntry> entries = args.getAuthorizationList();
-        if (entries == null || entries.isEmpty()) {
-            return null;
-        }
-        return AuthorizationListCodec.parseFromCallArguments(entries);
+        return entries == null ? List.of() : AuthorizationListCodec.parseFromCallArguments(entries);
     }
 
     public TransactionType resolveType() {

--- a/rskj-core/src/main/java/org/ethereum/rpc/converters/CallArgumentsToByteArray.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/converters/CallArgumentsToByteArray.java
@@ -59,11 +59,16 @@ public class CallArgumentsToByteArray {
     }
 
     private BigInteger effectiveGasPrice() {
-        if (!isAbsent(args.getGasPrice())) {
-            return HexUtils.strHexOrStrNumberToBigInteger(args.getGasPrice());
-        }
+        boolean hasGasPrice = !isAbsent(args.getGasPrice());
         boolean hasMaxFee = !isAbsent(args.getMaxFeePerGas());
         boolean hasMaxPriority = !isAbsent(args.getMaxPriorityFeePerGas());
+
+        if (hasGasPrice && (hasMaxFee || hasMaxPriority)) {
+            throw invalidParamError(Rskip546FeeValidation.ERR_GAS_PRICE_WITH_FEE_CAPS);
+        }
+        if (hasGasPrice) {
+            return HexUtils.strHexOrStrNumberToBigInteger(args.getGasPrice());
+        }
 
         if (hasMaxFee || hasMaxPriority) {
             if (!hasMaxPriority) {

--- a/rskj-core/src/main/java/org/ethereum/rpc/converters/CallArgumentsToByteArray.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/converters/CallArgumentsToByteArray.java
@@ -167,13 +167,14 @@ public class CallArgumentsToByteArray {
         return isAbsent(args.getMaxFeePerGas()) ? null : HexUtils.strHexOrStrNumberToByteArray(args.getMaxFeePerGas());
     }
 
-    public byte getChainId(byte defaultChainId) {
+
+    public byte getChainId(TransactionType type, byte defaultChainId) {
         String hex = args.getChainId();
         if (hex == null || hex.isEmpty()) {
             return defaultChainId;
         }
         byte[] bytes = HexUtils.strHexOrStrNumberToByteArray(hex);
-        if (bytes.length != 1) {
+        if (bytes.length != 1 || (bytes[0] == 0 && type != TransactionType.LEGACY)) {
             throw invalidParamError("Invalid chainId: " + hex);
         }
         return bytes[0];

--- a/rskj-core/src/main/java/org/ethereum/rpc/converters/CallArgumentsToByteArray.java
+++ b/rskj-core/src/main/java/org/ethereum/rpc/converters/CallArgumentsToByteArray.java
@@ -21,13 +21,19 @@ package org.ethereum.rpc.converters;
 import co.rsk.core.RskAddress;
 import co.rsk.util.HexUtils;
 import org.bouncycastle.util.BigIntegers;
+import org.ethereum.core.transaction.SetCodeAuthorization;
+import org.ethereum.core.transaction.TransactionType;
+import org.ethereum.core.transaction.parser.util.AccessListCodec;
+import org.ethereum.core.transaction.parser.util.AuthorizationListCodec;
 import org.ethereum.core.transaction.parser.util.Rskip546FeeValidation;
 import org.ethereum.rpc.CallArguments;
 import org.ethereum.util.ByteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.math.BigInteger;
+import java.util.List;
 
 import static org.ethereum.rpc.exception.RskJsonRpcRequestException.invalidParamError;
 
@@ -125,6 +131,53 @@ public class CallArgumentsToByteArray {
         }
 
         return new RskAddress(HexUtils.strHexOrStrNumberToByteArray(args.getFrom()));
+    }
+
+    public List<SetCodeAuthorization> getAuthorizationList() {
+        List<CallArguments.AuthorizationListEntry> entries = args.getAuthorizationList();
+        if (entries == null || entries.isEmpty()) {
+            return null;
+        }
+        return AuthorizationListCodec.parseFromCallArguments(entries);
+    }
+
+    public TransactionType resolveType() {
+        if (args.getAuthorizationList() != null) {
+            return TransactionType.TYPE_4;
+        }
+        if (!isAbsent(args.getMaxFeePerGas()) || !isAbsent(args.getMaxPriorityFeePerGas())) {
+            return TransactionType.TYPE_2;
+        }
+        if (args.getAccessList() != null) {
+            return TransactionType.TYPE_1;
+        }
+        return TransactionType.LEGACY;
+    }
+
+    public byte[] getAccessListBytes() {
+        return AccessListCodec.encodeAccessList(args.getAccessList());
+    }
+
+
+    public byte[] getMaxPriorityFeePerGasBytes() {
+        return isAbsent(args.getMaxPriorityFeePerGas()) ? null : HexUtils.strHexOrStrNumberToByteArray(args.getMaxPriorityFeePerGas());
+    }
+
+
+    public byte[] getMaxFeePerGasBytes() {
+        return isAbsent(args.getMaxFeePerGas()) ? null : HexUtils.strHexOrStrNumberToByteArray(args.getMaxFeePerGas());
+    }
+
+    public byte getChainId(byte defaultChainId) {
+        String hex = args.getChainId();
+        if (hex == null || hex.isEmpty()) {
+            return defaultChainId;
+        }
+        byte[] bytes = HexUtils.strHexOrStrNumberToByteArray(hex);
+        if (bytes.length != 1) {
+            throw invalidParamError("Invalid chainId: " + hex);
+        }
+        return bytes[0];
     }
 
     public byte[] gasLimitForCall(long gasCap) {

--- a/rskj-core/src/test/java/co/rsk/core/ReversibleTransactionExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/ReversibleTransactionExecutorTest.java
@@ -19,22 +19,48 @@
 
 package co.rsk.core;
 
+import co.rsk.db.RepositorySnapshot;
 import co.rsk.util.TestContract;
 import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.TestUtils;
 import org.ethereum.core.Block;
 import org.ethereum.core.CallTransaction;
+import org.ethereum.core.Repository;
+import org.ethereum.core.Rskip545TestSupport;
+import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionExecutor;
+import org.ethereum.core.transaction.SetCodeAuthorization;
 import org.ethereum.core.transaction.TransactionType;
+import org.ethereum.core.transaction.parser.util.AccessListCodec;
+import org.ethereum.rpc.CallArguments;
 import org.ethereum.util.ContractRunner;
 import org.ethereum.util.RskTestFactory;
+import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.ProgramResult;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 
 import java.math.BigInteger;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class ReversibleTransactionExecutorTest {
 
@@ -44,7 +70,7 @@ class ReversibleTransactionExecutorTest {
     private RskTestFactory factory;
     private ContractRunner contractRunner;
     private ReversibleTransactionExecutor reversibleTransactionExecutor;
-
+    private byte[] gasPrice = {0x07};
     @BeforeEach
     void setup() {
         factory = new RskTestFactory(tempDir);
@@ -74,8 +100,8 @@ class ReversibleTransactionExecutorTest {
                 )
         );
 
-        Assertions.assertNull(result.getException());
-        Assertions.assertArrayEquals(
+        assertNull(result.getException());
+        assertArrayEquals(
                 new String[]{"chinchilla"},
                 helloFn.decodeResult(result.getHReturn()));
     }
@@ -92,8 +118,8 @@ class ReversibleTransactionExecutorTest {
                 true
         );
 
-        Assertions.assertNull(result.getException());
-        Assertions.assertArrayEquals(
+        assertNull(result.getException());
+        assertArrayEquals(
                 new String[]{"greet me"},
                 greeterFn.decodeResult(result.getHReturn()));
     }
@@ -145,8 +171,8 @@ class ReversibleTransactionExecutorTest {
                 )
         );
 
-        Assertions.assertNull(result.getException());
-        Assertions.assertArrayEquals(
+        assertNull(result.getException());
+        assertArrayEquals(
                 new String[]{"calls: 1"},
                 callsFn.decodeResult(result.getHReturn()));
 
@@ -159,9 +185,276 @@ class ReversibleTransactionExecutorTest {
                 )
         );
 
-        Assertions.assertNull(result2.getException());
-        Assertions.assertArrayEquals(
+        assertNull(result2.getException());
+        assertArrayEquals(
                 new String[]{"calls: 1"},
                 callsFn.decodeResult(result2.getHReturn()));
+    }
+
+    @Test
+    void reversibleTransaction_type1_preservesAccessList() {
+        byte[] accessList = accessListBytes();
+
+        Transaction tx = executeAndCaptureTransaction(params(TransactionType.TYPE_1, accessList, null, null, null, new byte[]{0x07}));
+
+        assertEquals(TransactionType.TYPE_1, tx.getType());
+        assertEquals((byte) 33, tx.getChainId());
+        assertArrayEquals(accessList, tx.getAccessListBytes());
+        assertEquals(Coin.valueOf(7), tx.getGasPrice());
+        assertNull(tx.getMaxPriorityFeePerGas());
+        assertNull(tx.getMaxFeePerGas());
+        assertNull(tx.getAuthorizationList());
+    }
+
+    @Test
+    void reversibleTransaction_type2_preservesFeeCapsAndAccessList() {
+        byte[] accessList = accessListBytes();
+
+        Transaction tx = executeAndCaptureTransaction(params(TransactionType.TYPE_2, accessList, null, new byte[]{0x02}, new byte[]{0x05}, new byte[]{0x07}));
+
+        assertEquals(TransactionType.TYPE_2, tx.getType());
+        assertEquals((byte) 33, tx.getChainId());
+
+        assertArrayEquals(accessList, tx.getAccessListBytes());
+        assertEquals(Coin.valueOf(2), tx.getMaxPriorityFeePerGas());
+        assertEquals(Coin.valueOf(5), tx.getMaxFeePerGas());
+        // effective gas price = min(priority, maxFee)
+        assertEquals(Coin.valueOf(2), tx.getGasPrice());
+        assertNull(tx.getAuthorizationList());
+    }
+
+    @Test
+    void reversibleTransaction_type4_preservesAuthorizationFeesAndAccessList() {
+        byte[] accessList = accessListBytes();
+
+        SetCodeAuthorization authorization = Rskip545TestSupport.minimalAuthorization((byte) 33);
+
+        Transaction tx = executeAndCaptureTransaction(params(TransactionType.TYPE_4, accessList, List.of(authorization), new byte[]{0x02}, new byte[]{0x05}, new byte[]{0x07}));
+
+        assertEquals(TransactionType.TYPE_4, tx.getType());
+        assertEquals((byte) 33, tx.getChainId());
+
+        assertArrayEquals(accessList, tx.getAccessListBytes());
+
+        assertEquals(Coin.valueOf(2), tx.getMaxPriorityFeePerGas());
+        assertEquals(Coin.valueOf(5), tx.getMaxFeePerGas());
+
+        assertNotNull(tx.getAuthorizationList());
+        assertEquals(List.of(authorization), tx.getAuthorizationList());
+    }
+
+    @Test
+    void reversibleTransaction_type2WithPriorityOnly_defaultsMaxFeeToGasPrice() {
+        Transaction tx = executeAndCaptureTransaction(params(TransactionType.TYPE_2, null, null, new byte[]{0x03},
+                null, new byte[]{0x07}));
+
+        assertEquals(TransactionType.TYPE_2, tx.getType());
+
+        assertEquals(
+                Coin.valueOf(3),
+                tx.getMaxPriorityFeePerGas()
+        );
+
+        assertEquals(
+                Coin.valueOf(7),
+                tx.getMaxFeePerGas()
+        );
+    }
+
+    @Test
+    void reversibleTransaction_type2WithMaxFeeOnly_defaultsPriorityToGasPrice() {
+        Transaction tx = executeAndCaptureTransaction(params(TransactionType.TYPE_2, null, null, null, new byte[]{0x09}, gasPrice));
+
+        assertEquals(TransactionType.TYPE_2, tx.getType());
+
+        assertEquals(Coin.valueOf(7), tx.getMaxPriorityFeePerGas());
+        assertEquals(Coin.valueOf(9), tx.getMaxFeePerGas());
+    }
+
+    @Test
+    void reversibleTransaction_type4WithoutFeeCaps_usesGasPriceForBoth() {
+        SetCodeAuthorization authorization =
+                Rskip545TestSupport.minimalAuthorization((byte) 33);
+
+        Transaction tx = executeAndCaptureTransaction(params(TransactionType.TYPE_4, null, List.of(authorization),
+                null, null, gasPrice));
+
+        assertEquals(TransactionType.TYPE_4, tx.getType());
+
+        assertEquals(valueOf(gasPrice), tx.getMaxPriorityFeePerGas());
+        assertEquals(valueOf(gasPrice), tx.getMaxFeePerGas());
+        assertEquals(valueOf(gasPrice), tx.getGasPrice());
+    }
+
+    @Test
+    void reversibleTransaction_type4WithAllTypedFields_preservesAllFields() {
+        byte[] accessList = accessListBytes();
+
+        SetCodeAuthorization authorization = Rskip545TestSupport.minimalAuthorization((byte) 33);
+
+        Transaction tx = executeAndCaptureTransaction(
+                new ReversibleTransactionExecutor.ReversibleTransactionParams(
+                        new byte[]{0x07},
+                        BigInteger.valueOf(500_000).toByteArray(),
+                        TestUtils.generateAddress("to").getBytes(),
+                        new byte[]{0},
+                        new byte[0],
+                        TestUtils.generateAddress("from"),
+                        List.of(authorization),
+                        (byte) 33,
+                        TransactionType.TYPE_4,
+                        accessList,
+                        new byte[]{0x03},
+                        new byte[]{0x09}
+                )
+        );
+
+        assertAll(
+                () -> assertEquals(TransactionType.TYPE_4, tx.getType()),
+                () -> assertEquals((byte) 33, tx.getChainId()),
+                () -> assertArrayEquals(accessList, tx.getAccessListBytes()),
+                () -> assertEquals(Coin.valueOf(3), tx.getMaxPriorityFeePerGas()),
+                () -> assertEquals(Coin.valueOf(9), tx.getMaxFeePerGas()),
+                () -> assertEquals(List.of(authorization), tx.getAuthorizationList())
+        );
+    }
+
+    static Stream<Arguments> transactionTypes() {
+        byte[] accessList = accessListBytes();
+        SetCodeAuthorization auth = Rskip545TestSupport.minimalAuthorization((byte) 33);
+
+        return Stream.of(
+                Arguments.of(TransactionType.LEGACY, null, null, null, null),
+                Arguments.of(TransactionType.TYPE_1, accessList, null, null, null),
+                Arguments.of(TransactionType.TYPE_2, accessList, null, new byte[]{0x02}, new byte[]{0x05}),
+                Arguments.of(TransactionType.TYPE_4, accessList, List.of(auth), new byte[]{0x02}, new byte[]{0x05})
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("transactionTypes")
+    void reversibleTransaction_buildsExpectedTransactionType(TransactionType expectedType, byte[] accessList, List<SetCodeAuthorization> authorizationList, byte[] priority, byte[] maxFee) {
+        Transaction tx = executeAndCaptureTransaction(params(expectedType, accessList, authorizationList, priority, maxFee, new byte[]{0x07}));
+
+        assertEquals(expectedType, tx.getType());
+        assertEquals((byte) 33, tx.getChainId());
+
+        if (expectedType == TransactionType.TYPE_1 || expectedType == TransactionType.TYPE_2 || expectedType == TransactionType.TYPE_4) {
+            assertArrayEquals(accessList, tx.getAccessListBytes());
+        } else {
+            assertNull(tx.getAccessListBytes());
+        }
+
+        if (expectedType == TransactionType.TYPE_2 || expectedType == TransactionType.TYPE_4) {
+            assertNotNull(tx.getMaxPriorityFeePerGas());
+            assertNotNull(tx.getMaxFeePerGas());
+        } else {
+            assertNull(tx.getMaxPriorityFeePerGas());
+            assertNull(tx.getMaxFeePerGas());
+        }
+
+        if (expectedType == TransactionType.TYPE_4) {
+            assertEquals(authorizationList, tx.getAuthorizationList());
+        } else {
+            assertNull(tx.getAuthorizationList());
+        }
+    }
+
+    @Test
+    void type4WithOnlyPriorityFee_defaultsMaxFeeFromGasPrice() {
+        SetCodeAuthorization authorization =
+                Rskip545TestSupport.minimalAuthorization((byte) 33);
+
+        Transaction tx = executeAndCaptureTransaction(params(TransactionType.TYPE_4, null, List.of(authorization), new byte[]{0x03}, null, gasPrice));
+        assertEquals(TransactionType.TYPE_4, tx.getType());
+
+        assertEquals(Coin.valueOf(3), tx.getMaxPriorityFeePerGas());
+        assertEquals(valueOf(gasPrice), tx.getMaxFeePerGas());
+    }
+
+    @Test
+    void type4WithOnlyMaxFee_defaultsPriorityFromGasPrice() {
+        SetCodeAuthorization authorization =
+                Rskip545TestSupport.minimalAuthorization((byte) 33);
+
+        Transaction tx = executeAndCaptureTransaction(params(TransactionType.TYPE_4, null, List.of(authorization), null, new byte[]{0x09}, gasPrice));
+        assertEquals(TransactionType.TYPE_4, tx.getType());
+        assertEquals(valueOf(gasPrice), tx.getMaxPriorityFeePerGas());
+        assertEquals(Coin.valueOf(9), tx.getMaxFeePerGas());
+    }
+
+    public static Coin valueOf(byte[] value) {
+        return new Coin(new BigInteger(1, value));
+    }
+
+    private static byte[] accessListBytes() {
+        CallArguments.AccessListEntry entry = new CallArguments.AccessListEntry();
+        entry.setAddress("0x0000000000000000000000000000000000000001");
+        entry.setStorageKeys(List.of("0x" + "0".repeat(63) + "1"));
+
+        return AccessListCodec.encodeAccessList(List.of(entry));
+    }
+
+    private Transaction executeAndCaptureTransaction(ReversibleTransactionExecutor.ReversibleTransactionParams params) {
+
+        RepositorySnapshot snapshot = mock(RepositorySnapshot.class);
+        Repository track = mock(Repository.class);
+        TransactionExecutorFactory executorFactory = mock(TransactionExecutorFactory.class);
+        TransactionExecutor transactionExecutor = mock(TransactionExecutor.class);
+        PrecompiledContracts precompiledContracts = mock(PrecompiledContracts.class);
+
+        Block block = mock(Block.class);
+        RskAddress coinbase = TestUtils.generateAddress("coinbase");
+
+        when(snapshot.startTracking()).thenReturn(track);
+        when(track.getNonce(any(RskAddress.class))).thenReturn(BigInteger.ZERO);
+
+        when(executorFactory.newInstance(
+                any(Transaction.class),
+                eq(0),
+                eq(coinbase),
+                eq(track),
+                eq(block),
+                eq(0L),
+                eq(precompiledContracts)
+        )).thenReturn(transactionExecutor);
+
+        when(transactionExecutor.setLocalCall(true)).thenReturn(transactionExecutor);
+
+        ReversibleTransactionExecutor executor = new ReversibleTransactionExecutor(
+                        mock(co.rsk.db.RepositoryLocator.class),
+                        executorFactory,
+                        precompiledContracts);
+
+        executor.executeTransactionOnSnapshot(snapshot, block, coinbase, precompiledContracts, params);
+
+        ArgumentCaptor<Transaction> txCaptor = ArgumentCaptor.forClass(Transaction.class);
+
+        verify(executorFactory).newInstance(txCaptor.capture(), eq(0), eq(coinbase), eq(track), eq(block), eq(0L), eq(precompiledContracts));
+        return txCaptor.getValue();
+    }
+
+    private static ReversibleTransactionExecutor.ReversibleTransactionParams params(
+            TransactionType type,
+            byte[] accessList,
+            List<SetCodeAuthorization> authorizationList,
+            byte[] maxPriorityFeePerGas,
+            byte[] maxFeePerGas,
+            byte[] gasPrice) {
+
+        return new ReversibleTransactionExecutor.ReversibleTransactionParams(
+                gasPrice,
+                BigInteger.valueOf(500_000).toByteArray(),
+                TestUtils.generateAddress("to").getBytes(),
+                new byte[]{0},
+                new byte[0],
+                TestUtils.generateAddress("from"),
+                authorizationList,
+                (byte) 33,
+                type,
+                accessList,
+                maxPriorityFeePerGas,
+                maxFeePerGas
+        );
     }
 }

--- a/rskj-core/src/test/java/co/rsk/core/ReversibleTransactionExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/ReversibleTransactionExecutorTest.java
@@ -24,6 +24,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.ethereum.TestUtils;
 import org.ethereum.core.Block;
 import org.ethereum.core.CallTransaction;
+import org.ethereum.core.transaction.TransactionType;
 import org.ethereum.util.ContractRunner;
 import org.ethereum.util.RskTestFactory;
 import org.ethereum.vm.program.ProgramResult;
@@ -64,15 +65,13 @@ class ReversibleTransactionExecutorTest {
 
         Block bestBlock = factory.getBlockchain().getBestBlock();
 
-        ProgramResult result = reversibleTransactionExecutor.executeTransaction(
+        ProgramResult result = reversibleTransactionExecutor.executeTransactionAtBlock(
                 bestBlock,
                 bestBlock.getCoinbase(),
-                gasPrice,
-                gasLimit,
-                contractAddress.getBytes(),
-                value,
-                helloFn.encode(),
-                from
+                new ReversibleTransactionExecutor.ReversibleTransactionParams(
+                        gasPrice, gasLimit, contractAddress.getBytes(), value, helloFn.encode(), from,
+                        null, (byte) 0, TransactionType.LEGACY, null, null, null
+                )
         );
 
         Assertions.assertNull(result.getException());
@@ -112,15 +111,13 @@ class ReversibleTransactionExecutorTest {
 
         Block bestBlock = factory.getBlockchain().getBestBlock();
 
-        ProgramResult result = reversibleTransactionExecutor.executeTransaction(
+        ProgramResult result = reversibleTransactionExecutor.executeTransactionAtBlock(
                 bestBlock,
                 bestBlock.getCoinbase(),
-                gasPrice,
-                gasLimit,
-                contractAddress.getBytes(),
-                value,
-                greeterFn.encode("greet me"),
-                from
+                new ReversibleTransactionExecutor.ReversibleTransactionParams(
+                        gasPrice, gasLimit, contractAddress.getBytes(), value, greeterFn.encode("greet me"), from,
+                        null, (byte) 0, TransactionType.LEGACY, null, null, null
+                )
         );
 
         Assertions.assertTrue(result.isRevert());
@@ -139,15 +136,13 @@ class ReversibleTransactionExecutorTest {
 
         Block bestBlock = factory.getBlockchain().getBestBlock();
 
-        ProgramResult result = reversibleTransactionExecutor.executeTransaction(
+        ProgramResult result = reversibleTransactionExecutor.executeTransactionAtBlock(
                 bestBlock,
                 bestBlock.getCoinbase(),
-                gasPrice,
-                gasLimit,
-                contractAddress.getBytes(),
-                value,
-                callsFn.encodeSignature(),
-                from
+                new ReversibleTransactionExecutor.ReversibleTransactionParams(
+                        gasPrice, gasLimit, contractAddress.getBytes(), value, callsFn.encodeSignature(), from,
+                        null, (byte) 0, TransactionType.LEGACY, null, null, null
+                )
         );
 
         Assertions.assertNull(result.getException());
@@ -155,15 +150,13 @@ class ReversibleTransactionExecutorTest {
                 new String[]{"calls: 1"},
                 callsFn.decodeResult(result.getHReturn()));
 
-        ProgramResult result2 = reversibleTransactionExecutor.executeTransaction(
+        ProgramResult result2 = reversibleTransactionExecutor.executeTransactionAtBlock(
                 bestBlock,
                 bestBlock.getCoinbase(),
-                gasPrice,
-                gasLimit,
-                contractAddress.getBytes(),
-                value,
-                callsFn.encodeSignature(),
-                from
+                new ReversibleTransactionExecutor.ReversibleTransactionParams(
+                        gasPrice, gasLimit, contractAddress.getBytes(), value, callsFn.encodeSignature(), from,
+                        null, (byte) 0, TransactionType.LEGACY, null, null, null
+                )
         );
 
         Assertions.assertNull(result2.getException());

--- a/rskj-core/src/test/java/co/rsk/core/ReversibleTransactionExecutorTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/ReversibleTransactionExecutorTest.java
@@ -32,6 +32,7 @@ import org.ethereum.core.TransactionExecutor;
 import org.ethereum.core.transaction.SetCodeAuthorization;
 import org.ethereum.core.transaction.TransactionType;
 import org.ethereum.core.transaction.parser.util.AccessListCodec;
+import org.ethereum.crypto.HashUtil;
 import org.ethereum.rpc.CallArguments;
 import org.ethereum.util.ContractRunner;
 import org.ethereum.util.RskTestFactory;
@@ -383,6 +384,39 @@ class ReversibleTransactionExecutorTest {
         assertEquals(Coin.valueOf(9), tx.getMaxFeePerGas());
     }
 
+    @Test
+    void reversibleTransaction_nonce128_isEncodedUnsigned() {
+        Transaction tx = executeAndCaptureTransaction(
+                params(TransactionType.LEGACY, null, null, null, null, gasPrice),
+                BigInteger.valueOf(128));
+
+        assertArrayEquals(new byte[]{(byte) 0x80}, tx.getNonce());
+    }
+
+    @Test
+    void reversibleTransaction_nonce128ContractCreation_computesCanonicalContractAddress() {
+        RskAddress from = TestUtils.generateAddress("from");
+        ReversibleTransactionExecutor.ReversibleTransactionParams createParams =
+                new ReversibleTransactionExecutor.ReversibleTransactionParams(
+                        gasPrice,
+                        BigInteger.valueOf(500_000).toByteArray(),
+                        null,
+                        new byte[]{0},
+                        new byte[0],
+                        from,
+                        null,
+                        (byte) 33,
+                        TransactionType.LEGACY,
+                        null,
+                        null,
+                        null);
+
+        Transaction tx = executeAndCaptureTransaction(createParams, BigInteger.valueOf(128));
+
+        RskAddress expectedContractAddress = new RskAddress(HashUtil.calcNewAddr(from.getBytes(), new byte[]{(byte) 0x80}));
+        assertEquals(expectedContractAddress, tx.getContractAddress());
+    }
+
     public static Coin valueOf(byte[] value) {
         return new Coin(new BigInteger(1, value));
     }
@@ -396,6 +430,10 @@ class ReversibleTransactionExecutorTest {
     }
 
     private Transaction executeAndCaptureTransaction(ReversibleTransactionExecutor.ReversibleTransactionParams params) {
+        return executeAndCaptureTransaction(params, BigInteger.ZERO);
+    }
+
+    private Transaction executeAndCaptureTransaction(ReversibleTransactionExecutor.ReversibleTransactionParams params, BigInteger nonce) {
 
         RepositorySnapshot snapshot = mock(RepositorySnapshot.class);
         Repository track = mock(Repository.class);
@@ -407,7 +445,7 @@ class ReversibleTransactionExecutorTest {
         RskAddress coinbase = TestUtils.generateAddress("coinbase");
 
         when(snapshot.startTracking()).thenReturn(track);
-        when(track.getNonce(any(RskAddress.class))).thenReturn(BigInteger.ZERO);
+        when(track.getNonce(any(RskAddress.class))).thenReturn(nonce);
 
         when(executorFactory.newInstance(
                 any(Transaction.class),

--- a/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/mine/TransactionModuleTest.java
@@ -633,7 +633,8 @@ class TransactionModuleTest {
 
         ReversibleTransactionExecutor reversibleTransactionExecutor1 = new ReversibleTransactionExecutor(
                 repositoryLocator,
-                this.transactionExecutorFactory
+                this.transactionExecutorFactory,
+                null
         );
 
         if (mineInstant) {

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleDSLTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleDSLTest.java
@@ -123,6 +123,44 @@ class EthModuleDSLTest {
         assertEquals(20, HexUtils.jsonHexToInt(result2));
     }
 
+    @Test
+    void testCall_StateOverride_withType2AccessListCall_stateIsOverridden() throws DslProcessorException, FileNotFoundException {
+        // Given
+        World world = new World();
+        // given a deployed contract with stored state = 10
+        String contractAddress = deployContractAndGetAddressFromDsl("dsl/eth_module/simple_contract.txt", world);
+
+        EthModule eth = EthModuleTestUtils.buildBasicEthModule(world);
+
+        CallArguments.AccessListEntry entry = new CallArguments.AccessListEntry();
+        entry.setAddress("0x" + contractAddress);
+        entry.setStorageKeys(List.of("0x" + "0".repeat(63) + "1"));
+
+        final CallArguments args = new CallArguments();
+        args.setTo("0x" + contractAddress);
+        args.setData(SIMPLE_CONTRACT_GET_METHOD); //call get() function
+        args.setMaxPriorityFeePerGas("0x1");
+        args.setMaxFeePerGas("0x2");
+        args.setAccessList(List.of(entry));
+        BlockIdentifierParam blockIdentifierParam = new BlockIdentifierParam("latest");
+        CallArgumentsParam callArgumentsParam = TransactionFactoryHelper.toCallArgumentsParam(args);
+
+
+        String result = eth.call(callArgumentsParam, blockIdentifierParam);
+        // then the result is the stored state value: 10 — Type 2 resolution/encoding does not break a plain call
+        assertEquals(SIMPLE_CONTRACT_STORED_DATA, HexUtils.jsonHexToInt(result));
+
+        AccountOverride accountOverride = new AccountOverride(new RskAddress(contractAddress));
+        DataWord key = DataWord.valueFromHex("0000000000000000000000000000000000000000000000000000000000000000");
+        DataWord value = DataWord.valueFromHex("0000000000000000000000000000000000000000000000000000000000000014");
+        // given the same Type 2 + access list call, now combined with a state override setting storage[0] = 20
+        accountOverride.setState(Map.of(key, value));
+        // when calling get() as a Type 2 call, with the override
+        String result2 = eth.call(callArgumentsParam, blockIdentifierParam, List.of(accountOverride));
+        // then the override still takes effect: the returned value is 20, not 10
+        assertEquals(20, HexUtils.jsonHexToInt(result2));
+    }
+
     /**
      * Runtime bytecode of the contract:
      * <p>
@@ -202,6 +240,12 @@ class EthModuleDSLTest {
         String result2 = eth.call(callArgumentsParam, blockIdentifierParam, List.of(accountOverride));
         // then the returned balance is 30000
         assertEquals(defaultBalance, HexUtils.jsonHexToInt(result2));
+
+        // when calling getMyBalance() again with no override at all
+        String result3 = eth.call(callArgumentsParam, blockIdentifierParam);
+        // then the override must not have leaked into the real state: the balance is back to the original, non-overridden value
+        assertEquals(HexUtils.jsonHexToInt(result), HexUtils.jsonHexToInt(result3));
+        assertNotEquals(defaultBalance, HexUtils.jsonHexToInt(result3));
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleGasEstimationDSLTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleGasEstimationDSLTest.java
@@ -72,7 +72,7 @@ class EthModuleGasEstimationDSLTest {
 
         assertEquals(0, eth.getEstimationResult().getDeductedRefund());
 
-        ProgramResult callConstantResult = eth.callConstant(args, block);
+        ProgramResult callConstantResult = eth.simulateTransactionExecution(args, block);
 
         assertEquals(callConstantResult.getGasUsed(), estimatedGas);
 
@@ -129,7 +129,7 @@ class EthModuleGasEstimationDSLTest {
         Block block = world.getBlockChain().getBlockByNumber(2); // block 2 contains 0 tx
 
         // Evaluate the gas used
-        ProgramResult callConstant = eth.callConstant(args, block);
+        ProgramResult callConstant = eth.simulateTransactionExecution(args, block);
         long gasUsed = callConstant.getGasUsed();
         assertEquals(ByteUtil.byteArrayToLong(callWithValueReceipt.getGasUsed()), gasUsed);
         assertFalse(callConstant.getMovedRemainingGasToChild()); // it just moved STIPEND_CALL (2300) to child
@@ -193,7 +193,7 @@ class EthModuleGasEstimationDSLTest {
                 "0000000000000000000000000000000000000000000000000000000000000001" +
                 "0000000000000000000000000000000000000000000000000000000000000000"); // setValue(1,0)
 
-        ProgramResult callConstantResult = eth.callConstant(args, block);
+        ProgramResult callConstantResult = eth.simulateTransactionExecution(args, block);
 
         long clearStorageGasUsed = callConstantResult.getGasUsed();
         long clearStorageEstimatedGas = estimateGas(eth, args, BlockTag.LATEST.getTag());
@@ -220,7 +220,7 @@ class EthModuleGasEstimationDSLTest {
         args.setData("0x7b8d56e3" +
                 "0000000000000000000000000000000000000000000000000000000000000001" +
                 "0000000000000000000000000000000000000000000000000000000000000001"); // setValue(1,1)
-        long updateStorageGasUsed = eth.callConstant(args, block).getGasUsed();
+        long updateStorageGasUsed = eth.simulateTransactionExecution(args, block).getGasUsed();
         long updateStorageEstimatedGas = estimateGas(eth, args, BlockTag.LATEST.getTag());
         assertEquals(26661, updateStorageEstimatedGas);
 
@@ -254,7 +254,7 @@ class EthModuleGasEstimationDSLTest {
                 "0000000000000000000000000000000000000000000000000000000000000000");
         args.setGas(HexUtils.toQuantityJsonHex(BLOCK_GAS_LIMIT));
 
-        ProgramResult anotherCallConstantResult = eth.callConstant(args, block);
+        ProgramResult anotherCallConstantResult = eth.simulateTransactionExecution(args, block);
         long anotherClearStorageGasUsed = anotherCallConstantResult.getGasUsed();
         long anotherClearStorageEstimatedGas = estimateGas(eth, args, BlockTag.LATEST.getTag());
         assertEquals(26649, anotherClearStorageEstimatedGas);
@@ -323,7 +323,7 @@ class EthModuleGasEstimationDSLTest {
         args.setGas(HexUtils.toQuantityJsonHex(BLOCK_GAS_LIMIT));
         args.setData("0x5b3f8140"); // clearStorageAndSendValue()
 
-        ProgramResult callConstant = eth.callConstant(args, block);
+        ProgramResult callConstant = eth.simulateTransactionExecution(args, block);
         long callConstantGasUsed = callConstant.getGasUsed();
 
         long estimatedGas = estimateGas(eth, args, BlockTag.LATEST.getTag());
@@ -390,7 +390,7 @@ class EthModuleGasEstimationDSLTest {
         args.setGas(HexUtils.toQuantityJsonHex(BLOCK_GAS_LIMIT));
         args.setData("0xfb60f709"); // callAddressWithValue()
 
-        ProgramResult callConstant = eth.callConstant(args, block);
+        ProgramResult callConstant = eth.simulateTransactionExecution(args, block);
         List<InternalTransaction> internalTransactions = callConstant.getInternalTransactions();
 
         assertTrue(internalTransactions.stream().allMatch(i -> i.getValue().equals(Coin.valueOf(1))));
@@ -467,7 +467,7 @@ class EthModuleGasEstimationDSLTest {
         args.setGas(HexUtils.toQuantityJsonHex(BLOCK_GAS_LIMIT));
         args.setData("0x18d3af63"); // callNextAddress()
 
-        ProgramResult callConstant = eth.callConstant(args, block);
+        ProgramResult callConstant = eth.simulateTransactionExecution(args, block);
         List<InternalTransaction> internalTransactions = callConstant.getInternalTransactions();
 
         assertEquals(internalTransactions.get(internalTransactions.size() - 1).getValue(), Coin.valueOf(1000));
@@ -540,7 +540,7 @@ class EthModuleGasEstimationDSLTest {
         args.setGas(HexUtils.toQuantityJsonHex(BLOCK_GAS_LIMIT));
         args.setData("0x18d3af63"); // callNextAddress()
 
-        ProgramResult callConstant = eth.callConstant(args, block);
+        ProgramResult callConstant = eth.simulateTransactionExecution(args, block);
         List<InternalTransaction> internalTransactions = callConstant.getInternalTransactions();
 
         assertEquals(internalTransactions.get(internalTransactions.size() - 1).getValue(), Coin.valueOf(1000));
@@ -599,7 +599,7 @@ class EthModuleGasEstimationDSLTest {
         Block block = world.getBlockChain().getBlockByNumber(2); // block 2 contains 0 tx
 
         // Evaluate the gas used
-        ProgramResult callConstant = eth.callConstant(args, block);
+        ProgramResult callConstant = eth.simulateTransactionExecution(args, block);
         long gasUsed = callConstant.getGasUsed();
         assertEquals(ByteUtil.byteArrayToLong(callWithValueReceipt.getGasUsed()), gasUsed);
 
@@ -672,7 +672,7 @@ class EthModuleGasEstimationDSLTest {
         args.setGas(HexUtils.toQuantityJsonHex(BLOCK_GAS_LIMIT));
         args.setData("0xfb60f709"); // callAddressWithValue()
 
-        ProgramResult callConstant = eth.callConstant(args, block);
+        ProgramResult callConstant = eth.simulateTransactionExecution(args, block);
         List<InternalTransaction> internalTransactions = callConstant.getInternalTransactions();
 
         assertTrue(internalTransactions.stream().allMatch(i -> i.getValue().equals(Coin.valueOf(1))));
@@ -750,7 +750,7 @@ class EthModuleGasEstimationDSLTest {
         args.setGas(HexUtils.toQuantityJsonHex(BLOCK_GAS_LIMIT));
         args.setData("0xfb60f709"); // callAddressWithValue()
 
-        ProgramResult callConstant = eth.callConstant(args, block);
+        ProgramResult callConstant = eth.simulateTransactionExecution(args, block);
         List<InternalTransaction> internalTransactions = callConstant.getInternalTransactions();
 
         assertTrue(internalTransactions.stream().allMatch(i -> i.getValue().equals(Coin.valueOf(1))));
@@ -1099,7 +1099,7 @@ class EthModuleGasEstimationDSLTest {
             "608060405260405161025e38038061025e833981016040819052610022916100ed565b817f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc555f80836001600160a01b03168360405161005f91906101b5565b5f60405180830381855af49150503d805f8114610097576040519150601f19603f3d011682016040523d82523d5f602084013e61009c565b606091505b5091509150816100ae57805160208201fd5b505050506101d0565b634e487b7160e01b5f52604160045260245ffd5b5f5b838110156100e55781810151838201526020016100cd565b50505f910152565b5f80604083850312156100fe575f80fd5b82516001600160a01b0381168114610114575f80fd5b60208401519092506001600160401b0380821115610130575f80fd5b818501915085601f830112610143575f80fd5b815181811115610155576101556100b7565b604051601f8201601f19908116603f0116810190838211818310171561017d5761017d6100b7565b81604052828152886020848701011115610195575f80fd5b6101a68360208301602088016100cb565b80955050505050509250929050565b5f82516101c68184602087016100cb565b9190910192915050565b6082806101dc5f395ff3fe608060405236600a57005b7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc8054365f80375f80365f845af490503d5f803e8080156048573d5ff35b3d5ffdfea2646970667358221220c69507ddaa45264afbc0bbb56cf7c588c4482bbf2fe8d71d8fcd32eb3cfc674364736f6c63430008140033";
 
     public boolean runWithArgumentsAndBlock(EthModuleTestUtils.EthModuleGasEstimation ethModule, CallArguments args, Block block) {
-        ProgramResult localCallResult = ethModule.callConstant(args, block);
+        ProgramResult localCallResult = ethModule.simulateTransactionExecution(args, block);
 
         return localCallResult.getException() == null;
     }

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
@@ -95,7 +95,7 @@ class EthModuleTest {
                 .thenReturn(hReturn);
 
         ReversibleTransactionExecutor executor = mock(ReversibleTransactionExecutor.class);
-        when(executor.executeTransaction(eq(blockResult.getBlock()), any(), any(), any(), any(), any(), any(), any()))
+        when(executor.executeTransactionAtBlock(eq(block), any(), any()))
                 .thenReturn(executorResult);
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(null, null, null, signatureCache);
@@ -109,7 +109,7 @@ class EthModuleTest {
                 null,
                 executor,
                 retriever,
-                null,
+                mock(RepositoryLocator.class),
                 null,
                 null,
                 bridgeSupportFactory,
@@ -152,7 +152,7 @@ class EthModuleTest {
         when(repositoryLocator.snapshotAt(any())).thenReturn(snapshot);
 
         ReversibleTransactionExecutor executor = mock(ReversibleTransactionExecutor.class);
-        when(executor.executeTransaction(any(),eq(block), any(), any(), any(), any(), any(), any(), any(), any()))
+        when(executor.executeTransactionOnSnapshot(any(), eq(block), any(), any(), any()))
                 .thenReturn(executorResult);
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(null, null, null, signatureCache);
@@ -405,7 +405,7 @@ class EthModuleTest {
         when(repositoryLocator.snapshotAt(any())).thenReturn(snapshot);
 
         ReversibleTransactionExecutor executor = mock(ReversibleTransactionExecutor.class);
-        when(executor.executeTransaction(any(),eq(block), any(), any(), any(), any(), any(), any(), any(), any()))
+        when(executor.executeTransactionOnSnapshot(any(), eq(block), any(), any(), any()))
                 .thenReturn(executorResult);
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(null, null, null, signatureCache);
@@ -454,7 +454,7 @@ class EthModuleTest {
                 .thenReturn(hReturn);
 
         ReversibleTransactionExecutor executor = mock(ReversibleTransactionExecutor.class);
-        when(executor.executeTransaction(eq(blockResult.getBlock()), any(), any(), any(), any(), any(), any(), any()))
+        when(executor.executeTransactionAtBlock(eq(block), any(), any()))
                 .thenReturn(executorResult);
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(null, null, null, signatureCache);
@@ -466,7 +466,7 @@ class EthModuleTest {
                 null,
                 executor,
                 retriever,
-                null,
+                mock(RepositoryLocator.class),
                 null,
                 null,
                 bridgeSupportFactory,
@@ -508,7 +508,7 @@ class EthModuleTest {
                 .thenReturn(hReturn);
 
         ReversibleTransactionExecutor executor = mock(ReversibleTransactionExecutor.class);
-        when(executor.executeTransaction(eq(blockResult.getBlock()), any(), any(), any(), any(), any(), any(), any()))
+        when(executor.executeTransactionAtBlock(eq(block), any(), any()))
                 .thenReturn(executorResult);
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(null, null, null, signatureCache);
@@ -520,7 +520,7 @@ class EthModuleTest {
                 null,
                 executor,
                 retriever,
-                null,
+                mock(RepositoryLocator.class),
                 null,
                 null,
                 bridgeSupportFactory,
@@ -563,7 +563,7 @@ class EthModuleTest {
         when(executorResult.isRevert()).thenReturn(true);
 
         ReversibleTransactionExecutor executor = mock(ReversibleTransactionExecutor.class);
-        when(executor.executeTransaction(eq(blockResult.getBlock()), any(), any(), any(), any(), any(), any(), any()))
+        when(executor.executeTransactionAtBlock(eq(block), any(), any()))
                 .thenReturn(executorResult);
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(null, null, null, signatureCache);
@@ -575,7 +575,7 @@ class EthModuleTest {
                 null,
                 executor,
                 retriever,
-                null,
+                mock(RepositoryLocator.class),
                 null,
                 null,
                 bridgeSupportFactory,
@@ -867,7 +867,7 @@ class EthModuleTest {
                 .thenReturn(hReturn);
 
         ReversibleTransactionExecutor executor = mock(ReversibleTransactionExecutor.class);
-        when(executor.executeTransaction(eq(blockResult.getBlock()), any(), any(), any(), any(), any(), any(), any()))
+        when(executor.executeTransactionAtBlock(eq(block), any(), any()))
                 .thenReturn(executorResult);
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(null, null, null, signatureCache);
@@ -879,7 +879,7 @@ class EthModuleTest {
                 null,
                 executor,
                 retriever,
-                null,
+                mock(RepositoryLocator.class),
                 null,
                 null,
                 bridgeSupportFactory,
@@ -895,10 +895,10 @@ class EthModuleTest {
 
         eth.call(callArgumentsParam, blockIdentifierParam);
 
-        ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
+        ArgumentCaptor<ReversibleTransactionExecutor.ReversibleTransactionParams> paramsCaptor = ArgumentCaptor.forClass(ReversibleTransactionExecutor.ReversibleTransactionParams.class);
         verify(executor, times(1))
-                .executeTransaction(eq(blockResult.getBlock()), any(), any(), any(), any(), any(), dataCaptor.capture(), any());
-        assertArrayEquals(HexUtils.strHexOrStrNumberToByteArray(args.getData()), dataCaptor.getValue());
+                .executeTransactionAtBlock(eq(block), any(), paramsCaptor.capture());
+        assertArrayEquals(HexUtils.strHexOrStrNumberToByteArray(args.getData()), paramsCaptor.getValue().data());
     }
 
     @Test
@@ -918,7 +918,7 @@ class EthModuleTest {
                 .thenReturn(hReturn);
 
         ReversibleTransactionExecutor executor = mock(ReversibleTransactionExecutor.class);
-        when(executor.executeTransaction(eq(blockResult.getBlock()), any(), any(), any(), any(), any(), any(), any()))
+        when(executor.executeTransactionAtBlock(eq(block), any(), any()))
                 .thenReturn(executorResult);
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(null, null, null, signatureCache);
@@ -930,7 +930,7 @@ class EthModuleTest {
                 null,
                 executor,
                 retriever,
-                null,
+                mock(RepositoryLocator.class),
                 null,
                 null,
                 bridgeSupportFactory,
@@ -946,10 +946,10 @@ class EthModuleTest {
 
         eth.call(callArgumentsParam, blockIdentifierParam);
 
-        ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
+        ArgumentCaptor<ReversibleTransactionExecutor.ReversibleTransactionParams> paramsCaptor = ArgumentCaptor.forClass(ReversibleTransactionExecutor.ReversibleTransactionParams.class);
         verify(executor, times(1))
-                .executeTransaction(eq(blockResult.getBlock()), any(), any(), any(), any(), any(), dataCaptor.capture(), any());
-        assertArrayEquals(HexUtils.strHexOrStrNumberToByteArray(args.getInput()), dataCaptor.getValue());
+                .executeTransactionAtBlock(eq(block), any(), paramsCaptor.capture());
+        assertArrayEquals(HexUtils.strHexOrStrNumberToByteArray(args.getInput()), paramsCaptor.getValue().data());
     }
 
     @Test
@@ -970,7 +970,7 @@ class EthModuleTest {
                 .thenReturn(hReturn);
 
         ReversibleTransactionExecutor executor = mock(ReversibleTransactionExecutor.class);
-        when(executor.executeTransaction(eq(blockResult.getBlock()), any(), any(), any(), any(), any(), any(), any()))
+        when(executor.executeTransactionAtBlock(eq(block), any(), any()))
                 .thenReturn(executorResult);
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(null, null, null, signatureCache);
@@ -982,7 +982,7 @@ class EthModuleTest {
                 null,
                 executor,
                 retriever,
-                null,
+                mock(RepositoryLocator.class),
                 null,
                 null,
                 bridgeSupportFactory,
@@ -999,10 +999,10 @@ class EthModuleTest {
 
         eth.call(callArgumentsParam, blockIdentifierParam);
 
-        ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
+        ArgumentCaptor<ReversibleTransactionExecutor.ReversibleTransactionParams> paramsCaptor = ArgumentCaptor.forClass(ReversibleTransactionExecutor.ReversibleTransactionParams.class);
         verify(executor, times(1))
-                .executeTransaction(eq(blockResult.getBlock()), any(), any(), any(), any(), any(), dataCaptor.capture(), any());
-        assertArrayEquals(HexUtils.strHexOrStrNumberToByteArray(args.getInput()), dataCaptor.getValue());
+                .executeTransactionAtBlock(eq(block), any(), paramsCaptor.capture());
+        assertArrayEquals(HexUtils.strHexOrStrNumberToByteArray(args.getInput()), paramsCaptor.getValue().data());
     }
 
     @Test
@@ -1022,7 +1022,7 @@ class EthModuleTest {
                 .thenReturn(executorResult);
 
         ReversibleTransactionExecutor reversibleTransactionExecutor = mock(ReversibleTransactionExecutor.class);
-        when(reversibleTransactionExecutor.estimateGas(eq(block), any(), any(), any(), any(), any(), any(), any(), any()))
+        when(reversibleTransactionExecutor.estimateGas(eq(block), any(), any(), any()))
                 .thenReturn(transactionExecutor);
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(null, null, null, signatureCache);
@@ -1049,10 +1049,10 @@ class EthModuleTest {
 
         eth.estimateGas(callArgumentsParam, new BlockIdentifierParam("latest"));
 
-        ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
+        ArgumentCaptor<ReversibleTransactionExecutor.ReversibleTransactionParams> paramsCaptor = ArgumentCaptor.forClass(ReversibleTransactionExecutor.ReversibleTransactionParams.class);
         verify(reversibleTransactionExecutor, times(1))
-                .estimateGas(eq(block), any(), any(), any(), any(), any(), dataCaptor.capture(), any(), any());
-        assertArrayEquals(HexUtils.strHexOrStrNumberToByteArray(args.getData()), dataCaptor.getValue());
+                .estimateGas(eq(block), any(), any(), paramsCaptor.capture());
+        assertArrayEquals(HexUtils.strHexOrStrNumberToByteArray(args.getData()), paramsCaptor.getValue().data());
     }
 
     @Test
@@ -1072,7 +1072,7 @@ class EthModuleTest {
                 .thenReturn(executorResult);
 
         ReversibleTransactionExecutor reversibleTransactionExecutor = mock(ReversibleTransactionExecutor.class);
-        when(reversibleTransactionExecutor.estimateGas(eq(block), any(), any(), any(), any(), any(), any(), any(), any()))
+        when(reversibleTransactionExecutor.estimateGas(eq(block), any(), any(), any()))
                 .thenReturn(transactionExecutor);
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(null, null, null, signatureCache);
@@ -1120,7 +1120,7 @@ class EthModuleTest {
                 .thenReturn(executorResult);
 
         ReversibleTransactionExecutor reversibleTransactionExecutor = mock(ReversibleTransactionExecutor.class);
-        when(reversibleTransactionExecutor.estimateGas(eq(block), any(), any(), any(), any(), any(), any(), any(), any()))
+        when(reversibleTransactionExecutor.estimateGas(eq(block), any(), any(), any()))
                 .thenReturn(transactionExecutor);
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(null, null, null, signatureCache);
@@ -1147,10 +1147,10 @@ class EthModuleTest {
 
         eth.estimateGas(callArgumentsParam, new BlockIdentifierParam("latest"));
 
-        ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
+        ArgumentCaptor<ReversibleTransactionExecutor.ReversibleTransactionParams> paramsCaptor = ArgumentCaptor.forClass(ReversibleTransactionExecutor.ReversibleTransactionParams.class);
         verify(reversibleTransactionExecutor, times(1))
-                .estimateGas(eq(block), any(), any(), any(), any(), any(), dataCaptor.capture(), any(), any());
-        assertArrayEquals(HexUtils.strHexOrStrNumberToByteArray(args.getInput()), dataCaptor.getValue());
+                .estimateGas(eq(block), any(), any(), paramsCaptor.capture());
+        assertArrayEquals(HexUtils.strHexOrStrNumberToByteArray(args.getInput()), paramsCaptor.getValue().data());
     }
 
     @Test
@@ -1171,7 +1171,7 @@ class EthModuleTest {
                 .thenReturn(executorResult);
 
         ReversibleTransactionExecutor reversibleTransactionExecutor = mock(ReversibleTransactionExecutor.class);
-        when(reversibleTransactionExecutor.estimateGas(eq(block), any(), any(), any(), any(), any(), any(), any(), any()))
+        when(reversibleTransactionExecutor.estimateGas(eq(block), any(), any(), any()))
                 .thenReturn(transactionExecutor);
 
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(null, null, null, signatureCache);
@@ -1198,10 +1198,10 @@ class EthModuleTest {
 
         eth.estimateGas(callArgumentsParam, new BlockIdentifierParam("latest"));
 
-        ArgumentCaptor<byte[]> dataCaptor = ArgumentCaptor.forClass(byte[].class);
+        ArgumentCaptor<ReversibleTransactionExecutor.ReversibleTransactionParams> paramsCaptor = ArgumentCaptor.forClass(ReversibleTransactionExecutor.ReversibleTransactionParams.class);
         verify(reversibleTransactionExecutor, times(1))
-                .estimateGas(eq(block), any(), any(), any(), any(), any(), dataCaptor.capture(), any(), any());
-        assertArrayEquals(HexUtils.strHexOrStrNumberToByteArray(args.getInput()), dataCaptor.getValue());
+                .estimateGas(eq(block), any(), any(), paramsCaptor.capture());
+        assertArrayEquals(HexUtils.strHexOrStrNumberToByteArray(args.getInput()), paramsCaptor.getValue().data());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
@@ -38,6 +38,7 @@ import org.ethereum.TestUtils;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.*;
+import org.ethereum.core.transaction.TransactionType;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.signature.ECDSASignature;
 import org.ethereum.datasource.HashMapDB;
@@ -1460,6 +1461,137 @@ class EthModuleTest {
         List<Transaction> result = ethModule.ethPendingTransactions();
 
         assertTrue(result.isEmpty(), "Expected no transactions as wallet is disabled");
+    }
+
+    @Test
+    void call_type4WithStateOverride_usesSnapshotAndPreservesTypedParams() {
+        RskAddress from = TestUtils.generateAddress("from");
+        RskAddress to = TestUtils.generateAddress("to");
+        CallArguments args = Rskip545TestSupport.defaultType4CallArguments(new byte[0]);
+
+        args.setFrom(from.toJsonString());
+        args.setTo(to.toJsonString());
+
+        AccountOverride accountOverride = new AccountOverride(to);
+
+        accountOverride.setBalance(BigInteger.valueOf(100_000));
+
+        ExecutionBlockRetriever.Result blockResult = mock(ExecutionBlockRetriever.Result.class);
+        Block block = mock(Block.class);
+        ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
+
+        when(retriever.retrieveExecutionBlock("latest")).thenReturn(blockResult);
+        when(blockResult.getBlock()).thenReturn(block);
+
+        RepositoryLocator repositoryLocator = mock(RepositoryLocator.class);
+        RepositorySnapshot snapshot = new MutableRepository(new TrieStoreImpl(new HashMapDB()), new Trie());
+        when(repositoryLocator.snapshotAt(any())).thenReturn(snapshot);
+
+        ProgramResult result = mock(ProgramResult.class);
+        when(result.getHReturn()).thenReturn(new byte[0]);
+
+        ReversibleTransactionExecutor executor = mock(ReversibleTransactionExecutor.class);
+
+        when(executor.executeTransactionOnSnapshot(any(), eq(block), any(), any(), any())).thenReturn(result);
+
+        BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(null, null, null, signatureCache);
+        EthModule eth = new EthModule(
+                        null,
+                        Constants.REGTEST_CHAIN_ID,
+                        null,
+                        null,
+                        executor,
+                        retriever,
+                        repositoryLocator,
+                        null,
+                        null,
+                        bridgeSupportFactory,
+                        config.getGasEstimationCap(),
+                        config.getCallGasCap(),
+                        config.getActivationConfig(),
+                        new PrecompiledContracts(
+                                config,
+                                bridgeSupportFactory,
+                                signatureCache),
+                        true,
+                        new DefaultStateOverrideApplier(
+                                config.getActivationConfig()));
+
+
+        eth.call(TransactionFactoryHelper.toCallArgumentsParam(args), new BlockIdentifierParam("latest"), List.of(accountOverride));
+        ArgumentCaptor<ReversibleTransactionExecutor.ReversibleTransactionParams> captor = ArgumentCaptor.forClass(ReversibleTransactionExecutor.ReversibleTransactionParams.class);
+
+        verify(executor).executeTransactionOnSnapshot(any(), eq(block), any(), any(), captor.capture());
+        verify(executor, never()).executeTransactionAtBlock(any(), any(), any());
+
+        ReversibleTransactionExecutor.ReversibleTransactionParams params = captor.getValue();
+
+        assertEquals(TransactionType.TYPE_4, params.type());
+        assertEquals(Constants.REGTEST_CHAIN_ID, params.chainId());
+        assertNotNull(params.authorizationList());
+        assertEquals(1, params.authorizationList().size());
+    }
+
+    @Test
+    void call_type4WithoutStateOverride_usesBlockAndPreservesTypedParams() {
+        RskAddress from = TestUtils.generateAddress("from");
+        RskAddress to = TestUtils.generateAddress("to");
+
+        CallArguments args = Rskip545TestSupport.defaultType4CallArguments(new byte[0]);
+        args.setFrom(from.toJsonString());
+        args.setTo(to.toJsonString());
+
+        ExecutionBlockRetriever.Result blockResult = mock(ExecutionBlockRetriever.Result.class);
+        Block block = mock(Block.class);
+        ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
+        when(retriever.retrieveExecutionBlock("latest")).thenReturn(blockResult);
+        when(blockResult.getBlock()).thenReturn(block);
+
+        ProgramResult result = mock(ProgramResult.class);
+        when(result.getHReturn()).thenReturn(new byte[0]);
+
+        ReversibleTransactionExecutor executor = mock(ReversibleTransactionExecutor.class);
+
+        when(executor.executeTransactionAtBlock(eq(block), any(), any())).thenReturn(result);
+
+        BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(null, null, null, signatureCache);
+
+        EthModule eth =
+                new EthModule(
+                        null,
+                        Constants.REGTEST_CHAIN_ID,
+                        null,
+                        null,
+                        executor,
+                        retriever,
+                        mock(RepositoryLocator.class),
+                        null,
+                        null,
+                        bridgeSupportFactory,
+                        config.getGasEstimationCap(),
+                        config.getCallGasCap(),
+                        config.getActivationConfig(),
+                        new PrecompiledContracts(
+                                config,
+                                bridgeSupportFactory,
+                                signatureCache),
+                        true,
+                        new DefaultStateOverrideApplier(
+                                config.getActivationConfig()));
+
+        eth.call(TransactionFactoryHelper.toCallArgumentsParam(args), new BlockIdentifierParam("latest"));
+
+        ArgumentCaptor<ReversibleTransactionExecutor.ReversibleTransactionParams> captor = ArgumentCaptor.forClass(ReversibleTransactionExecutor.ReversibleTransactionParams.class);
+
+        verify(executor).executeTransactionAtBlock(eq(block), any(), captor.capture());
+        verify(executor, never()).executeTransactionOnSnapshot(any(), any(), any(), any(), any());
+        ReversibleTransactionExecutor.ReversibleTransactionParams params = captor.getValue();
+
+        assertEquals(TransactionType.TYPE_4, params.type());
+        assertEquals(Constants.REGTEST_CHAIN_ID, params.chainId());
+
+        assertNotNull(params.authorizationList());
+        assertEquals(1, params.authorizationList().size());
     }
 
     private Transaction createMockTransaction(String fromAddress) {

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTest.java
@@ -39,6 +39,7 @@ import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
 import org.ethereum.core.*;
 import org.ethereum.core.transaction.TransactionType;
+import org.ethereum.core.transaction.parser.util.AccessListCodec;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.signature.ECDSASignature;
 import org.ethereum.datasource.HashMapDB;
@@ -436,6 +437,71 @@ class EthModuleTest {
 
         // Then
         assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    void callWithAccountOverrideAndBlockFinalStateIsNotNull_preservesType4Params() {
+        RskAddress from = TestUtils.generateAddress("from");
+        RskAddress to = TestUtils.generateAddress("to");
+
+        CallArguments.AccessListEntry entry = new CallArguments.AccessListEntry();
+        entry.setAddress(to.toJsonString());
+        entry.setStorageKeys(List.of("0x" + "0".repeat(63) + "1"));
+        List<CallArguments.AccessListEntry> accessList = List.of(entry);
+
+        CallArguments args = Rskip545TestSupport.defaultType4CallArguments(new byte[0]);
+        args.setFrom(from.toJsonString());
+        args.setTo(to.toJsonString());
+        args.setAccessList(accessList);
+
+        AccountOverride accountOverride = new AccountOverride(to);
+        accountOverride.setBalance(BigInteger.valueOf(100_000));
+
+        ExecutionBlockRetriever.Result blockResult = mock(ExecutionBlockRetriever.Result.class);
+        Block block = mock(Block.class);
+        ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
+        when(retriever.retrieveExecutionBlock("latest")).thenReturn(blockResult);
+        when(blockResult.getBlock()).thenReturn(block);
+        when(blockResult.getFinalState()).thenReturn(new Trie());
+
+        ProgramResult result = mock(ProgramResult.class);
+        when(result.getHReturn()).thenReturn(new byte[0]);
+
+        ReversibleTransactionExecutor executor = mock(ReversibleTransactionExecutor.class);
+        when(executor.executeTransactionOnSnapshot(any(), eq(block), any(), any(), any())).thenReturn(result);
+
+        BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(null, null, null, signatureCache);
+        EthModule eth = new EthModule(
+                null,
+                Constants.REGTEST_CHAIN_ID,
+                null,
+                null,
+                executor,
+                retriever,
+                mock(RepositoryLocator.class),
+                null,
+                null,
+                bridgeSupportFactory,
+                config.getGasEstimationCap(),
+                config.getCallGasCap(),
+                config.getActivationConfig(),
+                new PrecompiledContracts(config, bridgeSupportFactory, signatureCache),
+                true,
+                new DefaultStateOverrideApplier(config.getActivationConfig()));
+
+        eth.call(TransactionFactoryHelper.toCallArgumentsParam(args), new BlockIdentifierParam("latest"), List.of(accountOverride));
+
+        ArgumentCaptor<ReversibleTransactionExecutor.ReversibleTransactionParams> captor = ArgumentCaptor.forClass(ReversibleTransactionExecutor.ReversibleTransactionParams.class);
+        verify(executor).executeTransactionOnSnapshot(any(), eq(block), any(), any(), captor.capture());
+
+        ReversibleTransactionExecutor.ReversibleTransactionParams params = captor.getValue();
+
+        assertAll(
+                () -> assertEquals(TransactionType.TYPE_4, params.type()),
+                () -> assertArrayEquals(AccessListCodec.encodeAccessList(accessList), params.accessListBytes()),
+                () -> assertNotNull(params.authorizationList()),
+                () -> assertEquals(1, params.authorizationList().size())
+        );
     }
 
     @Test
@@ -1472,6 +1538,12 @@ class EthModuleTest {
         args.setFrom(from.toJsonString());
         args.setTo(to.toJsonString());
 
+        CallArguments.AccessListEntry accessListEntry = new CallArguments.AccessListEntry();
+        accessListEntry.setAddress(to.toJsonString());
+        accessListEntry.setStorageKeys(List.of("0x" + "0".repeat(63) + "1"));
+        List<CallArguments.AccessListEntry> accessList = List.of(accessListEntry);
+        args.setAccessList(accessList);
+
         AccountOverride accountOverride = new AccountOverride(to);
 
         accountOverride.setBalance(BigInteger.valueOf(100_000));
@@ -1526,10 +1598,212 @@ class EthModuleTest {
 
         ReversibleTransactionExecutor.ReversibleTransactionParams params = captor.getValue();
 
-        assertEquals(TransactionType.TYPE_4, params.type());
-        assertEquals(Constants.REGTEST_CHAIN_ID, params.chainId());
-        assertNotNull(params.authorizationList());
-        assertEquals(1, params.authorizationList().size());
+        assertAll(
+                () -> assertEquals(TransactionType.TYPE_4, params.type()),
+                () -> assertEquals(Constants.REGTEST_CHAIN_ID, params.chainId()),
+                () -> assertArrayEquals(AccessListCodec.encodeAccessList(accessList), params.accessListBytes()),
+                () -> assertArrayEquals(new byte[]{0x0a}, params.maxPriorityFeePerGas()),
+                () -> assertArrayEquals(new byte[]{0x64}, params.maxFeePerGas()),
+                () -> assertNotNull(params.authorizationList()),
+                () -> assertEquals(1, params.authorizationList().size())
+        );
+    }
+
+    @Test
+    void call_type2WithStateOverride_usesSnapshotAndPreservesTypedParams() {
+        RskAddress from = TestUtils.generateAddress("from");
+        RskAddress to = TestUtils.generateAddress("to");
+
+        CallArguments.AccessListEntry entry = new CallArguments.AccessListEntry();
+        entry.setAddress(to.toJsonString());
+        entry.setStorageKeys(List.of("0x" + "0".repeat(63) + "1"));
+        List<CallArguments.AccessListEntry> accessList = List.of(entry);
+
+        CallArguments args = new CallArguments();
+        args.setFrom(from.toJsonString());
+        args.setTo(to.toJsonString());
+        args.setGas("0x100000");
+        args.setMaxPriorityFeePerGas("0x2");
+        args.setMaxFeePerGas("0x5");
+        args.setAccessList(accessList);
+
+        AccountOverride accountOverride = new AccountOverride(to);
+        accountOverride.setBalance(BigInteger.valueOf(100_000));
+
+        ExecutionBlockRetriever.Result blockResult = mock(ExecutionBlockRetriever.Result.class);
+        Block block = mock(Block.class);
+        ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
+
+        when(retriever.retrieveExecutionBlock("latest")).thenReturn(blockResult);
+        when(blockResult.getBlock()).thenReturn(block);
+
+        RepositoryLocator repositoryLocator = mock(RepositoryLocator.class);
+        RepositorySnapshot snapshot = new MutableRepository(new TrieStoreImpl(new HashMapDB()), new Trie());
+        when(repositoryLocator.snapshotAt(any())).thenReturn(snapshot);
+
+        ProgramResult result = mock(ProgramResult.class);
+        when(result.getHReturn()).thenReturn(new byte[0]);
+
+        ReversibleTransactionExecutor executor = mock(ReversibleTransactionExecutor.class);
+        when(executor.executeTransactionOnSnapshot(any(), eq(block), any(), any(), any())).thenReturn(result);
+
+        BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(null, null, null, signatureCache);
+        EthModule eth = new EthModule(
+                null,
+                Constants.REGTEST_CHAIN_ID,
+                null,
+                null,
+                executor,
+                retriever,
+                repositoryLocator,
+                null,
+                null,
+                bridgeSupportFactory,
+                config.getGasEstimationCap(),
+                config.getCallGasCap(),
+                config.getActivationConfig(),
+                new PrecompiledContracts(config, bridgeSupportFactory, signatureCache),
+                true,
+                new DefaultStateOverrideApplier(config.getActivationConfig()));
+
+        eth.call(TransactionFactoryHelper.toCallArgumentsParam(args), new BlockIdentifierParam("latest"), List.of(accountOverride));
+
+        ArgumentCaptor<ReversibleTransactionExecutor.ReversibleTransactionParams> captor = ArgumentCaptor.forClass(ReversibleTransactionExecutor.ReversibleTransactionParams.class);
+
+        verify(executor).executeTransactionOnSnapshot(any(), eq(block), any(), any(), captor.capture());
+        verify(executor, never()).executeTransactionAtBlock(any(), any(), any());
+
+        ReversibleTransactionExecutor.ReversibleTransactionParams params = captor.getValue();
+
+        assertAll(
+                () -> assertEquals(TransactionType.TYPE_2, params.type()),
+                () -> assertEquals(Constants.REGTEST_CHAIN_ID, params.chainId()),
+                () -> assertArrayEquals(AccessListCodec.encodeAccessList(accessList), params.accessListBytes()),
+                () -> assertArrayEquals(new byte[]{0x02}, params.maxPriorityFeePerGas()),
+                () -> assertArrayEquals(new byte[]{0x05}, params.maxFeePerGas()),
+                () -> assertTrue(params.authorizationList().isEmpty())
+        );
+    }
+
+    @Test
+    void estimateGas_type4_preservesAllTypedTransactionParams() {
+        RskAddress from = TestUtils.generateAddress("from");
+        RskAddress to = TestUtils.generateAddress("to");
+
+        CallArguments.AccessListEntry entry = new CallArguments.AccessListEntry();
+        entry.setAddress(to.toJsonString());
+        entry.setStorageKeys(List.of("0x" + "0".repeat(63) + "1"));
+        List<CallArguments.AccessListEntry> accessList = List.of(entry);
+
+        CallArguments args = Rskip545TestSupport.defaultType4CallArguments(new byte[0]);
+        args.setFrom(from.toJsonString());
+        args.setTo(to.toJsonString());
+        args.setMaxPriorityFeePerGas("0x3");
+        args.setMaxFeePerGas("0x9");
+        args.setAccessList(accessList);
+
+        Block block = mock(Block.class);
+        ExecutionBlockRetriever.Result blockResult = mock(ExecutionBlockRetriever.Result.class);
+        when(blockResult.getBlock()).thenReturn(block);
+
+        ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
+        when(retriever.retrieveExecutionBlock("latest")).thenReturn(blockResult);
+
+        RepositoryLocator repositoryLocator = mock(RepositoryLocator.class);
+        RepositorySnapshot snapshot = mock(RepositorySnapshot.class);
+        when(repositoryLocator.snapshotAt(any())).thenReturn(snapshot);
+
+        ProgramResult programResult = mock(ProgramResult.class);
+        TransactionExecutor transactionExecutor = mock(TransactionExecutor.class);
+        when(transactionExecutor.getResult()).thenReturn(programResult);
+
+        ReversibleTransactionExecutor executor = mock(ReversibleTransactionExecutor.class);
+        when(executor.estimateGas(eq(block), any(), eq(snapshot), any())).thenReturn(transactionExecutor);
+
+        BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(null, null, null, signatureCache);
+
+        EthModule eth = new EthModule(
+                null,
+                Constants.REGTEST_CHAIN_ID,
+                mock(Blockchain.class),
+                null,
+                executor,
+                retriever,
+                repositoryLocator,
+                null,
+                null,
+                bridgeSupportFactory,
+                config.getGasEstimationCap(),
+                config.getCallGasCap(),
+                config.getActivationConfig(),
+                new PrecompiledContracts(config, bridgeSupportFactory, signatureCache),
+                false,
+                null);
+
+        eth.estimateGas(TransactionFactoryHelper.toCallArgumentsParam(args), new BlockIdentifierParam("latest"));
+
+        ArgumentCaptor<ReversibleTransactionExecutor.ReversibleTransactionParams> captor = ArgumentCaptor.forClass(ReversibleTransactionExecutor.ReversibleTransactionParams.class);
+        verify(executor).estimateGas(eq(block), any(), eq(snapshot), captor.capture());
+
+        ReversibleTransactionExecutor.ReversibleTransactionParams params = captor.getValue();
+
+        assertAll(
+                () -> assertEquals(TransactionType.TYPE_4, params.type()),
+                () -> assertEquals(Constants.REGTEST_CHAIN_ID, params.chainId()),
+                () -> assertArrayEquals(AccessListCodec.encodeAccessList(accessList), params.accessListBytes()),
+                () -> assertArrayEquals(new byte[]{0x03}, params.maxPriorityFeePerGas()),
+                () -> assertArrayEquals(new byte[]{0x09}, params.maxFeePerGas()),
+                () -> assertNotNull(params.authorizationList()),
+                () -> assertEquals(1, params.authorizationList().size())
+        );
+    }
+
+    @Test
+    void call_maxPriorityHigherThanMaxFee_rejects() {
+        RskAddress from = TestUtils.generateAddress("from");
+        RskAddress to = TestUtils.generateAddress("to");
+
+        CallArguments args = new CallArguments();
+        args.setFrom(from.toJsonString());
+        args.setTo(to.toJsonString());
+        args.setMaxPriorityFeePerGas("0xa");
+        args.setMaxFeePerGas("0x5");
+
+        ExecutionBlockRetriever.Result blockResult = mock(ExecutionBlockRetriever.Result.class);
+        Block block = mock(Block.class);
+        ExecutionBlockRetriever retriever = mock(ExecutionBlockRetriever.class);
+        when(retriever.retrieveExecutionBlock("latest")).thenReturn(blockResult);
+        when(blockResult.getBlock()).thenReturn(block);
+
+        ReversibleTransactionExecutor executor = mock(ReversibleTransactionExecutor.class);
+        BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(null, null, null, signatureCache);
+
+        EthModule eth = new EthModule(
+                null,
+                Constants.REGTEST_CHAIN_ID,
+                null,
+                null,
+                executor,
+                retriever,
+                mock(RepositoryLocator.class),
+                null,
+                null,
+                bridgeSupportFactory,
+                config.getGasEstimationCap(),
+                config.getCallGasCap(),
+                config.getActivationConfig(),
+                new PrecompiledContracts(config, bridgeSupportFactory, signatureCache),
+                false,
+                null);
+
+        RskJsonRpcRequestException exception = assertThrows(
+                RskJsonRpcRequestException.class,
+                () -> eth.call(TransactionFactoryHelper.toCallArgumentsParam(args), new BlockIdentifierParam("latest")));
+
+        assertEquals(-32602, exception.getCode());
+
+        verify(executor, never()).executeTransactionAtBlock(any(), any(), any());
+        verify(executor, never()).executeTransactionOnSnapshot(any(), any(), any(), any(), any());
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleType4CallSimulationTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleType4CallSimulationTest.java
@@ -235,6 +235,79 @@ class EthModuleType4CallSimulationTest {
         assertEquals(BigInteger.ZERO, chainState.getNonce(plainEOA_WITH_NO_CODE.getAddress()));
     }
 
+    @Test
+    void call_type4WithAccessList_executesDelegatedCode() {
+        SetCodeAuthorization auth = Rskip545TestSupport.createSignedAuthorization(authorityA.getEcKey(), const42, BigInteger.ZERO, CHAIN_ID);
+
+        List<CallArguments.AccessListEntry> accessList = List.of(accessListEntry(const42));
+
+        CallArgumentsParam params =
+                callArgumentsParam(
+                        authorityA.getAddress(),
+                        authorityA.getAddress(),
+                        new byte[0],
+                        List.of(auth),
+                        accessList);
+
+        String result = eth.call(params, new BlockIdentifierParam("latest"));
+        assertEquals("0x" + "00".repeat(31) + "2a", result);
+    }
+
+    @Test
+    void estimateGas_type4WithAccessList_includesAccessListIntrinsicGas() {
+        SetCodeAuthorization auth = Rskip545TestSupport.createSignedAuthorization(authorityA.getEcKey(), const42, BigInteger.ZERO, CHAIN_ID);
+        List<CallArguments.AccessListEntry> accessList = List.of(accessListEntry(const42));
+
+        byte[] encodedAccessList = AccessListCodec.encodeAccessList(accessList);
+
+        long withoutAccessList = estimate(authorityA.getAddress(), new byte[0], List.of(auth), null);
+        long withAccessList = estimate(authorityA.getAddress(), new byte[0], List.of(auth), accessList);
+        assertEquals(encodedAccessList.length * GasCost.ACCESS_LIST_GAS_PER_BYTE, withAccessList - withoutAccessList);
+    }
+
+    @Test
+    void estimateGas_emptyAuthorizationList_rejectsInvalidParams() {
+        CallArguments args = new CallArguments();
+        args.setFrom(authorityA.getAddress().toJsonString());
+        args.setTo(authorityA.getAddress().toJsonString());
+        args.setGas("0x5B8D80");
+        args.setAuthorizationList(List.of());
+
+        CallArgumentsParam params = TransactionFactoryHelper.toCallArgumentsParam(args);
+        BlockIdentifierParam latest = new BlockIdentifierParam("latest");
+
+        RskJsonRpcRequestException ex = assertThrows(RskJsonRpcRequestException.class, () -> ethGas.estimateGas(params, latest));
+        assertEquals(-32602, ex.getCode());
+    }
+
+    @Test
+    void estimateGas_type4_executesDelegatedCode() {
+        SetCodeAuthorization auth = Rskip545TestSupport.createSignedAuthorization(authorityA.getEcKey(), simpleStorage, BigInteger.ZERO, CHAIN_ID);
+
+        long noDelegation = estimate(authorityA.getAddress(), SET_VALUE_42, null);
+        long delegated = estimate(authorityA.getAddress(), SET_VALUE_42, List.of(auth));
+        long authorizationIntrinsicCost = GasCost.PER_EMPTY_ACCOUNT_COST;
+
+        assertTrue(delegated > noDelegation + authorizationIntrinsicCost, "delegated execution should consume execution gas in addition " + "to the authorization intrinsic cost");
+    }
+
+    @Test
+    void estimateGas_type4DelegatedExecutionReverts_propagatesError() {
+        SetCodeAuthorization auth = Rskip545TestSupport.createSignedAuthorization(authorityA.getEcKey(), reverter, BigInteger.ZERO, CHAIN_ID);
+        RskJsonRpcRequestException ex = assertThrows(RskJsonRpcRequestException.class, () -> estimate(authorityA.getAddress(), new byte[0], List.of(auth)));
+
+        assertTrue(ex.getMessage() != null && ex.getMessage().toLowerCase().contains("revert"), "expected delegated revert to propagate through eth_estimateGas");
+    }
+
+
+
+    private CallArguments.AccessListEntry accessListEntry(RskAddress address) {
+        CallArguments.AccessListEntry entry = new CallArguments.AccessListEntry();
+        entry.setAddress(address.toJsonString());
+        entry.setStorageKeys(List.of("0x" + "0".repeat(63) + "1"));
+        return entry;
+    }
+
     private long estimate(RskAddress to, byte[] data, List<SetCodeAuthorization> authorizationList) {
         return estimate(to, data, authorizationList, null);
     }

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleType4CallSimulationTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleType4CallSimulationTest.java
@@ -188,7 +188,10 @@ class EthModuleType4CallSimulationTest {
     void delegatedRevert_propagatesAsEthCallRevert() {
         SetCodeAuthorization auth = Rskip545TestSupport.createSignedAuthorization(plainEOA_WITH_NO_CODE.getEcKey(), reverter, BigInteger.ZERO, CHAIN_ID);
 
-        RskJsonRpcRequestException ex = assertThrows(RskJsonRpcRequestException.class, () -> eth.call(callArgumentsParam(plainEOA_WITH_NO_CODE.getAddress(), plainEOA_WITH_NO_CODE.getAddress(), new byte[0], List.of(auth), null), new BlockIdentifierParam("latest")));
+        CallArgumentsParam params = callArgumentsParam(plainEOA_WITH_NO_CODE.getAddress(), plainEOA_WITH_NO_CODE.getAddress(), new byte[0], List.of(auth), null);
+        BlockIdentifierParam latest = new BlockIdentifierParam("latest");
+
+        RskJsonRpcRequestException ex = assertThrows(RskJsonRpcRequestException.class, () -> eth.call(params, latest));
         assertTrue(ex.getMessage() != null && ex.getMessage().toLowerCase().contains("revert"), "expected a revert error, got: " + ex.getMessage());
     }
 

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleType4CallSimulationTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleType4CallSimulationTest.java
@@ -1,0 +1,292 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2026 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.rpc.modules.eth;
+
+import co.rsk.config.TestSystemProperties;
+import co.rsk.core.RskAddress;
+import co.rsk.db.RepositorySnapshot;
+import co.rsk.test.World;
+import co.rsk.test.builders.AccountBuilder;
+import co.rsk.test.builders.BlockBuilder;
+import co.rsk.util.HexUtils;
+import com.typesafe.config.ConfigValueFactory;
+import org.bouncycastle.util.encoders.Hex;
+import org.ethereum.core.Account;
+import org.ethereum.core.Block;
+import org.ethereum.core.ImportResult;
+import org.ethereum.core.Rskip545TestSupport;
+import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionReceipt;
+import org.ethereum.core.transaction.SetCodeAuthorization;
+import org.ethereum.core.transaction.TransactionType;
+import org.ethereum.crypto.ECKey;
+import org.ethereum.crypto.HashUtil;
+import org.ethereum.rpc.CallArguments;
+import org.ethereum.rpc.exception.RskJsonRpcRequestException;
+import org.ethereum.rpc.parameters.BlockIdentifierParam;
+import org.ethereum.rpc.parameters.CallArgumentsParam;
+import org.ethereum.util.EthModuleTestUtils;
+import org.ethereum.util.TransactionFactoryHelper;
+import org.ethereum.vm.GasCost;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+class EthModuleType4CallSimulationTest {
+
+    private static final byte CHAIN_ID = 33; // Constants.REGTEST_CHAIN_ID
+
+    /** getValue()/setValue(uint256) storage contract, reused from Rskip545RealWorldContractTest. */
+    private static final byte[] SIMPLE_STORAGE_INIT = Hex.decode("603980600b6000396000f36004361060205760003560e01c806360fe47b114602557632a1afcd914602d575b600080fd5b600435600055005b60005460005260206000f3");
+    private static final byte[] SET_VALUE_42 = Hex.decode("60fe47b1000000000000000000000000000000000000000000000000000000000000002a");
+    private static final byte[] GET_VALUE = Hex.decode("2a1afcd9");
+
+    /** Always returns 32-byte 0x2a, regardless of calldata or storage: proves delegated code ran. */
+    private static final byte[] CONST42_INIT = Hex.decode("600a80600b6000396000f3602a60005260206000f3");
+
+    /** Always reverts, regardless of calldata: proves a delegated revert propagates through eth_call. */
+    private static final byte[] REVERT_INIT = Hex.decode("600580600b6000396000f360006000fd");
+
+    private World world;
+    private EthModule eth;
+    private EthModuleTestUtils.EthModuleGasEstimation ethGas;
+    private RskAddress simpleStorage;
+    private RskAddress const42;
+    private RskAddress reverter;
+
+    private Account plainEOA_WITH_NO_CODE;
+    private Account authorityA;
+    private Account authorityB;
+
+    @BeforeEach
+    void setup() {
+        world = new World(activateType1Type2Type4FromGenesis());
+
+        ECKey deployerKey = createFundedDeployer();
+        createTestAccounts();
+        precomputeContractAddresses(deployerKey);
+
+        Block deployBlock = deployContracts(deployerKey);
+        assertContractsWereDeployed(deployBlock);
+
+        eth = EthModuleTestUtils.buildBasicEthModule(world);
+        ethGas = EthModuleTestUtils.buildBasicEthModuleForGasEstimation(world);
+    }
+
+    private static TestSystemProperties activateType1Type2Type4FromGenesis() {
+        return new TestSystemProperties(rawConfig ->
+                rawConfig
+                        .withValue("blockchain.config.consensusRules.rskip543", ConfigValueFactory.fromAnyRef(0))
+                        .withValue("blockchain.config.consensusRules.rskip546", ConfigValueFactory.fromAnyRef(0))
+                        .withValue("blockchain.config.consensusRules.rskip545", ConfigValueFactory.fromAnyRef(0))
+        );
+    }
+
+    private ECKey createFundedDeployer() {
+        byte[] deployerPk = HashUtil.keccak256("deployer".getBytes());
+        ECKey deployerKey = ECKey.fromPrivate(deployerPk);
+        Account deployer = new AccountBuilder(world).name("deployer")
+                .balance(co.rsk.core.Coin.valueOf(10).multiply(BigInteger.valueOf(1_000_000_000_000_000_000L)))
+                .build();
+        assertEquals(new RskAddress(deployerKey.getAddress()), deployer.getAddress());
+        return deployerKey;
+    }
+
+    private void createTestAccounts() {
+        plainEOA_WITH_NO_CODE = new AccountBuilder(world).name("plainEOA_WITH_NO_CODE").build();
+        authorityA = new AccountBuilder(world).name("authorityA").build();
+        authorityB = new AccountBuilder(world).name("authorityB").build();
+    }
+
+    private void precomputeContractAddresses(ECKey deployerKey) {
+        byte[] deployerAddress = deployerKey.getAddress();
+        simpleStorage = new RskAddress(HashUtil.calcNewAddr(deployerAddress, BigInteger.ZERO.toByteArray()));
+        const42 = new RskAddress(HashUtil.calcNewAddr(deployerAddress, BigInteger.ONE.toByteArray()));
+        reverter = new RskAddress(HashUtil.calcNewAddr(deployerAddress, BigInteger.TWO.toByteArray()));
+    }
+
+
+    private Block deployContracts(ECKey deployerKey) {
+        byte[] deployerPk = deployerKey.getPrivKeyBytes();
+        Block parent = world.getBlockChain().getBestBlock();
+        return mine(parent, List.of(
+                deployTx(deployerPk, BigInteger.ZERO, SIMPLE_STORAGE_INIT),
+                deployTx(deployerPk, BigInteger.ONE, CONST42_INIT),
+                deployTx(deployerPk, BigInteger.TWO, REVERT_INIT)
+        ));
+    }
+
+    private void assertContractsWereDeployed(Block deployBlock) {
+        RepositorySnapshot deployed = world.getRepositoryLocator().snapshotAt(deployBlock.getHeader());
+        assertTrue(deployed.getCode(simpleStorage).length > 0, "SimpleStorage not deployed");
+        assertTrue(deployed.getCode(const42).length > 0, "Const42 not deployed");
+        assertTrue(deployed.getCode(reverter).length > 0, "Reverter not deployed");
+    }
+
+    @Test
+    void selfAuthorization_delegateThenInvoke_runsDelegatedCodeInSingleCall() {
+        assertEquals("0x", callHex(plainEOA_WITH_NO_CODE.getAddress(), GET_VALUE, null));
+        SetCodeAuthorization selfAuth = Rskip545TestSupport.createSignedAuthorization(plainEOA_WITH_NO_CODE.getEcKey(), simpleStorage, BigInteger.ZERO, CHAIN_ID);
+        String result = callHex(plainEOA_WITH_NO_CODE.getAddress(), GET_VALUE, List.of(selfAuth));
+        assertEquals("0x" + "00".repeat(32), result);
+    }
+
+    @Test
+    void selfAuthorization_arbitraryAuthorityAccount_delegationStillApplies() {
+        assertEquals("0x", callHex(authorityA.getAddress(), new byte[0], null));
+
+        SetCodeAuthorization selfAuth = Rskip545TestSupport.createSignedAuthorization(authorityA.getEcKey(), const42, BigInteger.ZERO, CHAIN_ID);
+
+        String result = callHex(authorityA.getAddress(), new byte[0], List.of(selfAuth));
+        assertEquals("0x" + "00".repeat(31) + "2a", result);
+    }
+
+    @Test
+    void multipleAuthorizations_eachTupleInTheListIsApplied() {
+        SetCodeAuthorization authA = Rskip545TestSupport.createSignedAuthorization(authorityA.getEcKey(), const42, BigInteger.ZERO, CHAIN_ID);
+        SetCodeAuthorization authB = Rskip545TestSupport.createSignedAuthorization(authorityB.getEcKey(), const42, BigInteger.ZERO, CHAIN_ID);
+        List<SetCodeAuthorization> both = List.of(authA, authB);
+
+        assertEquals("0x" + "00".repeat(31) + "2a", callHex(authorityA.getAddress(), new byte[0], both));
+        assertEquals("0x" + "00".repeat(31) + "2a", callHex(authorityB.getAddress(), new byte[0], both));
+    }
+
+    @Test
+    void invalidAuthorizationTuple_isSkipped_validTuplesStillApply() {
+        SetCodeAuthorization valid = Rskip545TestSupport.createSignedAuthorization(authorityA.getEcKey(), const42, BigInteger.ZERO, CHAIN_ID);
+        SetCodeAuthorization invalidNonce = Rskip545TestSupport.createSignedAuthorization(authorityB.getEcKey(), const42, BigInteger.ONE, CHAIN_ID);
+        List<SetCodeAuthorization> list = List.of(valid, invalidNonce);
+
+        assertEquals("0x" + "00".repeat(31) + "2a", callHex(authorityA.getAddress(), new byte[0], list));
+        assertEquals("0x", callHex(authorityB.getAddress(), new byte[0], list));
+    }
+
+    @Test
+    void delegatedRevert_propagatesAsEthCallRevert() {
+        SetCodeAuthorization auth = Rskip545TestSupport.createSignedAuthorization(plainEOA_WITH_NO_CODE.getEcKey(), reverter, BigInteger.ZERO, CHAIN_ID);
+
+        RskJsonRpcRequestException ex = assertThrows(RskJsonRpcRequestException.class, () -> eth.call(callArgumentsParam(plainEOA_WITH_NO_CODE.getAddress(), plainEOA_WITH_NO_CODE.getAddress(), new byte[0], List.of(auth)), new BlockIdentifierParam("latest")));
+        assertTrue(ex.getMessage() != null && ex.getMessage().toLowerCase().contains("revert"), "expected a revert error, got: " + ex.getMessage());
+    }
+
+    @Test
+    void estimateGas_type4_includesPerAuthorizationIntrinsicGas() {
+        RskAddress emptyDelegate = authorityB.getAddress();
+        SetCodeAuthorization auth = Rskip545TestSupport.createSignedAuthorization(authorityA.getEcKey(), emptyDelegate, BigInteger.ZERO, CHAIN_ID);
+
+        long baseline = estimate(authorityA.getAddress(), new byte[0], null);
+        long withAuthorization = estimate(authorityA.getAddress(), new byte[0], List.of(auth));
+
+        assertTrue(withAuthorization - baseline >= GasCost.PER_EMPTY_ACCOUNT_COST, "expected at least the RSKIP-545 per-authorization intrinsic gas (" + GasCost.PER_EMPTY_ACCOUNT_COST
+                        + ") to be added; baseline=" + baseline + " withAuthorization=" + withAuthorization);
+    }
+
+    @Test
+    void stateChangesFromDelegatedExecution_areDiscardedAfterTheCall() {
+        SetCodeAuthorization selfAuth = Rskip545TestSupport.createSignedAuthorization(plainEOA_WITH_NO_CODE.getEcKey(), simpleStorage, BigInteger.ZERO, CHAIN_ID);
+
+        String result = callHex(plainEOA_WITH_NO_CODE.getAddress(), SET_VALUE_42, List.of(selfAuth));
+        assertEquals("0x", result);
+
+        RepositorySnapshot chainState = world.getRepositoryLocator().snapshotAt(world.getBlockChain().getBestBlock().getHeader());
+        byte[] eoaCodeAfterCall = chainState.getCode(plainEOA_WITH_NO_CODE.getAddress());
+        assertTrue(eoaCodeAfterCall == null || eoaCodeAfterCall.length == 0, "plainEOA_WITH_NO_CODE must not have been delegated on real chain state");
+        assertEquals(BigInteger.ZERO, chainState.getNonce(plainEOA_WITH_NO_CODE.getAddress()));
+    }
+
+    private long estimate(RskAddress to, byte[] data, List<SetCodeAuthorization> authorizationList) {
+        CallArgumentsParam params = callArgumentsParam(to, to, data, authorizationList);
+        String hex = ethGas.estimateGas(params, new BlockIdentifierParam("latest"));
+        return HexUtils.jsonHexToLong(hex);
+    }
+
+    private String callHex(RskAddress to, byte[] data, List<SetCodeAuthorization> authorizationList) {
+        CallArgumentsParam params = callArgumentsParam(to, to, data, authorizationList);
+        return eth.call(params, new BlockIdentifierParam("latest"));
+    }
+
+    private CallArgumentsParam callArgumentsParam(RskAddress from, RskAddress to, byte[] data,
+                                                   List<SetCodeAuthorization> authorizationList) {
+        CallArguments args = new CallArguments();
+        args.setFrom(from.toJsonString());
+        args.setTo(to.toJsonString());
+        args.setGas("0x5B8D80");
+        args.setData(data == null || data.length == 0 ? "0x" : "0x" + Hex.toHexString(data));
+        args.setType("0x4");
+        if (authorizationList != null && !authorizationList.isEmpty()) {
+            args.setAuthorizationList(authorizationList.stream().map(this::toEntry).toList());
+        }
+        return TransactionFactoryHelper.toCallArgumentsParam(args);
+    }
+
+    private CallArguments.AuthorizationListEntry toEntry(SetCodeAuthorization auth) {
+        CallArguments.AuthorizationListEntry entry = new CallArguments.AuthorizationListEntry();
+        entry.setChainId(toHex(auth.getChainId()));
+        entry.setAddress(auth.getAddress().toJsonString());
+        entry.setNonce(toHex(auth.getNonceAsInteger()));
+        byte yParity = (byte) (auth.getSignature().getV() - Transaction.LOWER_REAL_V);
+        entry.setYParity(toHex(BigInteger.valueOf(yParity)));
+        entry.setR(toHex(auth.getSignature().getR()));
+        entry.setS(toHex(auth.getSignature().getS()));
+        return entry;
+    }
+
+    private static String toHex(BigInteger value) {
+        return "0x" + value.toString(16);
+    }
+
+    private Transaction deployTx(byte[] deployerPk, BigInteger nonce, byte[] initCode) {
+        Transaction tx = Transaction.builder()
+                .type(TransactionType.TYPE_2)
+                .chainId(CHAIN_ID)
+                .nonce(nonce)
+                .gasLimit(BigInteger.valueOf(300_000))
+                .maxPriorityFeePerGas(co.rsk.core.Coin.valueOf(1_000_000_000L))
+                .maxFeePerGas(co.rsk.core.Coin.valueOf(2_000_000_000L))
+                .data(initCode)
+                .value(co.rsk.core.Coin.ZERO)
+                .build();
+        tx.sign(deployerPk);
+        return tx;
+    }
+
+    private Block mine(Block parent, List<Transaction> txs) {
+        Block block = new BlockBuilder(world.getBlockChain(), world.getBridgeSupportFactory(), world.getBlockStore())
+                .trieStore(world.getTrieStore())
+                .parent(parent)
+                .transactions(txs)
+                .build();
+        ImportResult result = world.getBlockChain().tryToConnect(block);
+        assertEquals(ImportResult.IMPORTED_BEST, result);
+        for (Transaction tx : txs) {
+            TransactionReceipt receipt = world.getReceiptStore()
+                    .getInMainChain(tx.getHash().getBytes(), world.getBlockStore())
+                    .orElseThrow()
+                    .getReceipt();
+            assertTrue(receipt.isSuccessful(), "deploy tx failed: " + tx.getHash());
+        }
+        return block;
+    }
+}

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleType4CallSimulationTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleType4CallSimulationTest.java
@@ -34,6 +34,7 @@ import org.ethereum.core.Transaction;
 import org.ethereum.core.TransactionReceipt;
 import org.ethereum.core.transaction.SetCodeAuthorization;
 import org.ethereum.core.transaction.TransactionType;
+import org.ethereum.core.transaction.parser.util.AccessListCodec;
 import org.ethereum.crypto.ECKey;
 import org.ethereum.crypto.HashUtil;
 import org.ethereum.rpc.CallArguments;
@@ -187,7 +188,7 @@ class EthModuleType4CallSimulationTest {
     void delegatedRevert_propagatesAsEthCallRevert() {
         SetCodeAuthorization auth = Rskip545TestSupport.createSignedAuthorization(plainEOA_WITH_NO_CODE.getEcKey(), reverter, BigInteger.ZERO, CHAIN_ID);
 
-        RskJsonRpcRequestException ex = assertThrows(RskJsonRpcRequestException.class, () -> eth.call(callArgumentsParam(plainEOA_WITH_NO_CODE.getAddress(), plainEOA_WITH_NO_CODE.getAddress(), new byte[0], List.of(auth)), new BlockIdentifierParam("latest")));
+        RskJsonRpcRequestException ex = assertThrows(RskJsonRpcRequestException.class, () -> eth.call(callArgumentsParam(plainEOA_WITH_NO_CODE.getAddress(), plainEOA_WITH_NO_CODE.getAddress(), new byte[0], List.of(auth), null), new BlockIdentifierParam("latest")));
         assertTrue(ex.getMessage() != null && ex.getMessage().toLowerCase().contains("revert"), "expected a revert error, got: " + ex.getMessage());
     }
 
@@ -204,6 +205,21 @@ class EthModuleType4CallSimulationTest {
     }
 
     @Test
+    void estimateGas_type4WithAccessList_addsAccessListIntrinsicGas() {
+        SetCodeAuthorization auth = Rskip545TestSupport.createSignedAuthorization(authorityA.getEcKey(), const42, BigInteger.ZERO, CHAIN_ID);
+        CallArguments.AccessListEntry entry = new CallArguments.AccessListEntry();
+        entry.setAddress(const42.toJsonString());
+        entry.setStorageKeys(List.of("0x" + "0".repeat(63) + "1"));
+        List<CallArguments.AccessListEntry> accessList = List.of(entry);
+        byte[] encoded = AccessListCodec.encodeAccessList(accessList);
+
+        long withoutAccessList = estimate(authorityA.getAddress(), new byte[0], List.of(auth), null);
+        long withAccessList = estimate(authorityA.getAddress(), new byte[0], List.of(auth), accessList);
+
+        assertEquals(encoded.length * GasCost.ACCESS_LIST_GAS_PER_BYTE, withAccessList - withoutAccessList, "a Type 4 call with authorizationList must still be charged RSKIP-546's access-list intrinsic gas");
+    }
+
+    @Test
     void stateChangesFromDelegatedExecution_areDiscardedAfterTheCall() {
         SetCodeAuthorization selfAuth = Rskip545TestSupport.createSignedAuthorization(plainEOA_WITH_NO_CODE.getEcKey(), simpleStorage, BigInteger.ZERO, CHAIN_ID);
 
@@ -217,18 +233,24 @@ class EthModuleType4CallSimulationTest {
     }
 
     private long estimate(RskAddress to, byte[] data, List<SetCodeAuthorization> authorizationList) {
-        CallArgumentsParam params = callArgumentsParam(to, to, data, authorizationList);
+        return estimate(to, data, authorizationList, null);
+    }
+
+    private long estimate(RskAddress to, byte[] data, List<SetCodeAuthorization> authorizationList,
+                           List<CallArguments.AccessListEntry> accessList) {
+        CallArgumentsParam params = callArgumentsParam(to, to, data, authorizationList, accessList);
         String hex = ethGas.estimateGas(params, new BlockIdentifierParam("latest"));
         return HexUtils.jsonHexToLong(hex);
     }
 
     private String callHex(RskAddress to, byte[] data, List<SetCodeAuthorization> authorizationList) {
-        CallArgumentsParam params = callArgumentsParam(to, to, data, authorizationList);
+        CallArgumentsParam params = callArgumentsParam(to, to, data, authorizationList, null);
         return eth.call(params, new BlockIdentifierParam("latest"));
     }
 
     private CallArgumentsParam callArgumentsParam(RskAddress from, RskAddress to, byte[] data,
-                                                   List<SetCodeAuthorization> authorizationList) {
+                                                   List<SetCodeAuthorization> authorizationList,
+                                                   List<CallArguments.AccessListEntry> accessList) {
         CallArguments args = new CallArguments();
         args.setFrom(from.toJsonString());
         args.setTo(to.toJsonString());
@@ -237,6 +259,9 @@ class EthModuleType4CallSimulationTest {
         args.setType("0x4");
         if (authorizationList != null && !authorizationList.isEmpty()) {
             args.setAuthorizationList(authorizationList.stream().map(this::toEntry).toList());
+        }
+        if (accessList != null) {
+            args.setAccessList(accessList);
         }
         return TransactionFactoryHelper.toCallArgumentsParam(args);
     }

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleType4CallSimulationTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleType4CallSimulationTest.java
@@ -50,6 +50,8 @@ import org.junit.jupiter.api.Test;
 import java.math.BigInteger;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -77,7 +79,7 @@ class EthModuleType4CallSimulationTest {
     private RskAddress const42;
     private RskAddress reverter;
 
-    private Account plainEOA_WITH_NO_CODE;
+    private Account plainEoaWithNoCode;
     private Account authorityA;
     private Account authorityB;
 
@@ -116,7 +118,7 @@ class EthModuleType4CallSimulationTest {
     }
 
     private void createTestAccounts() {
-        plainEOA_WITH_NO_CODE = new AccountBuilder(world).name("plainEOA_WITH_NO_CODE").build();
+        plainEoaWithNoCode = new AccountBuilder(world).name("plainEOA_WITH_NO_CODE").build();
         authorityA = new AccountBuilder(world).name("authorityA").build();
         authorityB = new AccountBuilder(world).name("authorityB").build();
     }
@@ -148,9 +150,9 @@ class EthModuleType4CallSimulationTest {
 
     @Test
     void selfAuthorization_delegateThenInvoke_runsDelegatedCodeInSingleCall() {
-        assertEquals("0x", callHex(plainEOA_WITH_NO_CODE.getAddress(), GET_VALUE, null));
-        SetCodeAuthorization selfAuth = Rskip545TestSupport.createSignedAuthorization(plainEOA_WITH_NO_CODE.getEcKey(), simpleStorage, BigInteger.ZERO, CHAIN_ID);
-        String result = callHex(plainEOA_WITH_NO_CODE.getAddress(), GET_VALUE, List.of(selfAuth));
+        assertEquals("0x", callHex(plainEoaWithNoCode.getAddress(), GET_VALUE, null));
+        SetCodeAuthorization selfAuth = Rskip545TestSupport.createSignedAuthorization(plainEoaWithNoCode.getEcKey(), simpleStorage, BigInteger.ZERO, CHAIN_ID);
+        String result = callHex(plainEoaWithNoCode.getAddress(), GET_VALUE, List.of(selfAuth));
         assertEquals("0x" + "00".repeat(32), result);
     }
 
@@ -185,10 +187,29 @@ class EthModuleType4CallSimulationTest {
     }
 
     @Test
-    void delegatedRevert_propagatesAsEthCallRevert() {
-        SetCodeAuthorization auth = Rskip545TestSupport.createSignedAuthorization(plainEOA_WITH_NO_CODE.getEcKey(), reverter, BigInteger.ZERO, CHAIN_ID);
+    void mixedValidAndInvalidAuthorizations_onlyValidOnesAreApplied() {
+        ECKey authorityCKey = new ECKey();
+        RskAddress authorityC = new RskAddress(authorityCKey.getAddress());
 
-        CallArgumentsParam params = callArgumentsParam(plainEOA_WITH_NO_CODE.getAddress(), plainEOA_WITH_NO_CODE.getAddress(), new byte[0], List.of(auth), null);
+        SetCodeAuthorization validA = Rskip545TestSupport.createSignedAuthorization(authorityA.getEcKey(), const42, BigInteger.ZERO, CHAIN_ID);
+        SetCodeAuthorization validB = Rskip545TestSupport.createSignedAuthorization(authorityB.getEcKey(), const42, BigInteger.ZERO, CHAIN_ID);
+        SetCodeAuthorization invalidNonce = Rskip545TestSupport.createSignedAuthorization(plainEoaWithNoCode.getEcKey(), const42, BigInteger.ONE, CHAIN_ID);
+        SetCodeAuthorization wrongChainId = Rskip545TestSupport.createSignedAuthorization(authorityCKey, const42, BigInteger.ZERO, (byte) (CHAIN_ID + 1));
+        List<SetCodeAuthorization> mixed = List.of(validA, validB, invalidNonce, wrongChainId);
+
+        assertAll(
+                () -> assertEquals("0x" + "00".repeat(31) + "2a", callHex(authorityA.getAddress(), new byte[0], mixed), "authorityA's valid tuple must apply"),
+                () -> assertEquals("0x" + "00".repeat(31) + "2a", callHex(authorityB.getAddress(), new byte[0], mixed), "authorityB's valid tuple must apply"),
+                () -> assertEquals("0x", callHex(plainEoaWithNoCode.getAddress(), new byte[0], mixed), "the nonce-mismatched tuple must not apply"),
+                () -> assertEquals("0x", callHex(authorityC, new byte[0], mixed), "the wrong-chainId tuple must not apply")
+        );
+    }
+
+    @Test
+    void delegatedRevert_propagatesAsEthCallRevert() {
+        SetCodeAuthorization auth = Rskip545TestSupport.createSignedAuthorization(plainEoaWithNoCode.getEcKey(), reverter, BigInteger.ZERO, CHAIN_ID);
+
+        CallArgumentsParam params = callArgumentsParam(plainEoaWithNoCode.getAddress(), plainEoaWithNoCode.getAddress(), new byte[0], List.of(auth), null);
         BlockIdentifierParam latest = new BlockIdentifierParam("latest");
 
         RskJsonRpcRequestException ex = assertThrows(RskJsonRpcRequestException.class, () -> eth.call(params, latest));
@@ -224,15 +245,15 @@ class EthModuleType4CallSimulationTest {
 
     @Test
     void stateChangesFromDelegatedExecution_areDiscardedAfterTheCall() {
-        SetCodeAuthorization selfAuth = Rskip545TestSupport.createSignedAuthorization(plainEOA_WITH_NO_CODE.getEcKey(), simpleStorage, BigInteger.ZERO, CHAIN_ID);
+        SetCodeAuthorization selfAuth = Rskip545TestSupport.createSignedAuthorization(plainEoaWithNoCode.getEcKey(), simpleStorage, BigInteger.ZERO, CHAIN_ID);
 
-        String result = callHex(plainEOA_WITH_NO_CODE.getAddress(), SET_VALUE_42, List.of(selfAuth));
+        String result = callHex(plainEoaWithNoCode.getAddress(), SET_VALUE_42, List.of(selfAuth));
         assertEquals("0x", result);
 
         RepositorySnapshot chainState = world.getRepositoryLocator().snapshotAt(world.getBlockChain().getBestBlock().getHeader());
-        byte[] eoaCodeAfterCall = chainState.getCode(plainEOA_WITH_NO_CODE.getAddress());
+        byte[] eoaCodeAfterCall = chainState.getCode(plainEoaWithNoCode.getAddress());
         assertTrue(eoaCodeAfterCall == null || eoaCodeAfterCall.length == 0, "plainEOA_WITH_NO_CODE must not have been delegated on real chain state");
-        assertEquals(BigInteger.ZERO, chainState.getNonce(plainEOA_WITH_NO_CODE.getAddress()));
+        assertEquals(BigInteger.ZERO, chainState.getNonce(plainEoaWithNoCode.getAddress()));
     }
 
     @Test
@@ -299,7 +320,121 @@ class EthModuleType4CallSimulationTest {
         assertTrue(ex.getMessage() != null && ex.getMessage().toLowerCase().contains("revert"), "expected delegated revert to propagate through eth_estimateGas");
     }
 
+    @Test
+    void call_type4_wrongAuthorizationChainId_doesNotApplyDelegation() {
+        byte wrongChainId = (byte) (CHAIN_ID + 1);
+        SetCodeAuthorization auth = Rskip545TestSupport.createSignedAuthorization(authorityA.getEcKey(), const42, BigInteger.ZERO, wrongChainId);
 
+        String result = callHex(authorityA.getAddress(), new byte[0], List.of(auth));
+        assertEquals("0x", result);
+
+        RepositorySnapshot chainState = world.getRepositoryLocator().snapshotAt(world.getBlockChain().getBestBlock().getHeader());
+        byte[] code = chainState.getCode(authorityA.getAddress());
+
+        assertAll(
+                () -> assertTrue(code == null || code.length == 0, "authorization from another chain must not install delegation"),
+                () -> assertEquals(BigInteger.ZERO, chainState.getNonce(authorityA.getAddress()), "invalid authorization must not change authority nonce")
+        );
+    }
+
+    @Test
+    void call_type4_authorizationNonceMismatch_doesNotMutateAuthority() {
+        SetCodeAuthorization invalidNonce = Rskip545TestSupport.createSignedAuthorization(authorityA.getEcKey(), const42, BigInteger.ONE, CHAIN_ID);
+
+        RepositorySnapshot before = world.getRepositoryLocator().snapshotAt(world.getBlockChain().getBestBlock().getHeader());
+        BigInteger nonceBefore = before.getNonce(authorityA.getAddress());
+        byte[] codeBefore = normalizeCode(before.getCode(authorityA.getAddress()));
+
+        String result = callHex(authorityA.getAddress(), new byte[0], List.of(invalidNonce));
+        assertEquals("0x", result);
+
+        RepositorySnapshot after = world.getRepositoryLocator().snapshotAt(world.getBlockChain().getBestBlock().getHeader());
+
+        assertAll(
+                () -> assertEquals(nonceBefore, after.getNonce(authorityA.getAddress())),
+                () -> assertArrayEquals(codeBefore, normalizeCode(after.getCode(authorityA.getAddress())))
+        );
+    }
+
+    @Test
+    void call_type4_executionDoesNotPersistAuthorization() {
+        RskAddress authority = authorityA.getAddress();
+
+        RepositorySnapshot before = world.getRepositoryLocator().snapshotAt(world.getBlockChain().getBestBlock().getHeader());
+        BigInteger nonceBefore = before.getNonce(authority);
+        byte[] codeBefore = normalizeCode(before.getCode(authority));
+
+        SetCodeAuthorization auth = Rskip545TestSupport.createSignedAuthorization(authorityA.getEcKey(), const42, BigInteger.ZERO, CHAIN_ID);
+
+        String result = callHex(authority, new byte[0], List.of(auth));
+        assertEquals("0x" + "00".repeat(31) + "2a", result);
+
+        RepositorySnapshot after = world.getRepositoryLocator().snapshotAt(world.getBlockChain().getBestBlock().getHeader());
+
+        assertAll(
+                () -> assertEquals(nonceBefore, after.getNonce(authority), "eth_call must not persist the authorization nonce"),
+                () -> assertArrayEquals(codeBefore, normalizeCode(after.getCode(authority)), "eth_call must not persist delegation code")
+        );
+    }
+
+    @Test
+    void estimateGas_type4_executionDoesNotPersistAuthorization() {
+        RskAddress authority = authorityA.getAddress();
+
+        RepositorySnapshot before = world.getRepositoryLocator().snapshotAt(world.getBlockChain().getBestBlock().getHeader());
+        BigInteger nonceBefore = before.getNonce(authority);
+        byte[] codeBefore = normalizeCode(before.getCode(authority));
+
+        SetCodeAuthorization auth = Rskip545TestSupport.createSignedAuthorization(authorityA.getEcKey(), simpleStorage, BigInteger.ZERO, CHAIN_ID);
+
+        long estimated = estimate(authority, SET_VALUE_42, List.of(auth));
+        assertTrue(estimated > 0);
+
+        RepositorySnapshot after = world.getRepositoryLocator().snapshotAt(world.getBlockChain().getBestBlock().getHeader());
+
+        assertAll(
+                () -> assertEquals(nonceBefore, after.getNonce(authority), "eth_estimateGas must not persist authorization nonce"),
+                () -> assertArrayEquals(codeBefore, normalizeCode(after.getCode(authority)), "eth_estimateGas must not persist delegation code")
+        );
+    }
+
+    @Test
+    void estimateGas_type4_multipleAuthorizationsChargesEachAuthorization() {
+        SetCodeAuthorization authA = Rskip545TestSupport.createSignedAuthorization(authorityA.getEcKey(), authorityB.getAddress(), BigInteger.ZERO, CHAIN_ID);
+        SetCodeAuthorization authB = Rskip545TestSupport.createSignedAuthorization(authorityB.getEcKey(), authorityA.getAddress(), BigInteger.ZERO, CHAIN_ID);
+
+        long withOneAuthorization = estimate(plainEoaWithNoCode.getAddress(), new byte[0], List.of(authA));
+        long withTwoAuthorizations = estimate(plainEoaWithNoCode.getAddress(), new byte[0], List.of(authA, authB));
+
+        assertTrue(withTwoAuthorizations - withOneAuthorization >= GasCost.PER_EMPTY_ACCOUNT_COST,
+                "each additional authorization must contribute its intrinsic gas; one=" + withOneAuthorization + " two=" + withTwoAuthorizations);
+    }
+
+    @Test
+    void call_revertedType4_doesNotPersistDelegationOrNonce() {
+        RskAddress authority = authorityA.getAddress();
+
+        RepositorySnapshot before = world.getRepositoryLocator().snapshotAt(world.getBlockChain().getBestBlock().getHeader());
+        BigInteger nonceBefore = before.getNonce(authority);
+        byte[] codeBefore = normalizeCode(before.getCode(authority));
+
+        SetCodeAuthorization auth = Rskip545TestSupport.createSignedAuthorization(authorityA.getEcKey(), reverter, BigInteger.ZERO, CHAIN_ID);
+        CallArgumentsParam params = callArgumentsParam(authority, authority, new byte[0], List.of(auth), null);
+
+        RskJsonRpcRequestException ex = assertThrows(RskJsonRpcRequestException.class, () -> eth.call(params, new BlockIdentifierParam("latest")));
+        assertTrue(ex.getMessage() != null && ex.getMessage().toLowerCase().contains("revert"));
+
+        RepositorySnapshot after = world.getRepositoryLocator().snapshotAt(world.getBlockChain().getBestBlock().getHeader());
+
+        assertAll(
+                () -> assertEquals(nonceBefore, after.getNonce(authority), "reverted eth_call must not persist authority nonce"),
+                () -> assertArrayEquals(codeBefore, normalizeCode(after.getCode(authority)), "reverted eth_call must not persist delegation code")
+        );
+    }
+
+    private static byte[] normalizeCode(byte[] code) {
+        return code == null ? new byte[0] : code;
+    }
 
     private CallArguments.AccessListEntry accessListEntry(RskAddress address) {
         CallArguments.AccessListEntry entry = new CallArguments.AccessListEntry();

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTypedCallSimulationTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/eth/EthModuleTypedCallSimulationTest.java
@@ -1,0 +1,129 @@
+/*
+ * This file is part of RskJ
+ * Copyright (C) 2026 RSK Labs Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package co.rsk.rpc.modules.eth;
+
+import co.rsk.config.TestSystemProperties;
+import co.rsk.core.RskAddress;
+import co.rsk.test.World;
+import co.rsk.test.builders.AccountBuilder;
+import co.rsk.util.HexUtils;
+import org.ethereum.core.Account;
+import org.ethereum.core.transaction.parser.util.AccessListCodec;
+import org.ethereum.rpc.CallArguments;
+import org.ethereum.rpc.parameters.BlockIdentifierParam;
+import org.ethereum.rpc.parameters.CallArgumentsParam;
+import org.ethereum.util.EthModuleTestUtils;
+import org.ethereum.util.TransactionFactoryHelper;
+import org.ethereum.vm.GasCost;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+class EthModuleTypedCallSimulationTest {
+
+    private Account from;
+    private RskAddress to;
+    private EthModuleTestUtils.EthModuleGasEstimation eth;
+
+    @BeforeEach
+    void setup() {
+        World world = new World(new TestSystemProperties());
+        from = new AccountBuilder(world).name("from").build();
+        to = new AccountBuilder(world).name("to").build().getAddress();
+        eth = EthModuleTestUtils.buildBasicEthModuleForGasEstimation(world);
+    }
+
+    @Test
+    void accessListAlonePresent_resolvesToType1_addsAccessListIntrinsicGas() {
+        List<CallArguments.AccessListEntry> accessList = List.of(accessListEntry(to, "0x01"));
+        byte[] encoded = AccessListCodec.encodeAccessList(accessList);
+
+        long baseline = estimate(eth, null, null, null, null);
+        long withAccessList = estimate(eth, accessList, null, null, null);
+
+        assertEquals(encoded.length * GasCost.ACCESS_LIST_GAS_PER_BYTE, withAccessList - baseline, "an access list with no fee-cap fields must resolve to Type 1 and be charged RSKIP-546's 80 gas/byte");
+    }
+
+    @Test
+    void feeCapsPresent_resolvesToType2_addsAccessListIntrinsicGasWhenGiven() {
+        List<CallArguments.AccessListEntry> accessList = List.of(accessListEntry(to, "0x01"));
+        byte[] encoded = AccessListCodec.encodeAccessList(accessList);
+
+        long baseline = estimate(eth, null, "0x1", "0x2", null);
+        long withAccessList = estimate(eth, accessList, "0x1", "0x2", null);
+
+        assertEquals(encoded.length * GasCost.ACCESS_LIST_GAS_PER_BYTE, withAccessList - baseline, "fee-cap fields must resolve to Type 2 and its access list charged the same 80 gas/byte");
+    }
+
+    @Test
+    void feeCapsPresentWithoutAccessList_estimatesSuccessfully() {
+        long estimated = estimate(eth, null, "0x1", "0x2", null);
+        assertTrue(estimated > 0, "expected a positive gas estimate for a fee-cap-only call");
+    }
+
+    @Test
+    void explicitTypeField_isIgnoredWhenNoMatchingAttributesPresent() {
+        long withoutType = estimate(eth, null, null, null, null);
+        long withUnbackedType2 = estimate(eth, null, null, null, "0x2");
+
+        assertEquals(withoutType, withUnbackedType2, "an unbacked `type` field must not change the simulated shape");
+    }
+
+    @Test
+    void explicitTypeField_isIgnoredWhenAttributesImplyADifferentType() {
+        List<CallArguments.AccessListEntry> accessList = List.of(accessListEntry(to, "0x01"));
+
+        long asType1 = estimate(eth, accessList, null, null, null);
+        long claimingType2 = estimate(eth, accessList, null, null, "0x2");
+
+        assertEquals(asType1, claimingType2, "an access-list-only call must resolve to Type 1 regardless of a mismatched `type` field");
+    }
+
+    private long estimate(EthModuleTestUtils.EthModuleGasEstimation eth, List<CallArguments.AccessListEntry> accessList, String maxPriorityFeePerGas, String maxFeePerGas, String type) {
+        CallArguments args = new CallArguments();
+        args.setFrom(from.getAddress().toJsonString());
+        args.setTo(to.toJsonString());
+        if (accessList != null) {
+            args.setAccessList(accessList);
+        }
+        if (maxPriorityFeePerGas != null) {
+            args.setMaxPriorityFeePerGas(maxPriorityFeePerGas);
+        }
+        if (maxFeePerGas != null) {
+            args.setMaxFeePerGas(maxFeePerGas);
+        }
+        if (type != null) {
+            args.setType(type);
+        }
+        CallArgumentsParam params = TransactionFactoryHelper.toCallArgumentsParam(args);
+        String hex = eth.estimateGas(params, new BlockIdentifierParam("latest"));
+        return HexUtils.jsonHexToLong(hex);
+    }
+
+    private static CallArguments.AccessListEntry accessListEntry(RskAddress address, String storageKeySuffix) {
+        CallArguments.AccessListEntry entry = new CallArguments.AccessListEntry();
+        entry.setAddress(address.toJsonString());
+        entry.setStorageKeys(List.of("0x" + "0".repeat(62) + storageKeySuffix.substring(2)));
+        return entry;
+    }
+}

--- a/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/Web3ImplTest.java
@@ -3056,7 +3056,8 @@ class Web3ImplTest {
 
         ReversibleTransactionExecutor executor = new ReversibleTransactionExecutor(
                 repositoryLocator,
-                buildTransactionExecutorFactory(blockStore, null)
+                buildTransactionExecutorFactory(blockStore, null),
+                null
         );
 
         Web3InformationRetriever retriever = new Web3InformationRetriever(transactionPool, blockchain, repositoryLocator, executionBlockRetriever);
@@ -3131,7 +3132,7 @@ class Web3ImplTest {
         ReversibleTransactionExecutor executor = mock(ReversibleTransactionExecutor.class);
         ProgramResult res = new ProgramResult();
         res.setHReturn(new byte[0]);
-        when(executor.executeTransaction(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(res);
+        when(executor.executeTransactionAtBlock(any(Block.class), any(), any())).thenReturn(res);
         Web3InformationRetriever retriever = new Web3InformationRetriever(transactionPool, blockchain, repositoryLocator, executionBlockRetriever);
         BridgeSupportFactory bridgeSupportFactory = new BridgeSupportFactory(
                 null, config.getNetworkConstants().getBridgeConstants(), config.getActivationConfig(), signatureCache);

--- a/rskj-core/src/test/java/org/ethereum/rpc/converters/CallArgumentsToByteArrayTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/converters/CallArgumentsToByteArrayTest.java
@@ -18,11 +18,16 @@
 
 package org.ethereum.rpc.converters;
 
+import org.ethereum.core.Rskip545TestSupport;
+import org.ethereum.core.transaction.SetCodeAuthorization;
+import org.ethereum.core.transaction.TransactionType;
 import org.ethereum.rpc.CallArguments;
 import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.ethereum.util.ByteUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import co.rsk.config.TestSystemProperties;
 import co.rsk.util.HexUtils;
@@ -278,5 +283,130 @@ class CallArgumentsToByteArrayTest {
         CallArgumentsToByteArray byteArrayArgs = new CallArgumentsToByteArray(args);
 
         Assertions.assertArrayEquals(new byte[] {0x7}, byteArrayArgs.getGasPrice());
+    }
+
+    @Test
+    void getAuthorizationListWhenValueIsNull() {
+        CallArguments args = new CallArguments();
+
+        CallArgumentsToByteArray byteArrayArgs = new CallArgumentsToByteArray(args);
+
+        Assertions.assertNull(byteArrayArgs.getAuthorizationList());
+    }
+
+    @Test
+    void getAuthorizationListWhenValueIsEmpty() {
+        CallArguments args = new CallArguments();
+        args.setAuthorizationList(List.of());
+
+        CallArgumentsToByteArray byteArrayArgs = new CallArgumentsToByteArray(args);
+
+        Assertions.assertNull(byteArrayArgs.getAuthorizationList());
+    }
+
+    @Test
+    void getAuthorizationListParsesEntriesIntoSetCodeAuthorizations() {
+        CallArguments.AuthorizationListEntry entry = Rskip545TestSupport.defaultType4AuthorizationEntry();
+        CallArguments args = new CallArguments();
+        args.setAuthorizationList(List.of(entry));
+
+        CallArgumentsToByteArray byteArrayArgs = new CallArgumentsToByteArray(args);
+
+        List<SetCodeAuthorization> authorizations = byteArrayArgs.getAuthorizationList();
+        Assertions.assertEquals(1, authorizations.size());
+        Assertions.assertEquals(entry.getAddress(), authorizations.get(0).getAddress().toJsonString());
+    }
+
+    @Test
+    void getChainIdWhenValueIsNull_returnsDefault() {
+        CallArguments args = new CallArguments();
+
+        CallArgumentsToByteArray byteArrayArgs = new CallArgumentsToByteArray(args);
+
+        Assertions.assertEquals((byte) 33, byteArrayArgs.getChainId((byte) 33));
+    }
+
+    @Test
+    void getChainIdWhenValueIsEmpty_returnsDefault() {
+        CallArguments args = new CallArguments();
+        args.setChainId("");
+
+        CallArgumentsToByteArray byteArrayArgs = new CallArgumentsToByteArray(args);
+
+        Assertions.assertEquals((byte) 33, byteArrayArgs.getChainId((byte) 33));
+    }
+
+    @Test
+    void getChainIdWhenValueIsSet_returnsParsedValue() {
+        CallArguments args = new CallArguments();
+        args.setChainId("0x21");
+
+        CallArgumentsToByteArray byteArrayArgs = new CallArgumentsToByteArray(args);
+
+        Assertions.assertEquals((byte) 33, byteArrayArgs.getChainId((byte) 1));
+    }
+
+    @Test
+    void getChainIdWhenValueIsInvalid_rejectsRequest() {
+        CallArguments args = new CallArguments();
+        args.setChainId("0x1234");
+
+        CallArgumentsToByteArray byteArrayArgs = new CallArgumentsToByteArray(args);
+
+        RskJsonRpcRequestException ex = Assertions.assertThrows(
+                RskJsonRpcRequestException.class,
+                () -> byteArrayArgs.getChainId((byte) 1));
+        Assertions.assertEquals(-32602, ex.getCode());
+        Assertions.assertEquals("Invalid chainId: 0x1234", ex.getMessage());
+    }
+
+    @Test
+    void resolveType_noAttributesPresent_returnsLegacy() {
+        CallArguments args = new CallArguments();
+
+        Assertions.assertEquals(TransactionType.LEGACY, new CallArgumentsToByteArray(args).resolveType());
+    }
+
+    @Test
+    void resolveType_typeFieldAlone_isIgnored() {
+        CallArguments args = new CallArguments();
+        args.setType("0x2");
+        Assertions.assertEquals(TransactionType.LEGACY, new CallArgumentsToByteArray(args).resolveType());
+    }
+
+    @Test
+    void resolveType_accessListPresentButEmpty_returnsType1() {
+        CallArguments args = new CallArguments();
+        args.setAccessList(List.of());
+        Assertions.assertEquals(TransactionType.TYPE_1, new CallArgumentsToByteArray(args).resolveType());
+    }
+
+    @Test
+    void resolveType_accessListNonEmpty_returnsType1() {
+        CallArguments args = new CallArguments();
+        args.setAccessList(List.of(new CallArguments.AccessListEntry()));
+
+        Assertions.assertEquals(TransactionType.TYPE_1, new CallArgumentsToByteArray(args).resolveType());
+    }
+
+    @Test
+    void resolveType_feeCapsPresent_returnsType2_evenWithAccessListAlsoPresent() {
+        CallArguments args = new CallArguments();
+        args.setMaxPriorityFeePerGas("0x1");
+        args.setMaxFeePerGas("0x2");
+        args.setAccessList(List.of());
+
+        Assertions.assertEquals(TransactionType.TYPE_2, new CallArgumentsToByteArray(args).resolveType());
+    }
+
+    @Test
+    void resolveType_authorizationListPresentButEmpty_returnsType4_evenWithEverythingElsePresent() {
+        CallArguments args = new CallArguments();
+        args.setMaxPriorityFeePerGas("0x1");
+        args.setMaxFeePerGas("0x2");
+        args.setAccessList(List.of());
+        args.setAuthorizationList(List.of());
+
+        Assertions.assertEquals(TransactionType.TYPE_4, new CallArgumentsToByteArray(args).resolveType());
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/rpc/converters/CallArgumentsToByteArrayTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/converters/CallArgumentsToByteArrayTest.java
@@ -26,8 +26,12 @@ import org.ethereum.rpc.exception.RskJsonRpcRequestException;
 import org.ethereum.util.ByteUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import co.rsk.config.TestSystemProperties;
 import co.rsk.util.HexUtils;
@@ -286,22 +290,26 @@ class CallArgumentsToByteArrayTest {
     }
 
     @Test
-    void getAuthorizationListWhenValueIsNull() {
+    void getAuthorizationListWhenValueIsNull_returnsEmptyList() {
         CallArguments args = new CallArguments();
 
         CallArgumentsToByteArray byteArrayArgs = new CallArgumentsToByteArray(args);
 
-        Assertions.assertNull(byteArrayArgs.getAuthorizationList());
+        Assertions.assertTrue(byteArrayArgs.getAuthorizationList().isEmpty());
     }
 
     @Test
-    void getAuthorizationListWhenValueIsEmpty() {
+    void getAuthorizationListWhenValueIsEmpty_rejectsRequest() {
         CallArguments args = new CallArguments();
         args.setAuthorizationList(List.of());
 
         CallArgumentsToByteArray byteArrayArgs = new CallArgumentsToByteArray(args);
 
-        Assertions.assertNull(byteArrayArgs.getAuthorizationList());
+        RskJsonRpcRequestException ex = Assertions.assertThrows(
+                RskJsonRpcRequestException.class,
+                byteArrayArgs::getAuthorizationList);
+        Assertions.assertEquals(-32602, ex.getCode());
+        Assertions.assertEquals("Set-code transaction authorization_list must not be empty", ex.getMessage());
     }
 
     @Test
@@ -317,33 +325,25 @@ class CallArgumentsToByteArrayTest {
         Assertions.assertEquals(entry.getAddress(), authorizations.get(0).getAddress().toJsonString());
     }
 
-    @Test
-    void getChainIdWhenValueIsNull_returnsDefault() {
+    @ParameterizedTest(name = "chainId=\"{0}\", default={1} -> {2}")
+    @MethodSource("chainIdDefaultingCases")
+    void getChainIdWhenValueIsAbsentOrSet_returnsExpected(String chainId, byte defaultChainId, byte expected) {
         CallArguments args = new CallArguments();
+        if (chainId != null) {
+            args.setChainId(chainId);
+        }
 
         CallArgumentsToByteArray byteArrayArgs = new CallArgumentsToByteArray(args);
 
-        Assertions.assertEquals((byte) 33, byteArrayArgs.getChainId(TransactionType.LEGACY, (byte) 33));
+        Assertions.assertEquals(expected, byteArrayArgs.getChainId(TransactionType.LEGACY, defaultChainId));
     }
 
-    @Test
-    void getChainIdWhenValueIsEmpty_returnsDefault() {
-        CallArguments args = new CallArguments();
-        args.setChainId("");
-
-        CallArgumentsToByteArray byteArrayArgs = new CallArgumentsToByteArray(args);
-
-        Assertions.assertEquals((byte) 33, byteArrayArgs.getChainId(TransactionType.LEGACY, (byte) 33));
-    }
-
-    @Test
-    void getChainIdWhenValueIsSet_returnsParsedValue() {
-        CallArguments args = new CallArguments();
-        args.setChainId("0x21");
-
-        CallArgumentsToByteArray byteArrayArgs = new CallArgumentsToByteArray(args);
-
-        Assertions.assertEquals((byte) 33, byteArrayArgs.getChainId(TransactionType.LEGACY, (byte) 1));
+    private static Stream<Arguments> chainIdDefaultingCases() {
+        return Stream.of(
+                Arguments.of(null, (byte) 33, (byte) 33),
+                Arguments.of("", (byte) 33, (byte) 33),
+                Arguments.of("0x21", (byte) 1, (byte) 33)
+        );
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/rpc/converters/CallArgumentsToByteArrayTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/converters/CallArgumentsToByteArrayTest.java
@@ -323,7 +323,7 @@ class CallArgumentsToByteArrayTest {
 
         CallArgumentsToByteArray byteArrayArgs = new CallArgumentsToByteArray(args);
 
-        Assertions.assertEquals((byte) 33, byteArrayArgs.getChainId((byte) 33));
+        Assertions.assertEquals((byte) 33, byteArrayArgs.getChainId(TransactionType.LEGACY, (byte) 33));
     }
 
     @Test
@@ -333,7 +333,7 @@ class CallArgumentsToByteArrayTest {
 
         CallArgumentsToByteArray byteArrayArgs = new CallArgumentsToByteArray(args);
 
-        Assertions.assertEquals((byte) 33, byteArrayArgs.getChainId((byte) 33));
+        Assertions.assertEquals((byte) 33, byteArrayArgs.getChainId(TransactionType.LEGACY, (byte) 33));
     }
 
     @Test
@@ -343,7 +343,7 @@ class CallArgumentsToByteArrayTest {
 
         CallArgumentsToByteArray byteArrayArgs = new CallArgumentsToByteArray(args);
 
-        Assertions.assertEquals((byte) 33, byteArrayArgs.getChainId((byte) 1));
+        Assertions.assertEquals((byte) 33, byteArrayArgs.getChainId(TransactionType.LEGACY, (byte) 1));
     }
 
     @Test
@@ -355,9 +355,32 @@ class CallArgumentsToByteArrayTest {
 
         RskJsonRpcRequestException ex = Assertions.assertThrows(
                 RskJsonRpcRequestException.class,
-                () -> byteArrayArgs.getChainId((byte) 1));
+                () -> byteArrayArgs.getChainId(TransactionType.LEGACY, (byte) 1));
         Assertions.assertEquals(-32602, ex.getCode());
         Assertions.assertEquals("Invalid chainId: 0x1234", ex.getMessage());
+    }
+
+    @Test
+    void getChainIdWhenValueIsExplicitZeroForTypedTransaction_rejectsRequest() {
+        CallArguments args = new CallArguments();
+        args.setChainId("0x0");
+
+        CallArgumentsToByteArray byteArrayArgs = new CallArgumentsToByteArray(args);
+
+        RskJsonRpcRequestException ex = Assertions.assertThrows(RskJsonRpcRequestException.class,
+                () -> byteArrayArgs.getChainId(TransactionType.TYPE_2, (byte) 33));
+        Assertions.assertEquals(-32602, ex.getCode());
+        Assertions.assertEquals("Invalid chainId: 0x0", ex.getMessage());
+    }
+
+    @Test
+    void getChainIdWhenValueIsExplicitZeroForLegacyTransaction_returnsZero() {
+        CallArguments args = new CallArguments();
+        args.setChainId("0x0");
+
+        CallArgumentsToByteArray byteArrayArgs = new CallArgumentsToByteArray(args);
+
+        Assertions.assertEquals((byte) 0, byteArrayArgs.getChainId(TransactionType.LEGACY, (byte) 33));
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/rpc/converters/CallArgumentsToByteArrayTest.java
+++ b/rskj-core/src/test/java/org/ethereum/rpc/converters/CallArgumentsToByteArrayTest.java
@@ -255,18 +255,24 @@ class CallArgumentsToByteArrayTest {
     }
 
     @Test
-    void getGasPrice_whenGasPriceSetAndOnlyMaxPriorityFee_usesGasPriceWithoutError() {
+    void getGasPrice_whenGasPriceAndMaxPriorityFeeBothSet_rejectsRequest() {
         CallArguments args = new CallArguments();
         args.setGasPrice("0x7");
         args.setMaxPriorityFeePerGas("0x64");
 
         CallArgumentsToByteArray byteArrayArgs = new CallArgumentsToByteArray(args);
 
-        Assertions.assertArrayEquals(new byte[] {0x7}, byteArrayArgs.getGasPrice());
+        RskJsonRpcRequestException ex = Assertions.assertThrows(
+                RskJsonRpcRequestException.class,
+                byteArrayArgs::getGasPrice);
+        Assertions.assertEquals(-32602, ex.getCode());
+        Assertions.assertEquals(
+                "both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified",
+                ex.getMessage());
     }
 
     @Test
-    void getGasPrice_whenGasPriceExplicitlySet_takesPrecedenceOverMaxFees() {
+    void getGasPrice_whenGasPriceAndBothMaxFeesSet_rejectsRequest() {
         CallArguments args = new CallArguments();
         args.setGasPrice("0x7");
         args.setMaxFeePerGas("0xff");
@@ -274,19 +280,30 @@ class CallArgumentsToByteArrayTest {
 
         CallArgumentsToByteArray byteArrayArgs = new CallArgumentsToByteArray(args);
 
-        Assertions.assertArrayEquals(new byte[] {0x7}, byteArrayArgs.getGasPrice());
+        RskJsonRpcRequestException ex = Assertions.assertThrows(
+                RskJsonRpcRequestException.class,
+                byteArrayArgs::getGasPrice);
+        Assertions.assertEquals(-32602, ex.getCode());
+        Assertions.assertEquals(
+                "both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified",
+                ex.getMessage());
     }
 
     @Test
-    void getGasPrice_whenGasPriceSetAndMaxPriorityExceedsMaxFee_usesGasPriceWithoutError() {
+    void getGasPrice_whenGasPriceAndMaxFeeSet_rejectsRequest() {
         CallArguments args = new CallArguments();
         args.setGasPrice("0x7");
         args.setMaxFeePerGas("0x1");
-        args.setMaxPriorityFeePerGas("0x64");
 
         CallArgumentsToByteArray byteArrayArgs = new CallArgumentsToByteArray(args);
 
-        Assertions.assertArrayEquals(new byte[] {0x7}, byteArrayArgs.getGasPrice());
+        RskJsonRpcRequestException ex = Assertions.assertThrows(
+                RskJsonRpcRequestException.class,
+                byteArrayArgs::getGasPrice);
+        Assertions.assertEquals(-32602, ex.getCode());
+        Assertions.assertEquals(
+                "both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified",
+                ex.getMessage());
     }
 
     @Test

--- a/rskj-core/src/test/java/org/ethereum/util/EthModuleTestUtils.java
+++ b/rskj-core/src/test/java/org/ethereum/util/EthModuleTestUtils.java
@@ -29,11 +29,14 @@ import co.rsk.rpc.modules.eth.*;
 import co.rsk.test.World;
 import org.ethereum.config.Constants;
 import org.ethereum.config.blockchain.upgrades.ActivationConfig;
+import org.ethereum.core.Block;
 import org.ethereum.core.BlockFactory;
 import org.ethereum.core.BlockTxSignatureCache;
 import org.ethereum.core.Blockchain;
 import org.ethereum.core.TransactionPool;
 import org.ethereum.db.ReceiptStore;
+import org.ethereum.rpc.CallArguments;
+import org.ethereum.rpc.converters.CallArgumentsToByteArray;
 import org.ethereum.vm.OverrideablePrecompiledContracts;
 import org.ethereum.vm.PrecompiledContracts;
 import org.ethereum.vm.program.ProgramResult;
@@ -54,7 +57,7 @@ public class EthModuleTestUtils {
                 Constants.REGTEST_CHAIN_ID,
                 world.getBlockChain(),
                 null,
-                new ReversibleTransactionExecutor(world.getRepositoryLocator(), executor),
+                new ReversibleTransactionExecutor(world.getRepositoryLocator(), executor, null),
                 new ExecutionBlockRetriever(world.getBlockChain(), null, null),
                 world.getRepositoryLocator(),
                 null,
@@ -77,7 +80,7 @@ public class EthModuleTestUtils {
                 Constants.REGTEST_CHAIN_ID,
                 world.getBlockChain(),
                 null,
-                new ReversibleTransactionExecutor(world.getRepositoryLocator(), executor),
+                new ReversibleTransactionExecutor(world.getRepositoryLocator(), executor, null),
                 new ExecutionBlockRetriever(world.getBlockChain(), null, null),
                 world.getRepositoryLocator(),
                 null,
@@ -111,6 +114,10 @@ public class EthModuleTestUtils {
     }
 
     public static class EthModuleGasEstimation extends EthModule {
+        private final ReversibleTransactionExecutor reversibleTransactionExecutor;
+        private final byte chainId;
+        private final long gasCallCap;
+
         private EthModuleGasEstimation(BridgeConstants bridgeConstants, byte chainId, Blockchain blockchain,
                                        TransactionPool transactionPool, ReversibleTransactionExecutor reversibleTransactionExecutor,
                                        ExecutionBlockRetriever executionBlockRetriever, RepositoryLocator repositoryLocator,
@@ -123,6 +130,9 @@ public class EthModuleTestUtils {
                     executionBlockRetriever, repositoryLocator, ethModuleWallet, ethModuleTransaction,
                     bridgeSupportFactory, gasEstimationCap, gasCap, activationConfig, overrideablePrecompiledContracts,
                     allowCallStateOverride, stateOverrideApplier);
+            this.reversibleTransactionExecutor = reversibleTransactionExecutor;
+            this.chainId = chainId;
+            this.gasCallCap = gasCap;
         }
 
         private ProgramResult estimationResult;
@@ -137,6 +147,12 @@ public class EthModuleTestUtils {
             estimationResult = reversibleExecutionResult;
 
             return estimatedGas;
+        }
+
+        public ProgramResult simulateTransactionExecution(CallArguments args, Block executionBlock) {
+            CallArgumentsToByteArray hexArgs = new CallArgumentsToByteArray(args);
+            ReversibleTransactionExecutor.ReversibleTransactionParams params = EthModule.buildParams(hexArgs, hexArgs.gasLimitForCall(gasCallCap), chainId);
+            return reversibleTransactionExecutor.executeTransactionAtBlock(executionBlock, executionBlock.getCoinbase(), params);
         }
     }
 }

--- a/rskj-core/src/test/java/org/ethereum/vm/program/NestedContractsTest.java
+++ b/rskj-core/src/test/java/org/ethereum/vm/program/NestedContractsTest.java
@@ -213,7 +213,7 @@ class NestedContractsTest {
                 Constants.REGTEST_CHAIN_ID,
                 world.getBlockChain(),
                 world.getTransactionPool(),
-                new ReversibleTransactionExecutor(world.getRepositoryLocator(), executor),
+                new ReversibleTransactionExecutor(world.getRepositoryLocator(), executor, null),
                 new ExecutionBlockRetriever(world.getBlockChain(), null, null),
                 world.getRepositoryLocator(),
                 null,


### PR DESCRIPTION
## Description
 Extends eth_call and eth_estimateGas to correctly simulate Type 1 (RSKIP-546/EIP-2930), Type 2 (RSKIP-546/EIP-1559) and Type 4 (RSKIP-545/EIP-7702) transactions, instead of always treating the call as legacy. 

## Motivation and Context
RSKIP-545 and RSKIP-546 added Type 1/2/4 transaction support to the protocol, but eth_call/eth_estimateGas still simulated every call as legacy, ignoring authorizationList, accessList, and fee caps. This left it unable it to estimate gas or simulate EIP-7702 delegations before sending them on-chain.

## How Has This Been Tested?
  - Existing unit tests updated for the new signatures.                                                                                                                                                                                  
  - Two new integration test suites against a real test blockchain (no mocks): EthModuleType4CallSimulationTest, EthModuleTypedCallSimulationTest.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Requires Activation Code (Hard Fork)

* **Other information**:
RPC/simulation-only change — no consensus or block-validation rules touched, so no activation code is needed. 