### PR TITLE
Adding new storage key federationsPendingBtcUTXOs 

### DIFF
--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageIndexKey.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageIndexKey.java
@@ -8,6 +8,7 @@ public enum FederationStorageIndexKey {
     NEW_FEDERATION_BTC_UTXOS_KEY_FOR_TESTNET_PRE_HOP("newFederationBtcUTXOsForTestnet"),
     NEW_FEDERATION_BTC_UTXOS_KEY_FOR_TESTNET_POST_HOP("newFedBtcUTXOsForTestnetPostHop"),
     OLD_FEDERATION_BTC_UTXOS_KEY("oldFederationBtcUTXOs"),
+    FEDERATIONS_PENDING_BTC_UTXOS_KEY("federationsPendingBtcUTXOs"),
 
     NEW_FEDERATION_KEY("newFederation"),
     OLD_FEDERATION_KEY("oldFederation"),
@@ -36,5 +37,9 @@ public enum FederationStorageIndexKey {
 
     public DataWord getKey() {
         return DataWord.fromString(key);
+    }
+
+    public DataWord getCompoundKey(String delimiter, String identifier) {
+        return DataWord.fromLongString(key + delimiter + identifier);
     }
 }

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProvider.java
@@ -18,6 +18,7 @@ public interface FederationStorageProvider {
     List<UTXO> getOldFederationBtcUTXOs();
 
     Optional<List<UTXO>> getFederationsPendingBtcUTXOs(Sha256Hash btcTxId);
+    void setFederationsPendingBtcUTXOs(Sha256Hash btcTxId, List<UTXO> utxos);
 
     Federation getNewFederation(FederationConstants federationConstants, ActivationConfig.ForBlock activations);
     void setNewFederation(Federation federation);

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProvider.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProvider.java
@@ -1,6 +1,7 @@
 package co.rsk.peg.federation;
 
 import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.bitcoinj.core.UTXO;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.peg.federation.constants.FederationConstants;
@@ -15,6 +16,8 @@ public interface FederationStorageProvider {
 
     List<UTXO> getNewFederationBtcUTXOs(NetworkParameters networkParameters, ActivationConfig.ForBlock activations);
     List<UTXO> getOldFederationBtcUTXOs();
+
+    Optional<List<UTXO>> getFederationsPendingBtcUTXOs(Sha256Hash btcTxId);
 
     Federation getNewFederation(FederationConstants federationConstants, ActivationConfig.ForBlock activations);
     void setNewFederation(Federation federation);

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
@@ -131,6 +131,11 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
     }
 
     @Override
+    public void setFederationsPendingBtcUTXOs(Sha256Hash btcTxId, List<UTXO> utxos) {
+        federationsPendingBtcUTXOs.put(btcTxId, utxos);
+    }
+
+    @Override
     public Federation getNewFederation(FederationConstants federationConstants, ActivationConfig.ForBlock activations) {
         if (newFederation != null) {
             return newFederation;

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
@@ -1,6 +1,7 @@
 package co.rsk.peg.federation;
 
 import co.rsk.bitcoinj.core.NetworkParameters;
+import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.bitcoinj.core.UTXO;
 import co.rsk.bitcoinj.script.Script;
 import co.rsk.peg.BridgeSerializationUtils;
@@ -103,6 +104,11 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
 
         oldFederationBtcUTXOs = bridgeStorageAccessor.getFromRepository(OLD_FEDERATION_BTC_UTXOS_KEY.getKey(), BridgeSerializationUtils::deserializeUTXOList);
         return oldFederationBtcUTXOs;
+    }
+
+    @Override
+    public Optional<List<UTXO>> getFederationsPendingBtcUTXOs(Sha256Hash btcTxId) {
+        return Optional.empty();
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
@@ -108,7 +108,18 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
 
     @Override
     public Optional<List<UTXO>> getFederationsPendingBtcUTXOs(Sha256Hash btcTxId) {
-        return Optional.empty();
+        DataWord key = getStorageKeyForFederationsPendingBtcUTXOs(btcTxId);
+        List<UTXO> utxos = bridgeStorageAccessor.getFromRepository(key, BridgeSerializationUtils::deserializeUTXOList);
+
+        if (utxos.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(utxos);
+    }
+
+    private DataWord getStorageKeyForFederationsPendingBtcUTXOs(Sha256Hash btcTxId) {
+        return FEDERATIONS_PENDING_BTC_UTXOS_KEY.getCompoundKey("-", btcTxId.toString());
     }
 
     @Override

--- a/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
+++ b/rskj-core/src/main/java/co/rsk/peg/federation/FederationStorageProviderImpl.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static co.rsk.peg.federation.FederationStorageIndexKey.*;
@@ -27,6 +28,7 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
     private static final Logger logger = LoggerFactory.getLogger(FederationStorageProviderImpl.class);
     private final StorageAccessor bridgeStorageAccessor;
     private final HashMap<DataWord, Optional<Integer>> storageVersionEntries;
+    private final Map<Sha256Hash, List<UTXO>> federationsPendingBtcUTXOs;
 
     private List<UTXO> newFederationBtcUTXOs;
     private List<UTXO> oldFederationBtcUTXOs;
@@ -50,6 +52,7 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
     public FederationStorageProviderImpl(StorageAccessor bridgeStorageAccessor) {
         this.bridgeStorageAccessor = bridgeStorageAccessor;
         this.storageVersionEntries = new HashMap<>();
+        this.federationsPendingBtcUTXOs = new HashMap<>();
     }
 
     @Override
@@ -108,6 +111,10 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
 
     @Override
     public Optional<List<UTXO>> getFederationsPendingBtcUTXOs(Sha256Hash btcTxId) {
+        if (federationsPendingBtcUTXOs.containsKey(btcTxId)) {
+            return Optional.of(federationsPendingBtcUTXOs.get(btcTxId));
+        }
+
         DataWord key = getStorageKeyForFederationsPendingBtcUTXOs(btcTxId);
         List<UTXO> utxos = bridgeStorageAccessor.getFromRepository(key, BridgeSerializationUtils::deserializeUTXOList);
 
@@ -115,6 +122,7 @@ public class FederationStorageProviderImpl implements FederationStorageProvider 
             return Optional.empty();
         }
 
+        federationsPendingBtcUTXOs.put(btcTxId, utxos);
         return Optional.of(utxos);
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
+++ b/rskj-core/src/test/java/co/rsk/peg/BridgeSerializationUtilsTest.java
@@ -20,6 +20,7 @@ package co.rsk.peg;
 
 import static co.rsk.peg.BridgeSerializationUtils.*;
 import static co.rsk.peg.PegTestUtils.createHash3;
+import static co.rsk.peg.bitcoin.BitcoinTestAssertions.assertUtxosEquals;
 import static org.ethereum.util.ByteUtil.EMPTY_BYTE_ARRAY;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -941,21 +942,6 @@ class BridgeSerializationUtilsTest {
             assertThrows(SerializationException.class, () -> BridgeSerializationUtils.deserializeUTXOList(data));
         }
 
-        private void assertUtxosEquals(List<UTXO> expected, List<UTXO> actual) {
-            assertEquals(expected.size(), actual.size());
-            for (int i = 0; i < expected.size(); i++) {
-                assertUtxoEquals(expected.get(i), actual.get(i));
-            }
-        }
-
-        private void assertUtxoEquals(UTXO expected, UTXO actual) {
-            assertEquals(expected.getHash(), actual.getHash());
-            assertEquals(expected.getIndex(), actual.getIndex());
-            assertEquals(expected.getValue(), actual.getValue());
-            assertEquals(expected.getHeight(), actual.getHeight());
-            assertEquals(expected.isCoinbase(), actual.isCoinbase());
-            assertEquals(expected.getScript(), actual.getScript());
-        }
     }
 
     @Test

--- a/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinTestAssertions.java
+++ b/rskj-core/src/test/java/co/rsk/peg/bitcoin/BitcoinTestAssertions.java
@@ -2,6 +2,7 @@ package co.rsk.peg.bitcoin;
 
 import co.rsk.bitcoinj.core.Sha256Hash;
 import co.rsk.bitcoinj.core.TransactionWitness;
+import co.rsk.bitcoinj.core.UTXO;
 import co.rsk.bitcoinj.script.*;
 
 import java.util.List;
@@ -158,6 +159,22 @@ public class BitcoinTestAssertions {
         Script actualStandardScript = new ScriptBuilder().addChunks(actualStandardChunks).build();
         Script expectedStandardScript = new ScriptBuilder().addChunks(expectedStandardChunks).build();
         assertArrayEquals(expectedStandardScript.getProgram(), actualStandardScript.getProgram());
+    }
+
+    public static void assertUtxosEquals(List<UTXO> expected, List<UTXO> actual) {
+        assertEquals(expected.size(), actual.size());
+        for (int i = 0; i < expected.size(); i++) {
+            assertUtxoEquals(expected.get(i), actual.get(i));
+        }
+    }
+
+    public static void assertUtxoEquals(UTXO expected, UTXO actual) {
+        assertEquals(expected.getHash(), actual.getHash());
+        assertEquals(expected.getIndex(), actual.getIndex());
+        assertEquals(expected.getValue(), actual.getValue());
+        assertEquals(expected.getHeight(), actual.getHeight());
+        assertEquals(expected.isCoinbase(), actual.isCoinbase());
+        assertEquals(expected.getScript(), actual.getScript());
     }
 
     public static void assertSegwitScriptSigContainsHashedRedeemScript(Script segwitScriptSig, Script redeemScript) {

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
@@ -1179,6 +1179,38 @@ class FederationStorageProviderImplTests {
         }
 
         @Test
+        void getFederationsPendingBtcUTXOs_whenMultipleUtxosPresentInStorage_shouldReturnUtxosStored() {
+            // arrange
+            List<UTXO> multipleUtxos = UTXOBuilder.builder()
+                .withScriptPubKey(p2shP2wshErpFederationScript)
+                .buildMany(3, i -> createHash(i + 1));
+            storageAccessor.saveToRepository(key, multipleUtxos, BridgeSerializationUtils::serializeUTXOList);
+
+            // act
+            Optional<List<UTXO>> actualUtxos = federationStorageProvider.getFederationsPendingBtcUTXOs(btcTxId);
+
+            // assert
+            assertTrue(actualUtxos.isPresent());
+            assertUtxosEquals(multipleUtxos, actualUtxos.get());
+        }
+
+        @Test
+        void getFederationsPendingBtcUTXOs_whenLargeNumberOfUtxosPresentInStorage_shouldReturnUtxosStored() {
+            // arrange
+            List<UTXO> largeNumberOfUtxos = UTXOBuilder.builder()
+                .withScriptPubKey(p2shP2wshErpFederationScript)
+                .buildMany(200, i -> createHash(i + 1));
+            storageAccessor.saveToRepository(key, largeNumberOfUtxos, BridgeSerializationUtils::serializeUTXOList);
+
+            // act
+            Optional<List<UTXO>> actualUtxos = federationStorageProvider.getFederationsPendingBtcUTXOs(btcTxId);
+
+            // assert
+            assertTrue(actualUtxos.isPresent());
+            assertUtxosEquals(largeNumberOfUtxos, actualUtxos.get());
+        }
+
+        @Test
         void getFederationsPendingBtcUTXOs_whenCalledTwice_shouldReturnCachedUtxos() {
             // arrange
             storageAccessor.saveToRepository(key, expectedUtxos, BridgeSerializationUtils::serializeUTXOList);

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
@@ -1164,6 +1164,29 @@ class FederationStorageProviderImplTests {
             // assert
             assertTrue(actualUtxos.isEmpty());
         }
+
+        @Test
+        void getFederationsPendingBtcUTXOs_whenPresentInStorage_shouldReturnUtxosStored() {
+            // arrange
+            StorageAccessor storageAccessor = new InMemoryStorage();
+            FederationStorageProvider federationStorageProvider = new FederationStorageProviderImpl(storageAccessor);
+            Sha256Hash btcTxId = createHash(1);
+            DataWord key = FEDERATIONS_PENDING_BTC_UTXOS_KEY.getCompoundKey("-", btcTxId.toString());
+
+            List<UTXO> expectedUtxos = List.of(
+                UTXOBuilder.builder()
+                    .withScriptPubKey(p2shP2wshErpFederationScript)
+                    .build()
+            );
+            storageAccessor.saveToRepository(key, expectedUtxos, BridgeSerializationUtils::serializeUTXOList);
+
+            // act
+            Optional<List<UTXO>> actualUtxos = federationStorageProvider.getFederationsPendingBtcUTXOs(btcTxId);
+
+            // assert
+            assertTrue(actualUtxos.isPresent());
+            assertUtxosEquals(expectedUtxos, actualUtxos.get());
+        }
     }
 
     private static Federation createNonStandardErpFederation() {

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
@@ -1150,6 +1150,20 @@ class FederationStorageProviderImplTests {
             // assert
             assertUtxosEquals(expectedUtxos, actualUtxos);
         }
+
+        @Test
+        void getFederationsPendingBtcUTXOs_whenNotCachedAndNotInStorage_shouldReturnEmpty() {
+            // arrange
+            StorageAccessor storageAccessor = new InMemoryStorage();
+            FederationStorageProvider federationStorageProvider = new FederationStorageProviderImpl(storageAccessor);
+            Sha256Hash btcTxId = createHash(1);
+
+            // act
+            Optional<List<UTXO>> actualUtxos = federationStorageProvider.getFederationsPendingBtcUTXOs(btcTxId);
+
+            // assert
+            assertTrue(actualUtxos.isEmpty());
+        }
     }
 
     private static Federation createNonStandardErpFederation() {

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
@@ -1131,7 +1131,7 @@ class FederationStorageProviderImplTests {
         private final Script p2shP2wshErpFederationScript = P2shP2wshErpFederationBuilder.builder().build().getP2SHScript();
 
         @Test
-        void federationsPendingBtcUTXOsKey_shouldSaveAndRetrieveUtxosFromStorage() {
+        void storeInStorage_withFederationsPendingBtcUTXOsKey_shouldSaveAndRetrieveUtxosFromStorage() {
             // arrange
             StorageAccessor storageAccessor = new InMemoryStorage();
             Sha256Hash btcTxId = createHash(1);

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
@@ -1187,6 +1187,43 @@ class FederationStorageProviderImplTests {
             assertTrue(actualUtxos.isPresent());
             assertUtxosEquals(expectedUtxos, actualUtxos.get());
         }
+
+        @Test
+        void getFederationsPendingBtcUTXOs_whenCalledTwice_shouldReturnCachedUtxos() {
+            // arrange
+            StorageAccessor storageAccessor = new InMemoryStorage();
+            FederationStorageProvider federationStorageProvider = new FederationStorageProviderImpl(storageAccessor);
+            Sha256Hash btcTxId = createHash(1);
+            DataWord key = FEDERATIONS_PENDING_BTC_UTXOS_KEY.getCompoundKey("-", btcTxId.toString());
+
+            List<UTXO> expectedUtxos = List.of(
+                UTXOBuilder.builder()
+                    .withScriptPubKey(p2shP2wshErpFederationScript)
+                    .build()
+            );
+            storageAccessor.saveToRepository(key, expectedUtxos, BridgeSerializationUtils::serializeUTXOList);
+
+            // act
+            Optional<List<UTXO>> actualCachedUtxos = federationStorageProvider.getFederationsPendingBtcUTXOs(btcTxId);
+
+            List<UTXO> extraUtxosOverwritingPreviousValue = UTXOBuilder.builder()
+                .withScriptPubKey(p2shP2wshErpFederationScript)
+                .buildMany(2, i -> expectedUtxos.get(0).getHash());
+
+            storageAccessor.saveToRepository(key, extraUtxosOverwritingPreviousValue, BridgeSerializationUtils::serializeUTXOList);
+
+            Optional<List<UTXO>> cachedUtxosAfterSecondGet = federationStorageProvider.getFederationsPendingBtcUTXOs(btcTxId);
+
+            // assert
+            assertTrue(actualCachedUtxos.isPresent());
+            assertUtxosEquals(expectedUtxos, actualCachedUtxos.get());
+
+            assertTrue(cachedUtxosAfterSecondGet.isPresent());
+            assertUtxosEquals(expectedUtxos, cachedUtxosAfterSecondGet.get());
+
+            List<UTXO> actualUtxosInStorage = storageAccessor.getFromRepository(key, BridgeSerializationUtils::deserializeUTXOList);
+            assertUtxosEquals(extraUtxosOverwritingPreviousValue, actualUtxosInStorage);
+        }
     }
 
     private static Federation createNonStandardErpFederation() {

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
@@ -3,6 +3,7 @@ package co.rsk.peg.federation;
 import static co.rsk.bitcoinj.core.NetworkParameters.ID_MAINNET;
 import static co.rsk.bitcoinj.core.NetworkParameters.ID_TESTNET;
 import static co.rsk.peg.BridgeSerializationUtils.serializeElection;
+import static co.rsk.peg.bitcoin.BitcoinTestAssertions.assertUtxosEquals;
 import static co.rsk.peg.bitcoin.BitcoinTestUtils.createHash;
 import static co.rsk.peg.federation.FederationFormatVersion.*;
 import static co.rsk.peg.federation.FederationStorageIndexKey.*;
@@ -1122,6 +1123,32 @@ class FederationStorageProviderImplTests {
 
             Optional<Federation> actualProposedFederation = federationStorageProvider.getProposedFederation(federationConstants, allActivations);
             assertEquals(Optional.of(proposedFederation), actualProposedFederation);
+        }
+    }
+
+    @Nested
+    class PendingFederationsBtcUTXOs {
+        private final Script p2shP2wshErpFederationScript = P2shP2wshErpFederationBuilder.builder().build().getP2SHScript();
+
+        @Test
+        void federationsPendingBtcUTXOsKey_shouldSaveAndRetrieveUtxosFromStorage() {
+            // arrange
+            StorageAccessor storageAccessor = new InMemoryStorage();
+            Sha256Hash btcTxId = createHash(1);
+            DataWord key = FEDERATIONS_PENDING_BTC_UTXOS_KEY.getCompoundKey("-", btcTxId.toString());
+
+            List<UTXO> expectedUtxos = List.of(
+                UTXOBuilder.builder()
+                    .withScriptPubKey(p2shP2wshErpFederationScript)
+                    .build()
+            );
+
+            // act
+            storageAccessor.saveToRepository(key, expectedUtxos, BridgeSerializationUtils::serializeUTXOList);
+            List<UTXO> actualUtxos = storageAccessor.getFromRepository(key, BridgeSerializationUtils::deserializeUTXOList);
+
+            // assert
+            assertUtxosEquals(expectedUtxos, actualUtxos);
         }
     }
 

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
@@ -1236,6 +1236,17 @@ class FederationStorageProviderImplTests {
             List<UTXO> actualUtxosInStorage = storageAccessor.getFromRepository(key, BridgeSerializationUtils::deserializeUTXOList);
             assertUtxosEquals(extraUtxosOverwritingPreviousValue, actualUtxosInStorage);
         }
+
+        @Test
+        void setFederationsPendingBtcUTXOs_withOneUtxo_shouldStoreInCache() {
+            // act
+            federationStorageProvider.setFederationsPendingBtcUTXOs(btcTxId, expectedUtxos);
+            Optional<List<UTXO>> actualUtxos = federationStorageProvider.getFederationsPendingBtcUTXOs(btcTxId);
+
+            // assert
+            assertTrue(actualUtxos.isPresent());
+            assertUtxosEquals(expectedUtxos, actualUtxos.get());
+        }
     }
 
     private static Federation createNonStandardErpFederation() {

--- a/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
+++ b/rskj-core/src/test/java/co/rsk/peg/federation/FederationStorageProviderImplTests.java
@@ -1128,21 +1128,26 @@ class FederationStorageProviderImplTests {
 
     @Nested
     class PendingFederationsBtcUTXOs {
-        private final Script p2shP2wshErpFederationScript = P2shP2wshErpFederationBuilder.builder().build().getP2SHScript();
+        private static final Sha256Hash btcTxId = createHash(1);
+        private static final Script p2shP2wshErpFederationScript = P2shP2wshErpFederationBuilder.builder().build().getP2SHScript();
+        private static final DataWord key = FEDERATIONS_PENDING_BTC_UTXOS_KEY.getCompoundKey("-", btcTxId.toString());
+        private static final List<UTXO> expectedUtxos = List.of(
+            UTXOBuilder.builder()
+                .withScriptPubKey(p2shP2wshErpFederationScript)
+                .build()
+        );
+
+        private StorageAccessor storageAccessor;
+        private FederationStorageProvider federationStorageProvider;
+
+        @BeforeEach
+        void setup() {
+            storageAccessor = new InMemoryStorage();
+            federationStorageProvider = new FederationStorageProviderImpl(storageAccessor);
+        }
 
         @Test
         void storeInStorage_withFederationsPendingBtcUTXOsKey_shouldSaveAndRetrieveUtxosFromStorage() {
-            // arrange
-            StorageAccessor storageAccessor = new InMemoryStorage();
-            Sha256Hash btcTxId = createHash(1);
-            DataWord key = FEDERATIONS_PENDING_BTC_UTXOS_KEY.getCompoundKey("-", btcTxId.toString());
-
-            List<UTXO> expectedUtxos = List.of(
-                UTXOBuilder.builder()
-                    .withScriptPubKey(p2shP2wshErpFederationScript)
-                    .build()
-            );
-
             // act
             storageAccessor.saveToRepository(key, expectedUtxos, BridgeSerializationUtils::serializeUTXOList);
             List<UTXO> actualUtxos = storageAccessor.getFromRepository(key, BridgeSerializationUtils::deserializeUTXOList);
@@ -1153,11 +1158,6 @@ class FederationStorageProviderImplTests {
 
         @Test
         void getFederationsPendingBtcUTXOs_whenNotCachedAndNotInStorage_shouldReturnEmpty() {
-            // arrange
-            StorageAccessor storageAccessor = new InMemoryStorage();
-            FederationStorageProvider federationStorageProvider = new FederationStorageProviderImpl(storageAccessor);
-            Sha256Hash btcTxId = createHash(1);
-
             // act
             Optional<List<UTXO>> actualUtxos = federationStorageProvider.getFederationsPendingBtcUTXOs(btcTxId);
 
@@ -1168,16 +1168,6 @@ class FederationStorageProviderImplTests {
         @Test
         void getFederationsPendingBtcUTXOs_whenPresentInStorage_shouldReturnUtxosStored() {
             // arrange
-            StorageAccessor storageAccessor = new InMemoryStorage();
-            FederationStorageProvider federationStorageProvider = new FederationStorageProviderImpl(storageAccessor);
-            Sha256Hash btcTxId = createHash(1);
-            DataWord key = FEDERATIONS_PENDING_BTC_UTXOS_KEY.getCompoundKey("-", btcTxId.toString());
-
-            List<UTXO> expectedUtxos = List.of(
-                UTXOBuilder.builder()
-                    .withScriptPubKey(p2shP2wshErpFederationScript)
-                    .build()
-            );
             storageAccessor.saveToRepository(key, expectedUtxos, BridgeSerializationUtils::serializeUTXOList);
 
             // act
@@ -1191,16 +1181,6 @@ class FederationStorageProviderImplTests {
         @Test
         void getFederationsPendingBtcUTXOs_whenCalledTwice_shouldReturnCachedUtxos() {
             // arrange
-            StorageAccessor storageAccessor = new InMemoryStorage();
-            FederationStorageProvider federationStorageProvider = new FederationStorageProviderImpl(storageAccessor);
-            Sha256Hash btcTxId = createHash(1);
-            DataWord key = FEDERATIONS_PENDING_BTC_UTXOS_KEY.getCompoundKey("-", btcTxId.toString());
-
-            List<UTXO> expectedUtxos = List.of(
-                UTXOBuilder.builder()
-                    .withScriptPubKey(p2shP2wshErpFederationScript)
-                    .build()
-            );
             storageAccessor.saveToRepository(key, expectedUtxos, BridgeSerializationUtils::serializeUTXOList);
 
             // act


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

We need to create a new variable federationsPendingBtcUTXOs::Map<Sha256Hash, List<UTXO>> that, given a pegout or a migration tx, maps the txid to the tx’s outputs. This will belong to FederationStorageProvider and it will identify whether a registered transaction is a release transaction. 

This PR adds the storage primitives (setFederationsPendingBtcUTXOs / getFederationsPendingBtcUTXOs / removeFederationsPendingBtcUTXOs) but does not yet wire them into the bridge flow. The intended callers are:

- settleReleaseRequest — calls setFederationsPendingBtcUTXOs(btcTxId, utxos) when a release transaction (migration, pegout, or SVP) is built, keyed by that release transaction's own BTC txid.
- registerPegoutTransaction— calls removeFederationsPendingBtcUTXOs(btcTxId) once the corresponding release transaction is confirmed on the BTC chain.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] Tests for the changes have been added (for bug fixes / features)
- [] Requires Activation Code (Hard Fork)


* **Other information**:
