### PR TITLE
Make trace enum serialization locale-independent

### DIFF
--- a/rskj-core/src/main/java/co/rsk/rpc/modules/trace/TraceAction.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/trace/TraceAction.java
@@ -21,6 +21,8 @@ package co.rsk.rpc.modules.trace;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.util.Locale;
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TraceAction {
     private final CallType callType;
@@ -66,7 +68,7 @@ public class TraceAction {
             return null;
         }
 
-        return this.callType.name().toLowerCase();
+        return this.callType.name().toLowerCase(Locale.ROOT);
     }
 
     @JsonGetter("from")

--- a/rskj-core/src/main/java/co/rsk/rpc/modules/trace/TraceTransformer.java
+++ b/rskj-core/src/main/java/co/rsk/rpc/modules/trace/TraceTransformer.java
@@ -31,6 +31,7 @@ import org.ethereum.vm.trace.SummarizedProgramTrace;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 public class TraceTransformer {
     private TraceTransformer() {
@@ -111,7 +112,7 @@ public class TraceTransformer {
         String blockHash = HexUtils.toUnformattedJsonHex(txInfo.getBlockHash());
         String transactionHash = txInfo.getReceipt().getTransaction().getHash().toJsonString();
         int transactionPosition = txInfo.getIndex();
-        String type = traceType.name().toLowerCase();
+        String type = traceType.name().toLowerCase(Locale.ROOT);
 
         return new TransactionTrace(
                 action,

--- a/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceTransformerTest.java
+++ b/rskj-core/src/test/java/co/rsk/rpc/modules/trace/TraceTransformerTest.java
@@ -19,12 +19,26 @@
 package co.rsk.rpc.modules.trace;
 
 import co.rsk.core.types.bytes.Bytes;
+import co.rsk.crypto.Keccak256;
+import org.ethereum.core.Transaction;
+import org.ethereum.core.TransactionReceipt;
+import org.ethereum.db.TransactionInfo;
 import org.ethereum.vm.DataWord;
+import org.ethereum.vm.program.ProgramResult;
 import org.ethereum.vm.program.invoke.ProgramInvoke;
 import org.ethereum.vm.program.invoke.ProgramInvokeImpl;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
 
+import java.util.Locale;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@Isolated
 class TraceTransformerTest {
     @Test
     void getActionFromInvokeData() {
@@ -61,6 +75,70 @@ class TraceTransformerTest {
         // a CALL action carries calldata in input, never creation-only fields
         Assertions.assertNull(action.getInit());
         Assertions.assertNull(action.getCreationMethod());
+    }
+
+    @Test
+    @ResourceLock(Resources.LOCALE)
+    void getCallTypeIsLocaleIndependent() {
+        Locale previous = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+
+            TraceAction action = new TraceAction(
+                    CallType.STATICCALL,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null);
+
+            Assertions.assertEquals("staticcall", action.getCallType());
+        } finally {
+            Locale.setDefault(previous);
+        }
+    }
+
+    @Test
+    @ResourceLock(Resources.LOCALE)
+    void traceTypeIsLocaleIndependent() {
+        Locale previous = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+
+            ProgramInvoke invoke = mock(ProgramInvoke.class);
+            when(invoke.getCallerAddress()).thenReturn(DataWord.valueOf(1));
+            when(invoke.getOwnerAddress()).thenReturn(DataWord.valueOf(2));
+            when(invoke.getCallValue()).thenReturn(DataWord.ZERO);
+
+            Transaction transaction = mock(Transaction.class);
+            when(transaction.getHash()).thenReturn(new Keccak256(new byte[Keccak256.HASH_LEN]));
+            TransactionReceipt receipt = new TransactionReceipt();
+            receipt.setTransaction(transaction);
+            TransactionInfo txInfo = new TransactionInfo(receipt, new byte[Keccak256.HASH_LEN], 0);
+
+            TransactionTrace trace = TraceTransformer.toTrace(
+                    TraceType.SUICIDE,
+                    invoke,
+                    ProgramResult.empty(),
+                    txInfo,
+                    1L,
+                    new TraceAddress(),
+                    CallType.NONE,
+                    null,
+                    null,
+                    null,
+                    0,
+                    null);
+
+            Assertions.assertEquals("suicide", trace.getType());
+        } finally {
+            Locale.setDefault(previous);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Description

Make trace enum serialization independent of the JVM default Locale.

`TraceAction.getCallType()` and `TraceTransformer` serialize enum names as lowercase JSON-RPC values. Both conversions now use `Locale.ROOT`.

## Motivation and Context

JSON-RPC trace fields are protocol values and must not vary with the host machine's Locale.

With a Turkish default Locale, Java's locale-sensitive lowercasing converts uppercase `I` to a dotless `ı`. This could cause values such as:

- `STATICCALL` -> `statıccall`
- `SUICIDE` -> `suıcıde`

As a result, identical RSK nodes could return different trace JSON depending on the JVM Locale.

## How Has This Been Tested?

Added regression tests using `tr-TR` as the default Locale:

- Verifies `TraceAction` serializes `STATICCALL` as `staticcall`.
- Verifies `TraceTransformer` serializes `SUICIDE` as `suicide`.
- Locale-dependent tests are isolated with JUnit `@Isolated` and `@ResourceLock(Resources.LOCALE)`.

Attempted test command:

    ./gradlew :rskj-core:test --tests co.rsk.rpc.modules.trace.TraceTransformerTest

The command could not run in the current environment because no Java Runtime is installed. The project requires JDK 17.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Requires Activation Code (Hard Fork)

* **Other information**:

No consensus, VM, activation, or protocol behavior changes are involved. No existing issue is being referenced.